### PR TITLE
Fix byte-compile warning and treat warnings as errors in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Byte-compile
         run: |
           emacs --batch -Q -L . \
+            --eval "(setq byte-compile-error-on-warn t)" \
             -f batch-byte-compile \
             ghostel.el ghostel-debug.el
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ melpazoid:
 		make -C "$(MELPAZOID_DIR)"
 
 byte-compile:
-	$(EMACS) --batch -Q -L . -f batch-byte-compile ghostel.el ghostel-debug.el
+	$(EMACS) --batch -Q -L . --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile ghostel.el ghostel-debug.el
 
 bench:
 	bash bench/run-bench.sh

--- a/ghostel.el
+++ b/ghostel.el
@@ -311,6 +311,7 @@ These keys pass through to Emacs instead."
 (declare-function ghostel--write-input "ghostel-module")
 (declare-function package-desc-version "package" (pkg-desc))
 (declare-function package-version-join "package" (vlist))
+(declare-function global-hl-line-unhighlight "hl-line")
 
 
 ;;; Automatic download and compilation of native module


### PR DESCRIPTION
## Summary
- Add `declare-function` for `global-hl-line-unhighlight` to fix byte-compile warning
- Set `byte-compile-error-on-warn` in CI and Makefile so future warnings fail the build

## Test plan
- [x] `emacs --batch -Q -L . --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile ghostel.el ghostel-debug.el` exits 0 with no warnings
- [ ] CI byte-compile job passes on all Emacs versions
- [ ] Melpazoid workflow stays green