### PR TITLE
Show cursor in copy-mode even when terminal app hid it

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -1048,6 +1048,9 @@ Set mark, navigate to select, then \\[ghostel-copy-mode-copy] to copy.")
 (defvar-local ghostel--saved-local-map nil
   "Saved keymap before entering copy mode.")
 
+(defvar-local ghostel--saved-cursor-type nil
+  "Saved `cursor-type' before entering copy mode.")
+
 (defun ghostel-copy-mode ()
   "Enter copy mode for selecting and copying terminal text.
 The display is frozen and standard Emacs navigation keys work.
@@ -1061,6 +1064,9 @@ Press \\`q' or \\[ghostel-copy-mode-exit] to exit without copying."
     (when ghostel--redraw-timer
       (cancel-timer ghostel--redraw-timer)
       (setq ghostel--redraw-timer nil))
+    ;; Ensure cursor is visible for navigation
+    (setq ghostel--saved-cursor-type cursor-type)
+    (setq cursor-type (default-value 'cursor-type))
     ;; Switch to copy mode keymap (standard Emacs keys work by default)
     (setq ghostel--saved-local-map (current-local-map))
     (use-local-map ghostel-copy-mode-map)
@@ -1074,6 +1080,7 @@ Press \\`q' or \\[ghostel-copy-mode-exit] to exit without copying."
   (interactive)
   (when ghostel--copy-mode-active
     (setq ghostel--copy-mode-active nil)
+    (setq cursor-type ghostel--saved-cursor-type)
     (deactivate-mark)
     (use-local-map ghostel--saved-local-map)
     (setq buffer-read-only nil)

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -842,6 +842,32 @@
       (should (string-match-p "unknown eval command" (car messages))))))
 
 ;; -----------------------------------------------------------------------
+;; Test: copy-mode cursor visibility
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-copy-mode-cursor ()
+  "Test that copy-mode restores cursor visibility when terminal hid it."
+  (let ((buf (generate-new-buffer " *ghostel-test-copy-cursor*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          ;; Simulate a terminal app hiding the cursor
+          (ghostel--set-cursor-style 1 nil)
+          (should (null cursor-type))                       ; cursor hidden
+          ;; Enter copy mode — cursor should become visible
+          (let ((ghostel--copy-mode-active nil)
+                (ghostel--redraw-timer nil))
+            (ghostel-copy-mode)
+            (should ghostel--copy-mode-active)              ; in copy mode
+            (should cursor-type)                            ; cursor visible
+            (should (equal cursor-type (default-value 'cursor-type))) ; uses user default
+            ;; Exit copy mode — cursor should be hidden again
+            (ghostel-copy-mode-exit)
+            (should-not ghostel--copy-mode-active)          ; exited copy mode
+            (should (null cursor-type))))                   ; cursor hidden again
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
 ;; Runner
 ;; -----------------------------------------------------------------------
 
@@ -855,7 +881,8 @@
     ghostel-test-prompt-navigation
     ghostel-test-sync-theme
     ghostel-test-osc51-eval
-    ghostel-test-osc51-eval-unknown)
+    ghostel-test-osc51-eval-unknown
+    ghostel-test-copy-mode-cursor)
   "Tests that require only Elisp (no native module).")
 
 (defun ghostel-test-run-elisp ()


### PR DESCRIPTION
## Summary

- Programs that hide the terminal cursor (e.g. via `ESC[?25l` / DECTCEM) caused copy-mode to have an invisible cursor, making navigation impossible
- Save and restore `cursor-type` around copy-mode entry/exit, using the user's global Emacs default so the cursor is always visible during selection

## Test plan

- [ ] Run a TUI app that hides the cursor (e.g. `less`, Claude Code)
- [ ] Enter copy-mode (`C-c C-t`) — cursor should be visible
- [ ] Exit copy-mode — cursor should return to its previous state
- [ ] `make all` passes (build + tests + lint)