### PR TITLE
Improve typing responsiveness with immediate redraw and input coalescing

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Soft-wrapped newlines are automatically stripped from copied text.
 ### Rendering
 - Incremental redraw — only dirty rows are re-rendered
 - Timer-based batched updates with adaptive frame rate
+- **Immediate redraw** for interactive typing echo — small PTY output arriving shortly after a keystroke bypasses the timer, eliminating 16–33ms of latency per keypress
+- **Input coalescing** — rapid keystrokes are batched into a single PTY write to reduce syscall overhead
 - Cursor position updates even without cell changes
 - Theme-aware color palette (syncs with Emacs theme via `ghostel-sync-theme`)
 
@@ -267,6 +269,9 @@ individual faces with `M-x customize-face`.
 | `ghostel-max-scrollback`         | `10000`              | Maximum scrollback lines                                 |
 | `ghostel-timer-delay`            | `0.033`              | Base redraw delay in seconds (~30fps)                    |
 | `ghostel-adaptive-fps`           | `t`                  | Adaptive frame rate (shorter delay after idle, stop timer when idle) |
+| `ghostel-immediate-redraw-threshold` | `256`            | Max output bytes to trigger immediate redraw (0 to disable) |
+| `ghostel-immediate-redraw-interval`  | `0.05`           | Max seconds since last keystroke for immediate redraw    |
+| `ghostel-input-coalesce-delay`   | `0.003`              | Seconds to buffer rapid keystrokes before sending (0 to disable) |
 | `ghostel-full-redraw`            | `nil`                | Always do full redraws instead of incremental updates    |
 | `ghostel-kill-buffer-on-exit`    | `t`                  | Kill buffer when shell exits                             |
 | `ghostel-eval-cmds`              | `(see above)`        | Whitelisted functions for OSC 51 eval                    |
@@ -290,6 +295,7 @@ individual faces with `M-x customize-face`.
 | `M-x ghostel-next-prompt`      | Jump to next shell prompt                    |
 | `M-x ghostel-previous-prompt`  | Jump to previous shell prompt                |
 | `M-x ghostel-force-redraw`     | Force a full terminal redraw                 |
+| `M-x ghostel-debug-typing-latency` | Measure per-keystroke typing latency     |
 | `M-x ghostel-sync-theme`       | Re-sync color palette after theme change     |
 | `M-x ghostel-download-module`  | Download pre-built native module             |
 | `M-x ghostel-module-compile`   | Compile native module from source            |
@@ -338,11 +344,27 @@ The "no detect" row shows throughput with this detection disabled
 emulators do not have this feature, so their numbers are comparable to the "no
 detect" row.
 
+### Typing latency
+
+Interactive keystrokes are optimized separately from bulk throughput.  When
+you type a character, the PTY echo is detected and rendered immediately
+(bypassing the 33ms redraw timer), so the character appears on screen with
+minimal delay.  Use `M-x ghostel-debug-typing-latency` to measure the
+end-to-end latency on your system — it reports per-keystroke PTY, render,
+and total latency with min/median/p99/max statistics.
+
 Run the benchmarks yourself:
 
 ```sh
-bench/run-bench.sh              # full suite
+bench/run-bench.sh              # full suite (throughput)
 bench/run-bench.sh --quick      # quick sanity check
+```
+
+The typing latency benchmark can be run from Elisp:
+
+```elisp
+(require 'ghostel-debug)
+M-x ghostel-debug-typing-latency    ; interactive measurement
 ```
 
 ## Ghostel vs vterm

--- a/bench/ghostel-bench.el
+++ b/bench/ghostel-bench.el
@@ -860,6 +860,104 @@ real-world performance (see PTY and streaming benchmarks for that)."
   (setq ghostel-bench-terminal-sizes '((24 . 80)))
   (ghostel-bench-run-all))
 
