### PR TITLE
Fix copy-mode end-of-buffer and exit scroll position

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -945,7 +945,9 @@ pasted using bracketed paste."
     (ghostel--scroll-bottom ghostel--term)
     (let ((inhibit-read-only t))
       (ghostel--redraw ghostel--term ghostel-full-redraw))
-    (goto-char (point-max))))
+    ;; The native redraw already positions point at the terminal cursor,
+    ;; so no explicit goto-char needed here.
+    ))
 
 (defun ghostel-copy-mode-end-of-line ()
   "Move to the last non-whitespace character on the line."
@@ -1094,6 +1096,8 @@ Press \\`q' or \\[ghostel-copy-mode-exit] to exit without copying."
     (setq buffer-read-only nil)
     (setq mode-name "Ghostel")
     (force-mode-line-update)
+    (when ghostel--term
+      (ghostel--scroll-bottom ghostel--term))
     (ghostel--invalidate)
     (message "Copy mode exited")))
 


### PR DESCRIPTION
## Summary
- **M-> in copy-mode** now lands at the terminal cursor (after the last prompt) instead of the bottom-right corner of the terminal grid. The native redraw already positions point correctly; removed the `(goto-char (point-max))` override.
- **Exiting copy-mode** after scrolling up now scrolls the viewport back to the bottom before redrawing, so the prompt is visible immediately.

## Test plan
- [x] Elisp tests pass (12/12)
- [x] Byte-compile clean (no new warnings)
- [ ] Manual: enter copy-mode, press `M->`, verify cursor lands after last prompt
- [ ] Manual: scroll up in copy-mode, exit with `C-c C-t`, verify view jumps to bottom showing prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)