### PR TITLE
Fix send-next-key for prefix and modified keys

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -694,26 +694,50 @@ Used for prompt navigation and optional re-application after full redraws.")
 (defun ghostel-send-next-key ()
   "Read the next key event and send it to the terminal.
 This is an escape hatch for sending keys that are normally
-intercepted by Emacs (e.g., interrupt or prefix keys)."
+intercepted by Emacs (e.g., interrupt or prefix keys).
+Uses `read-event' so that prefix keys return immediately instead
+of waiting for a continuation keystroke."
   (interactive)
-  (let* ((key (read-key-sequence "Send key: "))
-         (char (aref key 0)))
+  (let ((event (read-event "Send key: ")))
     (cond
-     ;; Control character
-     ((and (integerp char) (<= char 31))
-      (ghostel--send-key (string char)))
-     ;; Regular character
-     ((and (integerp char) (< char 128))
-      (ghostel--send-key (string char)))
-     ;; Multi-byte character
-     ((integerp char)
-      (ghostel--send-key (encode-coding-string (string char) 'utf-8)))
-     ;; Function key / special key — look up in keymap
+     ;; Control character (C-@=0, C-a=1 through C-_=31)
+     ((and (integerp event) (<= event 31))
+      (ghostel--send-key (string event)))
+     ;; ASCII (32-127)
+     ((and (integerp event) (<= event 127))
+      (ghostel--send-key (string event)))
+     ;; Non-ASCII character without modifier bits — send as UTF-8
+     ((and (integerp event) (< event #x400000))
+      (ghostel--send-key (encode-coding-string (string event) 'utf-8)))
+     ;; Modified key (M-x, C-M-a, etc.) or function key — use encoder
      (t
-      (let* ((binding (key-binding key)))
-        (if (and binding (commandp binding))
-            (call-interactively binding)
-          (message "ghostel: unrecognized key %S" key)))))))
+      (let* ((base (event-basic-type event))
+             (mods (event-modifiers event))
+             (key-name (cond
+                        ((eq base 'backtab) "tab")
+                        ((integerp base)
+                         (and (< base 128) (string base)))
+                        ((eq base 'deletechar) "delete")
+                        ((and base (symbolp base)) (symbol-name base))
+                        ((and (null base) (symbolp event))
+                         (replace-regexp-in-string
+                          "\\`\\(?:[CMSHs]-\\)*" "" (symbol-name event)))
+                        (t nil)))
+             (mods (if (eq base 'backtab) (cons 'shift mods) mods))
+             (mod-str (mapconcat
+                       #'identity
+                       (delq nil
+                             (mapcar
+                              (lambda (m)
+                                (pcase m
+                                  ('shift "shift") ('control "ctrl")
+                                  ('meta "meta") ('alt "alt")
+                                  ('hyper "hyper") ('super "super")))
+                              mods))
+                       ",")))
+        (if key-name
+            (ghostel--send-encoded key-name mod-str)
+          (message "ghostel: unrecognized key %S" event)))))))
 
 (defun ghostel--send-key (key)
   "Send KEY string to the terminal process.

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1740,6 +1740,61 @@ cell, so the visual line width must equal the terminal column count."
               (should-not recenter-called))))
       (kill-buffer buf))))
 
+;; -----------------------------------------------------------------------
+;; Test: ghostel-send-next-key
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-send-next-key-control-x ()
+  "send-next-key sends C-x as raw byte 24 (not intercepted by Emacs)."
+  (let (sent-key)
+    (cl-letf (((symbol-function 'ghostel--send-key)
+               (lambda (str) (setq sent-key str))))
+      (let ((unread-command-events (list ?\C-x)))
+        (ghostel-send-next-key))
+      (should (equal (string 24) sent-key)))))
+
+(ert-deftest ghostel-test-send-next-key-control-h ()
+  "send-next-key sends C-h as raw byte 8."
+  (let (sent-key)
+    (cl-letf (((symbol-function 'ghostel--send-key)
+               (lambda (str) (setq sent-key str))))
+      (let ((unread-command-events (list ?\C-h)))
+        (ghostel-send-next-key))
+      (should (equal (string 8) sent-key)))))
+
+(ert-deftest ghostel-test-send-next-key-regular-char ()
+  "send-next-key sends a regular character as-is."
+  (let (sent-key)
+    (cl-letf (((symbol-function 'ghostel--send-key)
+               (lambda (str) (setq sent-key str))))
+      (let ((unread-command-events (list ?a)))
+        (ghostel-send-next-key))
+      (should (equal "a" sent-key)))))
+
+(ert-deftest ghostel-test-send-next-key-meta-x ()
+  "send-next-key routes M-x through the encoder with meta modifier."
+  (let (captured-key captured-mods
+        (ghostel--term 'fake))
+    (cl-letf (((symbol-function 'ghostel--send-encoded)
+               (lambda (key mods &optional _utf8)
+                 (setq captured-key key captured-mods mods))))
+      (let ((unread-command-events (list ?\M-x)))
+        (ghostel-send-next-key))
+      (should (equal "x" captured-key))
+      (should (equal "meta" captured-mods)))))
+
+(ert-deftest ghostel-test-send-next-key-function-key ()
+  "send-next-key routes function keys through the encoder."
+  (let (captured-key captured-mods
+        (ghostel--term 'fake))
+    (cl-letf (((symbol-function 'ghostel--send-encoded)
+               (lambda (key mods &optional _utf8)
+                 (setq captured-key key captured-mods mods))))
+      (let ((unread-command-events (list 'up)))
+        (ghostel-send-next-key))
+      (should (equal "up" captured-key))
+      (should (equal "" captured-mods)))))
+
 (defconst ghostel-test--elisp-tests
   '(ghostel-test-raw-key-sequences
     ghostel-test-modifier-number
@@ -1778,7 +1833,12 @@ cell, so the visual line width must equal the terminal column count."
     ghostel-test-scroll-on-input-disabled
     ghostel-test-control-key-bindings
     ghostel-test-meta-key-bindings
-    ghostel-test-copy-mode-recenter)
+    ghostel-test-copy-mode-recenter
+    ghostel-test-send-next-key-control-x
+    ghostel-test-send-next-key-control-h
+    ghostel-test-send-next-key-regular-char
+    ghostel-test-send-next-key-meta-x
+    ghostel-test-send-next-key-function-key)
   "Tests that require only Elisp (no native module).")
 
 (defun ghostel-test-run-elisp ()


### PR DESCRIPTION
## Summary

- Fix `ghostel-send-next-key` not working for prefix keys (C-x, C-h, C-u) — `read-key-sequence` treated them as prefixes and never returned
- Fix M-x producing ø instead of sending the correct meta sequence — the meta bit was misinterpreted as a Unicode codepoint
- Switch from `read-key-sequence` to `read-event` which bypasses keymap lookup, and route modified keys through `ghostel--send-encoded`

## Test plan

- [x] 5 new tests: C-x, C-h, regular char, M-x, function key (up arrow)
- [x] `make all` passes (build, 43 tests, byte-compile, lint)
- [x] Manual: open ghostel, press `C-c C-q` then `C-x` — should send control-X to the terminal