### PR TITLE
Fix build on musl-based distros (Alpine Linux)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -30,6 +30,9 @@ pub fn build(b: *std.Build) void {
         }
     }
 
+    // Project headers (emacs-module-wrapper.h for musl compatibility)
+    mod.addIncludePath(b.path("src"));
+
     // libghostty-vt headers — try both source tree and build output
     mod.addIncludePath(b.path("vendor/ghostty/include"));
     mod.addIncludePath(b.path("vendor/ghostty/zig-out/include"));
@@ -97,6 +100,7 @@ pub fn build(b: *std.Build) void {
         }
     }
 
+    check_mod.addIncludePath(b.path("src"));
     check_mod.addIncludePath(b.path("vendor/ghostty/include"));
     check_mod.addIncludePath(b.path("vendor/ghostty/zig-out/include"));
 

--- a/src/emacs-module-wrapper.h
+++ b/src/emacs-module-wrapper.h
@@ -1,0 +1,31 @@
+/*
+ * Wrapper for emacs-module.h that works around musl libc's struct timespec
+ * definition using bit-field padding expressions that Zig's translate-c
+ * cannot parse (producing an opaque type instead of a concrete struct).
+ *
+ * On musl, we provide a plain struct timespec definition and set the guard
+ * macro so musl's <bits/alltypes.h> skips its version.
+ *
+ * GHOSTEL_MUSL is defined by emacs.zig when the Zig target ABI is musl.
+ */
+
+/* Ensure struct timespec is visible (glibc gates it behind this). */
+#define _POSIX_C_SOURCE 199309L
+
+#ifdef GHOSTEL_MUSL
+/* musl libc — pre-define struct timespec with a layout Zig can translate.
+   ABI-compatible: tv_sec is time_t, tv_nsec is long, with padding to keep
+   sizeof(struct timespec) == 2 * sizeof(time_t). */
+#define __NEED_time_t
+#include <bits/alltypes.h>          /* get time_t */
+#ifndef __DEFINED_struct_timespec
+#define __DEFINED_struct_timespec
+struct timespec {
+    time_t tv_sec;
+    long   tv_nsec;
+    char   __padding[sizeof(time_t) - sizeof(long)];
+};
+#endif
+#endif
+
+#include <emacs-module.h>

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -3,12 +3,16 @@
 /// Provides type-safe access to emacs_env functions, cached symbol
 /// interning, and helper methods for common operations.
 const std = @import("std");
+const builtin = @import("builtin");
 
 pub const c = @cImport({
-    // Ensure struct timespec is fully defined on Linux (glibc gates it
-    // behind _POSIX_C_SOURCE).  Harmless on macOS/BSDs.
-    @cDefine("_POSIX_C_SOURCE", "199309L");
-    @cInclude("emacs-module.h");
+    // Detect musl from Zig's target ABI and tell the wrapper header.
+    // We cannot rely on __GLIBC__ because Zig's translate-c does not
+    // implicitly include glibc's <features.h>.
+    if (builtin.abi == .musl or builtin.abi == .musleabi or builtin.abi == .musleabihf) {
+        @cDefine("GHOSTEL_MUSL", "1");
+    }
+    @cInclude("emacs-module-wrapper.h");
 });
 
 /// Emacs value type alias for convenience.


### PR DESCRIPTION
## Summary
- musl's `struct timespec` uses computed bit-field padding that Zig's `translate-c` can't parse, making it opaque and breaking `emacs-module.h` compilation
- Add `src/emacs-module-wrapper.h` that detects musl (`__linux__ && !__GLIBC__`) and pre-defines `struct timespec` with a plain ABI-compatible layout
- Transparent on glibc and macOS — the workaround is guarded by preprocessor conditionals

## Test plan
- [x] Full `build.sh` succeeds on Alpine 3.21 (aarch64, musl, Zig 0.15.2)
- [x] All 27 Elisp tests pass on Alpine
- [x] ABI verified: struct size/offsets match musl's native layout
- [x] `zig build check` still passes on macOS

Note: Alpine users also need `apk add linux-headers` for Zig's bundled libc++ (`linux/futex.h`)