### PR TITLE
Add full scrollback copy mode and copy-all command

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,15 @@ After `C-c C-a`, the entire scrollback history is loaded into the buffer
 as styled text. Standard Emacs commands work across the full content:
 `C-x h` to select all, `C-s` to search, mark/region spanning any distance.
 
+Set `ghostel-copy-mode-auto-load-scrollback` to `t` to skip the
+viewport-only step and load the full scrollback immediately when
+entering copy mode. Advantages: produces a pure Emacs buffer where
+all standard commands work (incremental search, `occur`, `M-x
+flush-lines`, etc.) without an extra keystroke. Disadvantages: entering
+copy mode takes longer for large scrollback buffers, clickable links
+(URLs, file references, OSC 8 hyperlinks) are not detected in the
+loaded scrollback.
+
 ## Features
 
 ### Terminal Emulation
@@ -323,6 +332,7 @@ individual faces with `M-x customize-face`.
 | `ghostel-enable-url-detection`   | `t`                  | Linkify plain-text URLs in terminal output               |
 | `ghostel-enable-file-detection`  | `t`                  | Linkify file:line references in terminal output          |
 | `ghostel-keymap-exceptions`      | `("C-c" "C-x" ...)` | Keys passed through to Emacs                             |
+| `ghostel-copy-mode-auto-load-scrollback` | `nil`        | Load full scrollback automatically when entering copy mode |
 | `ghostel-exit-functions`         | `nil`                | Hook run when the shell process exits                    |
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ test "$INSIDE_EMACS" = 'ghostel'; and source "$EMACS_GHOSTEL_PATH/etc/ghostel.fi
 | `C-c C-d`   | Send EOF (C-d)                         |
 | `C-c C-\`   | Send quit (C-\)                        |
 | `C-c C-t`   | Enter copy mode                        |
+| `C-c M-w`   | Copy entire scrollback to kill ring    |
 | `C-y`       | Yank from kill ring (bracketed paste)  |
 | `M-y`       | Yank-pop (cycle through kill ring)     |
 | `C-c C-y`   | Paste from kill ring                   |
@@ -183,20 +184,25 @@ Keys listed in `ghostel-keymap-exceptions` (default: `C-c`, `C-x`, `C-u`,
 Enter with `C-c C-t`. Standard Emacs navigation works.
 Normal letter keys exit copy mode and send the key to the terminal.
 
-| Key           | Action                          |
-|---------------|---------------------------------|
-| `C-SPC`       | Set mark                        |
-| `M-w` / `C-w` | Copy selection and exit         |
-| `C-n` / `C-p` | Move line (scrolls at edges)    |
-| `M-v` / `C-v` | Scroll page up / down           |
-| `M-<` / `M->` | Jump to top / bottom of buffer  |
-| `C-c C-n`     | Jump to next prompt             |
-| `C-c C-p`     | Jump to previous prompt         |
-| `C-l`         | Recenter viewport               |
-| `C-c C-t`     | Exit without copying            |
-| `a`–`z`       | Exit and send key to terminal   |
+| Key           | Action                           |
+|---------------|----------------------------------|
+| `C-SPC`       | Set mark                         |
+| `M-w` / `C-w` | Copy selection and exit          |
+| `C-n` / `C-p` | Move line (scrolls at edges)     |
+| `M-v` / `C-v` | Scroll page up / down            |
+| `M-<` / `M->` | Jump to top / bottom of buffer   |
+| `C-c C-n`     | Jump to next prompt              |
+| `C-c C-p`     | Jump to previous prompt          |
+| `C-l`         | Recenter viewport                |
+| `C-c C-a`     | Load full scrollback into buffer |
+| `C-c C-t`     | Exit without copying             |
+| `a`–`z`       | Exit and send key to terminal    |
 
 Soft-wrapped newlines are automatically stripped from copied text.
+
+After `C-c C-a`, the entire scrollback history is loaded into the buffer
+as styled text. Standard Emacs commands work across the full content:
+`C-x h` to select all, `C-s` to search, mark/region spanning any distance.
 
 ## Features
 
@@ -329,6 +335,7 @@ individual faces with `M-x customize-face`.
 | `M-x ghostel-clear`            | Clear screen and scrollback                  |
 | `M-x ghostel-clear-scrollback` | Clear scrollback only                        |
 | `M-x ghostel-copy-mode`        | Enter copy mode                              |
+| `M-x ghostel-copy-all`         | Copy entire scrollback to kill ring          |
 | `M-x ghostel-paste`            | Paste from kill ring                         |
 | `M-x ghostel-send-next-key`    | Send next key literally                      |
 | `M-x ghostel-next-prompt`      | Jump to next shell prompt                    |

--- a/ghostel.el
+++ b/ghostel.el
@@ -223,6 +223,15 @@ into the scrollback will first jump to the bottom of the terminal
 before sending the input."
   :type 'boolean)
 
+(defcustom ghostel-copy-mode-auto-load-scrollback nil
+  "Automatically load the full scrollback when entering copy mode.
+When non-nil, entering copy mode immediately loads the entire
+scrollback history into the buffer, producing a plain Emacs buffer
+that supports all standard commands (search, select-all, etc.).
+When nil (the default), copy mode shows only the current viewport
+and scrollback can be loaded on demand with \\[ghostel-copy-mode-load-all]."
+  :type 'boolean)
+
 ;;; ANSI color faces
 
 (defface ghostel-color-black
@@ -1282,9 +1291,11 @@ Press \\`q' or \\[ghostel-copy-mode-exit] to exit without copying."
     (when ghostel--saved-hl-line-mode
       (hl-line-mode 1))
     (setq buffer-read-only t)
