### PR TITLE
Suppress hl-line-mode in terminal buffer to prevent prompt flicker

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -1051,6 +1051,10 @@ Set mark, navigate to select, then \\[ghostel-copy-mode-copy] to copy.")
 (defvar-local ghostel--saved-cursor-type nil
   "Saved `cursor-type' before entering copy mode.")
 
+(defvar-local ghostel--saved-hl-line-mode nil
+  "Non-nil if line highlighting was active when `ghostel-mode' suppressed it.
+Covers both `global-hl-line-mode' and buffer-local `hl-line-mode'.")
+
 (defun ghostel-copy-mode ()
   "Enter copy mode for selecting and copying terminal text.
 The display is frozen and standard Emacs navigation keys work.
@@ -1070,6 +1074,8 @@ Press \\`q' or \\[ghostel-copy-mode-exit] to exit without copying."
     ;; Switch to copy mode keymap (standard Emacs keys work by default)
     (setq ghostel--saved-local-map (current-local-map))
     (use-local-map ghostel-copy-mode-map)
+    (when ghostel--saved-hl-line-mode
+      (hl-line-mode 1))
     (setq buffer-read-only t)
     (setq mode-name "Ghostel:Copy")
     (force-mode-line-update)
@@ -1083,6 +1089,8 @@ Press \\`q' or \\[ghostel-copy-mode-exit] to exit without copying."
     (setq cursor-type ghostel--saved-cursor-type)
     (deactivate-mark)
     (use-local-map ghostel--saved-local-map)
+    (when ghostel--saved-hl-line-mode
+      (hl-line-mode -1))
     (setq buffer-read-only nil)
     (setq mode-name "Ghostel")
     (force-mode-line-update)
@@ -1727,6 +1735,24 @@ PROCESS is the shell, HEIGHT and WIDTH the final dimensions."
   (setq-local window-adjust-process-window-size-function
               #'ghostel--window-adjust-process-window-size)
   (add-function :after after-focus-change-function #'ghostel--focus-change))
+
+(defun ghostel--suppress-hl-line-mode ()
+  "Disable hl-line highlighting to prevent redraw flicker.
+Handles both `global-hl-line-mode' (which manages its own overlay via
+`post-command-hook', independent of the buffer-local `hl-line-mode')
+and buffer-local `hl-line-mode'."
+  ;; global-hl-line-mode: opt this buffer out by setting the variable
+  ;; buffer-locally to nil (as documented in the hl-line.el commentary).
+  (when (bound-and-true-p global-hl-line-mode)
+    (setq ghostel--saved-hl-line-mode t)
+    (setq-local global-hl-line-mode nil)
+    (global-hl-line-unhighlight))
+  ;; Buffer-local hl-line-mode
+  (when (bound-and-true-p hl-line-mode)
+    (setq ghostel--saved-hl-line-mode t)
+    (hl-line-mode -1)))
+
+(add-hook 'ghostel-mode-hook #'ghostel--suppress-hl-line-mode)
 
 
 ;;; Entry point

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -868,6 +868,40 @@
       (kill-buffer buf))))
 
 ;; -----------------------------------------------------------------------
+;; Test: copy-mode hl-line-mode management
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-copy-mode-hl-line ()
+  "Test that global-hl-line-mode is suppressed and hl-line restored in copy-mode."
+  (let ((buf (generate-new-buffer " *ghostel-test-hl-line*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (require 'hl-line)
+          ;; Simulate global-hl-line-mode being active
+          (let ((global-hl-line-mode t))
+            (should global-hl-line-mode)
+            ;; Suppress should opt this buffer out
+            (ghostel--suppress-hl-line-mode)
+            (should ghostel--saved-hl-line-mode)
+            ;; Buffer-local global-hl-line-mode must be nil — this is the
+            ;; mechanism that prevents global-hl-line-highlight (on
+            ;; post-command-hook) from creating overlays in this buffer.
+            (should-not global-hl-line-mode))
+          ;; Enter copy mode — local hl-line-mode should be enabled
+          (let ((ghostel--copy-mode-active nil)
+                (ghostel--redraw-timer nil))
+            (ghostel-copy-mode)
+            (should (bound-and-true-p hl-line-mode))
+            ;; Exit copy mode — local hl-line-mode disabled again
+            (ghostel-copy-mode-exit)
+            (should-not (bound-and-true-p hl-line-mode))))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf
+          (kill-local-variable 'global-hl-line-mode))
+        (kill-buffer buf)))))
+
+;; -----------------------------------------------------------------------
 ;; Runner
 ;; -----------------------------------------------------------------------
 
@@ -882,7 +916,8 @@
     ghostel-test-sync-theme
     ghostel-test-osc51-eval
     ghostel-test-osc51-eval-unknown
-    ghostel-test-copy-mode-cursor)
+    ghostel-test-copy-mode-cursor
+    ghostel-test-copy-mode-hl-line)
   "Tests that require only Elisp (no native module).")
 
 (defun ghostel-test-run-elisp ()


### PR DESCRIPTION
global-hl-line-mode causes visible flicker during terminal redraws because the line highlight overlay is repeatedly created/destroyed. Opt the ghostel buffer out by setting global-hl-line-mode buffer-locally to nil (the officially supported mechanism, see hl-line.el commentary). In copy-mode, enable local hl-line-mode since the display is frozen.