### PR TITLE
Add evil-mode integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,31 @@ jobs:
             -l test/ghostel-test.el \
             -f ghostel-test-run-elisp
 
+  test-evil:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs_version:
+          - '29.4'
+          - 'snapshot'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs_version }}
+
+      - name: Install evil
+        run: |
+          git clone --depth 1 https://github.com/emacs-evil/evil.git /tmp/evil
+
+      - name: Run ghostel-evil tests
+        run: |
+          emacs --batch -Q -L /tmp/evil -L . \
+            -l ert \
+            -l test/ghostel-evil-test.el \
+            -f ghostel-evil-test-run-elisp
+
   build-native:
     strategy:
       fail-fast: false

--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -19,7 +19,34 @@ jobs:
       - name: Run
         env:
           LOCAL_REPO: ${{ github.workspace }}
-          RECIPE: (ghostel :fetcher github :repo "dakra/ghostel")
+          RECIPE: (ghostel :fetcher github :repo "dakra/ghostel" :files ("ghostel.el" "ghostel-debug.el" "ghostel-module.*"))
+          EXIST_OK: false
+          WARN_IS_ERROR: true
+        run: make -C ~/melpazoid
+
+  build-evil:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with: { python-version: '3.10' }
+      - name: Install
+        run: |
+          sudo apt-get install emacs && emacs --version
+          git clone https://github.com/riscy/melpazoid.git ~/melpazoid
+      - name: Install dependencies
+        run: |
+          emacs --batch -Q \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(package-refresh-contents)" \
+            --eval "(package-install 'evil)"
+      - name: Run
+        env:
+          LOCAL_REPO: ${{ github.workspace }}
+          RECIPE: (ghostel-evil :fetcher github :repo "dakra/ghostel" :files ("ghostel-evil.el"))
           EXIST_OK: false
           WARN_IS_ERROR: true
         run: make -C ~/melpazoid

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,13 @@ EMACS ?= emacs
 
 XDG_CACHE_HOME ?= $(HOME)/.cache
 MELPAZOID_DIR  ?= $(XDG_CACHE_HOME)/melpazoid
+EVIL_DIR       ?= $(XDG_CACHE_HOME)/evil
 
 ELC := ghostel.elc ghostel-debug.elc
 
-.PHONY: all build check test test-all lint melpazoid byte-compile bench bench-quick clean
+.PHONY: all build check test test-all test-evil lint melpazoid byte-compile bench bench-quick clean
 
-all: build test-all lint
+all: build test-all test-evil lint
 
 build:
 	./build.sh
@@ -27,6 +28,13 @@ test: $(ELC)
 
 test-all: build $(ELC)
 	$(EMACS) --batch -Q -L . -l ert -l test/ghostel-test.el -f ghostel-test-run
+
+test-evil:
+	@if [ ! -d "$(EVIL_DIR)" ]; then \
+		git clone --depth 1 https://github.com/emacs-evil/evil.git "$(EVIL_DIR)"; \
+	fi
+	$(EMACS) --batch -Q -L "$(EVIL_DIR)" -L . \
+		-l ert -l test/ghostel-evil-test.el -f ghostel-evil-test-run
 
 byte-compile: $(ELC)
 
@@ -60,7 +68,7 @@ melpazoid:
 	@if [ ! -d "$(MELPAZOID_DIR)" ]; then \
 		git clone https://github.com/riscy/melpazoid.git "$(MELPAZOID_DIR)"; \
 	fi
-	RECIPE='(ghostel :fetcher github :repo "dakra/ghostel")' \
+	RECIPE='(ghostel :fetcher github :repo "dakra/ghostel" :files ("ghostel.el" "ghostel-debug.el" "ghostel-module.*"))' \
 		LOCAL_REPO=$(CURDIR) \
 		make -C "$(MELPAZOID_DIR)"
 

--- a/README.md
+++ b/README.md
@@ -406,6 +406,35 @@ individual faces with `M-x customize-face`.
 | `ghostel-copy-mode-auto-load-scrollback` | `nil`        | Load full scrollback automatically when entering copy mode |
 | `ghostel-exit-functions`         | `nil`                | Hook run when the shell process exits                    |
 
+## Evil-mode
+
+Ghostel includes optional `evil-mode` support via `ghostel-evil.el`.
+It synchronizes the terminal cursor with Emacs point during evil state
+transitions so that normal-mode navigation (`hjkl` etc.) works
+correctly.
+
+To enable:
+
+```elisp
+(use-package ghostel-evil
+  :after (ghostel evil)
+  :hook (ghostel-mode . ghostel-evil-mode))
+```
+
+When `ghostel-evil-mode` is active:
+
+- Ghostel starts in **insert state** (terminal input works normally)
+- Pressing **ESC** enters normal state and snaps point to the terminal cursor
+- Normal-mode navigation (`h`, `j`, `k`, `l`, `w`, `b`, `e`, `0`, `$`, ...) works as expected
+- **Insert/append** (`i`, `a`, `I`, `A`) sync the terminal cursor to point before entering insert state
+- **Delete** (`d`, `dw`, `dd`, `D`, `x`, `X`) yanks text to the kill ring and deletes via the shell
+- **Change** (`c`, `cw`, `cc`, `C`, `s`, `S`) deletes then enters insert state
+- **Replace** (`r`) replaces the character under the cursor
+- **Paste** (`p`, `P`) pastes from the kill ring via bracketed paste
+- **Undo** (`u`) sends readline undo (`Ctrl+_`)
+- Cursor shape follows evil state (block for normal, bar for insert)
+- Alt-screen programs (vim, less, htop) are unaffected
+
 ## Commands
 
 | Command                        | Description                                  |

--- a/ghostel-evil.el
+++ b/ghostel-evil.el
@@ -1,0 +1,349 @@
+;;; ghostel-evil.el --- Evil-mode integration for ghostel -*- lexical-binding: t; -*-
+
+;; Copyright (c) 2026 Daniel Kraus <daniel@kraus.my>
+
+;; Author: Daniel Kraus <daniel@kraus.my>
+;; URL: https://github.com/dakra/ghostel
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "28.1") (evil "1.0") (ghostel "0.8.0"))
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is NOT part of GNU Emacs.
+
+;;; Commentary:
+
+;; Provides evil-mode compatibility for the ghostel terminal emulator.
+;; Synchronizes the terminal cursor with Emacs point during evil state
+;; transitions so that normal-mode navigation works correctly.
+;;
+;; Enable by adding to your init:
+;;
+;;   (use-package ghostel-evil
+;;     :after (ghostel evil)
+;;     :hook (ghostel-mode . ghostel-evil-mode))
+
+;;; Code:
+
+(require 'evil)
+(require 'ghostel)
+
+;; ---------------------------------------------------------------------------
+;; Guard predicate
+;; ---------------------------------------------------------------------------
+
+(defun ghostel-evil--active-p ()
+  "Return non-nil when ghostel-evil editing should intercept."
+  (and ghostel-evil-mode
+       ghostel--term
+       (not (ghostel--mode-enabled ghostel--term 1049))
+       (not ghostel--copy-mode-active)))
+
+;; ---------------------------------------------------------------------------
+;; Cursor synchronization
+;; ---------------------------------------------------------------------------
+
+(defun ghostel-evil--reset-cursor-point ()
+  "Move Emacs point to the terminal cursor position."
+  (when ghostel--term
+    (let ((pos (ghostel--cursor-position ghostel--term)))
+      (when pos
+        (goto-char (point-min))
+        (forward-line (cdr pos))
+        (move-to-column (car pos))))))
+
+(defun ghostel-evil--cursor-to-point ()
+  "Move the terminal cursor to Emacs point by sending arrow keys."
+  (when ghostel--term
+    (let* ((tpos (ghostel--cursor-position ghostel--term))
+           (tcol (car tpos))
+           (trow (cdr tpos))
+           (ecol (current-column))
+           (erow (- (line-number-at-pos (point) t) 1))
+           (dy (- erow trow))
+           (dx (- ecol tcol)))
+      (cond ((> dy 0) (dotimes (_ dy) (ghostel--send-encoded "down" "")))
+            ((< dy 0) (dotimes (_ (abs dy)) (ghostel--send-encoded "up" ""))))
+      (cond ((> dx 0) (dotimes (_ dx) (ghostel--send-encoded "right" "")))
+            ((< dx 0) (dotimes (_ (abs dx)) (ghostel--send-encoded "left" "")))))))
+
+;; ---------------------------------------------------------------------------
+;; Redraw: preserve point in normal state
+;; ---------------------------------------------------------------------------
+
+(defun ghostel-evil--around-redraw (orig-fn term &optional full)
+  "Preserve Emacs point during redraws in evil normal state.
+Without this, the ~30fps redraw timer would snap point back to
+the terminal cursor, undoing any evil normal-mode navigation."
+  (if (and ghostel-evil-mode
+           (not (eq evil-state 'insert))
+           (not (ghostel--mode-enabled term 1049)))
+      (let ((saved-point (point)))
+        (funcall orig-fn term full)
+        (goto-char (min saved-point (point-max))))
+    (funcall orig-fn term full)))
+
+;; ---------------------------------------------------------------------------
+;; Cursor style: let evil control cursor shape
+;; ---------------------------------------------------------------------------
+
+(defun ghostel-evil--override-cursor-style (orig-fn style visible)
+  "Let evil control cursor shape instead of the terminal.
+In alt-screen mode, defer to the terminal's cursor style."
+  (if (and ghostel-evil-mode
+           ghostel--term
+           (not (ghostel--mode-enabled ghostel--term 1049)))
+      (evil-refresh-cursor)
+    (funcall orig-fn style visible)))
+
+;; ---------------------------------------------------------------------------
+;; Evil state hooks
+;; ---------------------------------------------------------------------------
+
+(defvar ghostel-evil--sync-inhibit nil
+  "When non-nil, skip arrow-key sync in the insert-state-entry hook.
+Set by the `I'/`A' advice which send Home/End directly.")
+
+(defun ghostel-evil--normal-state-entry ()
+  "Snap Emacs point to the terminal cursor when entering normal state."
+  (when (and (derived-mode-p 'ghostel-mode) (ghostel-evil--active-p))
+    (ghostel-evil--reset-cursor-point)))
+
+(defun ghostel-evil--insert-state-entry ()
+  "Sync terminal cursor to Emacs point when entering insert state.
+Skipped when `ghostel-evil--sync-inhibit' is set (by I/A advice
+which already sent C-a/C-e).
+When point is on a different row from the terminal cursor, snap
+back to the terminal cursor instead of sending up/down arrows
+which the shell would interpret as history navigation."
+  (when (derived-mode-p 'ghostel-mode)
+    (if ghostel-evil--sync-inhibit
+        (setq ghostel-evil--sync-inhibit nil)
+      (when ghostel--term
+        (let* ((tpos (ghostel--cursor-position ghostel--term))
+               (trow (cdr tpos))
+               (erow (- (line-number-at-pos (point) t) 1)))
+          (if (= erow trow)
+              (ghostel-evil--cursor-to-point)
+            (ghostel-evil--reset-cursor-point)))))))
+
+(defun ghostel-evil--escape-stay ()
+  "Disable `evil-move-cursor-back' in ghostel buffers.
+Moving the cursor back on ESC desynchronizes point from the terminal
+cursor."
+  (setq-local evil-move-cursor-back nil))
+
+;; ---------------------------------------------------------------------------
+;; Advice for evil insert-line / append-line
+;; ---------------------------------------------------------------------------
+
+(defun ghostel-evil--before-insert-line (&rest _)
+  "Send C-a to move terminal cursor to start of input."
+  (when (and ghostel-evil-mode ghostel--term)
+    (ghostel--send-encoded "a" "ctrl")
+    (setq ghostel-evil--sync-inhibit t)))
+
+(defun ghostel-evil--before-append-line (&rest _)
+  "Send C-e to move terminal cursor to end of input."
+  (when (and ghostel-evil-mode ghostel--term)
+    (ghostel--send-encoded "e" "ctrl")
+    (setq ghostel-evil--sync-inhibit t)))
+
+;; ---------------------------------------------------------------------------
+;; Editing primitives
+;; ---------------------------------------------------------------------------
+
+(defun ghostel-evil--delete-region (beg end)
+  "Delete text between BEG and END via the terminal PTY.
+Moves terminal cursor to END, then sends backspace keys.
+Uses backspace rather than forward-delete because the Delete key
+escape sequence is not bound in all shell configurations."
+  (let ((count (- end beg)))
+    (when (> count 0)
+      (goto-char end)
+      (ghostel-evil--cursor-to-point)
+      (dotimes (_ count)
+        (ghostel--send-encoded "backspace" ""))
+      (goto-char beg))))
+
+;; ---------------------------------------------------------------------------
+;; Advice for evil editing operators
+;; ---------------------------------------------------------------------------
+
+(defun ghostel-evil--around-delete (orig-fn beg end type register yank-handler)
+  "Intercept `evil-delete' in ghostel buffers.
+Yanks text to REGISTER, then deletes via PTY.
+Covers d, dd, D, x, X."
+  (if (ghostel-evil--active-p)
+      (progn
+        (unless register
+          (let ((text (filter-buffer-substring beg end)))
+            (unless (string-match-p "\n" text)
+              (evil-set-register ?- text))))
+        (let ((evil-was-yanked-without-register nil))
+          (evil-yank beg end type register yank-handler))
+        (if (eq type 'line)
+            ;; For line-type (dd): clear the input line
+            (progn
+              (ghostel--send-encoded "e" "ctrl")
+              (ghostel--send-encoded "u" "ctrl"))
+          (ghostel-evil--delete-region beg end)))
+    (funcall orig-fn beg end type register yank-handler)))
+
+(defun ghostel-evil--around-change
+    (orig-fn beg end type register yank-handler &optional delete-func)
+  "Intercept `evil-change' in ghostel buffers.
+Deletes via PTY, then enters insert state.
+Covers c, cc, C, s, S."
+  (if (ghostel-evil--active-p)
+      (progn
+        (let ((evil-was-yanked-without-register nil))
+          (evil-yank beg end type register yank-handler))
+        (if (eq type 'line)
+            (progn
+              (ghostel--send-encoded "e" "ctrl")
+              (ghostel--send-encoded "u" "ctrl"))
+          (ghostel-evil--delete-region beg end))
+        (setq ghostel-evil--sync-inhibit t)
+        (evil-insert 1))
+    (funcall orig-fn beg end type register yank-handler delete-func)))
+
+(defun ghostel-evil--around-replace (orig-fn beg end type char)
+  "Intercept `evil-replace' in ghostel buffers.
+Deletes the range, then inserts replacement characters."
+  (if (ghostel-evil--active-p)
+      (when char
+        (let ((count (- end beg)))
+          (ghostel-evil--delete-region beg end)
+          (ghostel--paste-text (make-string count char))))
+    (funcall orig-fn beg end type char)))
+
+(defun ghostel-evil--around-paste-after
+    (orig-fn count &optional register yank-handler)
+  "Intercept `evil-paste-after' in ghostel buffers.
+Pastes from REGISTER via the terminal PTY."
+  (if (ghostel-evil--active-p)
+      (let ((text (if register
+                      (evil-get-register register)
+                    (current-kill 0)))
+            (count (prefix-numeric-value count)))
+        (when text
+          (ghostel-evil--cursor-to-point)
+          (ghostel--send-encoded "right" "")
+          (dotimes (_ count)
+            (ghostel--paste-text text))))
+    (funcall orig-fn count register yank-handler)))
+
+(defun ghostel-evil--around-paste-before
+    (orig-fn count &optional register yank-handler)
+  "Intercept `evil-paste-before' in ghostel buffers.
+Pastes from REGISTER via the terminal PTY."
+  (if (ghostel-evil--active-p)
+      (let ((text (if register
+                      (evil-get-register register)
+                    (current-kill 0)))
+            (count (prefix-numeric-value count)))
+        (when text
+          (ghostel-evil--cursor-to-point)
+          (dotimes (_ count)
+            (ghostel--paste-text text))))
+    (funcall orig-fn count register yank-handler)))
+
+;; ---------------------------------------------------------------------------
+;; Insert-state Ctrl key passthrough
+;; ---------------------------------------------------------------------------
+
+(defvar ghostel-evil-mode-map (make-sparse-keymap)
+  "Keymap for `ghostel-evil-mode'.
+Insert-state Ctrl key bindings are set up via `evil-define-key*'.")
+
+(defconst ghostel-evil--ctrl-passthrough-keys
+  '("a" "d" "e" "k" "n" "p" "r" "t" "u" "w" "y")
+  "Ctrl+key combinations to pass through to the terminal in insert state.
+These keys all have standard readline/zle bindings (C-a beginning-of-line,
+C-d EOF, C-e end-of-line, C-k kill-line, etc.) that would otherwise be
+intercepted by evil's insert-state commands.")
+
+(defun ghostel-evil--passthrough-ctrl (key)
+  "Send Ctrl+KEY to the terminal PTY, or fall back to evil's binding.
+Used for insert-state Ctrl keys that have readline/zle equivalents."
+  (if (ghostel-evil--active-p)
+      (ghostel--send-encoded key "ctrl")
+    (let ((cmd (lookup-key evil-insert-state-map (kbd (concat "C-" key)))))
+      (when (commandp cmd)
+        (call-interactively cmd)))))
+
+(dolist (key ghostel-evil--ctrl-passthrough-keys)
+  (let ((k key))
+    (evil-define-key* 'insert ghostel-evil-mode-map
+      (kbd (concat "C-" k))
+      (defalias (intern (format "ghostel-evil--passthrough-ctrl-%s" k))
+        (lambda ()
+          (interactive)
+          (ghostel-evil--passthrough-ctrl k))
+        (format "Send C-%s to the terminal or fall back to evil." k)))))
+
+(defun ghostel-evil--around-undo (orig-fn count)
+  "Intercept `evil-undo' in ghostel buffers.
+Sends Ctrl+_ (readline undo) COUNT times."
+  (if (ghostel-evil--active-p)
+      (dotimes (_ (or count 1))
+        (ghostel--send-encoded "_" "ctrl"))
+    (funcall orig-fn count)))
+
+(defun ghostel-evil--around-redo (orig-fn count)
+  "Intercept `evil-redo' in ghostel buffers."
+  (if (ghostel-evil--active-p)
+      (message "Redo not supported in terminal")
+    (funcall orig-fn count)))
+
+;; ---------------------------------------------------------------------------
+;; Minor mode
+;; ---------------------------------------------------------------------------
+
+;;;###autoload
+(define-minor-mode ghostel-evil-mode
+  "Minor mode for evil integration in ghostel terminal buffers.
+Synchronizes the terminal cursor with Emacs point during evil
+state transitions."
+  :lighter nil
+  :keymap ghostel-evil-mode-map
+  (if ghostel-evil-mode
+      (progn
+        (evil-set-initial-state 'ghostel-mode 'insert)
+        (ghostel-evil--escape-stay)
+        (add-hook 'evil-normal-state-entry-hook
+                  #'ghostel-evil--normal-state-entry nil t)
+        (add-hook 'evil-insert-state-entry-hook
+                  #'ghostel-evil--insert-state-entry nil t)
+        (advice-add 'evil-insert-line :before #'ghostel-evil--before-insert-line)
+        (advice-add 'evil-append-line :before #'ghostel-evil--before-append-line)
+        (advice-add 'evil-delete :around #'ghostel-evil--around-delete)
+        (advice-add 'evil-change :around #'ghostel-evil--around-change)
+        (advice-add 'evil-replace :around #'ghostel-evil--around-replace)
+        (advice-add 'evil-paste-after :around #'ghostel-evil--around-paste-after)
+        (advice-add 'evil-paste-before :around #'ghostel-evil--around-paste-before)
+        (advice-add 'evil-undo :around #'ghostel-evil--around-undo)
+        (advice-add 'evil-redo :around #'ghostel-evil--around-redo)
+        (advice-add 'ghostel--redraw :around #'ghostel-evil--around-redraw)
+        (advice-add 'ghostel--set-cursor-style :around
+                    #'ghostel-evil--override-cursor-style)
+        (evil-refresh-cursor))
+    (remove-hook 'evil-normal-state-entry-hook
+                 #'ghostel-evil--normal-state-entry t)
+    (remove-hook 'evil-insert-state-entry-hook
+                 #'ghostel-evil--insert-state-entry t)
+    (advice-remove 'evil-insert-line #'ghostel-evil--before-insert-line)
+    (advice-remove 'evil-append-line #'ghostel-evil--before-append-line)
+    (advice-remove 'evil-delete #'ghostel-evil--around-delete)
+    (advice-remove 'evil-change #'ghostel-evil--around-change)
+    (advice-remove 'evil-replace #'ghostel-evil--around-replace)
+    (advice-remove 'evil-paste-after #'ghostel-evil--around-paste-after)
+    (advice-remove 'evil-paste-before #'ghostel-evil--around-paste-before)
+    (advice-remove 'evil-undo #'ghostel-evil--around-undo)
+    (advice-remove 'evil-redo #'ghostel-evil--around-redo)
+    (advice-remove 'ghostel--redraw #'ghostel-evil--around-redraw)
+    (advice-remove 'ghostel--set-cursor-style
+                   #'ghostel-evil--override-cursor-style)))
+
+(provide 'ghostel-evil)
+;;; ghostel-evil.el ends here

--- a/test/ghostel-evil-test.el
+++ b/test/ghostel-evil-test.el
@@ -1,0 +1,579 @@
+;;; ghostel-evil-test.el --- Tests for ghostel-evil -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Run with:
+;;   emacs --batch -Q -L ~/.emacs.d/lib/evil -L . \
+;;     -l ert -l test/ghostel-evil-test.el -f ghostel-evil-test-run
+
+;;; Code:
+
+(require 'ert)
+(require 'evil)
+(require 'ghostel)
+(require 'ghostel-evil)
+
+;; -----------------------------------------------------------------------
+;; Helper: set up a ghostel buffer with evil
+;; -----------------------------------------------------------------------
+
+(defmacro ghostel-evil-test--with-buffer (rows cols text &rest body)
+  "Create a ghostel buffer with ROWS x COLS, feed TEXT, render, then run BODY.
+The buffer has evil-mode and ghostel-evil-mode active.
+The variable `term' is bound to the terminal handle.
+Requires the native module."
+  (declare (indent 3) (debug t))
+  `(let ((term (ghostel--new ,rows ,cols 100)))
+     (ghostel--write-input term ,text)
+     (with-temp-buffer
+       (ghostel-mode)
+       (setq-local ghostel--term term)
+       (evil-local-mode 1)
+       (ghostel-evil-mode 1)
+       (let ((inhibit-read-only t))
+         (ghostel--redraw term t))
+       ,@body)))
+
+(defmacro ghostel-evil-test--with-evil-buffer (&rest body)
+  "Set up a ghostel buffer with evil-mode active (no native module).
+Uses mocks for native functions."
+  (declare (indent 0) (debug t))
+  `(with-temp-buffer
+     (ghostel-mode)
+     (evil-local-mode 1)
+     (ghostel-evil-mode 1)
+     ,@body))
+
+;; -----------------------------------------------------------------------
+;; Test: mode activation
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-mode-activation ()
+  "Test that `ghostel-evil-mode' activates correctly."
+  (ghostel-evil-test--with-evil-buffer
+   (should ghostel-evil-mode)
+   (should (memq 'ghostel-evil--normal-state-entry
+                 evil-normal-state-entry-hook))
+   (should (memq 'ghostel-evil--insert-state-entry
+                 evil-insert-state-entry-hook))
+   (should (advice--p (advice--symbol-function 'evil-insert-line)))
+   (should (advice--p (advice--symbol-function 'ghostel--redraw)))
+   (should (advice--p (advice--symbol-function 'ghostel--set-cursor-style)))))
+
+(ert-deftest ghostel-evil-test-mode-deactivation ()
+  "Test that `ghostel-evil-mode' cleans up on deactivation."
+  (ghostel-evil-test--with-evil-buffer
+   (ghostel-evil-mode -1)
+   (should-not ghostel-evil-mode)
+   (should-not (memq 'ghostel-evil--normal-state-entry
+                     evil-normal-state-entry-hook))
+   (should-not (memq 'ghostel-evil--insert-state-entry
+                     evil-insert-state-entry-hook))))
+
+;; -----------------------------------------------------------------------
+;; Test: escape-stay (evil-move-cursor-back disabled)
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-escape-stay ()
+  "Test that `evil-move-cursor-back' is disabled in ghostel buffers."
+  (ghostel-evil-test--with-evil-buffer
+   (should-not evil-move-cursor-back)))
+
+;; -----------------------------------------------------------------------
+;; Test: reset-cursor-point
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-reset-cursor-point ()
+  "Test that `ghostel-evil--reset-cursor-point' moves point to terminal cursor."
+  (ghostel-evil-test--with-buffer 5 40 "hello world"
+                                  ;; Terminal cursor is at col 11, row 0
+                                  (should (equal '(11 . 0) (ghostel--cursor-position term)))
+                                  ;; Move point somewhere else
+                                  (goto-char (point-min))
+                                  (should (= 0 (current-column)))
+                                  ;; Reset should snap back to terminal cursor
+                                  (ghostel-evil--reset-cursor-point)
+                                  (should (= 11 (current-column)))
+                                  (should (= 1 (line-number-at-pos)))))
+
+(ert-deftest ghostel-evil-test-reset-cursor-point-multiline ()
+  "Test cursor reset with text on multiple lines."
+  (ghostel-evil-test--with-buffer 5 40 "line1\nline2-text"
+                                  ;; Cursor should be on row 1 (second line)
+                                  (let ((pos (ghostel--cursor-position term)))
+                                    (should (= 1 (cdr pos))))
+                                  (goto-char (point-min))
+                                  (ghostel-evil--reset-cursor-point)
+                                  (should (= 2 (line-number-at-pos)))))
+
+;; -----------------------------------------------------------------------
+;; Test: cursor-to-point (arrow key sending)
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-cursor-to-point ()
+  "Test that `ghostel-evil--cursor-to-point' sends correct arrow keys."
+  (ghostel-evil-test--with-buffer 5 40 "$ echo hello world"
+                                  ;; Terminal cursor at col 18, row 0
+                                  (should (equal '(18 . 0) (ghostel--cursor-position term)))
+                                  ;; Move point to col 7 (start of "hello")
+                                  (goto-char (point-min))
+                                  (move-to-column 7)
+                                  ;; Track what keys are sent
+                                  (let ((keys-sent '()))
+                                    (cl-letf (((symbol-function 'ghostel--send-encoded)
+                                               (lambda (key _mods &rest _)
+                                                 (push key keys-sent))))
+                                      (ghostel-evil--cursor-to-point))
+                                    ;; Should send 11 LEFT arrows (18 - 7 = 11)
+                                    (should (= 11 (length keys-sent)))
+                                    (should (cl-every (lambda (k) (equal k "left")) keys-sent)))))
+
+(ert-deftest ghostel-evil-test-cursor-to-point-right ()
+  "Test arrow key sending when point is to the right of terminal cursor."
+  (ghostel-evil-test--with-buffer 5 40 "hello"
+                                  ;; Terminal cursor at col 5
+                                  ;; Move cursor left in terminal, then move point right of it
+                                  (ghostel--write-input term "\e[3D") ; cursor left 3 → col 2
+                                  (goto-char (point-min))
+                                  (move-to-column 4) ; point at col 4
+                                  (let ((keys-sent '()))
+                                    (cl-letf (((symbol-function 'ghostel--send-encoded)
+                                               (lambda (key _mods &rest _)
+                                                 (push key keys-sent))))
+                                      (ghostel-evil--cursor-to-point))
+                                    ;; Should send 2 RIGHT arrows (4 - 2 = 2)
+                                    (should (= 2 (length keys-sent)))
+                                    (should (cl-every (lambda (k) (equal k "right")) keys-sent)))))
+
+(ert-deftest ghostel-evil-test-cursor-to-point-no-op ()
+  "Test that no arrows are sent when point matches terminal cursor."
+  (ghostel-evil-test--with-buffer 5 40 "hello"
+                                  ;; Point is already at terminal cursor after redraw
+                                  (let ((keys-sent '()))
+                                    (cl-letf (((symbol-function 'ghostel--send-encoded)
+                                               (lambda (key _mods &rest _)
+                                                 (push key keys-sent))))
+                                      (ghostel-evil--cursor-to-point))
+                                    (should (= 0 (length keys-sent))))))
+
+;; -----------------------------------------------------------------------
+;; Test: redraw preserves point in normal state
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-redraw-preserves-point-normal ()
+  "Test that redraws preserve point in evil normal state."
+  (ghostel-evil-test--with-buffer 5 40 "hello world"
+                                  (evil-normal-state)
+                                  ;; Move point to col 5 (between "hello" and "world")
+                                  (goto-char (point-min))
+                                  (move-to-column 5)
+                                  (should (= 5 (current-column)))
+                                  ;; Redraw — should NOT move point back to terminal cursor
+                                  (let ((inhibit-read-only t))
+                                    (ghostel--redraw term t))
+                                  (should (= 5 (current-column)))))
+
+(ert-deftest ghostel-evil-test-redraw-moves-point-insert ()
+  "Test that redraws move point to terminal cursor in insert state."
+  (ghostel-evil-test--with-buffer 5 40 "hello world"
+                                  (evil-insert-state)
+                                  ;; Move point away from terminal cursor
+                                  (goto-char (point-min))
+                                  ;; Redraw — should snap point to terminal cursor (col 11)
+                                  (let ((inhibit-read-only t))
+                                    (ghostel--redraw term t))
+                                  (should (= 11 (current-column)))))
+
+;; -----------------------------------------------------------------------
+;; Test: advice fires on evil-insert / evil-append
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-advice-on-insert ()
+  "Test that `ghostel-evil--before-insert' fires on `evil-insert'."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0))))
+     (evil-normal-state)
+     (let ((sync-called nil))
+       (cl-letf (((symbol-function 'ghostel-evil--cursor-to-point)
+                  (lambda () (setq sync-called t))))
+         (evil-insert 1))
+       (should sync-called)))))
+
+(ert-deftest ghostel-evil-test-advice-on-append ()
+  "Test that `ghostel-evil--before-append' fires on `evil-append'."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "hello")
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(5 . 0))))
+     (evil-normal-state)
+     (goto-char (point-min))
+     (move-to-column 2)
+     (let ((sync-called nil))
+       (cl-letf (((symbol-function 'ghostel-evil--cursor-to-point)
+                  (lambda () (setq sync-called t))))
+         (evil-append 1))
+       (should sync-called)))))
+
+(ert-deftest ghostel-evil-test-advice-insert-line-sends-home ()
+  "Test that `evil-insert-line' sends C-a and inhibits hook sync."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0))))
+     (evil-normal-state)
+     (let ((keys-sent '()))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _)
+                    (push key keys-sent))))
+         (evil-insert-line 1))
+       (should (member "a" keys-sent))
+       ;; Hook should NOT have sent additional arrow keys
+       (should-not (member "left" keys-sent))
+       (should-not (member "right" keys-sent))))))
+
+(ert-deftest ghostel-evil-test-advice-append-line-sends-end ()
+  "Test that `evil-append-line' sends C-e and inhibits hook sync."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0))))
+     (evil-normal-state)
+     (let ((keys-sent '()))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _)
+                    (push key keys-sent))))
+         (evil-append-line 1))
+       (should (member "e" keys-sent))
+       ;; Hook should NOT have sent additional arrow keys
+       (should-not (member "left" keys-sent))
+       (should-not (member "right" keys-sent))))))
+
+;; -----------------------------------------------------------------------
+;; Test: advice is no-op outside ghostel buffers
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-advice-no-op-outside-ghostel ()
+  "Test that advice does nothing when `ghostel-evil-mode' is nil."
+  (with-temp-buffer
+    (evil-local-mode 1)
+    (evil-normal-state)
+    (let ((sync-called nil))
+      (cl-letf (((symbol-function 'ghostel-evil--cursor-to-point)
+                 (lambda () (setq sync-called t))))
+        (evil-insert 1))
+      (should-not sync-called))))
+
+;; -----------------------------------------------------------------------
+;; Test: cursor style override
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-cursor-style-override ()
+  "Test that `ghostel--set-cursor-style' defers to evil."
+  (ghostel-evil-test--with-buffer 5 40 "hello"
+                                  (evil-normal-state)
+                                  (let ((evil-called nil)
+                                        (orig-called nil))
+                                    (cl-letf (((symbol-function 'evil-refresh-cursor)
+                                               (lambda (&rest _) (setq evil-called t))))
+                                      (ghostel--set-cursor-style 0 t)
+                                      (should evil-called)))))
+
+;; -----------------------------------------------------------------------
+;; Test: normal-state-entry hook
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-normal-entry-snaps-point ()
+  "Test that entering normal state snaps point to terminal cursor."
+  (ghostel-evil-test--with-buffer 5 40 "hello world"
+                                  (evil-insert-state)
+                                  ;; Move point away
+                                  (goto-char (point-min))
+                                  ;; Enter normal state — should snap to terminal cursor
+                                  (evil-normal-state)
+                                  (should (= 11 (current-column)))))
+
+;; -----------------------------------------------------------------------
+;; Test: delete-region primitive
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-delete-region ()
+  "Test that `ghostel-evil--delete-region' sends correct keys."
+  (ghostel-evil-test--with-buffer 5 40 "$ echo hello"
+                                  ;; Delete "hello" (col 7-12)
+                                  (let ((keys-sent '()))
+                                    (cl-letf (((symbol-function 'ghostel--send-encoded)
+                                               (lambda (key _mods &rest _)
+                                                 (push key keys-sent))))
+                                      (ghostel-evil--delete-region 8 13))
+                                    ;; Should send arrow keys to move cursor, then 5 backspaces
+                                    (should (= 5 (cl-count "backspace" keys-sent :test #'equal))))))
+
+;; -----------------------------------------------------------------------
+;; Test: evil-delete advice
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-delete-sends-backspace-keys ()
+  "Test that `evil-delete' advice sends backspace keys via PTY."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "hello world")
+   (goto-char (point-min))
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0)))
+             ((symbol-function 'ghostel-evil--cursor-to-point) #'ignore))
+     (evil-normal-state)
+     (let ((bs-count 0))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _)
+                    (when (equal key "backspace")
+                      (cl-incf bs-count)))))
+         ;; Delete 5 chars (simulates dw on "hello")
+         (evil-delete 1 6 'inclusive nil nil))
+       (should (= 5 bs-count))))))
+
+(ert-deftest ghostel-evil-test-delete-line-sends-ctrl-u ()
+  "Test that line-type `evil-delete' sends Ctrl+U to clear line."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "hello world")
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0))))
+     (evil-normal-state)
+     (let ((keys-sent '()))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key mods &rest _)
+                    (push (cons key mods) keys-sent))))
+         (evil-delete (point-min) (point-max) 'line nil nil))
+       ;; Should have sent C-e and Ctrl+U
+       (should (cl-find '("u" . "ctrl") keys-sent :test #'equal))
+       (should (cl-find '("e" . "ctrl") keys-sent :test #'equal))))))
+
+;; -----------------------------------------------------------------------
+;; Test: evil-change advice
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-change-deletes-and-inserts ()
+  "Test that `evil-change' advice deletes via PTY and enters insert state."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "hello world")
+   (goto-char (point-min))
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0)))
+             ((symbol-function 'ghostel-evil--cursor-to-point) #'ignore))
+     (evil-normal-state)
+     (let ((bs-count 0))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _)
+                    (when (equal key "backspace")
+                      (cl-incf bs-count)))))
+         (evil-change 1 6 'inclusive nil nil nil))
+       (should (= 5 bs-count))
+       (should (eq evil-state 'insert))))))
+
+(ert-deftest ghostel-evil-test-change-whole-line ()
+  "Test that `evil-change-whole-line' (cc/S) works without error.
+Regression: delete-func arg was not optional in advice signature."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "hello world")
+   (goto-char (point-min))
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0)))
+             ((symbol-function 'ghostel--send-encoded) #'ignore))
+     (evil-normal-state)
+     ;; evil-change-whole-line calls evil-change without delete-func
+     (evil-change-whole-line 1 12 nil nil)
+     (should (eq evil-state 'insert)))))
+
+;; -----------------------------------------------------------------------
+;; Test: evil-replace advice
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-replace-deletes-and-inserts ()
+  "Test that `evil-replace' deletes then inserts replacement text."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "hello")
+   (goto-char (point-min))
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0)))
+             ((symbol-function 'ghostel-evil--cursor-to-point) #'ignore))
+     (evil-normal-state)
+     (let ((bs-count 0)
+           (pasted nil))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _)
+                    (when (equal key "backspace")
+                      (cl-incf bs-count))))
+                 ((symbol-function 'ghostel--paste-text)
+                  (lambda (text) (setq pasted text))))
+         (evil-replace 1 4 'inclusive ?X))
+       (should (= 3 bs-count))
+       (should (equal "XXX" pasted))))))
+
+;; -----------------------------------------------------------------------
+;; Test: evil-paste advice
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-paste-after ()
+  "Test that `evil-paste-after' pastes via PTY."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "hello")
+   (kill-new "world")
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0)))
+             ((symbol-function 'ghostel-evil--cursor-to-point) #'ignore))
+     (evil-normal-state)
+     (let ((pasted nil))
+       (cl-letf (((symbol-function 'ghostel--paste-text)
+                  (lambda (text) (setq pasted text)))
+                 ((symbol-function 'ghostel--send-encoded) #'ignore))
+         (evil-paste-after 1))
+       (should (equal "world" pasted))))))
+
+;; -----------------------------------------------------------------------
+;; Test: insert-state Ctrl key passthrough
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-ctrl-passthrough-sends-to-terminal ()
+  "Test that Ctrl keys in insert state are sent to the terminal."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "hello world")
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(11 . 0))))
+     (evil-insert-state)
+     ;; Test a sample of keys from ghostel-evil--ctrl-passthrough-keys
+     (dolist (key '("a" "d" "e" "k" "r" "u" "w" "y"))
+       (let ((keys-sent '()))
+         (cl-letf (((symbol-function 'ghostel--send-encoded)
+                    (lambda (k mods &rest _)
+                      (push (cons k mods) keys-sent))))
+           (ghostel-evil--passthrough-ctrl key))
+         (should (cl-find (cons key "ctrl") keys-sent :test #'equal)))))))
+
+;; -----------------------------------------------------------------------
+;; Test: insert-state entry skips vertical sync
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-insert-entry-no-vertical-sync ()
+  "Test that entering insert from a different row snaps to terminal cursor.
+Prevents up/down arrows being sent as history navigation."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "line one\nline two\nline three")
+   ;; Terminal cursor on row 2 (last line), col 5
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(5 . 2))))
+     (evil-normal-state)
+     ;; Move point to row 0 (first line) simulating `kk`
+     (goto-char (point-min))
+     (let ((keys-sent '()))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key mods &rest _)
+                    (push key keys-sent))))
+         (evil-insert-state))
+       ;; Should NOT have sent up/down arrows
+       (should-not (member "up" keys-sent))
+       (should-not (member "down" keys-sent))
+       ;; Point should have snapped to terminal cursor row
+       (should (= (line-number-at-pos (point) t) 3))))))
+
+;; -----------------------------------------------------------------------
+;; Test: insert-state entry syncs column on same row
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-insert-entry-syncs-column-same-row ()
+  "Test that entering insert on the same row syncs column position."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "hello world")
+   ;; Terminal cursor on row 0, col 0
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0))))
+     (evil-normal-state)
+     ;; Move point to col 5 on the same row
+     (goto-char (point-min))
+     (move-to-column 5)
+     (let ((keys-sent '()))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _)
+                    (push key keys-sent))))
+         (evil-insert-state))
+       ;; Should have sent right arrows to sync column
+       (should (member "right" keys-sent))
+       ;; Should NOT have sent vertical arrows
+       (should-not (member "up" keys-sent))
+       (should-not (member "down" keys-sent))))))
+
+;; -----------------------------------------------------------------------
+;; Test: evil-undo advice
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-undo-sends-ctrl-underscore ()
+  "Test that `evil-undo' sends Ctrl+_ to the terminal."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0))))
+     (evil-normal-state)
+     (let ((keys-sent '()))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key mods &rest _)
+                    (push (cons key mods) keys-sent))))
+         (evil-undo 3))
+       (should (= 3 (cl-count '("_" . "ctrl") keys-sent :test #'equal)))))))
+
+;; -----------------------------------------------------------------------
+;; Test: advice is no-op outside ghostel
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-evil-test-delete-no-op-outside-ghostel ()
+  "Test that delete advice falls through when not in ghostel."
+  (with-temp-buffer
+    (evil-local-mode 1)
+    (evil-normal-state)
+    (insert "hello world")
+    (goto-char (point-min))
+    ;; evil-delete should work normally (modify buffer)
+    (evil-delete 1 6 'inclusive nil nil)
+    (should (equal " world" (buffer-string)))))
+
+;; -----------------------------------------------------------------------
+;; Runner
+;; -----------------------------------------------------------------------
+
+(defconst ghostel-evil-test--elisp-tests
+  '(ghostel-evil-test-mode-activation
+    ghostel-evil-test-mode-deactivation
+    ghostel-evil-test-escape-stay
+    ghostel-evil-test-advice-on-insert
+    ghostel-evil-test-advice-on-append
+    ghostel-evil-test-advice-insert-line-sends-home
+    ghostel-evil-test-advice-append-line-sends-end
+    ghostel-evil-test-advice-no-op-outside-ghostel
+    ghostel-evil-test-delete-sends-backspace-keys
+    ghostel-evil-test-delete-line-sends-ctrl-u
+    ghostel-evil-test-change-deletes-and-inserts
+    ghostel-evil-test-replace-deletes-and-inserts
+    ghostel-evil-test-paste-after
+    ghostel-evil-test-undo-sends-ctrl-underscore
+    ghostel-evil-test-change-whole-line
+    ghostel-evil-test-delete-no-op-outside-ghostel)
+  "Tests that require only Elisp (no native module).")
+
+(defun ghostel-evil-test-run-elisp ()
+  "Run only pure Elisp tests (no native module required)."
+  (ert-run-tests-batch-and-exit
+   `(member ,@ghostel-evil-test--elisp-tests)))
+
+(defun ghostel-evil-test-run ()
+  "Run all ghostel-evil tests."
+  (ert-run-tests-batch-and-exit "^ghostel-evil-test-"))
+
+;;; ghostel-evil-test.el ends here


### PR DESCRIPTION
## Summary
- Adds `ghostel-evil.el` with cursor synchronization between Emacs point and terminal cursor during evil state transitions
- Entering normal state snaps point to the terminal cursor; entering insert state (`i`/`a`/`I`/`A`) sends arrow keys to move the terminal cursor to point
- Alt-screen programs (vim, less) are unaffected
- Adds evil-mode section to README
- Splits melpazoid CI into two jobs: one for ghostel, one for ghostel-evil (with evil installed)

Closes #52

## Test plan
- [x] Open ghostel with evil-mode enabled
- [x] Type text in insert mode, ESC to normal, move with hjkl, press `i` — characters should appear at cursor position
- [x] Verify `a`, `I`, `A` also insert at the correct position
- [x] Verify alt-screen apps (vim, less) are unaffected
- [x] Byte-compile: `emacs --batch -Q -L . -f batch-byte-compile ghostel-evil.el`