-    (setq mode-line-process ":Copy")
-    (force-mode-line-update)
-    (message "Copy mode: C-SPC to mark, navigate to select, M-w to copy, q to exit")))
+    (if ghostel-copy-mode-auto-load-scrollback
+        (ghostel-copy-mode-load-all)
+      (setq mode-line-process ":Copy")
+      (force-mode-line-update)
+      (message "Copy mode: C-SPC to mark, navigate to select, M-w to copy, q to exit"))))
 
 (defun ghostel-copy-mode-exit ()
   "Exit copy mode and return to terminal mode."
@@ -1368,6 +1379,8 @@ the full scrollback history."
       (move-to-column saved-col)
       (recenter saved-line))
     (setq ghostel--copy-mode-full-buffer t)
+    (setq mode-line-process ":Emacs")
+    (force-mode-line-update)
     (message "Scrollback loaded")))
 
 (defun ghostel-copy-all ()

--- a/ghostel.el
+++ b/ghostel.el
@@ -1036,24 +1036,28 @@ pasted using bracketed paste."
 (defun ghostel-copy-mode-scroll-up ()
   "Scroll the terminal viewport up by a page in copy mode."
   (interactive)
-  (if ghostel--copy-mode-full-buffer
-      (scroll-down-command)
-    (when ghostel--term
-      (let ((height (count-lines (point-min) (point-max))))
-        (ghostel--scroll ghostel--term (- 2 height))
-        (let ((inhibit-read-only t))
-          (ghostel--redraw ghostel--term ghostel-full-redraw))))))
+  (let ((col (current-column)))
+    (if ghostel--copy-mode-full-buffer
+        (scroll-down-command)
+      (when ghostel--term
+        (let ((height (count-lines (point-min) (point-max))))
+          (ghostel--scroll ghostel--term (- 2 height))
+          (let ((inhibit-read-only t))
+            (ghostel--redraw ghostel--term ghostel-full-redraw)))))
+    (move-to-column col)))
 
 (defun ghostel-copy-mode-scroll-down ()
   "Scroll the terminal viewport down by a page in copy mode."
   (interactive)
-  (if ghostel--copy-mode-full-buffer
-      (scroll-up-command)
-    (when ghostel--term
-      (let ((height (count-lines (point-min) (point-max))))
-        (ghostel--scroll ghostel--term (- height 2))
-        (let ((inhibit-read-only t))
-          (ghostel--redraw ghostel--term ghostel-full-redraw))))))
+  (let ((col (current-column)))
+    (if ghostel--copy-mode-full-buffer
+        (scroll-up-command)
+      (when ghostel--term
+        (let ((height (count-lines (point-min) (point-max))))
+          (ghostel--scroll ghostel--term (- height 2))
+          (let ((inhibit-read-only t))
+            (ghostel--redraw ghostel--term ghostel-full-redraw)))))
+    (move-to-column col)))
 
 (defun ghostel-copy-mode-previous-line ()
   "Move to the previous line, scrolling the viewport if at the top."

--- a/ghostel.el
+++ b/ghostel.el
@@ -340,9 +340,11 @@ Bump this only when the Elisp code requires a newer native module
 (declare-function ghostel--encode-key "ghostel-module")
 (declare-function ghostel--focus-event "ghostel-module")
 (declare-function ghostel--mode-enabled "ghostel-module")
+(declare-function ghostel--copy-all-text "ghostel-module")
 (declare-function ghostel--module-version "ghostel-module")
 (declare-function ghostel--mouse-event "ghostel-module")
 (declare-function ghostel--new "ghostel-module")
+(declare-function ghostel--redraw-full-scrollback "ghostel-module")
 (declare-function ghostel--redraw "ghostel-module" (term &optional full))
 (declare-function ghostel--scroll "ghostel-module")
 (declare-function ghostel--scroll-bottom "ghostel-module")
@@ -556,6 +558,9 @@ DIR is the module directory."
 (defvar-local ghostel--copy-mode-active nil
   "Non-nil when copy mode is active.")
 
+(defvar-local ghostel--copy-mode-full-buffer nil
+  "Non-nil when full scrollback has been loaded into the buffer in copy mode.")
+
 (defvar-local ghostel--process nil
   "The shell process.")
 
@@ -647,6 +652,7 @@ Used for prompt navigation and optional re-application after full redraws.")
     (define-key map (kbd "C-c C-\\")  #'ghostel-send-C-backslash)
     (define-key map (kbd "C-c C-d")   #'ghostel-send-C-d)
     (define-key map (kbd "C-c C-t")   #'ghostel-copy-mode)
+    (define-key map (kbd "C-c M-w")   #'ghostel-copy-all)
     (define-key map (kbd "C-c C-y")   #'ghostel-paste)
     (define-key map (kbd "C-c C-l")   #'ghostel-clear-scrollback)
     (define-key map (kbd "C-c C-q")   #'ghostel-send-next-key)
@@ -1004,89 +1010,107 @@ pasted using bracketed paste."
 (defun ghostel--scroll-up (&optional _event)
   "Scroll the terminal viewport up (into scrollback)."
   (interactive "e")
-  (when ghostel--term
-    (ghostel--scroll ghostel--term -3)
-    (if ghostel--copy-mode-active
-        (let ((inhibit-read-only t))
-          (ghostel--redraw ghostel--term ghostel-full-redraw))
-      (setq ghostel--force-next-redraw t)
-      (ghostel--invalidate))))
+  (if ghostel--copy-mode-full-buffer
+      (scroll-down 3)
+    (when ghostel--term
+      (ghostel--scroll ghostel--term -3)
+      (if ghostel--copy-mode-active
+          (let ((inhibit-read-only t))
+            (ghostel--redraw ghostel--term ghostel-full-redraw))
+        (setq ghostel--force-next-redraw t)
+        (ghostel--invalidate)))))
 
 (defun ghostel--scroll-down (&optional _event)
   "Scroll the terminal viewport down."
   (interactive "e")
-  (when ghostel--term
-    (ghostel--scroll ghostel--term 3)
-    (if ghostel--copy-mode-active
-        (let ((inhibit-read-only t))
-          (ghostel--redraw ghostel--term ghostel-full-redraw))
-      (setq ghostel--force-next-redraw t)
-      (ghostel--invalidate))))
+  (if ghostel--copy-mode-full-buffer
+      (scroll-up 3)
+    (when ghostel--term
+      (ghostel--scroll ghostel--term 3)
+      (if ghostel--copy-mode-active
+          (let ((inhibit-read-only t))
+            (ghostel--redraw ghostel--term ghostel-full-redraw))
+        (setq ghostel--force-next-redraw t)
+        (ghostel--invalidate)))))
 
 (defun ghostel-copy-mode-scroll-up ()
   "Scroll the terminal viewport up by a page in copy mode."
   (interactive)
-  (when ghostel--term
-    (let ((height (count-lines (point-min) (point-max))))
-      (ghostel--scroll ghostel--term (- 2 height))
-      (let ((inhibit-read-only t))
-        (ghostel--redraw ghostel--term ghostel-full-redraw)))))
+  (if ghostel--copy-mode-full-buffer
+      (scroll-down-command)
+    (when ghostel--term
+      (let ((height (count-lines (point-min) (point-max))))
+        (ghostel--scroll ghostel--term (- 2 height))
+        (let ((inhibit-read-only t))
+          (ghostel--redraw ghostel--term ghostel-full-redraw))))))
 
 (defun ghostel-copy-mode-scroll-down ()
   "Scroll the terminal viewport down by a page in copy mode."
   (interactive)
-  (when ghostel--term
-    (let ((height (count-lines (point-min) (point-max))))
-      (ghostel--scroll ghostel--term (- height 2))
-      (let ((inhibit-read-only t))
-        (ghostel--redraw ghostel--term ghostel-full-redraw)))))
+  (if ghostel--copy-mode-full-buffer
+      (scroll-up-command)
+    (when ghostel--term
+      (let ((height (count-lines (point-min) (point-max))))
+        (ghostel--scroll ghostel--term (- height 2))
+        (let ((inhibit-read-only t))
+          (ghostel--redraw ghostel--term ghostel-full-redraw))))))
 
 (defun ghostel-copy-mode-previous-line ()
   "Move to the previous line, scrolling the viewport if at the top."
   (interactive)
   (let ((col (current-column)))
-    (if (= (line-number-at-pos) 1)
-        (when ghostel--term
-          (ghostel--scroll ghostel--term -1)
-          (let ((inhibit-read-only t))
-            (ghostel--redraw ghostel--term ghostel-full-redraw))
-          (goto-char (point-min)))
-      (forward-line -1))
+    (if ghostel--copy-mode-full-buffer
+        (forward-line -1)
+      (if (= (line-number-at-pos) 1)
+          (when ghostel--term
+            (ghostel--scroll ghostel--term -1)
+            (let ((inhibit-read-only t))
+              (ghostel--redraw ghostel--term ghostel-full-redraw))
+            (goto-char (point-min)))
+        (forward-line -1)))
     (move-to-column col)))
 
 (defun ghostel-copy-mode-next-line ()
   "Move to the next line, scrolling the viewport if at the bottom."
   (interactive)
   (let ((col (current-column)))
-    (if (>= (line-number-at-pos) (line-number-at-pos (point-max)))
-        (when ghostel--term
-          (ghostel--scroll ghostel--term 1)
-          (let ((inhibit-read-only t))
-            (ghostel--redraw ghostel--term ghostel-full-redraw))
-          (goto-char (point-max))
-          (beginning-of-line))
-      (forward-line 1))
+    (if ghostel--copy-mode-full-buffer
+        (forward-line 1)
+      (if (>= (line-number-at-pos) (line-number-at-pos (point-max)))
+          (when ghostel--term
+            (ghostel--scroll ghostel--term 1)
+            (let ((inhibit-read-only t))
+              (ghostel--redraw ghostel--term ghostel-full-redraw))
+            (goto-char (point-max))
+            (beginning-of-line))
+        (forward-line 1)))
     (move-to-column col)))
 
 (defun ghostel-copy-mode-beginning-of-buffer ()
   "Scroll to the top of scrollback in copy mode."
   (interactive)
-  (when ghostel--term
-    (ghostel--scroll-top ghostel--term)
-    (let ((inhibit-read-only t))
-      (ghostel--redraw ghostel--term ghostel-full-redraw))
-    (goto-char (point-min))))
+  (if ghostel--copy-mode-full-buffer
+      (goto-char (point-min))
+    (when ghostel--term
+      (ghostel--scroll-top ghostel--term)
+      (let ((inhibit-read-only t))
+        (ghostel--redraw ghostel--term ghostel-full-redraw))
+      (goto-char (point-min)))))
 
 (defun ghostel-copy-mode-end-of-buffer ()
   "Scroll to the bottom of scrollback in copy mode."
   (interactive)
-  (when ghostel--term
-    (ghostel--scroll-bottom ghostel--term)
-    (let ((inhibit-read-only t))
-      (ghostel--redraw ghostel--term ghostel-full-redraw))
-    ;; The native redraw already positions point at the terminal cursor,
-    ;; so no explicit goto-char needed here.
-    ))
+  (if ghostel--copy-mode-full-buffer
+      (progn
+        (goto-char (point-max))
+        (skip-chars-backward " \t\n"))
+    (when ghostel--term
+      (ghostel--scroll-bottom ghostel--term)
+      (let ((inhibit-read-only t))
+        (ghostel--redraw ghostel--term ghostel-full-redraw))
+      ;; The native redraw already positions point at the terminal cursor,
+      ;; so no explicit goto-char needed here.
+      )))
 
 (defun ghostel-copy-mode-end-of-line ()
   "Move to the last non-whitespace character on the line."
@@ -1100,30 +1124,32 @@ Scrolls the terminal viewport so the current line is vertically
 centered, then redraws.  When the scroll is clamped at a scrollback
 boundary (nothing to scroll into), does nothing."
   (interactive)
-  (when ghostel--term
-    (let* ((current-line (line-number-at-pos))
-           (win-height (window-body-height))
-           (center (/ win-height 2))
-           (col (current-column)))
-      (unless (= current-line center)
-        ;; Hash the buffer to detect whether the scroll was clamped.
-        (let ((old-hash (buffer-hash)))
-          (ghostel--scroll ghostel--term (- current-line center))
-          (let ((inhibit-read-only t))
-            (ghostel--redraw ghostel--term ghostel-full-redraw))
-          ;; If the buffer changed the viewport actually moved —
-          ;; reposition point at center.  Otherwise the scroll was
-          ;; clamped; restore point since redraw moved it to the
-          ;; terminal cursor.
-          (if (equal old-hash (buffer-hash))
-              (progn
-                (goto-char (point-min))
-                (forward-line (1- current-line))
-                (move-to-column col))
-            (goto-char (point-min))
-            (forward-line (1- (min center (line-number-at-pos (point-max)))))
-            (move-to-column col)
-            (recenter)))))))
+  (if ghostel--copy-mode-full-buffer
+      (recenter)
+    (when ghostel--term
+      (let* ((current-line (line-number-at-pos))
+             (win-height (window-body-height))
+             (center (/ win-height 2))
+             (col (current-column)))
+        (unless (= current-line center)
+          ;; Hash the buffer to detect whether the scroll was clamped.
+          (let ((old-hash (buffer-hash)))
+            (ghostel--scroll ghostel--term (- current-line center))
+            (let ((inhibit-read-only t))
+              (ghostel--redraw ghostel--term ghostel-full-redraw))
+            ;; If the buffer changed the viewport actually moved —
+            ;; reposition point at center.  Otherwise the scroll was
+            ;; clamped; restore point since redraw moved it to the
+            ;; terminal cursor.
+            (if (equal old-hash (buffer-hash))
+                (progn
+                  (goto-char (point-min))
+                  (forward-line (1- current-line))
+                  (move-to-column col))
+              (goto-char (point-min))
+              (forward-line (1- (min center (line-number-at-pos (point-max)))))
+              (move-to-column col)
+              (recenter))))))))
 
 
 ;;; Mouse input
@@ -1214,6 +1240,7 @@ boundary (nothing to scroll into), does nothing."
     (define-key map (kbd "M->")             #'ghostel-copy-mode-end-of-buffer)
     (define-key map (kbd "C-e")             #'ghostel-copy-mode-end-of-line)
     (define-key map (kbd "C-l")             #'ghostel-copy-mode-recenter)
+    (define-key map (kbd "C-c C-a")         #'ghostel-copy-mode-load-all)
     map)
   "Keymap for `ghostel-copy-mode'.
 Standard Emacs navigation works.
@@ -1259,19 +1286,26 @@ Press \\`q' or \\[ghostel-copy-mode-exit] to exit without copying."
   "Exit copy mode and return to terminal mode."
   (interactive)
   (when ghostel--copy-mode-active
-    (setq ghostel--copy-mode-active nil)
-    (setq cursor-type ghostel--saved-cursor-type)
-    (deactivate-mark)
-    (use-local-map ghostel--saved-local-map)
-    (when ghostel--saved-hl-line-mode
-      (hl-line-mode -1))
-    (setq buffer-read-only nil)
-    (setq mode-line-process nil)
-    (force-mode-line-update)
-    (when ghostel--term
-      (ghostel--scroll-bottom ghostel--term))
-    (ghostel--invalidate)
-    (message "Copy mode exited")))
+    (let ((was-full ghostel--copy-mode-full-buffer))
+      (setq ghostel--copy-mode-active nil)
+      (setq ghostel--copy-mode-full-buffer nil)
+      (setq cursor-type ghostel--saved-cursor-type)
+      (deactivate-mark)
+      (use-local-map ghostel--saved-local-map)
+      (when ghostel--saved-hl-line-mode
+        (hl-line-mode -1))
+      (setq buffer-read-only nil)
+      (setq mode-line-process nil)
+      (force-mode-line-update)
+      (when ghostel--term
+        (ghostel--scroll-bottom ghostel--term)
+        (when was-full
+          ;; Erase stale full-scrollback content so normal redraw rebuilds
+          (let ((inhibit-read-only t))
+            (erase-buffer)
+            (ghostel--redraw ghostel--term t))))
+      (ghostel--invalidate)
+      (message "Copy mode exited"))))
 
 (defun ghostel-copy-mode-exit-and-send ()
   "Exit copy mode and send the key that triggered exit to the terminal."
@@ -1312,6 +1346,34 @@ stripped so the copied text matches the original terminal content."
       (kill-new text)
       (message "Copied to kill ring")))
   (ghostel-copy-mode-exit))
+
+(defun ghostel-copy-mode-load-all ()
+  "Load the entire scrollback into the buffer for cross-viewport selection.
+After loading, standard Emacs navigation and selection work across
+the full scrollback history."
+  (interactive)
+  (when (and ghostel--copy-mode-active ghostel--term
+             (not ghostel--copy-mode-full-buffer))
+    (message "Loading scrollback...")
+    (let* ((saved-line (1- (line-number-at-pos))) ; 0-based line within viewport
+           (saved-col (current-column))
+           (inhibit-read-only t)
+           (viewport-line (ghostel--redraw-full-scrollback ghostel--term)))
+      (goto-char (point-min))
+      (forward-line (+ (1- viewport-line) saved-line))
+      (move-to-column saved-col)
+      (recenter saved-line))
+    (setq ghostel--copy-mode-full-buffer t)
+    (message "Scrollback loaded")))
+
+(defun ghostel-copy-all ()
+  "Copy the entire scrollback buffer to the kill ring."
+  (interactive)
+  (when ghostel--term
+    (let ((text (ghostel--copy-all-text ghostel--term)))
+      (when (and text (> (length text) 0))
+        (kill-new text)
+        (message "Copied %d characters to kill ring" (length text))))))
 
 
 ;;; Hyperlinks (OSC 8)

--- a/src/ghostty.zig
+++ b/src/ghostty.zig
@@ -121,3 +121,16 @@ pub const SCROLL_DELTA: c_int = c.GHOSTTY_SCROLL_VIEWPORT_DELTA;
 
 // Point tag constants
 pub const POINT_TAG_VIEWPORT: c_int = c.GHOSTTY_POINT_TAG_VIEWPORT;
+
+// Scrollbar / total rows constants
+pub const DATA_TOTAL_ROWS = c.GHOSTTY_TERMINAL_DATA_TOTAL_ROWS;
+pub const DATA_SCROLLBACK_ROWS = c.GHOSTTY_TERMINAL_DATA_SCROLLBACK_ROWS;
+pub const DATA_SCROLLBAR = c.GHOSTTY_TERMINAL_DATA_SCROLLBAR;
+pub const TerminalScrollbar = c.GhosttyTerminalScrollbar;
+
+// Formatter types
+pub const Formatter = c.GhosttyFormatter;
+pub const FormatterTerminalOptions = c.GhosttyFormatterTerminalOptions;
+pub const FormatterTerminalExtra = c.GhosttyFormatterTerminalExtra;
+pub const FormatterScreenExtra = c.GhosttyFormatterScreenExtra;
+pub const FORMATTER_PLAIN = c.GHOSTTY_FORMATTER_FORMAT_PLAIN;

--- a/src/module.zig
+++ b/src/module.zig
@@ -47,6 +47,8 @@ export fn emacs_module_init(runtime: *c.struct_emacs_runtime) callconv(.c) c_int
     env.bindFunction("ghostel--cursor-position", 1, 1, &fnCursorPosition, "Return terminal cursor position as (COL . ROW), 0-indexed.\n\n(ghostel--cursor-position TERM)");
     env.bindFunction("ghostel--debug-state", 1, 1, &fnDebugState, "Return debug info about terminal/render state.\n\n(ghostel--debug-state TERM)");
     env.bindFunction("ghostel--debug-feed", 2, 2, &fnDebugFeed, "Feed STR to terminal and return first row + cursor.\n\n(ghostel--debug-feed TERM STR)");
+    env.bindFunction("ghostel--redraw-full-scrollback", 1, 1, &fnRedrawFullScrollback, "Render entire scrollback into buffer, return original viewport line.\n\n(ghostel--redraw-full-scrollback TERM)");
+    env.bindFunction("ghostel--copy-all-text", 1, 1, &fnCopyAllText, "Return entire scrollback as plain text string.\n\n(ghostel--copy-all-text TERM)");
     env.bindFunction("ghostel--module-version", 0, 0, &fnModuleVersion, "Return the native module version string.\n\n(ghostel--module-version)");
 
     emacs.initSymbols(env);
@@ -744,6 +746,48 @@ fn fnCursorPosition(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _
     _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_CURSOR_VIEWPORT_Y, @ptrCast(&cy));
 
     return env.call2(emacs.sym.cons, env.makeInteger(@as(i64, cx)), env.makeInteger(@as(i64, cy)));
+}
+
+/// (ghostel--redraw-full-scrollback TERM)
+/// Render the entire scrollback into the current buffer.
+/// Returns the 1-based line number of the original viewport position.
+fn fnRedrawFullScrollback(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
+    const env = emacs.Env.init(raw_env.?);
+    const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
+    const line = render.redrawFullScrollback(env, term);
+    return env.makeInteger(line);
+}
+
+/// (ghostel--copy-all-text TERM)
+/// Return the entire scrollback as a plain text string using the formatter API.
+fn fnCopyAllText(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
+    const env = emacs.Env.init(raw_env.?);
+    const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
+
+    var options: gt.FormatterTerminalOptions = std.mem.zeroes(gt.FormatterTerminalOptions);
+    options.size = @sizeOf(gt.FormatterTerminalOptions);
+    options.emit = gt.FORMATTER_PLAIN;
+    options.unwrap = true;
+    options.trim = true;
+    // extra and selection stay zeroed (null)
+
+    var formatter: gt.Formatter = undefined;
+    if (gt.c.ghostty_formatter_terminal_new(null, &formatter, term.terminal, options) != gt.SUCCESS) {
+        env.signalError("ghostel: failed to create formatter");
+        return env.nil();
+    }
+    defer gt.c.ghostty_formatter_free(formatter);
+
+    var ptr: [*c]u8 = undefined;
+    var len: usize = 0;
+    if (gt.c.ghostty_formatter_format_alloc(formatter, null, &ptr, &len) != gt.SUCCESS) {
+        env.signalError("ghostel: formatter failed");
+        return env.nil();
+    }
+
+    if (len == 0 or ptr == null) return env.nil();
+    defer gt.c.ghostty_free(null, ptr, len);
+    return env.makeString(ptr[0..len]);
 }
 
 /// (ghostel--module-version)

--- a/src/render.zig
+++ b/src/render.zig
@@ -537,6 +537,145 @@ fn insertAndStyle(
     }
 }
 
+/// Render the entire scrollback + active screen into the Emacs buffer.
+/// Returns the 1-based buffer line number corresponding to the original viewport top.
+pub fn redrawFullScrollback(env: emacs.Env, term: *Terminal) i64 {
+    const total_rows = term.getTotalRows();
+    if (total_rows == 0) return 1;
+
+    // Save current viewport position
+    const sb = term.getScrollbar() orelse return 1;
+    const saved_offset = sb.offset;
+
+    // Get default colors
+    // (need a render_state_update to read them, use current viewport for that)
+    if (gt.c.ghostty_render_state_update(term.render_state, term.terminal) != gt.SUCCESS) {
+        return 1;
+    }
+    var default_fg = gt.ColorRgb{ .r = 204, .g = 204, .b = 204 };
+    var default_bg = gt.ColorRgb{ .r = 0, .g = 0, .b = 0 };
+    _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_COLOR_FOREGROUND, @ptrCast(&default_fg));
+    _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_COLOR_BACKGROUND, @ptrCast(&default_bg));
+
+    // Set buffer default face
+    var fg_hex: [7]u8 = undefined;
+    var bg_hex: [7]u8 = undefined;
+    _ = env.call2(
+        emacs.sym.@"ghostel--set-buffer-face",
+        env.makeString(formatColor(default_fg, &fg_hex)),
+        env.makeString(formatColor(default_bg, &bg_hex)),
+    );
+
+    // Erase buffer
+    env.eraseBuffer();
+
+    // Scroll to top of scrollback
+    term.scrollViewport(gt.SCROLL_TOP, 0);
+
+    // Shared buffers for row content
+    var runs: [512]RunInfo = undefined;
+    var text_buf: [16384]u8 = undefined;
+
+    var rendered: usize = 0;
+    var prev_wrapped: bool = false;
+
+    while (rendered < total_rows) {
+        // Query actual viewport position
+        const cur_sb = term.getScrollbar() orelse break;
+        const viewport_start = cur_sb.offset;
+
+        // Update render state for current viewport
+        if (gt.c.ghostty_render_state_update(term.render_state, term.terminal) != gt.SUCCESS) {
+            break;
+        }
+
+        // Get row iterator
+        if (gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_ROW_ITERATOR, @ptrCast(&term.row_iterator)) != gt.SUCCESS) {
+            break;
+        }
+
+        // How many rows to skip (already rendered from previous page overlap)
+        const viewport_rows: usize = term.rows;
+        const skip: usize = if (rendered > viewport_start) rendered - viewport_start else 0;
+        if (skip >= viewport_rows) break; // no new rows in this viewport
+        // How many rows to take from this viewport
+        const take: usize = @min(viewport_rows - skip, total_rows - rendered);
+        if (take == 0) break; // no progress possible
+
+        var row_in_page: usize = 0;
+        while (gt.c.ghostty_render_state_row_iterator_next(term.row_iterator)) {
+            defer row_in_page += 1;
+
+            if (row_in_page < skip) {
+                // Still need to track wrap state through skipped rows
+                prev_wrapped = isRowWrapped(term);
+                continue;
+            }
+            if (row_in_page >= skip + take) {
+                break;
+            }
+
+            // Get cells for this row
+            if (gt.c.ghostty_render_state_row_get(term.row_iterator, gt.RS_ROW_DATA_CELLS, @ptrCast(&term.row_cells)) != gt.SUCCESS) {
+                prev_wrapped = false;
+                rendered += 1;
+                continue;
+            }
+
+            // Insert newline between rows
+            if (rendered > 0) {
+                const nl_start = env.point();
+                env.insert("\n");
+                if (prev_wrapped) {
+                    env.putTextProperty(nl_start, env.point(), emacs.sym.@"ghostel-wrap", env.t());
+                }
+            }
+
+            // Build row content
+            var run_count: usize = 0;
+            const content = buildRowContent(term, &text_buf, &runs, &run_count);
+
+            // Insert text and apply styles
+            const row_start = env.extractInteger(env.point());
+            insertAndStyle(env, &text_buf, content, &runs, run_count, default_fg, default_bg);
+
+            // Mark prompt portion
+            if (content.prompt_char_len > 0) {
+                env.putTextProperty(
+                    env.makeInteger(row_start),
+                    env.makeInteger(row_start + @as(i64, @intCast(content.prompt_char_len))),
+                    emacs.sym.@"ghostel-prompt",
+                    env.t(),
+                );
+            } else if (isRowPrompt(term)) {
+                env.putTextProperty(
+                    env.makeInteger(row_start),
+                    env.point(),
+                    emacs.sym.@"ghostel-prompt",
+                    env.t(),
+                );
+            }
+
+            prev_wrapped = isRowWrapped(term);
+            rendered += 1;
+        }
+
+        if (rendered >= total_rows) break;
+
+        // Scroll down by viewport size for next page
+        term.scrollViewport(gt.SCROLL_DELTA, @intCast(term.rows));
+    }
+
+    // Restore viewport to saved position
+    term.scrollViewport(gt.SCROLL_TOP, 0);
+    if (saved_offset > 0) {
+        term.scrollViewport(gt.SCROLL_DELTA, @intCast(saved_offset));
+    }
+
+    // Return 1-based line number of the original viewport top
+    return @as(i64, @intCast(saved_offset)) + 1;
+}
+
 /// Redraw the terminal into the current Emacs buffer.
 /// When force_full is true, always erase and rebuild (matches Ghostty GPU behaviour).
 pub fn redraw(env: emacs.Env, term: *Terminal, force_full: bool) void {

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -211,6 +211,24 @@ pub fn isModeEnabled(self: *Self, mode: gt.c.GhosttyMode) bool {
     return enabled;
 }
 
+/// Get the total number of rows (scrollback + active screen).
+pub fn getTotalRows(self: *Self) usize {
+    var total: usize = 0;
+    if (gt.c.ghostty_terminal_get(self.terminal, gt.DATA_TOTAL_ROWS, @ptrCast(&total)) != gt.SUCCESS) {
+        return self.rows;
+    }
+    return total;
+}
+
+/// Get the scrollbar state (total, offset, len).
+pub fn getScrollbar(self: *Self) ?gt.TerminalScrollbar {
+    var sb: gt.TerminalScrollbar = undefined;
+    if (gt.c.ghostty_terminal_get(self.terminal, gt.DATA_SCROLLBAR, @ptrCast(&sb)) != gt.SUCCESS) {
+        return null;
+    }
+    return sb;
+}
+
 /// Emacs finalizer — called when the user-ptr is garbage collected.
 pub fn emacsFinalize(ptr: ?*anyopaque) callconv(.c) void {
     if (ptr) |p| {

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1267,6 +1267,100 @@ cell, so the visual line width must equal the terminal column count."
       (should (equal '(4) result)))))
 
 ;; -----------------------------------------------------------------------
+;; Test: copy-mode-load-all state management
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-copy-mode-load-all ()
+  "Test that `ghostel-copy-mode-load-all' sets full-buffer state."
+  (let ((buf (generate-new-buffer " *ghostel-test-load-all*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--copy-mode-active nil)
+                (ghostel--redraw-timer nil)
+                (ghostel--term 'fake-term))
+            ;; Enter copy mode
+            (ghostel-copy-mode)
+            (should ghostel--copy-mode-active)              ; in copy mode
+            (should-not ghostel--copy-mode-full-buffer)     ; not full yet
+            ;; Simulate a 3-line viewport with point on line 2, column 3
+            (let ((inhibit-read-only t))
+              (erase-buffer)
+              (insert "aaa\nbbbXbb\nccc"))
+            (goto-char (point-min))
+            (forward-line 1)
+            (move-to-column 3)                              ; on 'X' in line 2
+            ;; Stub the native function and recenter (no window in batch).
+            ;; The stub must NOT bind inhibit-read-only itself — the real
+            ;; native function doesn't, so the caller must have it set.
+            ;; Returns viewport-line=3 (viewport starts at line 3 in full buffer)
+            (cl-letf (((symbol-function 'ghostel--redraw-full-scrollback)
+                       (lambda (_term)
+                         (erase-buffer)
+                         (insert "sb1\nsb2\naaa\nbbbXbb\nccc")
+                         3))
+                      ((symbol-function 'recenter) #'ignore))
+              (ghostel-copy-mode-load-all)
+              (should ghostel--copy-mode-full-buffer)       ; now full
+              ;; Point should be on line 4 (viewport-line 3 + saved offset 1)
+              (should (= 4 (line-number-at-pos)))           ; preserved line
+              (should (= 3 (current-column))))
+            ;; Exit resets full-buffer state
+            (cl-letf (((symbol-function 'ghostel--scroll-bottom) #'ignore)
+                      ((symbol-function 'ghostel--redraw) #'ignore))
+              (ghostel-copy-mode-exit))
+            (should-not ghostel--copy-mode-full-buffer)))   ; reset on exit
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
+;; Test: ghostel-copy-all copies to kill ring
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-copy-all ()
+  "Test that `ghostel-copy-all' puts text into the kill ring."
+  (let ((buf (generate-new-buffer " *ghostel-test-copy-all*"))
+        (old-kill kill-ring))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake-term))
+            (cl-letf (((symbol-function 'ghostel--copy-all-text)
+                       (lambda (_term) "hello world")))
+              (ghostel-copy-all)
+              (should (equal "hello world" (car kill-ring))))))
+      (setq kill-ring old-kill)
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
+;; Test: copy-mode scroll commands in full-buffer mode
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-copy-mode-full-buffer-scroll ()
+  "Test that scroll commands use Emacs navigation in full-buffer mode."
+  (let ((buf (generate-new-buffer " *ghostel-test-full-scroll*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--copy-mode-active t)
+                (ghostel--copy-mode-full-buffer t)
+                (ghostel--term 'fake-term)
+                (inhibit-read-only t))
+            ;; Insert content
+            (insert (mapconcat #'number-to-string (number-sequence 1 20) "\n"))
+            (goto-char (point-min))
+            ;; Test beginning/end of buffer
+            (ghostel-copy-mode-end-of-buffer)
+            (should (= (point) (point-max)))                ; jumped to end
+            (ghostel-copy-mode-beginning-of-buffer)
+            (should (= (point) (point-min)))                ; jumped to beginning
+            ;; Test line navigation
+            (ghostel-copy-mode-next-line)
+            (should (= 2 (line-number-at-pos)))             ; moved to line 2
+            (ghostel-copy-mode-previous-line)
+            (should (= 1 (line-number-at-pos)))))           ; moved back to line 1
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
 ;; Runner
 ;; -----------------------------------------------------------------------
 
@@ -1662,6 +1756,9 @@ cell, so the visual line width must equal the terminal column count."
     ghostel-test-copy-mode-hl-line
     ghostel-test-project-buffer-name
     ghostel-test-project-universal-arg
+    ghostel-test-copy-mode-load-all
+    ghostel-test-copy-all
+    ghostel-test-copy-mode-full-buffer-scroll
     ghostel-test-package-version
     ghostel-test-module-version-match
     ghostel-test-module-version-mismatch


### PR DESCRIPTION
## Summary

- **`C-c M-w` (`ghostel-copy-all`)**: Instantly copies the entire scrollback to the kill ring using the ghostty formatter API. Works from normal mode, no copy mode needed.
- **`C-c C-a` (`ghostel-copy-mode-load-all`)**: In copy mode, loads the full scrollback into the buffer as styled text. After loading, standard Emacs selection works across the entire history (`C-x h`, `C-s`, mark/region spanning any distance). All scroll commands switch to native Emacs scrolling.
- Copy mode entry remains instant with no behavior change for quick single-viewport selections.

### Zig changes
- New `redrawFullScrollback` in render.zig: pages through all scrollback viewports, rendering styled text into the buffer while tracking position via the scrollbar API to avoid overlaps
- New `fnCopyAllText` in module.zig: uses the ghostty formatter API (`PLAIN` format, `unwrap=true`, `trim=true`) for zero-rendering copy-all
- New terminal helpers: `getTotalRows()`, `getScrollbar()`
- New ghostty.zig bindings: `DATA_TOTAL_ROWS`, `DATA_SCROLLBAR`, formatter types

### Elisp changes
- `ghostel-copy-mode-load-all` and `ghostel-copy-all` commands with keybindings
- All copy mode scroll/navigation commands branch on `ghostel--copy-mode-full-buffer` to use native Emacs operations when full scrollback is loaded
- Copy mode exit resets state and forces a full redraw when returning from full-buffer mode

## Test plan

- [ ] `make all` passes (build, tests, lint) ✅
- [ ] Copy mode enters instantly (no regression)
- [ ] `C-c M-w` from normal mode copies entire scrollback to kill ring
- [ ] In copy mode, `C-c C-a` loads full scrollback with "Loading scrollback..." message
- [ ] After load-all: set mark, scroll freely, M-w copies full range
- [ ] After load-all: `C-x h` + M-w copies everything
- [ ] After load-all: `C-s` searches across full scrollback
- [ ] Exit copy mode restores normal terminal rendering
- [ ] Test with small, medium, and large (10k lines) scrollback