### PR TITLE
Optimize release binaries: strip and dead-code elimination

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,10 @@ jobs:
       - name: Build native module
         run: ./build.sh
 
+      - name: Strip non-exported symbols (macOS)
+        if: runner.os == 'macOS'
+        run: strip -x ghostel-module${{ matrix.suffix }}
+
       - name: Rename artifact for release
         run: |
           mv ghostel-module${{ matrix.suffix }} \

--- a/build.zig
+++ b/build.zig
@@ -4,11 +4,14 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const is_release = optimize != .Debug;
     const mod = b.createModule(.{
         .root_source_file = b.path("src/module.zig"),
         .target = target,
         .optimize = optimize,
         .link_libc = true,
+        .strip = if (is_release) true else null,
+        .omit_frame_pointer = if (is_release) true else null,
     });
 
     // Emacs module header — check EMACS_INCLUDE_DIR env, then platform defaults
@@ -42,6 +45,18 @@ pub fn build(b: *std.Build) void {
     lib.addObjectFile(b.path("vendor/ghostty/zig-out/lib/libsimdutf.a"));
     lib.addObjectFile(b.path("vendor/ghostty/zig-out/lib/libhighway.a"));
     lib.linkSystemLibrary("c++");
+
+    // Release optimizations: dead-code elimination and symbol visibility
+    if (is_release) {
+        lib.link_gc_sections = true;
+        lib.link_function_sections = true;
+        lib.link_data_sections = true;
+        lib.dead_strip_dylibs = true;
+
+        if (target.result.os.tag == .linux) {
+            lib.setVersionScript(b.path("symbols.map"));
+        }
+    }
 
     b.installArtifact(lib);
 

--- a/symbols.map
+++ b/symbols.map
@@ -1,0 +1,1 @@
+{ global: emacs_module_init; plugin_is_GPL_compatible; local: *; };


### PR DESCRIPTION
## Summary
- Strip debug symbols and omit frame pointers in release builds (build.zig)
- Enable gc-sections and function/data section splitting for dead-code elimination
- Linux: version script restricts exported symbols to `emacs_module_init` and `plugin_is_GPL_compatible`
- macOS: `strip -x` in release workflow removes non-exported local symbols

Expected size reductions:
| Platform | Before | After |
|----------|--------|-------|
| macOS aarch64 | 1.5 MB | ~1.2 MB |
| Linux x86_64 | **8.9 MB** | ~2 MB |

The Linux binary is dramatically larger because ELF retains DWARF debug info from the C++ static libraries (simdutf, highway, libc++abi). Stripping removes ~7 MB of debug sections.

No performance impact — stripping removes metadata only, gc-sections removes dead code, and `omit_frame_pointer` frees a register for general use.

## Test plan
- [x] `make all` passes (build + 27 tests + lint)
- [ ] CI build passes on both platforms
- [ ] Verify release binary sizes after next tag