+
+;; ---------------------------------------------------------------------------
+;; Typing latency benchmark
+;; ---------------------------------------------------------------------------
+
+(defvar ghostel-bench-typing-count 50
+  "Number of keystrokes to send in the typing latency benchmark.")
+
+(defun ghostel-bench-typing-latency ()
+  "Benchmark per-keystroke typing latency through a real PTY.
+Spawns a shell, types characters one at a time, and measures the
+round-trip time from send to the echo appearing in the terminal.
+Reports min/median/p99/max for PTY, render, and total latency."
+  (interactive)
+  (ghostel-bench--load-backends)
+  (let* ((count ghostel-bench-typing-count)
+         (results (ghostel-bench--typing-latency-ghostel count)))
+    (ghostel-bench--typing-report "ghostel" results)
+    results))
+
+(defun ghostel-bench--typing-latency-ghostel (count)
+  "Send COUNT single-character keystrokes and measure round-trip latency.
+Returns a list of (PTY-MS RENDER-MS TOTAL-MS) for each keystroke."
+  (let* ((buf (generate-new-buffer " *ghostel-typing-bench*"))
+         (rows 24) (cols 80)
+         (results nil))
+    (with-current-buffer buf
+      (let* ((term (ghostel-bench--make-ghostel rows cols))
+             (inhibit-read-only t)
+             (pending nil)
+             (echo-received nil)
+             (echo-time nil)
+             ;; Start a cat process that echoes stdin
+             (proc (make-process
+                    :name "ghostel-typing-bench"
+                    :buffer buf
+                    :command (list "cat")
+                    :connection-type 'pty
+                    :coding 'binary
+                    :noquery t
+                    :filter (lambda (_proc output)
+                              (push output pending)
+                              (setq echo-time (current-time))
+                              (setq echo-received t))
+                    :sentinel #'ignore)))
+        (set-process-window-size proc rows cols)
+        ;; Wait for cat to be ready
+        (sleep-for 0.1)
+        ;; Type characters one at a time
+        (dotimes (i count)
+          (let* ((ch (string (+ ?a (% i 26))))
+                 (send-time (current-time))
+                 render-time)
+            (setq echo-received nil echo-time nil)
+            ;; Send character
+            (process-send-string proc ch)
+            ;; Wait for echo
+            (let ((deadline (+ (float-time) 1.0)))
+              (while (and (not echo-received)
+                          (< (float-time) deadline))
+                (accept-process-output proc 0.001)))
+            ;; Feed to terminal and render
+            (when pending
+              (ghostel--write-input term (apply #'concat (nreverse pending)))
+              (setq pending nil))
+            (ghostel--redraw term nil)
+            (setq render-time (current-time))
+            ;; Record latencies
+            (when echo-time
+              (push (list (* 1000 (float-time (time-subtract echo-time send-time)))
+                          (* 1000 (float-time (time-subtract render-time echo-time)))
+                          (* 1000 (float-time (time-subtract render-time send-time))))
+                    results))))
+        ;; Cleanup
+        (delete-process proc)))
+    (kill-buffer buf)
+    (nreverse results)))
+
+(defun ghostel-bench--typing-report (label results)
+  "Print a typing latency report for LABEL with RESULTS.
+RESULTS is a list of (PTY-MS RENDER-MS TOTAL-MS)."
+  (let ((n (length results)))
+    (message "\n=== Typing Latency Benchmark: %s (%d keystrokes) ===" label n)
+    (message "%-20s %8s %8s %8s %8s" "Phase" "Min" "Median" "P99" "Max")
+    (message "%s" (make-string 56 ?-))
+    (dolist (phase '(("PTY latency" 0) ("Render latency" 1) ("Total (e2e)" 2)))
+      (let* ((name (car phase))
+             (idx (cadr phase))
+             (vals (sort (mapcar (lambda (r) (nth idx r)) results) #'<)))
+        (when vals
+          (message "%-20s %7.2fms %7.2fms %7.2fms %7.2fms"
+                   name
+                   (car vals)
+                   (nth (/ n 2) vals)
+                   (nth (min (1- n) (floor (* n 0.99))) vals)
+                   (car (last vals))))))
+    (message "")))
+
 (provide 'ghostel-bench)
 
 ;;; ghostel-bench.el ends here

--- a/ghostel-debug.el
+++ b/ghostel-debug.el
@@ -30,6 +30,8 @@
 
 ;;; Code:
 
+(require 'cl-lib)
+
 (defvar ghostel-debug--log-buffer nil
   "Buffer used for ghostel debug logging.")
 
@@ -84,6 +86,124 @@ _PROC is ignored."
       (insert (format "[%s] SEND-ENCODED: key=%S mods=%S utf8=%S\n"
                       (format-time-string "%T.%3N")
                       key-name mods utf8)))))
+
+
+;;; Typing latency measurement
+
+(defvar ghostel-debug--latency-log nil
+  "List of (SEND-TIME ECHO-TIME RENDER-TIME) entries for latency analysis.")
+
+(defvar ghostel-debug--latency-send-time nil
+  "High-resolution time of the last send-key during latency measurement.")
+
+(defvar ghostel-debug--latency-active nil
+  "Non-nil when typing latency measurement is active.")
+
+(defun ghostel-debug-typing-latency (&optional count)
+  "Measure per-keystroke typing latency.
+Instruments the send→echo→render pipeline with high-resolution
+timestamps and logs a summary after COUNT keystrokes (default 20).
+Call this interactively in a ghostel buffer, then type normally.
+Results are displayed in *ghostel-debug* when complete.
+
+The latency breakdown shows:
+- PTY latency: time from send-key to process filter receiving echo
+- Render latency: time from echo receipt to redraw completion
+- Total latency: end-to-end from keystroke to visible update"
+  (interactive "p")
+  (unless (derived-mode-p 'ghostel-mode)
+    (user-error "Must be called from a ghostel buffer"))
+  (let ((n (or count 20)))
+    (setq ghostel-debug--latency-log nil)
+    (setq ghostel-debug--latency-active n)
+    (setq ghostel-debug--log-buffer (get-buffer-create "*ghostel-debug*"))
+    (with-current-buffer ghostel-debug--log-buffer
+      (erase-buffer)
+      (insert "=== Ghostel Typing Latency Measurement ===\n")
+      (insert (format "Type %d characters to collect measurements...\n\n" n)))
+    (advice-add 'ghostel--send-key :before #'ghostel-debug--latency-on-send)
+    (advice-add 'ghostel--filter :before #'ghostel-debug--latency-on-echo)
+    (advice-add 'ghostel--delayed-redraw :after #'ghostel-debug--latency-on-render)
+    (message "ghostel-debug: type %d characters to measure latency" n)))
+
+(defun ghostel-debug--latency-on-send (_key)
+  "Record send time for latency measurement."
+  (when ghostel-debug--latency-active
+    (setq ghostel-debug--latency-send-time (current-time))))
+
+(defun ghostel-debug--latency-on-echo (_proc _output)
+  "Record echo-receipt time for latency measurement."
+  (when (and ghostel-debug--latency-active ghostel-debug--latency-send-time)
+    ;; Store echo time on the send-time entry (will be completed on render)
+    (let ((echo-time (current-time)))
+      ;; Push partial entry: (send-time echo-time nil)
+      (push (list ghostel-debug--latency-send-time echo-time nil)
+            ghostel-debug--latency-log)
+      (setq ghostel-debug--latency-send-time nil))))
+
+(defun ghostel-debug--latency-on-render (_buffer)
+  "Record render-completion time and finalize latency entry."
+  (when ghostel-debug--latency-active
+    (let ((render-time (current-time)))
+      ;; Complete the most recent entry that has no render time
+      (catch 'done
+        (dolist (entry ghostel-debug--latency-log)
+          (when (and (nth 1 entry) (null (nth 2 entry)))
+            (setf (nth 2 entry) render-time)
+            (cl-decf ghostel-debug--latency-active)
+            (when (<= ghostel-debug--latency-active 0)
+              (ghostel-debug--latency-report))
+            (throw 'done nil)))))))
+
+(defun ghostel-debug--latency-report ()
+  "Generate and display the latency report."
+  (advice-remove 'ghostel--send-key #'ghostel-debug--latency-on-send)
+  (advice-remove 'ghostel--filter #'ghostel-debug--latency-on-echo)
+  (advice-remove 'ghostel--delayed-redraw #'ghostel-debug--latency-on-render)
+  (setq ghostel-debug--latency-active nil)
+  (let* ((complete (cl-remove-if-not (lambda (e) (nth 2 e))
+                                     ghostel-debug--latency-log))
+         (pty-times (mapcar (lambda (e)
+                              (* 1000 (float-time
+                                       (time-subtract (nth 1 e) (nth 0 e)))))
+                            complete))
+         (render-times (mapcar (lambda (e)
+                                 (* 1000 (float-time
+                                          (time-subtract (nth 2 e) (nth 1 e)))))
+                               complete))
+         (total-times (mapcar (lambda (e)
+                                (* 1000 (float-time
+                                         (time-subtract (nth 2 e) (nth 0 e)))))
+                              complete)))
+    (when ghostel-debug--log-buffer
+      (with-current-buffer ghostel-debug--log-buffer
+        (goto-char (point-max))
+        (insert (format "\n=== Results (%d samples) ===\n\n" (length complete)))
+        (insert (format "%-20s %8s %8s %8s %8s\n"
+                        "Phase" "Min" "Median" "P99" "Max"))
+        (insert (make-string 56 ?-) "\n")
+        (dolist (row `(("PTY latency" ,pty-times)
+                       ("Render latency" ,render-times)
+                       ("Total (end-to-end)" ,total-times)))
+          (let* ((name (car row))
+                 (vals (sort (cadr row) #'<))
+                 (n (length vals)))
+            (when (> n 0)
+              (insert (format "%-20s %7.2fms %7.2fms %7.2fms %7.2fms\n"
+                              name
+                              (car vals)
+                              (nth (/ n 2) vals)
+                              (nth (min (1- n) (floor (* n 0.99))) vals)
+                              (car (last vals)))))))
+        (insert "\nPer-keystroke detail:\n")
+        (dolist (e (reverse complete))
+          (let ((pty (float-time (time-subtract (nth 1 e) (nth 0 e))))
+                (rnd (float-time (time-subtract (nth 2 e) (nth 1 e))))
+                (tot (float-time (time-subtract (nth 2 e) (nth 0 e)))))
+            (insert (format "  pty=%.2fms render=%.2fms total=%.2fms\n"
+                            (* 1000 pty) (* 1000 rnd) (* 1000 tot)))))
+        (insert "\n")))
+    (message "ghostel-debug: latency report ready in *ghostel-debug*")))
 
 (provide 'ghostel-debug)
 ;;; ghostel-debug.el ends here

--- a/ghostel.el
+++ b/ghostel.el
@@ -111,6 +111,29 @@ feedback and stop the timer entirely when idle.  When nil, use the
 fixed `ghostel-timer-delay' unconditionally."
   :type 'boolean)
 
+(defcustom ghostel-immediate-redraw-threshold 256
+  "Maximum bytes of output to trigger an immediate redraw.
+When output arrives within `ghostel-immediate-redraw-interval'
+seconds of the last keystroke and is smaller than this threshold,
+redraw immediately instead of waiting for the timer.  This
+eliminates the 16-33ms timer delay for interactive typing echo.
+Set to 0 to disable immediate redraws."
+  :type 'integer)
+
+(defcustom ghostel-immediate-redraw-interval 0.05
+  "Maximum seconds since last keystroke for immediate redraw.
+Output arriving within this interval of a `ghostel--send-key'
+call is considered interactive echo and redrawn immediately
+when the output size is below `ghostel-immediate-redraw-threshold'."
+  :type 'number)
+
+(defcustom ghostel-input-coalesce-delay 0.003
+  "Delay in seconds to coalesce rapid keystrokes before sending.
+When non-zero, keystrokes are buffered for up to this many seconds
+and sent as a single write to the PTY.  This reduces per-key
+syscall overhead during fast typing.  Set to 0 to disable."
+  :type 'number)
+
 (defcustom ghostel-full-redraw nil
   "When non-nil, always perform full redraws instead of incremental updates.
 Full redraws are more robust with TUI apps like Claude Code that do
@@ -548,6 +571,15 @@ DIR is the module directory."
 (defvar-local ghostel--resize-timer nil
   "Timer for debounced SIGWINCH on alt screen.")
 
+(defvar-local ghostel--last-send-time nil
+  "Time of the last `ghostel--send-key' call, for immediate-redraw detection.")
+
+(defvar-local ghostel--input-buffer nil
+  "Accumulated keystrokes waiting to be flushed to the PTY.")
+
+(defvar-local ghostel--input-timer nil
+  "Timer for flushing coalesced input.")
+
 
 
 
@@ -661,9 +693,41 @@ intercepted by Emacs (e.g., interrupt or prefix keys)."
           (message "ghostel: unrecognized key %S" key)))))))
 
 (defun ghostel--send-key (key)
-  "Send KEY string to the terminal process."
+  "Send KEY string to the terminal process.
+Records the send time for immediate-redraw detection and optionally
+coalesces rapid keystrokes when `ghostel-input-coalesce-delay' > 0."
   (when (and ghostel--process (process-live-p ghostel--process))
-    (process-send-string ghostel--process key)))
+    (setq ghostel--last-send-time (current-time))
+    (if (and (> ghostel-input-coalesce-delay 0)
+             (= (length key) 1))
+        ;; Coalesce single-char keystrokes
+        (progn
+          (push key ghostel--input-buffer)
+          (unless ghostel--input-timer
+            (setq ghostel--input-timer
+                  (run-with-timer ghostel-input-coalesce-delay nil
+                                  #'ghostel--flush-input (current-buffer)))))
+      ;; Multi-byte or coalescing disabled: send immediately
+      (when ghostel--input-timer
+        (cancel-timer ghostel--input-timer)
+        (setq ghostel--input-timer nil)
+        ;; Flush any buffered input first
+        (when ghostel--input-buffer
+          (process-send-string ghostel--process
+                               (apply #'concat (nreverse ghostel--input-buffer)))
+          (setq ghostel--input-buffer nil)))
+      (process-send-string ghostel--process key))))
+
+(defun ghostel--flush-input (buffer)
+  "Flush coalesced input in BUFFER to the PTY."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (setq ghostel--input-timer nil)
+      (when (and ghostel--input-buffer ghostel--process
+                 (process-live-p ghostel--process))
+        (process-send-string ghostel--process
+                             (apply #'concat (nreverse ghostel--input-buffer)))
+        (setq ghostel--input-buffer nil)))))
 
 (defun ghostel--send-encoded (key-name mods &optional utf8)
   "Encode KEY-NAME with MODS via the terminal's key encoder and send.
@@ -1573,14 +1637,31 @@ VT parser.")
   "Process filter: feed PTY output to the terminal.
 PROCESS is the shell process, OUTPUT is the raw byte string.
 Output is accumulated and fed to the terminal in a single batch
-when the redraw timer fires, reducing per-call VT parser overhead."
+when the redraw timer fires, reducing per-call VT parser overhead.
+
+For interactive echo (small output arriving shortly after a keystroke),
+the redraw is performed immediately to minimize typing latency."
   (when (buffer-live-p (process-buffer process))
     (with-current-buffer (process-buffer process)
       (when ghostel--term
         ;; Accumulate output for batched write-input at redraw time.
         (push output ghostel--pending-output)
-        ;; Schedule redraw (which will flush pending output first).
-        (ghostel--invalidate)))))
+        ;; Immediate redraw for interactive echo: small output arriving
+        ;; within `ghostel-immediate-redraw-interval' of last keystroke.
+        (if (and (> ghostel-immediate-redraw-threshold 0)
+                 ghostel--last-send-time
+                 (<= (length output) ghostel-immediate-redraw-threshold)
+                 (< (float-time (time-subtract (current-time)
+                                               ghostel--last-send-time))
+                    ghostel-immediate-redraw-interval))
+            (progn
+              ;; Cancel pending timer — we're drawing now.
+              (when ghostel--redraw-timer
+                (cancel-timer ghostel--redraw-timer)
+                (setq ghostel--redraw-timer nil))
+              (ghostel--delayed-redraw (current-buffer)))
+          ;; Bulk output: batch and schedule as before.
+          (ghostel--invalidate))))))
 
 (defun ghostel--sentinel (process event)
   "Process sentinel: clean up when shell exits.
@@ -1597,6 +1678,9 @@ PROCESS is the shell process, EVENT describes the state change."
         (when ghostel--resize-timer
           (cancel-timer ghostel--resize-timer)
           (setq ghostel--resize-timer nil))
+        (when ghostel--input-timer
+          (cancel-timer ghostel--input-timer)
+          (setq ghostel--input-timer nil))
         (remove-function after-focus-change-function #'ghostel--focus-change)
         (run-hook-with-args 'ghostel-exit-functions buf event)
         (if ghostel-kill-buffer-on-exit

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1087,6 +1087,158 @@ cell, so the visual line width must equal the terminal column count."
       (ghostel--check-module-version "/tmp")
       (should-not warned))))
 
+;; -----------------------------------------------------------------------
+;; Test: immediate redraw for interactive echo
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-immediate-redraw-triggers-on-small-echo ()
+  "Small output after recent send-key triggers immediate redraw."
+  (with-temp-buffer
+    (let ((buf (current-buffer))
+          (ghostel--term 'fake)
+          (ghostel--pending-output nil)
+          (ghostel--redraw-timer nil)
+          (ghostel--last-send-time nil)
+          (ghostel-immediate-redraw-threshold 256)
+          (ghostel-immediate-redraw-interval 0.05)
+          (immediate-called nil)
+          (invalidate-called nil))
+      ;; Stub out process-buffer, delayed-redraw, and invalidate
+      (cl-letf (((symbol-function 'process-buffer) (lambda (_) buf))
+                ((symbol-function 'ghostel--delayed-redraw)
+                 (lambda (_buf) (setq immediate-called t)))
+                ((symbol-function 'ghostel--invalidate)
+                 (lambda () (setq invalidate-called t))))
+        ;; Simulate recent keystroke
+        (setq ghostel--last-send-time (current-time))
+        ;; Simulate small echo arriving
+        (ghostel--filter 'fake-proc "a")
+        (should immediate-called)
+        (should-not invalidate-called)))))
+
+(ert-deftest ghostel-test-immediate-redraw-skips-large-output ()
+  "Large output falls back to timer-based batching."
+  (with-temp-buffer
+    (let ((buf (current-buffer))
+          (ghostel--term 'fake)
+          (ghostel--pending-output nil)
+          (ghostel--redraw-timer nil)
+          (ghostel--last-send-time (current-time))
+          (ghostel-immediate-redraw-threshold 256)
+          (ghostel-immediate-redraw-interval 0.05)
+          (immediate-called nil)
+          (invalidate-called nil))
+      (cl-letf (((symbol-function 'process-buffer) (lambda (_) buf))
+                ((symbol-function 'ghostel--delayed-redraw)
+                 (lambda (_buf) (setq immediate-called t)))
+                ((symbol-function 'ghostel--invalidate)
+                 (lambda () (setq invalidate-called t))))
+        ;; Large output should batch
+        (ghostel--filter 'fake-proc (make-string 500 ?x))
+        (should-not immediate-called)
+        (should invalidate-called)))))
+
+(ert-deftest ghostel-test-immediate-redraw-skips-stale-send ()
+  "Output arriving long after last keystroke uses timer batching."
+  (with-temp-buffer
+    (let ((buf (current-buffer))
+          (ghostel--term 'fake)
+          (ghostel--pending-output nil)
+          (ghostel--redraw-timer nil)
+          (ghostel--last-send-time (time-subtract (current-time) 1))
+          (ghostel-immediate-redraw-threshold 256)
+          (ghostel-immediate-redraw-interval 0.05)
+          (immediate-called nil)
+          (invalidate-called nil))
+      (cl-letf (((symbol-function 'process-buffer) (lambda (_) buf))
+                ((symbol-function 'ghostel--delayed-redraw)
+                 (lambda (_buf) (setq immediate-called t)))
+                ((symbol-function 'ghostel--invalidate)
+                 (lambda () (setq invalidate-called t))))
+        (ghostel--filter 'fake-proc "a")
+        (should-not immediate-called)
+        (should invalidate-called)))))
+
+(ert-deftest ghostel-test-immediate-redraw-disabled-when-zero ()
+  "Immediate redraw is disabled when threshold is 0."
+  (with-temp-buffer
+    (let ((buf (current-buffer))
+          (ghostel--term 'fake)
+          (ghostel--pending-output nil)
+          (ghostel--redraw-timer nil)
+          (ghostel--last-send-time (current-time))
+          (ghostel-immediate-redraw-threshold 0)
+          (ghostel-immediate-redraw-interval 0.05)
+          (immediate-called nil)
+          (invalidate-called nil))
+      (cl-letf (((symbol-function 'process-buffer) (lambda (_) buf))
+                ((symbol-function 'ghostel--delayed-redraw)
+                 (lambda (_buf) (setq immediate-called t)))
+                ((symbol-function 'ghostel--invalidate)
+                 (lambda () (setq invalidate-called t))))
+        (ghostel--filter 'fake-proc "a")
+        (should-not immediate-called)
+        (should invalidate-called)))))
+
+;; -----------------------------------------------------------------------
+;; Test: input coalescing
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-input-coalesce-buffers-single-chars ()
+  "Single-char sends are buffered when coalescing is enabled."
+  (with-temp-buffer
+    (let* ((ghostel--process nil)
+           (ghostel--input-buffer nil)
+           (ghostel--input-timer nil)
+           (ghostel--last-send-time nil)
+           (ghostel-input-coalesce-delay 0.003)
+           (sent nil))
+      ;; Create a mock process
+      (cl-letf (((symbol-function 'process-live-p) (lambda (_) t))
+                ((symbol-function 'process-send-string)
+                 (lambda (_proc str) (push str sent)))
+                ((symbol-function 'run-with-timer)
+                 (lambda (_delay _repeat fn &rest args)
+                   ;; Return a fake timer but call function for test
+                   'fake-timer)))
+        (setq ghostel--process 'fake)
+        (ghostel--send-key "a")
+        ;; Should be buffered, not sent
+        (should (equal ghostel--input-buffer '("a")))
+        (should-not sent)))))
+
+(ert-deftest ghostel-test-input-coalesce-disabled ()
+  "With coalesce delay 0, characters are sent immediately."
+  (with-temp-buffer
+    (let* ((ghostel--process nil)
+           (ghostel--input-buffer nil)
+           (ghostel--input-timer nil)
+           (ghostel--last-send-time nil)
+           (ghostel-input-coalesce-delay 0)
+           (sent nil))
+      (cl-letf (((symbol-function 'process-live-p) (lambda (_) t))
+                ((symbol-function 'process-send-string)
+                 (lambda (_proc str) (push str sent))))
+        (setq ghostel--process 'fake)
+        (ghostel--send-key "a")
+        (should (member "a" sent))
+        (should-not ghostel--input-buffer)))))
+
+(ert-deftest ghostel-test-input-flush-sends-buffered ()
+  "Flushing input buffer sends concatenated characters."
+  (with-temp-buffer
+    (let* ((ghostel--process nil)
+           (ghostel--input-buffer '("c" "b" "a"))
+           (ghostel--input-timer nil)
+           (sent nil))
+      (cl-letf (((symbol-function 'process-live-p) (lambda (_) t))
+                ((symbol-function 'process-send-string)
+                 (lambda (_proc str) (push str sent))))
+        (setq ghostel--process 'fake)
+        (ghostel--flush-input (current-buffer))
+        (should (equal sent '("abc")))
+        (should-not ghostel--input-buffer)))))
+
 (defconst ghostel-test--elisp-tests
   '(ghostel-test-raw-key-sequences
     ghostel-test-modifier-number
@@ -1104,7 +1256,14 @@ cell, so the visual line width must equal the terminal column count."
     ghostel-test-elisp-version
     ghostel-test-module-version-match
     ghostel-test-module-version-mismatch
-    ghostel-test-module-version-newer-than-minimum)
+    ghostel-test-module-version-newer-than-minimum
+    ghostel-test-immediate-redraw-triggers-on-small-echo
+    ghostel-test-immediate-redraw-skips-large-output
+    ghostel-test-immediate-redraw-skips-stale-send
+    ghostel-test-immediate-redraw-disabled-when-zero
+    ghostel-test-input-coalesce-buffers-single-chars
+    ghostel-test-input-coalesce-disabled
+    ghostel-test-input-flush-sends-buffered)
   "Tests that require only Elisp (no native module).")
 
 (defun ghostel-test-run-elisp ()


### PR DESCRIPTION
Eliminate the 16-33ms timer delay for interactive typing echo by detecting
small PTY output arriving shortly after a keystroke and redrawing immediately.
Add input coalescing to batch rapid keystrokes into single PTY writes.

New user-facing tools:
- ghostel-debug-typing-latency: measure per-keystroke send→echo→render latency
- ghostel-bench-typing-latency: benchmark typing round-trip with statistics

New defcustoms:
- ghostel-immediate-redraw-threshold (256): max bytes for immediate redraw
- ghostel-immediate-redraw-interval (0.05s): max time since last keystroke
- ghostel-input-coalesce-delay (0.003s): keystroke batching window