### PR TITLE
Fix clicking ghostel buffer not switching window focus

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -1031,6 +1031,7 @@ pasted using bracketed paste."
 (defun ghostel--mouse-press (event)
   "Handle mouse button press EVENT for terminal mouse tracking."
   (interactive "e")
+  (select-window (posn-window (event-start event)))
   (when (and ghostel--term ghostel--process (process-live-p ghostel--process))
     (let* ((posn (event-start event))
            (col-row (posn-col-row posn))


### PR DESCRIPTION
## Summary
- The `ghostel--mouse-press` handler for `<down-mouse-1>` consumed the event without calling `select-window`, so clicking a ghostel buffer from another window never transferred focus
- Added `select-window` call before processing the terminal mouse event, matching Emacs's default mouse behavior

## Test plan
- [x] All 17 existing tests pass
- [ ] Open two windows, one with a ghostel buffer — verify clicking the ghostel buffer switches focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)