### PR TITLE
Add module version check to detect stale native modules

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .ghostel,
-    .version = "0.1.0",
+    .version = "0.3.0",
     .paths = .{""},
     .fingerprint = 0x5a44bdd1198a0f4b,
     .dependencies = .{},

--- a/ghostel.el
+++ b/ghostel.el
@@ -4,7 +4,7 @@
 
 ;; Author: Daniel Kraus
 ;; URL: https://github.com/dakra/ghostel
-;; Version: 0.1.0
+;; Version: 0.2.50
 ;; Keywords: terminals
 ;; Package-Requires: ((emacs "27.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
@@ -294,12 +294,18 @@ These keys pass through to Emacs instead."
   "https://github.com/dakra/ghostel/releases"
   "Base URL for ghostel GitHub releases.")
 
+(defconst ghostel--minimum-module-version "0.2"
+  "Minimum native module version required by this Elisp version.
+Bump this only when the Elisp code requires a newer native module
+\(e.g. new Zig-exported function or changed calling convention).")
+
 
 ;; Declare native module functions for the byte compiler
 
 (declare-function ghostel--encode-key "ghostel-module")
 (declare-function ghostel--focus-event "ghostel-module")
 (declare-function ghostel--mode-enabled "ghostel-module")
+(declare-function ghostel--module-version "ghostel-module")
 (declare-function ghostel--mouse-event "ghostel-module")
 (declare-function ghostel--new "ghostel-module")
 (declare-function ghostel--redraw "ghostel-module" (term &optional full))
@@ -467,6 +473,39 @@ The output is shown in a *ghostel-build* compilation buffer."
                                                     default-directory))))
     (compile (expand-file-name "build.sh") t)))
 
