### PR TITLE
Add ghostel-project function

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ individual faces with `M-x customize-face`.
 | Command                        | Description                                  |
 |--------------------------------|----------------------------------------------|
 | `M-x ghostel`                  | Open a new terminal                          |
+| `M-x ghostel-project`          | Open a terminal in the current project root  |
 | `M-x ghostel-other`            | Switch to next terminal or create one        |
 | `M-x ghostel-clear`            | Clear screen and scrollback                  |
 | `M-x ghostel-clear-scrollback` | Clear scrollback only                        |
@@ -336,6 +337,16 @@ individual faces with `M-x customize-face`.
 | `M-x ghostel-sync-theme`       | Re-sync color palette after theme change     |
 | `M-x ghostel-download-module`  | Download pre-built native module             |
 | `M-x ghostel-module-compile`   | Compile native module from source            |
+
+### Project integration
+
+`ghostel-project` opens a terminal in the current project's root directory
+with a project-prefixed buffer name.  To make it available from
+`project-switch-project` (`C-x p p`):
+
+```elisp
+(add-to-list 'project-switch-commands '(ghostel-project "Ghostel") t)
+```
 
 ## Running Tests
 

--- a/ghostel.el
+++ b/ghostel.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/dakra/ghostel
 ;; Version: 0.7.1
 ;; Keywords: terminals
-;; Package-Requires: ((emacs "27.1"))
+;; Package-Requires: ((emacs "28.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 
 ;; This file is NOT part of GNU Emacs.
@@ -78,6 +78,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'project)
 (require 'term)
 (require 'url-parse)
 (require 'face-remap)
@@ -1977,11 +1978,13 @@ wheel events reach ghostel's own scroll commands."
 ;;;###autoload
 (defun ghostel-project ()
   "Create a new Ghostel terminal in the current project's root.
-The buffer name is prefixed with the project name."
+The buffer name is prefixed with the project name.
+To add this to `project-switch-commands':
+  (add-to-list \\='project-switch-commands \\='(ghostel-project \"Ghostel\") t)"
   (interactive)
   (let ((default-directory (project-root (project-current t)))
-	(ghostel-buffer-name (project-prefixed-buffer-name
-			      (string-replace "*" "" ghostel-buffer-name))))
+        (ghostel-buffer-name (project-prefixed-buffer-name
+                              (string-trim ghostel-buffer-name "*" "*"))))
     (ghostel)))
 
 (defun ghostel-other ()

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1156,6 +1156,30 @@ cell, so the visual line width must equal the terminal column count."
         (kill-buffer buf)))))
 
 ;; -----------------------------------------------------------------------
+;; Test: ghostel-project buffer naming
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-project-buffer-name ()
+  "Test that `ghostel-project' derives the buffer name correctly."
+  (require 'project)
+  (let ((ghostel-buffer-name "*ghostel*")
+        result)
+    ;; Stub project-current, project-root, and ghostel to capture args
+    (cl-letf (((symbol-function 'project-current)
+               (lambda (_maybe-prompt) '(transient . "/tmp/myproj/")))
+              ((symbol-function 'project-root)
+               (lambda (proj) (cdr proj)))
+              ((symbol-function 'ghostel)
+               (lambda ()
+                 (setq result (cons default-directory ghostel-buffer-name)))))
+      (ghostel-project)
+      ;; default-directory should be the project root
+      (should (equal "/tmp/myproj/" (car result)))
+      ;; Buffer name should be project-prefixed (no raw asterisks passed)
+      (should (string-match-p "ghostel" (cdr result)))
+      (should-not (string-match-p "\\*\\*" (cdr result))))))
+
+;; -----------------------------------------------------------------------
 ;; Runner
 ;; -----------------------------------------------------------------------
 
@@ -1420,6 +1444,7 @@ cell, so the visual line width must equal the terminal column count."
     ghostel-test-osc51-eval-unknown
     ghostel-test-copy-mode-cursor
     ghostel-test-copy-mode-hl-line
+    ghostel-test-project-buffer-name
     ghostel-test-package-version
     ghostel-test-module-version-match
     ghostel-test-module-version-mismatch


### PR DESCRIPTION
First of all: Thanks for this package, it's awesome!

I have been playing around with it for the last 24 hours and one thing I was missing is support for `project.el`.
This small function is inspired by `eshell-project`.

The `string-replace` doesn't feel quite right to me but this way we respect the users choice for `ghostel-buffer-name` (if they want to change it).