### PR TITLE
Preserve manual Ghostel buffer renames

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -582,6 +582,11 @@ DIR is the module directory."
 (defvar-local ghostel--last-directory nil
   "Last known working directory from OSC 7, used for dedup.")
 
+(defvar-local ghostel--managed-buffer-name nil
+  "Last buffer name managed by Ghostel title tracking.
+Nil means title tracking has not claimed the buffer yet.  Clearing this
+variable re-enables automatic renaming for the next title update.")
+
 (defvar-local ghostel--prompt-positions nil
   "List of prompt positions as (buffer-line . exit-status) pairs.
 Used for prompt navigation and optional re-application after full redraws.")
@@ -1544,8 +1549,14 @@ This ensures terminal text is visible regardless of the Emacs theme."
                                  :background bg)))
 
 (defun ghostel--set-title (title)
-  "Update the buffer name with TITLE from the terminal."
-  (rename-buffer (format "*ghostel: %s*" title) t))
+  "Update the buffer name with TITLE from the terminal.
+Do not overwrite a manual buffer rename."
+  (let ((new-name (format "*ghostel: %s*" title)))
+    (when (or (null ghostel--managed-buffer-name)
+              (equal (buffer-name) ghostel--managed-buffer-name))
+      (rename-buffer new-name t)
+      ;; Keep the actual name because `rename-buffer' may uniquify it.
+      (setq ghostel--managed-buffer-name (buffer-name)))))
 
 (defun ghostel--set-cursor-style (style visible)
   "Set the cursor style based on terminal state.
@@ -1991,6 +2002,7 @@ wheel events reach ghostel's own scroll commands."
          (buffer (generate-new-buffer buf-name)))
     (with-current-buffer buffer
       (ghostel-mode)
+      (setq ghostel--managed-buffer-name (buffer-name))
       (let* ((height (window-body-height))
              (width (window-max-chars-per-line)))
         (setq ghostel--term

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -317,6 +317,35 @@ cell, so the visual line width must equal the terminal column count."
     (ghostel--write-input term "\e]2;My Title\e\\")
     (should (equal "My Title" (ghostel--get-title term))))) ; title set via OSC 2
 
+(ert-deftest ghostel-test-title-does-not-overwrite-manual-rename ()
+  "Test that title updates do not overwrite a manual buffer rename."
+  (let (buf)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--new)
+                   (lambda (&rest _args) 'fake-term))
+                  ((symbol-function 'ghostel--apply-palette)
+                   (lambda (&rest _args) nil))
+                  ((symbol-function 'ghostel--start-process)
+                   (lambda () nil)))
+          (let ((ghostel--buffer-counter 0))
+            (ghostel)
+            (setq buf (current-buffer)))
+          (with-current-buffer buf
+            (should (equal "*ghostel*" (buffer-name)))
+            (should (equal "*ghostel*" ghostel--managed-buffer-name))
+            (ghostel--set-title "Title A")
+            (should (equal "*ghostel: Title A*" (buffer-name)))
+            (should (equal "*ghostel: Title A*" ghostel--managed-buffer-name))
+            (ghostel--set-title "Title A2")
+            (should (equal "*ghostel: Title A2*" (buffer-name)))
+            (should (equal "*ghostel: Title A2*" ghostel--managed-buffer-name))
+            (rename-buffer "ghostel manual title test" t)
+            (ghostel--set-title "Title B")
+            (should (equal "ghostel manual title test" (buffer-name)))
+            (should (equal "*ghostel: Title A2*" ghostel--managed-buffer-name))))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: CRLF normalization in Zig
 ;; -----------------------------------------------------------------------
@@ -1511,6 +1540,7 @@ cell, so the visual line width must equal the terminal column count."
     ghostel-test-module-version-match
     ghostel-test-module-version-mismatch
     ghostel-test-module-version-newer-than-minimum
+    ghostel-test-title-does-not-overwrite-manual-rename
     ghostel-test-immediate-redraw-triggers-on-small-echo
     ghostel-test-immediate-redraw-skips-large-output
     ghostel-test-immediate-redraw-skips-stale-send


### PR DESCRIPTION
## Summary

This preserves manual buffer renames in Ghostel 

Before this change, `ghostel--set-title` unconditionally renamed the buffer on every title update. That meant a user could rename a Ghostel buffer, but the next shell/TUI title change would overwrite it. I found this particularly prevalent when running agents, e.g. Codex via Ghostel. 

With this change:
- Ghostel tracks the last buffer name it managed itself
- title updates only rename the buffer while the current name still matches that Ghostel-managed name
- once the user manually renames the buffer, later title updates no longer overwrite it

## Notes on Use Case

I like to spin up a bunch of terminals/rename them for a specific use case and ping back and forth. The aggressive title renaming was making this difficult, especially if they were spun up from the same directory. There's other ways to do this / I'm not particular to this implementation, but I would appreciate it being a feature to add if this PR is not how you'd like to approach the need. 

