### PR TITLE
Fix C-t and other control keys not sent to terminal

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -620,21 +620,26 @@ Used for prompt navigation and optional re-application after full redraws.")
     (define-key map (kbd "DEL") #'ghostel--send-event)
     ;; Emacs reports S-TAB as <backtab>
     (define-key map (kbd "<backtab>") #'ghostel--send-event)
-    ;; Control keys
-    (define-key map (kbd "C-d")       (lambda () (interactive) (ghostel--send-key "\x04")))
-    (define-key map (kbd "C-a")       (lambda () (interactive) (ghostel--send-key "\x01")))
-    (define-key map (kbd "C-e")       (lambda () (interactive) (ghostel--send-key "\x05")))
-    (define-key map (kbd "C-k")       (lambda () (interactive) (ghostel--send-key "\x0b")))
-    (define-key map (kbd "C-l")       (lambda () (interactive) (ghostel--send-key "\x0c")))
-    (define-key map (kbd "C-n")       (lambda () (interactive) (ghostel--send-key "\x0e")))
-    (define-key map (kbd "C-p")       (lambda () (interactive) (ghostel--send-key "\x10")))
-    (define-key map (kbd "C-r")       (lambda () (interactive) (ghostel--send-key "\x12")))
-    (define-key map (kbd "C-w")       (lambda () (interactive) (ghostel--send-key "\x17")))
+    ;; Control keys — bind all C-<letter> to send ASCII control codes,
+    ;; except keys in ghostel-keymap-exceptions and special cases.
+    ;; C-i = TAB and C-m = RET are equivalent to <tab>/<return> (bound above).
+    (let ((skip '(?i ?m ?y)))  ; i=TAB, m=RET already bound; y=ghostel-yank below
+      (dolist (c (number-sequence ?a ?z))
+        (let ((key-str (format "C-%c" c)))
+          (unless (or (member key-str ghostel-keymap-exceptions)
+                      (memq c skip))
+            (define-key map (kbd key-str)
+                        (let ((code (- c 96)))
+                          (lambda () (interactive)
+                            (ghostel--send-key (string code)))))))))
+    ;; C-@ (NUL, same as C-SPC) — used by programs like Emacs-in-terminal
+    (define-key map (kbd "C-@")
+                (lambda () (interactive) (ghostel--send-key "\x00")))
+    ;; C-y: yank from Emacs kill ring into the terminal
     (define-key map (kbd "C-y")       #'ghostel-yank)
     (when (eq system-type 'darwin)
       (define-key map (kbd "s-v")     #'ghostel-yank))
     (define-key map (kbd "M-y")       #'ghostel-yank-pop)
-    (define-key map (kbd "C-z")       (lambda () (interactive) (ghostel--send-key "\x1a")))
     ;; Terminal control via C-c prefix (pass through to Emacs, then handled here)
     (define-key map (kbd "C-c C-c")   #'ghostel-send-C-c)
     (define-key map (kbd "C-c C-z")   #'ghostel-send-C-z)

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1394,6 +1394,18 @@ cell, so the visual line width must equal the terminal column count."
         ;; send-key sets last-send-time via the fallback path
         (should ghostel--last-send-time)))))
 
+(ert-deftest ghostel-test-control-key-bindings ()
+  "All non-exception C-<letter> keys should be bound in ghostel-mode-map."
+  (dolist (c (number-sequence ?a ?z))
+    (let* ((key-str (format "C-%c" c))
+           (key-vec (kbd key-str))
+           (binding (lookup-key ghostel-mode-map key-vec)))
+      ;; Skip exceptions (may have sub-keymaps like C-c C-c)
+      (unless (member key-str ghostel-keymap-exceptions)
+        (should binding))))
+  ;; C-@ should also be bound (sends NUL)
+  (should (lookup-key ghostel-mode-map (kbd "C-@"))))
+
 (defconst ghostel-test--elisp-tests
   '(ghostel-test-raw-key-sequences
     ghostel-test-modifier-number
@@ -1420,7 +1432,8 @@ cell, so the visual line width must equal the terminal column count."
     ghostel-test-input-coalesce-disabled
     ghostel-test-input-flush-sends-buffered
     ghostel-test-send-encoded-sets-send-time
-    ghostel-test-send-encoded-no-send-time-on-fallback)
+    ghostel-test-send-encoded-no-send-time-on-fallback
+    ghostel-test-control-key-bindings)
   "Tests that require only Elisp (no native module).")
 
 (defun ghostel-test-run-elisp ()


### PR DESCRIPTION
## Summary
- Several control keys (C-b, C-f, C-j, C-o, C-q, C-s, C-t, C-v) were not bound in `ghostel-mode-map`, causing them to fall through to Emacs defaults (e.g. C-t triggered `transpose-chars` instead of sending `^T` to the shell)
- Replaced individual `define-key` calls with a loop that binds all C-a through C-z, skipping `ghostel-keymap-exceptions` (C-c, C-x, C-u, C-h, C-g, C-\), TAB/RET equivalents (C-i, C-m), and C-y (ghostel-yank)
- Added C-@ (NUL/C-SPC) binding for programs that use it
- Added ERT test verifying all non-exception control keys are bound in the keymap

## Test plan
- [x] `make all` passes (build, tests, byte-compile, lint)
- [x] Open ghostel, run `cat`, press C-t/C-b/C-f/C-s/C-v/C-q/C-j/C-o — confirm they reach the terminal
- [x] Verify C-c, C-x, C-g, C-h, C-u still invoke Emacs commands
- [x] Verify C-y still yanks from kill ring