### PR TITLE
Add ghostel-copy-mode-recenter (C-l) for copy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Normal letter keys exit copy mode and send the key to the terminal.
 | `M-<` / `M->` | Jump to top / bottom of buffer  |
 | `C-c C-n`     | Jump to next prompt             |
 | `C-c C-p`     | Jump to previous prompt         |
+| `C-l`         | Recenter viewport               |
 | `C-c C-t`     | Exit without copying            |
 | `a`–`z`       | Exit and send key to terminal   |
 

--- a/ghostel.el
+++ b/ghostel.el
@@ -1094,6 +1094,37 @@ pasted using bracketed paste."
   (end-of-line)
   (skip-chars-backward " \t"))
 
+(defun ghostel-copy-mode-recenter ()
+  "Recenter the terminal viewport around the current line in copy mode.
+Scrolls the terminal viewport so the current line is vertically
+centered, then redraws.  When the scroll is clamped at a scrollback
+boundary (nothing to scroll into), does nothing."
+  (interactive)
+  (when ghostel--term
+    (let* ((current-line (line-number-at-pos))
+           (win-height (window-body-height))
+           (center (/ win-height 2))
+           (col (current-column)))
+      (unless (= current-line center)
+        ;; Hash the buffer to detect whether the scroll was clamped.
+        (let ((old-hash (buffer-hash)))
+          (ghostel--scroll ghostel--term (- current-line center))
+          (let ((inhibit-read-only t))
+            (ghostel--redraw ghostel--term ghostel-full-redraw))
+          ;; If the buffer changed the viewport actually moved —
+          ;; reposition point at center.  Otherwise the scroll was
+          ;; clamped; restore point since redraw moved it to the
+          ;; terminal cursor.
+          (if (equal old-hash (buffer-hash))
+              (progn
+                (goto-char (point-min))
+                (forward-line (1- current-line))
+                (move-to-column col))
+            (goto-char (point-min))
+            (forward-line (1- (min center (line-number-at-pos (point-max)))))
+            (move-to-column col)
+            (recenter)))))))
+
 
 ;;; Mouse input
 
@@ -1182,6 +1213,7 @@ pasted using bracketed paste."
     (define-key map (kbd "M-<")             #'ghostel-copy-mode-beginning-of-buffer)
     (define-key map (kbd "M->")             #'ghostel-copy-mode-end-of-buffer)
     (define-key map (kbd "C-e")             #'ghostel-copy-mode-end-of-line)
+    (define-key map (kbd "C-l")             #'ghostel-copy-mode-recenter)
     map)
   "Keymap for `ghostel-copy-mode'.
 Standard Emacs navigation works.

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1579,6 +1579,73 @@ cell, so the visual line width must equal the terminal column count."
   ;; M-y should be bound to ghostel-yank-pop, not send-event
   (should (eq (lookup-key ghostel-mode-map (kbd "M-y")) #'ghostel-yank-pop)))
 
+;; -----------------------------------------------------------------------
+;; Test: ghostel-copy-mode-recenter
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-copy-mode-recenter ()
+  "Recenter scrolls terminal viewport to center the current line."
+  (let ((buf (generate-new-buffer " *ghostel-test-copy-mode-recenter*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (dotimes (i 20) (insert (format "line-%02d" i) (make-string 33 ?x) "\n"))
+          (setq ghostel--term 'fake-term)
+          (setq ghostel--copy-mode-active t)
+          (setq buffer-read-only t)
+          (let ((scroll-delta nil)
+                (redraw-called nil)
+                (recenter-called nil))
+            ;; Mock redraw that changes the first line (simulates viewport shift).
+            (cl-letf (((symbol-function 'ghostel--scroll)
+                       (lambda (_term delta) (setq scroll-delta delta)))
+                      ((symbol-function 'ghostel--redraw)
+                       (lambda (_term _full)
+                         (setq redraw-called t)
+                         (save-excursion
+                           (goto-char (point-min))
+                           (delete-char 1)
+                           (insert "!"))))
+                      ((symbol-function 'window-body-height)
+                       (lambda (&rest _) 20))
+                      ((symbol-function 'recenter)
+                       (lambda (&rest _) (setq recenter-called t))))
+              ;; Point on line 5 (above center 10) → scroll viewport up
+              (goto-char (point-min))
+              (forward-line 4)
+              (ghostel-copy-mode-recenter)
+              (should (equal -5 scroll-delta))
+              (should redraw-called)
+              (should recenter-called))
+
+            ;; Mock redraw that does NOT change buffer (simulates clamped scroll).
+            (cl-letf (((symbol-function 'ghostel--scroll)
+                       (lambda (_term delta) (setq scroll-delta delta)))
+                      ((symbol-function 'ghostel--redraw)
+                       (lambda (_term _full) (setq redraw-called t)))
+                      ((symbol-function 'window-body-height)
+                       (lambda (&rest _) 20))
+                      ((symbol-function 'recenter)
+                       (lambda (&rest _) (setq recenter-called t))))
+              ;; Point on line 15 (below center), scroll clamped → no-op
+              (setq scroll-delta nil redraw-called nil recenter-called nil)
+              (goto-char (point-min))
+              (forward-line 14)
+              (ghostel-copy-mode-recenter)
+              (should (equal 5 scroll-delta))
+              (should redraw-called)
+              (should-not recenter-called)
+              (should (= 15 (line-number-at-pos)))
+
+              ;; Point on line 10 (at center) → no scroll at all
+              (setq scroll-delta nil redraw-called nil recenter-called nil)
+              (goto-char (point-min))
+              (forward-line 9)
+              (ghostel-copy-mode-recenter)
+              (should-not scroll-delta)
+              (should-not redraw-called)
+              (should-not recenter-called))))
+      (kill-buffer buf))))
+
 (defconst ghostel-test--elisp-tests
   '(ghostel-test-raw-key-sequences
     ghostel-test-modifier-number
@@ -1613,7 +1680,8 @@ cell, so the visual line width must equal the terminal column count."
     ghostel-test-scroll-on-input-send-event
     ghostel-test-scroll-on-input-disabled
     ghostel-test-control-key-bindings
-    ghostel-test-meta-key-bindings)
+    ghostel-test-meta-key-bindings
+    ghostel-test-copy-mode-recenter)
   "Tests that require only Elisp (no native module).")
 
 (defun ghostel-test-run-elisp ()


### PR DESCRIPTION
## Summary

- Add `ghostel-copy-mode-recenter` bound to `C-l` in copy mode, which scrolls the terminal viewport so the current line is centered and redraws
- Uses `buffer-hash` to detect when the scroll is clamped at a scrollback boundary (top/bottom of scrollback), in which case it's a no-op
- Handles both directions: scrolls viewport up when point is above center (pulling in scrollback), down when below center (after M-v page-up)

## Test plan

- [x] `make all` passes (build, test, lint)
- [x] Manual: enter copy mode, navigate to various lines, press C-l — line should center with full buffer
- [x] Manual: near bottom of scrollback, C-l is a no-op (point stays put)
- [x] Manual: after M-v page-up, move cursor down, C-l recenters correctly with point following the text