+(defun ghostel--elisp-version ()
+  "Return the ghostel Elisp version from the package header."
+  (or (ghostel--package-version)
+      ;; Fall back to parsing the header from the source file.
+      (let ((file (or load-file-name
+                      (locate-library "ghostel")
+                      buffer-file-name)))
+        (when file
+          ;; Ensure we read the .el source, not a .elc byte-compiled file.
+          (when (string-suffix-p ".elc" file)
+            (setq file (substring file 0 -1)))
+          (when (file-exists-p file)
+            (with-temp-buffer
+              (insert-file-contents file nil 0 512)
+              (when (re-search-forward "^;; Version: \\([0-9.]+\\)" nil t)
+                (match-string 1))))))))
+
+(defun ghostel--check-module-version (dir)
+  "Check if the loaded module is older than required.
+When the module version is below `ghostel--minimum-module-version',
+offer to update using `ghostel-module-auto-install'.
+DIR is the module directory."
+  (let ((mod-ver (and (fboundp 'ghostel--module-version)
+                      (ghostel--module-version))))
+    (when (or (null mod-ver)
+              (version< mod-ver ghostel--minimum-module-version))
+      (display-warning 'ghostel
+                       (format "Module version %s is older than required %s"
+                               (or mod-ver "unknown")
+                               ghostel--minimum-module-version))
+      (unless noninteractive
+        (ghostel--ensure-module dir)))))
+
 ;; Load the native module
 (unless (featurep 'ghostel-module)
   (let* ((dir (file-name-directory (or load-file-name buffer-file-name)))
@@ -476,7 +515,9 @@ The output is shown in a *ghostel-build* compilation buffer."
       (ghostel--ensure-module dir))
     (if (file-exists-p mod)
         (condition-case err
-            (module-load mod)
+            (progn
+              (module-load mod)
+              (ghostel--check-module-version dir))
           (error
            (display-warning 'ghostel
                             (format "Failed to load native module: %s\nTry M-x ghostel-module-compile to rebuild"

--- a/src/module.zig
+++ b/src/module.zig
@@ -12,6 +12,9 @@ const input = @import("input.zig");
 
 const c = emacs.c;
 
+/// Module version — keep in sync with ghostel.el and build.zig.zon.
+const version = "0.2";
+
 // ---------------------------------------------------------------------------
 // Module entry point
 // ---------------------------------------------------------------------------
@@ -42,6 +45,7 @@ export fn emacs_module_init(runtime: *c.struct_emacs_runtime) callconv(.c) c_int
     env.bindFunction("ghostel--mode-enabled", 2, 2, &fnModeEnabled, "Return t if terminal DEC private MODE is enabled.\n\n(ghostel--mode-enabled TERM MODE)");
     env.bindFunction("ghostel--debug-state", 1, 1, &fnDebugState, "Return debug info about terminal/render state.\n\n(ghostel--debug-state TERM)");
     env.bindFunction("ghostel--debug-feed", 2, 2, &fnDebugFeed, "Feed STR to terminal and return first row + cursor.\n\n(ghostel--debug-feed TERM STR)");
+    env.bindFunction("ghostel--module-version", 0, 0, &fnModuleVersion, "Return the native module version string.\n\n(ghostel--module-version)");
 
     emacs.initSymbols(env);
     env.provide("ghostel-module");
@@ -666,6 +670,12 @@ fn fnDebugFeed(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*a
     pos += (std.fmt.bufPrint(buf[pos..], "\"", .{}) catch return env.nil()).len;
 
     return env.makeString(buf[0..pos]);
+}
+
+/// (ghostel--module-version)
+fn fnModuleVersion(raw_env: ?*c.emacs_env, _: isize, _: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
+    const env = emacs.Env.init(raw_env.?);
+    return env.makeString(version);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -984,6 +984,54 @@
 ;; Runner
 ;; -----------------------------------------------------------------------
 
+;; -----------------------------------------------------------------------
+;; Test: module version check
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-elisp-version ()
+  "Test that `ghostel--elisp-version' returns a version string."
+  (let ((ver (ghostel--elisp-version)))
+    (should (stringp ver))
+    (should (string-match-p "^[0-9]+\\.[0-9]+" ver))))
+
+(ert-deftest ghostel-test-module-version-match ()
+  "Test that version check does nothing when module meets minimum."
+  (let ((warned nil)
+        (ghostel--minimum-module-version "0.2"))
+    (cl-letf (((symbol-function 'ghostel--module-version)
+               (lambda () "0.2"))
+              ((symbol-function 'display-warning)
+               (lambda (&rest _) (setq warned t))))
+      (ghostel--check-module-version "/tmp")
+      (should-not warned))))
+
+(ert-deftest ghostel-test-module-version-mismatch ()
+  "Test that version check warns when module is below minimum."
+  (let ((warned nil)
+        (ensure-called nil)
+        (noninteractive nil)
+        (ghostel--minimum-module-version "0.2"))
+    (cl-letf (((symbol-function 'ghostel--module-version)
+               (lambda () "0.1"))
+              ((symbol-function 'display-warning)
+               (lambda (&rest _) (setq warned t)))
+              ((symbol-function 'ghostel--ensure-module)
+               (lambda (dir) (setq ensure-called dir))))
+      (ghostel--check-module-version "/tmp")
+      (should warned)
+      (should (equal "/tmp" ensure-called)))))
+
+(ert-deftest ghostel-test-module-version-newer-than-minimum ()
+  "Test that version check does nothing when module exceeds minimum."
+  (let ((warned nil)
+        (ghostel--minimum-module-version "0.2"))
+    (cl-letf (((symbol-function 'ghostel--module-version)
+               (lambda () "0.3"))
+              ((symbol-function 'display-warning)
+               (lambda (&rest _) (setq warned t))))
+      (ghostel--check-module-version "/tmp")
+      (should-not warned))))
+
 (defconst ghostel-test--elisp-tests
   '(ghostel-test-raw-key-sequences
     ghostel-test-modifier-number
@@ -996,7 +1044,11 @@
     ghostel-test-osc51-eval
     ghostel-test-osc51-eval-unknown
     ghostel-test-copy-mode-cursor
-    ghostel-test-copy-mode-hl-line)
+    ghostel-test-copy-mode-hl-line
+    ghostel-test-elisp-version
+    ghostel-test-module-version-match
+    ghostel-test-module-version-mismatch
+    ghostel-test-module-version-newer-than-minimum)
   "Tests that require only Elisp (no native module).")
 
 (defun ghostel-test-run-elisp ()


### PR DESCRIPTION
## Summary

- Adds a `ghostel--module-version` function to the Zig native module that returns its compiled version string
- After loading the module, compares the module version against the Elisp package version
- On mismatch (e.g. Elisp updated via git/package.el but module binary is from an older release), warns the user and offers to download/compile via the existing `ghostel-module-auto-install` mechanism
- Old modules without the version function are tolerated via `fboundp` guard

## Test plan

- [x] 4 new pure Elisp tests covering: version retrieval, match (no-op), mismatch (warn + ensure), missing function (old module)
- [x] `zig build check` passes
- [x] Byte-compile with warnings-as-errors passes
- [x] All 16 Elisp tests pass