### PR TITLE
Remove ghostel--pin-window-start that caused emoji clipping

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -1710,22 +1710,14 @@ frame after idle to improve interactive responsiveness."
           (let ((inhibit-read-only t)
                 (inhibit-redisplay t)
                 (inhibit-modification-hooks t))
-            (ghostel--redraw ghostel--term ghostel-full-redraw)
-            (ghostel--pin-window-start)))))))
-
-(defun ghostel--pin-window-start ()
-  "Pin the window so terminal row 1 stays at the top."
-  (let ((win (get-buffer-window)))
-    (when win
-      (set-window-start win (point-min)))))
+            (ghostel--redraw ghostel--term ghostel-full-redraw)))))))
 
 (defun ghostel-force-redraw ()
   "Force a full terminal redraw (for debugging)."
   (interactive)
   (when ghostel--term
     (let ((inhibit-read-only t))
-      (ghostel--redraw ghostel--term ghostel-full-redraw)
-      (ghostel--pin-window-start))))
+      (ghostel--redraw ghostel--term ghostel-full-redraw))))
 
 
 ;;; Window resize
@@ -1772,8 +1764,7 @@ PROCESS is the shell, HEIGHT and WIDTH the final dimensions."
         (let ((inhibit-read-only t)
               (inhibit-redisplay t)
               (inhibit-modification-hooks t))
-          (ghostel--redraw ghostel--term ghostel-full-redraw)
-          (ghostel--pin-window-start))))))
+          (ghostel--redraw ghostel--term ghostel-full-redraw))))))
 
 
 


### PR DESCRIPTION
## Summary
Remove `ghostel--pin-window-start` which was forcing `set-window-start` to `point-min` after every redraw. This caused bottom rows to be clipped when emoji/Unicode lines expanded line height beyond what `window-body-height` assumed.

Emacs already handles viewport management correctly via `scroll-conservatively 101` (set in `ghostel-mode`) — it scrolls minimally to keep point visible, naturally showing the bottom (prompt/cursor) when content overflows.

## What was wrong
`set-window-start (point-min)` forces the **top** of the buffer to be visible. When emoji lines are taller (20px vs 15px per the diagnostics), the total content height exceeds the window, and the **bottom** gets clipped. Removing the pin lets Emacs scroll to keep the cursor visible instead.

## Test plan
- [x] Byte-compile clean
- [x] All tests pass
- [ ] Manual: `echo 🟢` many times — bottom stays visible
- [ ] Manual: Claude Code status bar visible
- [ ] Manual: mouse scroll works
- [ ] Manual: no horizontal scroll drift or font size changes