### PR TITLE
Add prebuilt binaries for more platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,14 @@ jobs:
           - os: macos-latest
             platform: aarch64-macos
             suffix: .dylib
+          - os: macos-latest
+            platform: x86_64-macos
+            suffix: .dylib
+            target: x86_64-macos
+          - os: ubuntu-latest
+            platform: aarch64-linux
+            suffix: .so
+            target: aarch64-linux-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -127,7 +135,12 @@ jobs:
           version: 0.15.2
 
       - name: Build native module
-        run: ./build.sh
+        run: |
+          if [ -n "${{ matrix.target }}" ]; then
+            ./build.sh -t "${{ matrix.target }}"
+          else
+            ./build.sh
+          fi
 
       - name: Upload module artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,14 @@ jobs:
           - os: macos-latest
             platform: aarch64-macos
             suffix: .dylib
+          - os: macos-latest
+            platform: x86_64-macos
+            suffix: .dylib
+            target: x86_64-macos
+          - os: ubuntu-latest
+            platform: aarch64-linux
+            suffix: .so
+            target: aarch64-linux-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -83,7 +91,12 @@ jobs:
           version: 0.15.2
 
       - name: Build native module
-        run: ./build.sh
+        run: |
+          if [ -n "${{ matrix.target }}" ]; then
+            ./build.sh -t "${{ matrix.target }}"
+          else
+            ./build.sh
+          fi
 
       - name: Strip non-exported symbols (macOS)
         if: runner.os == 'macOS'

--- a/README.md
+++ b/README.md
@@ -29,10 +29,17 @@ process, keymap, and buffer.
 - Emacs 27.1+ with dynamic module support
 - macOS or Linux
 
-The native module is **automatically downloaded** on first use (pre-built
-binaries are available for macOS and Linux).  If you prefer to build from
-source, you'll also need [Zig](https://ziglang.org/) 0.14+ and the ghostty
-submodule (see [Building from source](#building-from-source)).
+The native module is **automatically downloaded** on first use.  Pre-built
+binaries are available for:
+
+- `aarch64-macos` (Apple Silicon)
+- `x86_64-macos` (Intel Mac)
+- `x86_64-linux`
+- `aarch64-linux`
+
+If you prefer to build from source or need a different platform, you'll also
+need [Zig](https://ziglang.org/) 0.14+ and the ghostty submodule (see
+[Building from source](#building-from-source)).
 
 ## Installation
 

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,21 @@ set -e
 
 cd "$(dirname "$0")"
 
+# Parse options
+ZIG_TARGET=""
+while getopts "t:" opt; do
+    case "$opt" in
+        t) ZIG_TARGET="$OPTARG" ;;
+        *) echo "Usage: $0 [-t zig-target-triple]"; exit 1 ;;
+    esac
+done
+
+# Build target flags for zig
+ZIG_TARGET_FLAG=""
+if [ -n "$ZIG_TARGET" ]; then
+    ZIG_TARGET_FLAG="-Dtarget=$ZIG_TARGET"
+fi
+
 # Check submodule
 if [ ! -f vendor/ghostty/build.zig ]; then
     echo "Initializing ghostty submodule..."
@@ -17,16 +32,25 @@ fi
 
 # Build libghostty-vt
 echo "Building libghostty-vt..."
-(cd vendor/ghostty && zig build -Demit-lib-vt=true -Doptimize=ReleaseFast)
+if [ -n "$ZIG_TARGET" ]; then
+    # When cross-compiling, use an isolated cache so that find does not pick up
+    # host-architecture .a files from a shared or restored zig cache.
+    GHOSTTY_CACHE="$(pwd)/vendor/ghostty/.zig-cache-$ZIG_TARGET"
+    (cd vendor/ghostty && \
+     ZIG_LOCAL_CACHE_DIR="$GHOSTTY_CACHE" ZIG_GLOBAL_CACHE_DIR="$GHOSTTY_CACHE" \
+     zig build -Demit-lib-vt=true -Doptimize=ReleaseFast $ZIG_TARGET_FLAG)
+    SEARCH_DIRS="$GHOSTTY_CACHE"
+else
+    (cd vendor/ghostty && zig build -Demit-lib-vt=true -Doptimize=ReleaseFast)
+    SEARCH_DIRS="vendor/ghostty/.zig-cache"
+    [ -n "$ZIG_LOCAL_CACHE_DIR" ] && SEARCH_DIRS="$SEARCH_DIRS $ZIG_LOCAL_CACHE_DIR"
+    [ -n "$ZIG_GLOBAL_CACHE_DIR" ] && SEARCH_DIRS="$SEARCH_DIRS $ZIG_GLOBAL_CACHE_DIR"
+fi
 
 # Copy bundled C++ dependencies to stable paths.
 # These are built by ghostty's zig build into a cache directory with
-# hash-based names.  Search the local .zig-cache first, then fall back
-# to the global/local cache dirs (which CI tools like setup-zig may override).
+# hash-based names.
 echo "Copying dependency libraries..."
-SEARCH_DIRS="vendor/ghostty/.zig-cache"
-[ -n "$ZIG_LOCAL_CACHE_DIR" ] && SEARCH_DIRS="$SEARCH_DIRS $ZIG_LOCAL_CACHE_DIR"
-[ -n "$ZIG_GLOBAL_CACHE_DIR" ] && SEARCH_DIRS="$SEARCH_DIRS $ZIG_GLOBAL_CACHE_DIR"
 
 SIMDUTF=""
 HIGHWAY=""
@@ -52,7 +76,19 @@ echo "  libhighway.a <- $HIGHWAY"
 
 # Build ghostel module
 echo "Building ghostel module..."
-zig build -Doptimize=ReleaseFast
+zig build -Doptimize=ReleaseFast $ZIG_TARGET_FLAG
 
-echo "Done! ghostel-module$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX") or ".so")' 2>/dev/null || echo '.dylib') is ready."
+# Determine output suffix from target or host OS
+if [ -n "$ZIG_TARGET" ]; then
+    case "$ZIG_TARGET" in
+        *macos*|*darwin*) MODULE_SUFFIX=".dylib" ;;
+        *)                MODULE_SUFFIX=".so" ;;
+    esac
+else
+    case "$(uname -s)" in
+        Darwin) MODULE_SUFFIX=".dylib" ;;
+        *)      MODULE_SUFFIX=".so" ;;
+    esac
+fi
+echo "Done! ghostel-module${MODULE_SUFFIX} is ready."
 echo "Load in Emacs with: (require 'ghostel)"


### PR DESCRIPTION
## Summary
- Add cross-compilation support to `build.sh` via `-t <zig-target-triple>` flag
- Expand CI and release matrices from 2 to 5 platforms: x86_64-linux, aarch64-macos, **x86_64-macos**, **aarch64-linux**, **riscv64-linux**
- Cross-compilation uses Zig's built-in support — no additional runners needed

## Test plan
- [ ] Verify native builds (x86_64-linux, aarch64-macos) still pass CI
- [ ] Verify cross-compiled builds (x86_64-macos, aarch64-linux, riscv64-linux) succeed in CI
- [ ] Test `./build.sh` locally without `-t` flag (backward compatible)
- [ ] Test `./build.sh -t x86_64-macos` on aarch64 Mac, verify with `file ghostel-module.dylib`
- [ ] Create a test tag to confirm all 5 binaries appear in the release

Closes #43