### PR TITLE
Fix dim/faint text rendering with color dimming

### DIFF
--- a/src/render.zig
+++ b/src/render.zig
@@ -63,6 +63,16 @@ fn colorEql(a: ?gt.ColorRgb, b: ?gt.ColorRgb) bool {
     return a.?.r == b.?.r and a.?.g == b.?.g and a.?.b == b.?.b;
 }
 
+/// Blend a foreground color toward a background color to produce a "dim" effect.
+/// Uses ~65% foreground / ~35% background weighting.
+fn dimColor(fg: gt.ColorRgb, bg: gt.ColorRgb) gt.ColorRgb {
+    return .{
+        .r = @intCast((@as(u16, fg.r) * 166 + @as(u16, bg.r) * 90) / 256),
+        .g = @intCast((@as(u16, fg.g) * 166 + @as(u16, bg.g) * 90) / 256),
+        .b = @intCast((@as(u16, fg.b) * 166 + @as(u16, bg.b) * 90) / 256),
+    };
+}
+
 /// Format an RGB color as "#RRGGBB" into a buffer.
 fn formatColor(color: gt.ColorRgb, buf: *[7]u8) []const u8 {
     const hex = "0123456789abcdef";
@@ -123,13 +133,23 @@ fn applyStyle(env: emacs.Env, start: i64, end: i64, style: CellStyle, default_fg
 
     var fg_buf: [7]u8 = undefined;
     var bg_buf: [7]u8 = undefined;
+    var dim_buf: [7]u8 = undefined;
 
     const effective_fg = if (style.inverse) (style.bg orelse default_bg) else (style.fg orelse default_fg);
     const effective_bg = if (style.inverse) (style.fg orelse default_fg) else (style.bg orelse default_bg);
 
     const s = &emacs.sym;
 
-    if (!colorEql(style.fg, null) or style.inverse) {
+    if (style.faint) {
+        // Dim text: blend foreground toward background to reduce intensity.
+        // Always set :foreground since we modify the color itself.
+        const dimmed = dimColor(effective_fg, effective_bg);
+        const dim_str = formatColor(dimmed, &dim_buf);
+        props[prop_count] = s.@":foreground";
+        prop_count += 1;
+        props[prop_count] = env.makeString(dim_str);
+        prop_count += 1;
+    } else if (!colorEql(style.fg, null) or style.inverse) {
         const fg_str = formatColor(effective_fg, &fg_buf);
         props[prop_count] = s.@":foreground";
         prop_count += 1;
@@ -149,13 +169,6 @@ fn applyStyle(env: emacs.Env, start: i64, end: i64, style: CellStyle, default_fg
         props[prop_count] = s.@":weight";
         prop_count += 1;
         props[prop_count] = s.bold;
-        prop_count += 1;
-    }
-
-    if (style.faint) {
-        props[prop_count] = s.@":weight";
-        prop_count += 1;
-        props[prop_count] = s.light;
         prop_count += 1;
     }
 

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -234,6 +234,35 @@
     (should (equal "HELLO normal" (ghostel-test--row0 term))))) ; styled text content
 
 ;; -----------------------------------------------------------------------
+;; Test: SGR 2 (dim/faint) renders with dimmed foreground color
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-dim-text ()
+  "Test that SGR 2 (faint) produces a dimmed foreground color, not :weight light."
+  (let ((buf (generate-new-buffer " *ghostel-test-dim*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 40 100))
+                 (inhibit-read-only t))
+            ;; Set a known palette so we can predict the dimmed color.
+            ;; Default FG=#ffffff, default BG=#000000, red=#ff0000.
+            (let ((rest (apply #'concat (make-list 14 "#000000"))))
+              (ghostel--set-palette term
+                                    (concat "#000000" "#ff0000" rest
+                                            "#ffffff" "#000000")))
+            ;; Dim text with default foreground
+            (ghostel--write-input term "\e[2mDIM\e[0m ok")
+            (ghostel--redraw term)
+            (goto-char (point-min))
+            (let ((face (get-text-property (point) 'face)))
+              (should face)                                   ; face property exists
+              (when face
+                ;; Should have a :foreground (dimmed color), not :weight light
+                (should (plist-get face :foreground))         ; dimmed :foreground set
+                (should-not (eq 'light (plist-get face :weight)))))))  ; no :weight light
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
 ;; Test: multi-byte character rendering (box drawing, Unicode)
 ;; -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Replace `:weight light` approach for SGR 2 (faint/dim) with actual foreground color dimming
- New `dimColor()` blends the foreground ~65% toward the background, matching how real terminals render dim text
- The old approach had no visible effect since most monospace fonts lack a "light" weight variant

## Test plan
- [x] `zig build check` passes
- [x] `emacs --batch -Q -L . -l test/ghostel-test.el -f ghostel-test-run-elisp` — all 24 tests pass
- [x] Byte-compile clean
- [x] Manual verification: `printf '\033[2mDim text\033[0m Normal text'` in a ghostel buffer shows visibly dimmed text

Closes #27