### PR TITLE
Prompt to install native module on first use

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -522,10 +522,9 @@ DIR is the module directory."
            (display-warning 'ghostel
                             (format "Failed to load native module: %s\nTry M-x ghostel-module-compile to rebuild"
                                     (error-message-string err)))))
-      (unless ghostel-module-auto-install
-        (display-warning 'ghostel
-                         (concat "Native module not found: " mod
-                                 "\nRun M-x ghostel-download-module or M-x ghostel-module-compile"))))))
+      (display-warning 'ghostel
+                       (concat "Native module not found: " mod
+                               "\nRun M-x ghostel-download-module or M-x ghostel-module-compile")))))
 
 
 ;;; Internal variables
@@ -1847,6 +1846,14 @@ and buffer-local `hl-line-mode'."
 (defun ghostel ()
   "Create a new Ghostel terminal buffer."
   (interactive)
+  (unless (fboundp 'ghostel--new)
+    (let ((dir (file-name-directory (locate-library "ghostel"))))
+      (ghostel--ensure-module dir)
+      (let ((mod (expand-file-name
+                  (concat "ghostel-module" module-file-suffix) dir)))
+        (if (file-exists-p mod)
+            (module-load mod)
+          (user-error "Ghostel native module not available")))))
   (let* ((index (cl-incf ghostel--buffer-counter))
          (buf-name (if (= index 1)
                        ghostel-buffer-name


### PR DESCRIPTION
## Summary

- When `M-x ghostel` is called and the native module isn't loaded (e.g. after `package-vc-install`), re-prompt the user to download or compile the module instead of crashing with `Symbol's function definition is void: ghostel--new`
- Always display the "module not found" warning after a failed install attempt, regardless of `ghostel-module-auto-install` setting — previously suppressed when set to the default `'ask`

## Context

With `package-vc-install`, the load-time module prompt can fail silently:
- **Download** fails if no matching GitHub release asset exists
- **Compile** fails because `package-vc-install` doesn't clone submodules

The `(unless ghostel-module-auto-install ...)` guard then suppressed the warning (since `'ask` is truthy), leaving the user with no feedback until `ghostel--new` crashes.

## Test plan

- [ ] `package-vc-install` ghostel in a clean Emacs, call `M-x ghostel` — should prompt to download/compile
- [ ] Skip the prompt, call `M-x ghostel` again — should re-prompt
- [ ] Verify warning buffer shows "Native module not found" after failed install