### PR TITLE
Add eat.el-like input modes (char, emacs, mode switching)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ process, keymap, and buffer.
 - [Installation](#installation)
 - [Building from source](#building-from-source)
 - [Shell Integration](#shell-integration)
-- [Key Bindings](#key-bindings)
+- [Input Modes](#input-modes)
 - [Features](#features)
   - [TRAMP (Remote Terminals)](#tramp-remote-terminals)
 - [Configuration](#configuration)
@@ -155,9 +155,33 @@ test "$INSIDE_EMACS" = 'ghostel'; and source "$EMACS_GHOSTEL_PATH/etc/ghostel.fi
 ```
 </details>
 
-## Key Bindings
+## Input Modes
 
-### Terminal mode
+Ghostel provides four input modes, inspired by
+[eat.el](https://codeberg.org/akib/emacs-eat):
+
+| Mode      | Indicator | Description                            |
+|-----------|-----------|----------------------------------------|
+| Semi-char | *(none)*  | Default — most keys go to terminal     |
+| Char      | `:Char`   | All keys go to terminal                |
+| Copy      | `:Copy`   | Frozen viewport for text selection     |
+| Emacs     | `:Emacs`  | Full scrollback as read-only buffer    |
+
+### Mode switching
+
+| Key       | Action                              |
+|-----------|-------------------------------------|
+| `C-c C-j` | Switch to semi-char (from any mode) |
+| `C-c M-d` | Switch to char mode                 |
+| `M-RET`   | Exit char mode to semi-char         |
+| `C-c C-t` | Toggle copy mode                    |
+| `C-c C-e` | Switch to emacs mode                |
+
+### Semi-char mode (default)
+
+Most keys are sent to the terminal. Keys listed in
+`ghostel-keymap-exceptions` (default: `C-c`, `C-x`, `C-u`, `C-h`,
+`C-g`, `M-x`, `M-o`, `M-:`, `C-\`) pass through to Emacs.
 
 | Key         | Action                                 |
 |-------------|----------------------------------------|
@@ -167,23 +191,30 @@ test "$INSIDE_EMACS" = 'ghostel'; and source "$EMACS_GHOSTEL_PATH/etc/ghostel.fi
 | `C-c C-d`   | Send EOF (C-d)                         |
 | `C-c C-\`   | Send quit (C-\)                        |
 | `C-c C-t`   | Enter copy mode                        |
+| `C-c C-e`   | Enter emacs mode                       |
+| `C-c M-d`   | Enter char mode                        |
 | `C-c M-w`   | Copy entire scrollback to kill ring    |
 | `C-y`       | Yank from kill ring (bracketed paste)  |
 | `M-y`       | Yank-pop (cycle through kill ring)     |
 | `C-c C-y`   | Paste from kill ring                   |
-| `C-c C-l`   | Clear scrollback                       |
+| `C-c M-l`   | Clear scrollback                       |
 | `C-c C-n`   | Jump to next prompt                    |
 | `C-c C-p`   | Jump to previous prompt                |
 | `C-c C-q`   | Send next key literally (escape hatch) |
 | Mouse wheel | Scroll through scrollback              |
 
-Keys listed in `ghostel-keymap-exceptions` (default: `C-c`, `C-x`, `C-u`,
-`C-h`, `C-g`, `M-x`, `M-o`, `M-:`, `C-\`) pass through to Emacs.
+### Char mode
+
+All supported keys are sent directly to the terminal — no exceptions.
+Enter with `C-c M-d`. The only way to exit is `M-RET`, which returns
+to semi-char mode. Useful for TUI apps that need keys like `M-x`,
+`C-x`, or `C-h`.
 
 ### Copy mode
 
-Enter with `C-c C-t`. Standard Emacs navigation works.
-Normal letter keys exit copy mode and send the key to the terminal.
+Enter with `C-c C-t`. The display is frozen and standard Emacs
+navigation works. Normal letter keys exit copy mode and send the
+key to the terminal.
 
 | Key           | Action                           |
 |---------------|----------------------------------|
@@ -195,24 +226,22 @@ Normal letter keys exit copy mode and send the key to the terminal.
 | `C-c C-n`     | Jump to next prompt              |
 | `C-c C-p`     | Jump to previous prompt          |
 | `C-l`         | Recenter viewport                |
-| `C-c C-a`     | Load full scrollback into buffer |
+| `C-c C-e`     | Load full scrollback (emacs mode)|
 | `C-c C-t`     | Exit without copying             |
-| `a`–`z`       | Exit and send key to terminal    |
+| `q`, `a`–`z`  | Exit and send key to terminal    |
 
 Soft-wrapped newlines are automatically stripped from copied text.
 
-After `C-c C-a`, the entire scrollback history is loaded into the buffer
-as styled text. Standard Emacs commands work across the full content:
-`C-x h` to select all, `C-s` to search, mark/region spanning any distance.
+### Emacs mode
 
-Set `ghostel-copy-mode-auto-load-scrollback` to `t` to skip the
-viewport-only step and load the full scrollback immediately when
-entering copy mode. Advantages: produces a pure Emacs buffer where
-all standard commands work (incremental search, `occur`, `M-x
-flush-lines`, etc.) without an extra keystroke. Disadvantages: entering
-copy mode takes longer for large scrollback buffers, clickable links
-(URLs, file references, OSC 8 hyperlinks) are not detected in the
-loaded scrollback.
+Enter with `C-c C-e`. The entire scrollback history is loaded into
+the buffer as styled, read-only text. All standard Emacs commands
+work: `C-s` to search, `occur`, `C-x h` to select all, mark/region
+spanning any distance. Type any character or press `q` to return to
+semi-char mode.
+
+Set `ghostel-copy-mode-auto-load-scrollback` to `t` to go directly
+to emacs mode when pressing `C-c C-t`.
 
 ## Features
 
@@ -415,7 +444,10 @@ individual faces with `M-x customize-face`.
 | `M-x ghostel-other`            | Switch to next terminal or create one        |
 | `M-x ghostel-clear`            | Clear screen and scrollback                  |
 | `M-x ghostel-clear-scrollback` | Clear scrollback only                        |
-| `M-x ghostel-copy-mode`        | Enter copy mode                              |
+| `M-x ghostel-semi-char-mode`   | Switch to semi-char input mode               |
+| `M-x ghostel-char-mode`        | Switch to char input mode                    |
+| `M-x ghostel-copy-mode`        | Toggle copy mode                             |
+| `M-x ghostel-emacs-mode`       | Switch to emacs mode (full scrollback)       |
 | `M-x ghostel-copy-all`         | Copy entire scrollback to kill ring          |
 | `M-x ghostel-paste`            | Paste from kill ring                         |
 | `M-x ghostel-send-next-key`    | Send next key literally                      |
@@ -533,6 +565,7 @@ powering Neovim's built-in terminal.
 | Elisp eval from shell         | Yes       | Yes     |
 | TRAMP remote terminals        | Yes       | Yes     |
 | OSC 52 clipboard              | Yes       | Yes     |
+| Input modes (semi-char/char/copy/emacs) | Yes | No |
 | Copy mode                     | Yes       | Yes     |
 | Drag-and-drop                 | Yes       | No      |
 | Auto module download          | Yes       | No      |

--- a/ghostel.el
+++ b/ghostel.el
@@ -39,22 +39,30 @@
 ;;   M-x ghostel          Open a new terminal
 ;;   M-x ghostel-other    Switch to next terminal or create one
 ;;
-;; Key bindings in the terminal buffer:
+;; Input modes:
 ;;
-;;   Most keys are sent directly to the shell.  Keys in
-;;   `ghostel-keymap-exceptions' (C-c, C-x, M-x, etc.) pass through
-;;   to Emacs.  Terminal control keys use a C-c prefix:
+;;   Semi-char (default) — most keys go to the shell, C-c prefix
+;;   reserved for Emacs.  Keys in `ghostel-keymap-exceptions' pass
+;;   through.
+;;
+;;   Char mode (C-c M-d) — all keys sent to the terminal.  Only
+;;   M-RET exits back to semi-char.
+;;
+;;   Copy mode (C-c C-t) — display frozen for text selection.  Set
+;;   mark, navigate, M-w to copy.  Soft-wrapped newlines are stripped.
+;;
+;;   Emacs mode (C-c C-e) — full scrollback loaded as a read-only
+;;   Emacs buffer.  All Emacs commands work (isearch, occur, etc.).
+;;
+;;   C-c C-j returns to semi-char from any mode.
+;;
+;; Key bindings (semi-char mode):
 ;;
 ;;   C-c C-c   Interrupt        C-c C-z   Suspend
 ;;   C-c C-d   EOF              C-c C-\   Quit
 ;;   C-c C-t   Copy mode        C-c C-y   Paste
-;;   C-c C-l   Clear scrollback C-c C-q   Send next key literally
+;;   C-c M-l   Clear scrollback C-c C-q   Send next key literally
 ;;   C-y       Yank             M-y       Yank-pop
-;;
-;; Copy mode (C-c C-t) freezes the display and enables standard Emacs
-;; navigation.  Set mark with C-SPC, select text, then M-w to copy.
-;; Soft-wrapped newlines and trailing whitespace are stripped
-;; automatically.
 ;;
 ;; Shell integration:
 ;;
@@ -593,11 +601,9 @@ DIR is the module directory."
 (defvar-local ghostel--term nil
   "Handle to the native terminal instance.")
 
-(defvar-local ghostel--copy-mode-active nil
-  "Non-nil when copy mode is active.")
-
-(defvar-local ghostel--copy-mode-full-buffer nil
-  "Non-nil when full scrollback has been loaded into the buffer in copy mode.")
+(defvar-local ghostel--input-mode 'semi-char
+  "Current input mode.
+One of `semi-char', `char', `copy', or `emacs'.")
 
 (defvar-local ghostel--process nil
   "The shell process.")
@@ -632,60 +638,104 @@ variable re-enables automatic renaming for the next title update.")
   "List of prompt positions as (buffer-line . exit-status) pairs.
 Used for prompt navigation and optional re-application after full redraws.")
 
+(defvar-local ghostel--saved-cursor-type nil
+  "Saved `cursor-type' before entering a frozen mode (copy or emacs).")
+
+(defvar-local ghostel--saved-hl-line-mode nil
+  "Non-nil if line highlighting was active when `ghostel-mode' suppressed it.
+Covers both `global-hl-line-mode' and buffer-local `hl-line-mode'.")
+
 
 
 ;;; Keymap
 
+(defsubst ghostel--frozen-p ()
+  "Return non-nil when the terminal display is frozen."
+  (memq ghostel--input-mode '(copy emacs)))
+
+(defsubst ghostel--full-scrollback-p ()
+  "Return non-nil when full scrollback is loaded."
+  (eq ghostel--input-mode 'emacs))
+
+
+;;; Keymaps
+
+(defun ghostel--define-terminal-keys (map &optional no-exceptions)
+  "Populate MAP with terminal key-sending bindings.
+When NO-EXCEPTIONS is non-nil, bind all keys including those
+in `ghostel-keymap-exceptions' (for char mode)."
+  ;; Self-insert characters
+  (define-key map [remap self-insert-command] #'ghostel--self-insert)
+  ;; Special keys — routed through the ghostty key encoder which
+  ;; respects terminal modes and handles all modifier combinations.
+  ;; Use angle-bracket forms so modifier prefixes compose correctly.
+  (dolist (key '("<return>" "<tab>" "<backspace>" "<escape>"
+                 "<up>" "<down>" "<right>" "<left>"
+                 "<home>" "<end>" "<prior>" "<next>"
+                 "<deletechar>" "<insert>"
+                 "<f1>" "<f2>" "<f3>" "<f4>" "<f5>" "<f6>"
+                 "<f7>" "<f8>" "<f9>" "<f10>" "<f11>" "<f12>"))
+    (define-key map (kbd key) #'ghostel--send-event)
+    (dolist (mod '("S-" "C-" "M-" "C-S-" "M-S-" "C-M-"))
+      (ignore-errors
+        (define-key map (kbd (concat mod key)) #'ghostel--send-event))))
+  ;; Bare aliases for unmodified keys (RET=\r, TAB=\t, DEL=\x7f)
+  (define-key map (kbd "RET") #'ghostel--send-event)
+  (define-key map (kbd "TAB") #'ghostel--send-event)
+  (define-key map (kbd "DEL") #'ghostel--send-event)
+  ;; Emacs reports S-TAB as <backtab>
+  (define-key map (kbd "<backtab>") #'ghostel--send-event)
+  ;; Control keys — bind all C-<letter> to send ASCII control codes.
+  ;; C-i = TAB and C-m = RET are equivalent to <tab>/<return> (bound above).
+  (let ((skip (if no-exceptions
+                  '(?i ?m)         ; only skip TAB/RET aliases
+                '(?i ?m ?y))))    ; also skip C-y for yank in semi-char
+    (dolist (c (number-sequence ?a ?z))
+      (let ((key-str (format "C-%c" c)))
+        (unless (or (memq c skip)
+                    (and (not no-exceptions)
+                         (member key-str ghostel-keymap-exceptions)))
+          (define-key map (kbd key-str)
+                      (let ((code (- c 96)))
+                        (lambda () (interactive)
+                          (ghostel--send-key (string code)))))))))
+  ;; Meta keys — bind all M-<letter> so they reach the terminal
+  ;; instead of running Emacs commands like forward-word.
+  (dolist (c (number-sequence ?a ?z))
+    (let ((key-str (format "M-%c" c)))
+      (when (or no-exceptions
+                (not (member key-str ghostel-keymap-exceptions)))
+        (define-key map (kbd key-str) #'ghostel--send-event))))
+  ;; C-@ (NUL, same as C-SPC) — used by programs like Emacs-in-terminal
+  (define-key map (kbd "C-@")
+              (lambda () (interactive) (ghostel--send-key "\x00")))
+  ;; In char mode, also bind non-letter exception keys that the loops above miss.
+  (when no-exceptions
+    (define-key map (kbd "C-\\")
+                (lambda () (interactive) (ghostel--send-key "\x1c")))
+    (define-key map (kbd "M-:") #'ghostel--send-event)))
+
+(defun ghostel--define-mouse-keys (map)
+  "Populate MAP with mouse bindings for terminal interaction."
+  ;; Mouse wheel for scrollback
+  (define-key map (kbd "<mouse-4>")       #'ghostel--scroll-up)
+  (define-key map (kbd "<mouse-5>")       #'ghostel--scroll-down)
+  (define-key map (kbd "<wheel-up>")      #'ghostel--scroll-up)
+  (define-key map (kbd "<wheel-down>")    #'ghostel--scroll-down)
+  ;; Mouse click events (for terminal mouse tracking)
+  (define-key map (kbd "<down-mouse-1>")  #'ghostel--mouse-press)
+  (define-key map (kbd "<mouse-1>")       #'ghostel--mouse-release)
+  (define-key map (kbd "<down-mouse-2>")  #'ghostel--mouse-press)
+  (define-key map (kbd "<mouse-2>")       #'ghostel--mouse-release)
+  (define-key map (kbd "<down-mouse-3>")  #'ghostel--mouse-press)
+  (define-key map (kbd "<mouse-3>")       #'ghostel--mouse-release)
+  (define-key map (kbd "<drag-mouse-1>")  #'ghostel--mouse-drag)
+  (define-key map (kbd "<drag-mouse-2>")  #'ghostel--mouse-drag)
+  (define-key map (kbd "<drag-mouse-3>")  #'ghostel--mouse-drag))
+
 (defvar ghostel-mode-map
   (let ((map (make-sparse-keymap)))
-    ;; Self-insert characters
-    (define-key map [remap self-insert-command] #'ghostel--self-insert)
-    ;; Special keys — routed through the ghostty key encoder which
-    ;; respects terminal modes and handles all modifier combinations.
-    ;; Use angle-bracket forms so modifier prefixes compose correctly.
-    (dolist (key '("<return>" "<tab>" "<backspace>" "<escape>"
-                   "<up>" "<down>" "<right>" "<left>"
-                   "<home>" "<end>" "<prior>" "<next>"
-                   "<deletechar>" "<insert>"
-                   "<f1>" "<f2>" "<f3>" "<f4>" "<f5>" "<f6>"
-                   "<f7>" "<f8>" "<f9>" "<f10>" "<f11>" "<f12>"))
-      (define-key map (kbd key) #'ghostel--send-event)
-      (dolist (mod '("S-" "C-" "M-" "C-S-" "M-S-" "C-M-"))
-        (ignore-errors
-          (define-key map (kbd (concat mod key)) #'ghostel--send-event))))
-    ;; Bare aliases for unmodified keys (RET=\r, TAB=\t, DEL=\x7f)
-    (define-key map (kbd "RET") #'ghostel--send-event)
-    (define-key map (kbd "TAB") #'ghostel--send-event)
-    (define-key map (kbd "DEL") #'ghostel--send-event)
-    ;; Emacs reports S-TAB as <backtab>
-    (define-key map (kbd "<backtab>") #'ghostel--send-event)
-    ;; Control keys — bind all C-<letter> to send ASCII control codes,
-    ;; except keys in ghostel-keymap-exceptions and special cases.
-    ;; C-i = TAB and C-m = RET are equivalent to <tab>/<return> (bound above).
-    (let ((skip '(?i ?m ?y)))  ; i=TAB, m=RET already bound; y=ghostel-yank below
-      (dolist (c (number-sequence ?a ?z))
-        (let ((key-str (format "C-%c" c)))
-          (unless (or (member key-str ghostel-keymap-exceptions)
-                      (memq c skip))
-            (define-key map (kbd key-str)
-                        (let ((code (- c 96)))
-                          (lambda () (interactive)
-                            (ghostel--send-key (string code)))))))))
-    ;; Meta keys — bind all M-<letter> so they reach the terminal
-    ;; instead of running Emacs commands like forward-word.
-    (dolist (c (number-sequence ?a ?z))
-      (let ((key-str (format "M-%c" c)))
-        (unless (member key-str ghostel-keymap-exceptions)
-          (define-key map (kbd key-str) #'ghostel--send-event))))
-    ;; C-@ (NUL, same as C-SPC) — used by programs like Emacs-in-terminal
-    (define-key map (kbd "C-@")
-                (lambda () (interactive) (ghostel--send-key "\x00")))
-    ;; C-y: yank from Emacs kill ring into the terminal
-    (define-key map (kbd "C-y")       #'ghostel-yank)
-    (when (eq system-type 'darwin)
-      (define-key map (kbd "s-v")     #'ghostel-yank))
-    (define-key map (kbd "M-y")       #'ghostel-yank-pop)
-    ;; Terminal control via C-c prefix (pass through to Emacs, then handled here)
+    ;; Terminal control via C-c prefix
     (define-key map (kbd "C-c C-c")   #'ghostel-send-C-c)
     (define-key map (kbd "C-c C-z")   #'ghostel-send-C-z)
     (define-key map (kbd "C-c C-\\")  #'ghostel-send-C-backslash)
@@ -693,30 +743,63 @@ Used for prompt navigation and optional re-application after full redraws.")
     (define-key map (kbd "C-c C-t")   #'ghostel-copy-mode)
     (define-key map (kbd "C-c M-w")   #'ghostel-copy-all)
     (define-key map (kbd "C-c C-y")   #'ghostel-paste)
-    (define-key map (kbd "C-c C-l")   #'ghostel-clear-scrollback)
+    (define-key map (kbd "C-c M-l")   #'ghostel-clear-scrollback)
     (define-key map (kbd "C-c C-q")   #'ghostel-send-next-key)
     ;; Prompt navigation (OSC 133)
     (define-key map (kbd "C-c C-n")   #'ghostel-next-prompt)
     (define-key map (kbd "C-c C-p")   #'ghostel-previous-prompt)
-    ;; Mouse wheel for scrollback
-    (define-key map (kbd "<mouse-4>")       #'ghostel--scroll-up)
-    (define-key map (kbd "<mouse-5>")       #'ghostel--scroll-down)
-    (define-key map (kbd "<wheel-up>")      #'ghostel--scroll-up)
-    (define-key map (kbd "<wheel-down>")    #'ghostel--scroll-down)
-    ;; Mouse click events (for terminal mouse tracking)
-    (define-key map (kbd "<down-mouse-1>")  #'ghostel--mouse-press)
-    (define-key map (kbd "<mouse-1>")       #'ghostel--mouse-release)
-    (define-key map (kbd "<down-mouse-2>")  #'ghostel--mouse-press)
-    (define-key map (kbd "<mouse-2>")       #'ghostel--mouse-release)
-    (define-key map (kbd "<down-mouse-3>")  #'ghostel--mouse-press)
-    (define-key map (kbd "<mouse-3>")       #'ghostel--mouse-release)
-    (define-key map (kbd "<drag-mouse-1>")  #'ghostel--mouse-drag)
-    (define-key map (kbd "<drag-mouse-2>")  #'ghostel--mouse-drag)
-    (define-key map (kbd "<drag-mouse-3>")  #'ghostel--mouse-drag)
+    ;; Mode switching
+    (define-key map (kbd "C-c C-e")   #'ghostel-emacs-mode)
+    (define-key map (kbd "C-c C-j")   #'ghostel-semi-char-mode)
+    (define-key map (kbd "C-c M-d")   #'ghostel-char-mode)
     ;; Drag and drop
-    (define-key map [drag-n-drop]           #'ghostel--drop)
+    (define-key map [drag-n-drop]     #'ghostel--drop)
     map)
-  "Keymap for `ghostel-mode'.")
+  "Base keymap for `ghostel-mode'.
+Contains C-c prefix commands available in all input modes.")
+
+(defvar ghostel-semi-char-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map ghostel-mode-map)
+    (ghostel--define-terminal-keys map)
+    ;; C-y: yank from Emacs kill ring into the terminal
+    (define-key map (kbd "C-y")       #'ghostel-yank)
+    (when (eq system-type 'darwin)
+      (define-key map (kbd "s-v")     #'ghostel-yank))
+    (define-key map (kbd "M-y")       #'ghostel-yank-pop)
+    ;; Mouse
+    (ghostel--define-mouse-keys map)
+    map)
+  "Keymap for semi-char mode.
+Most keys are sent to the terminal.  Keys in `ghostel-keymap-exceptions'
+pass through to Emacs.  Inherits C-c prefix from `ghostel-mode-map'.")
+
+(defvar ghostel-char-mode-map
+  (let ((map (make-sparse-keymap)))
+    ;; No parent — char mode captures everything
+    (ghostel--define-terminal-keys map 'no-exceptions)
+    ;; Mouse
+    (ghostel--define-mouse-keys map)
+    ;; Sole escape hatch: M-RET to exit char mode
+    (define-key map (kbd "M-RET") #'ghostel-semi-char-mode)
+    (define-key map (kbd "C-M-m") #'ghostel-semi-char-mode)
+    map)
+  "Keymap for char mode.
+All keys are sent to the terminal.  Only M-RET exits to semi-char mode.")
+
+(defvar ghostel-emacs-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map ghostel-mode-map)
+    ;; Self-insert exits to semi-char and sends the key
+    (define-key map [remap self-insert-command] #'ghostel-emacs-mode-exit-and-send)
+    ;; q exits to semi-char
+    (define-key map (kbd "q") #'ghostel-semi-char-mode)
+    ;; Mouse scroll uses standard Emacs behavior (no binding needed,
+    ;; falls through to global map since full scrollback is loaded)
+    map)
+  "Keymap for emacs mode.
+Full scrollback loaded in a read-only buffer.  All standard Emacs
+commands work.  Typing a character or pressing q exits to semi-char.")
 
 
 ;;; Key sending
@@ -1075,7 +1158,7 @@ pasted using bracketed paste."
 Return non-nil if the event was forwarded (mouse tracking is active)."
   (when (and event ghostel--term ghostel--process
              (process-live-p ghostel--process)
-             (not ghostel--copy-mode-active))
+             (not (ghostel--frozen-p)))
     (let* ((posn (event-start event))
            (col-row (posn-col-row posn))
            (col (car col-row))
@@ -1091,12 +1174,12 @@ Return non-nil if the event was forwarded (mouse tracking is active)."
 When the terminal has mouse tracking enabled, forward EVENT as a
 scroll event to the running application instead."
   (interactive "e")
-  (if ghostel--copy-mode-full-buffer
+  (if (ghostel--full-scrollback-p)
       (scroll-down 3)
     (when ghostel--term
       (unless (ghostel--forward-scroll-event event 4) ; button 4 = scroll up
         (ghostel--scroll ghostel--term -3)
-        (if ghostel--copy-mode-active
+        (if (ghostel--frozen-p)
             (let ((inhibit-read-only t))
               (ghostel--redraw ghostel--term ghostel-full-redraw))
           (setq ghostel--force-next-redraw t)
@@ -1107,12 +1190,12 @@ scroll event to the running application instead."
 When the terminal has mouse tracking enabled, forward EVENT as a
 scroll event to the running application instead."
   (interactive "e")
-  (if ghostel--copy-mode-full-buffer
+  (if (ghostel--full-scrollback-p)
       (scroll-up 3)
     (when ghostel--term
       (unless (ghostel--forward-scroll-event event 5) ; button 5 = scroll down
         (ghostel--scroll ghostel--term 3)
-        (if ghostel--copy-mode-active
+        (if (ghostel--frozen-p)
             (let ((inhibit-read-only t))
               (ghostel--redraw ghostel--term ghostel-full-redraw))
           (setq ghostel--force-next-redraw t)
@@ -1122,7 +1205,7 @@ scroll event to the running application instead."
   "Scroll the terminal viewport up by a page in copy mode."
   (interactive)
   (let ((col (current-column)))
-    (if ghostel--copy-mode-full-buffer
+    (if (ghostel--full-scrollback-p)
         (scroll-down-command)
       (when ghostel--term
         (let ((height (count-lines (point-min) (point-max))))
@@ -1135,7 +1218,7 @@ scroll event to the running application instead."
   "Scroll the terminal viewport down by a page in copy mode."
   (interactive)
   (let ((col (current-column)))
-    (if ghostel--copy-mode-full-buffer
+    (if (ghostel--full-scrollback-p)
         (scroll-up-command)
       (when ghostel--term
         (let ((height (count-lines (point-min) (point-max))))
@@ -1148,7 +1231,7 @@ scroll event to the running application instead."
   "Move to the previous line, scrolling the viewport if at the top."
   (interactive)
   (let ((col (current-column)))
-    (if ghostel--copy-mode-full-buffer
+    (if (ghostel--full-scrollback-p)
         (forward-line -1)
       (if (= (line-number-at-pos) 1)
           (when ghostel--term
@@ -1163,7 +1246,7 @@ scroll event to the running application instead."
   "Move to the next line, scrolling the viewport if at the bottom."
   (interactive)
   (let ((col (current-column)))
-    (if ghostel--copy-mode-full-buffer
+    (if (ghostel--full-scrollback-p)
         (forward-line 1)
       (if (>= (line-number-at-pos) (line-number-at-pos (point-max)))
           (when ghostel--term
@@ -1178,7 +1261,7 @@ scroll event to the running application instead."
 (defun ghostel-copy-mode-beginning-of-buffer ()
   "Scroll to the top of scrollback in copy mode."
   (interactive)
-  (if ghostel--copy-mode-full-buffer
+  (if (ghostel--full-scrollback-p)
       (goto-char (point-min))
     (when ghostel--term
       (ghostel--scroll-top ghostel--term)
@@ -1189,7 +1272,7 @@ scroll event to the running application instead."
 (defun ghostel-copy-mode-end-of-buffer ()
   "Scroll to the bottom of scrollback in copy mode."
   (interactive)
-  (if ghostel--copy-mode-full-buffer
+  (if (ghostel--full-scrollback-p)
       (progn
         (goto-char (point-max))
         (skip-chars-backward " \t\n"))
@@ -1213,7 +1296,7 @@ Scrolls the terminal viewport so the current line is vertically
 centered, then redraws.  When the scroll is clamped at a scrollback
 boundary (nothing to scroll into), does nothing."
   (interactive)
-  (if ghostel--copy-mode-full-buffer
+  (if (ghostel--full-scrollback-p)
       (recenter)
     (when ghostel--term
       (let* ((current-line (line-number-at-pos))
@@ -1304,19 +1387,119 @@ boundary (nothing to scroll into), does nothing."
                             (ghostel--mouse-mods event)))))
 
 
+;;; Input mode switching
+
+(defun ghostel--enter-frozen-state ()
+  "Common setup when entering a frozen mode (copy or emacs).
+Cancels pending redraws, shows cursor, enables hl-line, sets read-only."
+  (when ghostel--redraw-timer
+    (cancel-timer ghostel--redraw-timer)
+    (setq ghostel--redraw-timer nil))
+  (setq ghostel--saved-cursor-type cursor-type)
+  (setq cursor-type (default-value 'cursor-type))
+  (when ghostel--saved-hl-line-mode
+    (hl-line-mode 1))
+  (setq buffer-read-only t))
+
+(defun ghostel--leave-frozen-state ()
+  "Common teardown when leaving a frozen mode.
+Restores cursor, deactivates mark, disables hl-line, clears read-only."
+  (setq cursor-type ghostel--saved-cursor-type)
+  (deactivate-mark)
+  (when ghostel--saved-hl-line-mode
+    (hl-line-mode -1))
+  (setq buffer-read-only nil)
+  (setq mode-line-process nil)
+  (force-mode-line-update))
+
+(defun ghostel-semi-char-mode ()
+  "Switch to semi-char mode (default terminal input mode).
+Most keys are sent to the terminal.  Keys in `ghostel-keymap-exceptions'
+pass through to Emacs."
+  (interactive)
+  (unless (eq ghostel--input-mode 'semi-char)
+    (let ((was-frozen (ghostel--frozen-p))
+          (was-emacs (ghostel--full-scrollback-p)))
+      (when was-frozen
+        (ghostel--leave-frozen-state))
+      (setq ghostel--input-mode 'semi-char)
+      (use-local-map ghostel-semi-char-mode-map)
+      (setq mode-line-process nil)
+      (force-mode-line-update)
+      (when ghostel--term
+        (ghostel--scroll-bottom ghostel--term)
+        (when was-emacs
+          ;; Erase stale full-scrollback content so normal redraw rebuilds
+          (let ((inhibit-read-only t))
+            (erase-buffer)
+            (ghostel--redraw ghostel--term t))))
+      (ghostel--invalidate))))
+
+(defun ghostel-char-mode ()
+  "Switch to char mode (all keys sent to terminal).
+Only M-RET exits back to semi-char mode."
+  (interactive)
+  (when (ghostel--frozen-p)
+    ;; Leave frozen state first
+    (let ((was-emacs (ghostel--full-scrollback-p)))
+      (ghostel--leave-frozen-state)
+      (when (and ghostel--term was-emacs)
+        (let ((inhibit-read-only t))
+          (erase-buffer)
+          (ghostel--redraw ghostel--term t)))))
+  (setq ghostel--input-mode 'char)
+  (use-local-map ghostel-char-mode-map)
+  (setq mode-line-process ":Char")
+  (force-mode-line-update)
+  (when ghostel--term
+    (ghostel--invalidate))
+  (message "Char mode (M-RET to exit)"))
+
+(defun ghostel-emacs-mode ()
+  "Switch to emacs mode (frozen, full scrollback, read-only).
+The entire scrollback is loaded into the buffer as a standard
+read-only Emacs buffer.  All Emacs commands work: isearch, occur,
+region selection, etc.  Type any character or press q to return
+to semi-char mode."
+  (interactive)
+  (unless (eq ghostel--input-mode 'emacs)
+    (unless (ghostel--frozen-p)
+      (ghostel--enter-frozen-state))
+    (setq ghostel--input-mode 'emacs)
+    (use-local-map ghostel-emacs-mode-map)
+    (when ghostel--term
+      (message "Loading scrollback...")
+      (let* ((saved-line (1- (line-number-at-pos)))
+             (saved-col (current-column))
+             (inhibit-read-only t)
+             (viewport-line (ghostel--redraw-full-scrollback ghostel--term)))
+        (goto-char (point-min))
+        (forward-line (+ (1- viewport-line) saved-line))
+        (move-to-column saved-col)
+        (recenter saved-line))
+      (message "Scrollback loaded"))
+    (setq mode-line-process ":Emacs")
+    (force-mode-line-update)))
+
+(defun ghostel-emacs-mode-exit-and-send ()
+  "Exit emacs mode, switch to semi-char, and send the typed key."
+  (interactive)
+  (ghostel-semi-char-mode)
+  (when ghostel--term
+    (ghostel--self-insert)))
+
+
 ;;; Copy mode
 
 (defvar ghostel-copy-mode-map
   (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map ghostel-mode-map)
     ;; Normal letter keys exit copy mode and send the key to the terminal
     (define-key map [remap self-insert-command] #'ghostel-copy-mode-exit-and-send)
-    (define-key map (kbd "C-c C-t") #'ghostel-copy-mode-exit)
+    (define-key map (kbd "q") #'ghostel-copy-mode-exit)
     (define-key map (kbd "M-w") #'ghostel-copy-mode-copy)
     (define-key map (kbd "C-w") #'ghostel-copy-mode-copy)
-    ;; Prompt navigation works in copy mode too
-    (define-key map (kbd "C-c C-n") #'ghostel-next-prompt)
-    (define-key map (kbd "C-c C-p") #'ghostel-previous-prompt)
-    ;; Scrollback
+    ;; Scrollback navigation
     (define-key map (kbd "<mouse-4>")       #'ghostel--scroll-up)
     (define-key map (kbd "<mouse-5>")       #'ghostel--scroll-down)
     (define-key map (kbd "<wheel-up>")      #'ghostel--scroll-up)
@@ -1329,79 +1512,47 @@ boundary (nothing to scroll into), does nothing."
     (define-key map (kbd "M->")             #'ghostel-copy-mode-end-of-buffer)
     (define-key map (kbd "C-e")             #'ghostel-copy-mode-end-of-line)
     (define-key map (kbd "C-l")             #'ghostel-copy-mode-recenter)
-    (define-key map (kbd "C-c C-a")         #'ghostel-copy-mode-load-all)
     map)
-  "Keymap for `ghostel-copy-mode'.
-Standard Emacs navigation works.
+  "Keymap for copy mode.
+Standard Emacs navigation works.  Inherits C-c prefix and mode
+switching keys from `ghostel-mode-map'.
 Set mark, navigate to select, then \\[ghostel-copy-mode-copy] to copy.")
 
-(defvar-local ghostel--saved-local-map nil
-  "Saved keymap before entering copy mode.")
-
-(defvar-local ghostel--saved-cursor-type nil
-  "Saved `cursor-type' before entering copy mode.")
-
-(defvar-local ghostel--saved-hl-line-mode nil
-  "Non-nil if line highlighting was active when `ghostel-mode' suppressed it.
-Covers both `global-hl-line-mode' and buffer-local `hl-line-mode'.")
-
 (defun ghostel-copy-mode ()
-  "Enter copy mode for selecting and copying terminal text.
+  "Toggle copy mode for selecting and copying terminal text.
 The display is frozen and standard Emacs navigation keys work.
 Set mark, navigate to select, then \\[ghostel-copy-mode-copy] to copy.
-Press \\`q' or \\[ghostel-copy-mode-exit] to exit without copying."
+Press \\`q' or \\[ghostel-copy-mode-exit] to exit without copying.
+From other frozen modes (emacs), exits to semi-char."
   (interactive)
-  (if ghostel--copy-mode-active
-      (ghostel-copy-mode-exit)
-    ;; Freeze display
-    (setq ghostel--copy-mode-active t)
-    (when ghostel--redraw-timer
-      (cancel-timer ghostel--redraw-timer)
-      (setq ghostel--redraw-timer nil))
-    ;; Ensure cursor is visible for navigation
-    (setq ghostel--saved-cursor-type cursor-type)
-    (setq cursor-type (default-value 'cursor-type))
-    ;; Switch to copy mode keymap (standard Emacs keys work by default)
-    (setq ghostel--saved-local-map (current-local-map))
+  (cond
+   ;; Already in copy mode — toggle off
+   ((eq ghostel--input-mode 'copy)
+    (ghostel-semi-char-mode))
+   ;; In another frozen mode — exit to semi-char
+   ((ghostel--frozen-p)
+    (ghostel-semi-char-mode))
+   ;; Auto-load-scrollback sends us to emacs mode instead
+   (ghostel-copy-mode-auto-load-scrollback
+    (ghostel-emacs-mode))
+   ;; Enter copy mode from semi-char or char
+   (t
+    (ghostel--enter-frozen-state)
+    (setq ghostel--input-mode 'copy)
     (use-local-map ghostel-copy-mode-map)
-    (when ghostel--saved-hl-line-mode
-      (hl-line-mode 1))
-    (setq buffer-read-only t)
-    (if ghostel-copy-mode-auto-load-scrollback
-        (ghostel-copy-mode-load-all)
-      (setq mode-line-process ":Copy")
-      (force-mode-line-update)
-      (message "Copy mode: C-SPC to mark, navigate to select, M-w to copy, q to exit"))))
+    (setq mode-line-process ":Copy")
+    (force-mode-line-update)
+    (message "Copy mode: C-SPC to mark, navigate to select, M-w to copy, q to exit"))))
 
 (defun ghostel-copy-mode-exit ()
-  "Exit copy mode and return to terminal mode."
+  "Exit copy mode and return to semi-char mode."
   (interactive)
-  (when ghostel--copy-mode-active
-    (let ((was-full ghostel--copy-mode-full-buffer))
-      (setq ghostel--copy-mode-active nil)
-      (setq ghostel--copy-mode-full-buffer nil)
-      (setq cursor-type ghostel--saved-cursor-type)
-      (deactivate-mark)
-      (use-local-map ghostel--saved-local-map)
-      (when ghostel--saved-hl-line-mode
-        (hl-line-mode -1))
-      (setq buffer-read-only nil)
-      (setq mode-line-process nil)
-      (force-mode-line-update)
-      (when ghostel--term
-        (ghostel--scroll-bottom ghostel--term)
-        (when was-full
-          ;; Erase stale full-scrollback content so normal redraw rebuilds
-          (let ((inhibit-read-only t))
-            (erase-buffer)
-            (ghostel--redraw ghostel--term t))))
-      (ghostel--invalidate)
-      (message "Copy mode exited"))))
+  (ghostel-semi-char-mode))
 
 (defun ghostel-copy-mode-exit-and-send ()
   "Exit copy mode and send the key that triggered exit to the terminal."
   (interactive)
-  (ghostel-copy-mode-exit)
+  (ghostel-semi-char-mode)
   (when ghostel--term
     (ghostel--self-insert)))
 
@@ -1439,25 +1590,10 @@ stripped so the copied text matches the original terminal content."
   (ghostel-copy-mode-exit))
 
 (defun ghostel-copy-mode-load-all ()
-  "Load the entire scrollback into the buffer for cross-viewport selection.
-After loading, standard Emacs navigation and selection work across
-the full scrollback history."
+  "Switch to emacs mode, loading the full scrollback.
+This is an alias for `ghostel-emacs-mode' for backward compatibility."
   (interactive)
-  (when (and ghostel--copy-mode-active ghostel--term
-             (not ghostel--copy-mode-full-buffer))
-    (message "Loading scrollback...")
-    (let* ((saved-line (1- (line-number-at-pos))) ; 0-based line within viewport
-           (saved-col (current-column))
-           (inhibit-read-only t)
-           (viewport-line (ghostel--redraw-full-scrollback ghostel--term)))
-      (goto-char (point-min))
-      (forward-line (+ (1- viewport-line) saved-line))
-      (move-to-column saved-col)
-      (recenter saved-line))
-    (setq ghostel--copy-mode-full-buffer t)
-    (setq mode-line-process ":Emacs")
-    (force-mode-line-update)
-    (message "Scrollback loaded")))
+  (ghostel-emacs-mode))
 
 (defun ghostel-copy-all ()
   "Copy the entire scrollback buffer to the kill ring."
@@ -1671,14 +1807,14 @@ the last non-whitespace+whitespace boundary (e.g. after `$ ' or `# ')."
 (defun ghostel-next-prompt (&optional n)
   "Enter copy mode and move to the Nth next prompt."
   (interactive "p")
-  (unless ghostel--copy-mode-active
+  (unless (ghostel--frozen-p)
     (ghostel-copy-mode))
   (ghostel--navigate-next-prompt n))
 
 (defun ghostel-previous-prompt (&optional n)
   "Enter copy mode and move to the Nth previous prompt."
   (interactive "p")
-  (unless ghostel--copy-mode-active
+  (unless (ghostel--frozen-p)
     (ghostel-copy-mode))
   (ghostel--navigate-previous-prompt n))
 
@@ -1827,7 +1963,7 @@ Call this after changing the Emacs theme so terminals match."
     (with-current-buffer buf
       (when (and (derived-mode-p 'ghostel-mode) ghostel--term)
         (ghostel--apply-palette ghostel--term)
-        (when (not ghostel--copy-mode-active)
+        (when (not (ghostel--frozen-p))
           (let ((inhibit-read-only t))
             (ghostel--redraw ghostel--term)))))))
 
@@ -2243,7 +2379,7 @@ frame after idle to improve interactive responsiveness."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (setq ghostel--redraw-timer nil)
-      (when (and ghostel--term (not ghostel--copy-mode-active))
+      (when (and ghostel--term (not (ghostel--frozen-p)))
         ;; Flush accumulated output before rendering.
         (ghostel--flush-pending-output)
         ;; Skip during synchronized output unless forced by scroll/resize.
@@ -2325,7 +2461,10 @@ PROCESS is the shell, HEIGHT and WIDTH the final dimensions."
   (setq-local window-adjust-process-window-size-function
               #'ghostel--window-adjust-process-window-size)
   (add-function :after after-focus-change-function #'ghostel--focus-change)
-  (ghostel--suppress-interfering-modes))
+  (ghostel--suppress-interfering-modes)
+  ;; Start in semi-char mode
+  (setq ghostel--input-mode 'semi-char)
+  (use-local-map ghostel-semi-char-mode-map))
 
 (defun ghostel--suppress-interfering-modes ()
   "Disable global minor modes that interfere with ghostel.

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1082,16 +1082,16 @@ cell, so the visual line width must equal the terminal column count."
               (with-current-buffer buf
                 (ghostel-mode)
                 (setq ghostel--term 'fake-term)
-                (setq ghostel--copy-mode-active nil))
+                (setq ghostel--input-mode 'semi-char))
               ;; other buffer is not ghostel-mode
               (ghostel-sync-theme)
               (should (memq 'fake-term palette-calls))    ; palette applied to ghostel buffer
               (should (memq 'fake-term redraw-calls))     ; redraw called for ghostel buffer
 
-              ;; Verify copy-mode skips redraw
+              ;; Verify frozen mode skips redraw
               (setq palette-calls nil redraw-calls nil)
               (with-current-buffer buf
-                (setq ghostel--copy-mode-active t))
+                (setq ghostel--input-mode 'copy))
               (ghostel-sync-theme)
               (should (memq 'fake-term palette-calls))    ; palette still applied in copy mode
               (should-not (memq 'fake-term redraw-calls))) ; redraw skipped in copy mode
@@ -1164,15 +1164,15 @@ cell, so the visual line width must equal the terminal column count."
           (ghostel--set-cursor-style 1 nil)
           (should (null cursor-type))                       ; cursor hidden
           ;; Enter copy mode — cursor should become visible
-          (let ((ghostel--copy-mode-active nil)
+          (let ((ghostel--input-mode 'semi-char)
                 (ghostel--redraw-timer nil))
             (ghostel-copy-mode)
-            (should ghostel--copy-mode-active)              ; in copy mode
+            (should (eq ghostel--input-mode 'copy))         ; in copy mode
             (should cursor-type)                            ; cursor visible
             (should (equal cursor-type (default-value 'cursor-type))) ; uses user default
             ;; Exit copy mode — cursor should be hidden again
             (ghostel-copy-mode-exit)
-            (should-not ghostel--copy-mode-active)          ; exited copy mode
+            (should (eq ghostel--input-mode 'semi-char))    ; exited copy mode
             (should (null cursor-type))))                   ; cursor hidden again
       (kill-buffer buf))))
 
@@ -1198,7 +1198,7 @@ cell, so the visual line width must equal the terminal column count."
             ;; post-command-hook) from creating overlays in this buffer.
             (should-not global-hl-line-mode))
           ;; Enter copy mode — local hl-line-mode should be enabled
-          (let ((ghostel--copy-mode-active nil)
+          (let ((ghostel--input-mode 'semi-char)
                 (ghostel--redraw-timer nil))
             (ghostel-copy-mode)
             (should (bound-and-true-p hl-line-mode))
@@ -1271,18 +1271,17 @@ cell, so the visual line width must equal the terminal column count."
 ;; -----------------------------------------------------------------------
 
 (ert-deftest ghostel-test-copy-mode-load-all ()
-  "Test that `ghostel-copy-mode-load-all' sets full-buffer state."
+  "Test that `ghostel-copy-mode-load-all' switches to emacs mode."
   (let ((buf (generate-new-buffer " *ghostel-test-load-all*")))
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (let ((ghostel--copy-mode-active nil)
+          (let ((ghostel--input-mode 'semi-char)
                 (ghostel--redraw-timer nil)
                 (ghostel--term 'fake-term))
             ;; Enter copy mode
             (ghostel-copy-mode)
-            (should ghostel--copy-mode-active)              ; in copy mode
-            (should-not ghostel--copy-mode-full-buffer)     ; not full yet
+            (should (eq ghostel--input-mode 'copy))         ; in copy mode
             ;; Simulate a 3-line viewport with point on line 2, column 3
             (let ((inhibit-read-only t))
               (erase-buffer)
@@ -1291,8 +1290,6 @@ cell, so the visual line width must equal the terminal column count."
             (forward-line 1)
             (move-to-column 3)                              ; on 'X' in line 2
             ;; Stub the native function and recenter (no window in batch).
-            ;; The stub must NOT bind inhibit-read-only itself — the real
-            ;; native function doesn't, so the caller must have it set.
             ;; Returns viewport-line=3 (viewport starts at line 3 in full buffer)
             (cl-letf (((symbol-function 'ghostel--redraw-full-scrollback)
                        (lambda (_term)
@@ -1301,15 +1298,15 @@ cell, so the visual line width must equal the terminal column count."
                          3))
                       ((symbol-function 'recenter) #'ignore))
               (ghostel-copy-mode-load-all)
-              (should ghostel--copy-mode-full-buffer)       ; now full
+              (should (eq ghostel--input-mode 'emacs))      ; switched to emacs
               ;; Point should be on line 4 (viewport-line 3 + saved offset 1)
               (should (= 4 (line-number-at-pos)))           ; preserved line
               (should (= 3 (current-column))))
-            ;; Exit resets full-buffer state
+            ;; Exit emacs mode resets state
             (cl-letf (((symbol-function 'ghostel--scroll-bottom) #'ignore)
                       ((symbol-function 'ghostel--redraw) #'ignore))
-              (ghostel-copy-mode-exit))
-            (should-not ghostel--copy-mode-full-buffer)))   ; reset on exit
+              (ghostel-semi-char-mode))
+            (should (eq ghostel--input-mode 'semi-char))))  ; back to semi-char
       (kill-buffer buf))))
 
 ;; -----------------------------------------------------------------------
@@ -1336,13 +1333,12 @@ cell, so the visual line width must equal the terminal column count."
 ;; -----------------------------------------------------------------------
 
 (ert-deftest ghostel-test-copy-mode-full-buffer-scroll ()
-  "Test that scroll commands use Emacs navigation in full-buffer mode."
+  "Test that scroll commands use Emacs navigation in emacs mode (full scrollback)."
   (let ((buf (generate-new-buffer " *ghostel-test-full-scroll*")))
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (let ((ghostel--copy-mode-active t)
-                (ghostel--copy-mode-full-buffer t)
+          (let ((ghostel--input-mode 'emacs)
                 (ghostel--term 'fake-term)
                 (inhibit-read-only t))
             ;; Insert content
@@ -1652,8 +1648,7 @@ cell, so the visual line width must equal the terminal column count."
   "Scroll-up/down forward events when mouse tracking is active."
   (let ((ghostel--term 'fake)
         (ghostel--process 'fake)
-        (ghostel--copy-mode-active nil)
-        (ghostel--copy-mode-full-buffer nil)
+        (ghostel--input-mode 'semi-char)
         (ghostel--force-next-redraw nil)
         (mouse-event-args nil)
         (scroll-called nil)
@@ -1693,8 +1688,7 @@ cell, so the visual line width must equal the terminal column count."
   "Scroll-up/down fall back to viewport scroll when mouse tracking is off."
   (let ((ghostel--term 'fake)
         (ghostel--process 'fake)
-        (ghostel--copy-mode-active nil)
-        (ghostel--copy-mode-full-buffer nil)
+        (ghostel--input-mode 'semi-char)
         (ghostel--force-next-redraw nil)
         (scroll-delta nil)
         (fake-up-event `(wheel-up (,(selected-window) 1 (10 . 5) 0)))
@@ -1715,29 +1709,29 @@ cell, so the visual line width must equal the terminal column count."
       (should ghostel--force-next-redraw))))
 
 (ert-deftest ghostel-test-control-key-bindings ()
-  "All non-exception C-<letter> keys should be bound in ghostel-mode-map."
+  "All non-exception C-<letter> keys should be bound in ghostel-semi-char-mode-map."
   (dolist (c (number-sequence ?a ?z))
     (let* ((key-str (format "C-%c" c))
            (key-vec (kbd key-str))
-           (binding (lookup-key ghostel-mode-map key-vec)))
+           (binding (lookup-key ghostel-semi-char-mode-map key-vec)))
       ;; Skip exceptions (may have sub-keymaps like C-c C-c)
       (unless (member key-str ghostel-keymap-exceptions)
         (should binding))))
   ;; C-@ should also be bound (sends NUL)
-  (should (lookup-key ghostel-mode-map (kbd "C-@"))))
+  (should (lookup-key ghostel-semi-char-mode-map (kbd "C-@"))))
 
 (ert-deftest ghostel-test-meta-key-bindings ()
-  "All non-exception M-<letter> keys should be bound in ghostel-mode-map."
+  "All non-exception M-<letter> keys should be bound in ghostel-semi-char-mode-map."
   (dolist (c (number-sequence ?a ?z))
     (let* ((key-str (format "M-%c" c))
            (key-vec (kbd key-str))
-           (binding (lookup-key ghostel-mode-map key-vec)))
+           (binding (lookup-key ghostel-semi-char-mode-map key-vec)))
       (unless (eq c ?y)  ; M-y is ghostel-yank-pop
         (if (member key-str ghostel-keymap-exceptions)
             (should-not (eq binding #'ghostel--send-event))
           (should (eq binding #'ghostel--send-event))))))
   ;; M-y should be bound to ghostel-yank-pop, not send-event
-  (should (eq (lookup-key ghostel-mode-map (kbd "M-y")) #'ghostel-yank-pop)))
+  (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "M-y")) #'ghostel-yank-pop)))
 
 ;; -----------------------------------------------------------------------
 ;; Test: ghostel-copy-mode-recenter
@@ -1750,7 +1744,7 @@ cell, so the visual line width must equal the terminal column count."
         (with-current-buffer buf
           (dotimes (i 20) (insert (format "line-%02d" i) (make-string 33 ?x) "\n"))
           (setq ghostel--term 'fake-term)
-          (setq ghostel--copy-mode-active t)
+          (setq ghostel--input-mode 'copy)
           (setq buffer-read-only t)
           (let ((scroll-delta nil)
                 (redraw-called nil)
@@ -1898,6 +1892,257 @@ cell, so the visual line width must equal the terminal column count."
         (ghostel-shell "/bin/zsh"))
     (should (equal "/bin/zsh" (ghostel--get-shell)))))
 
+;; -----------------------------------------------------------------------
+;; Tests: input mode switching
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-frozen-p ()
+  "Test that `ghostel--frozen-p' reflects frozen modes."
+  (let ((ghostel--input-mode 'semi-char))
+    (should-not (ghostel--frozen-p)))
+  (let ((ghostel--input-mode 'char))
+    (should-not (ghostel--frozen-p)))
+  (let ((ghostel--input-mode 'copy))
+    (should (ghostel--frozen-p)))
+  (let ((ghostel--input-mode 'emacs))
+    (should (ghostel--frozen-p))))
+
+(ert-deftest ghostel-test-full-scrollback-p ()
+  "Test that `ghostel--full-scrollback-p' only returns t for emacs mode."
+  (let ((ghostel--input-mode 'semi-char))
+    (should-not (ghostel--full-scrollback-p)))
+  (let ((ghostel--input-mode 'copy))
+    (should-not (ghostel--full-scrollback-p)))
+  (let ((ghostel--input-mode 'emacs))
+    (should (ghostel--full-scrollback-p))))
+
+(ert-deftest ghostel-test-mode-starts-semi-char ()
+  "Test that `ghostel-mode' starts in semi-char mode."
+  (let ((buf (generate-new-buffer " *ghostel-test-mode-start*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (should (eq ghostel--input-mode 'semi-char))
+          (should (eq (current-local-map) ghostel-semi-char-mode-map)))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-char-mode-binds-exceptions ()
+  "Test that char mode binds keys from `ghostel-keymap-exceptions'."
+  ;; In char mode, exception keys like C-x and C-g should be bound
+  (dolist (key-str ghostel-keymap-exceptions)
+    (let* ((key-vec (kbd key-str))
+           (binding (lookup-key ghostel-char-mode-map key-vec)))
+      ;; C-c has sub-bindings (prefix key), skip it
+      (unless (string= key-str "C-c")
+        (should binding)))))
+
+(ert-deftest ghostel-test-char-mode-escape-hatch ()
+  "Test that M-RET is bound to exit char mode."
+  (should (eq (lookup-key ghostel-char-mode-map (kbd "M-RET"))
+              #'ghostel-semi-char-mode))
+  (should (eq (lookup-key ghostel-char-mode-map (kbd "C-M-m"))
+              #'ghostel-semi-char-mode)))
+
+(ert-deftest ghostel-test-semi-char-mode-inherits-base ()
+  "Test that semi-char-mode-map inherits from ghostel-mode-map."
+  (should (eq (keymap-parent ghostel-semi-char-mode-map) ghostel-mode-map))
+  ;; C-c C-e should be accessible via parent
+  (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "C-c C-e"))
+              #'ghostel-emacs-mode))
+  (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "C-c C-j"))
+              #'ghostel-semi-char-mode)))
+
+(ert-deftest ghostel-test-emacs-mode-map-exit-on-self-insert ()
+  "Test that emacs mode remaps self-insert to exit-and-send."
+  (should (eq (lookup-key ghostel-emacs-mode-map [remap self-insert-command])
+              #'ghostel-emacs-mode-exit-and-send))
+  ;; q should exit to semi-char
+  (should (eq (lookup-key ghostel-emacs-mode-map (kbd "q"))
+              #'ghostel-semi-char-mode)))
+
+(ert-deftest ghostel-test-copy-mode-map-inherits-base ()
+  "Test that copy-mode-map inherits mode switching from ghostel-mode-map."
+  (should (eq (keymap-parent ghostel-copy-mode-map) ghostel-mode-map))
+  ;; C-c C-e should be accessible for switching to emacs mode
+  (should (eq (lookup-key ghostel-copy-mode-map (kbd "C-c C-e"))
+              #'ghostel-emacs-mode))
+  ;; C-c C-j should be accessible for switching to semi-char
+  (should (eq (lookup-key ghostel-copy-mode-map (kbd "C-c C-j"))
+              #'ghostel-semi-char-mode)))
+
+(ert-deftest ghostel-test-switch-to-char-mode ()
+  "Test switching from semi-char to char mode and back."
+  (let ((buf (generate-new-buffer " *ghostel-test-char-switch*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (should (eq ghostel--input-mode 'semi-char))
+          ;; Switch to char mode
+          (ghostel-char-mode)
+          (should (eq ghostel--input-mode 'char))
+          (should (eq (current-local-map) ghostel-char-mode-map))
+          (should (equal mode-line-process ":Char"))
+          ;; Switch back to semi-char
+          (ghostel-semi-char-mode)
+          (should (eq ghostel--input-mode 'semi-char))
+          (should (eq (current-local-map) ghostel-semi-char-mode-map))
+          (should (null mode-line-process)))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-switch-to-emacs-mode ()
+  "Test switching to emacs mode loads scrollback and sets state."
+  (let ((buf (generate-new-buffer " *ghostel-test-emacs-switch*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term 'fake-term)
+          (let ((inhibit-read-only t))
+            (insert "line1\nline2\nline3"))
+          (goto-char (point-min))
+          ;; Stub scrollback loading
+          (cl-letf (((symbol-function 'ghostel--redraw-full-scrollback)
+                     (lambda (_term)
+                       (let ((inhibit-read-only t))
+                         (erase-buffer)
+                         (insert "sb1\nline1\nline2\nline3"))
+                       1))
+                    ((symbol-function 'recenter) #'ignore))
+            (ghostel-emacs-mode)
+            (should (eq ghostel--input-mode 'emacs))
+            (should (eq (current-local-map) ghostel-emacs-mode-map))
+            (should buffer-read-only)
+            (should (equal mode-line-process ":Emacs")))
+          ;; Exit back to semi-char
+          (cl-letf (((symbol-function 'ghostel--scroll-bottom) #'ignore)
+                    ((symbol-function 'ghostel--redraw) #'ignore)
+                    ((symbol-function 'ghostel--invalidate) #'ignore))
+            (ghostel-semi-char-mode)
+            (should (eq ghostel--input-mode 'semi-char))
+            (should-not buffer-read-only)
+            (should (null mode-line-process))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-copy-to-emacs-transition ()
+  "Test switching from copy mode to emacs mode."
+  (let ((buf (generate-new-buffer " *ghostel-test-copy-emacs*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term 'fake-term)
+          (let ((inhibit-read-only t))
+            (insert "line1\nline2"))
+          ;; Enter copy mode
+          (ghostel-copy-mode)
+          (should (eq ghostel--input-mode 'copy))
+          (should buffer-read-only)
+          ;; Switch to emacs mode from copy
+          (cl-letf (((symbol-function 'ghostel--redraw-full-scrollback)
+                     (lambda (_term)
+                       (let ((inhibit-read-only t))
+                         (erase-buffer)
+                         (insert "sb\nline1\nline2"))
+                       1))
+                    ((symbol-function 'recenter) #'ignore))
+            (ghostel-emacs-mode)
+            (should (eq ghostel--input-mode 'emacs))
+            (should buffer-read-only)
+            (should (equal mode-line-process ":Emacs")))
+          ;; Clean exit
+          (cl-letf (((symbol-function 'ghostel--scroll-bottom) #'ignore)
+                    ((symbol-function 'ghostel--redraw) #'ignore)
+                    ((symbol-function 'ghostel--invalidate) #'ignore))
+            (ghostel-semi-char-mode)))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-copy-mode-auto-load-goes-to-emacs ()
+  "Test that `ghostel-copy-mode-auto-load-scrollback' sends to emacs mode."
+  (let ((buf (generate-new-buffer " *ghostel-test-auto-load*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term 'fake-term)
+          (let ((ghostel-copy-mode-auto-load-scrollback t)
+                (inhibit-read-only t))
+            (insert "content")
+            (cl-letf (((symbol-function 'ghostel--redraw-full-scrollback)
+                       (lambda (_term)
+                         (let ((inhibit-read-only t))
+                           (erase-buffer)
+                           (insert "content"))
+                         1))
+                      ((symbol-function 'recenter) #'ignore))
+              ;; C-c C-t with auto-load should go to emacs mode, not copy
+              (ghostel-copy-mode)
+              (should (eq ghostel--input-mode 'emacs))
+              (should (equal mode-line-process ":Emacs"))))
+          ;; Clean exit
+          (cl-letf (((symbol-function 'ghostel--scroll-bottom) #'ignore)
+                    ((symbol-function 'ghostel--redraw) #'ignore)
+                    ((symbol-function 'ghostel--invalidate) #'ignore))
+            (ghostel-semi-char-mode)))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-mode-line-indicators ()
+  "Test that mode-line-process reflects the current input mode."
+  (let ((buf (generate-new-buffer " *ghostel-test-modeline*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          ;; Semi-char: no indicator
+          (should (null mode-line-process))
+          ;; Copy mode
+          (let ((ghostel--redraw-timer nil))
+            (ghostel-copy-mode)
+            (should (equal mode-line-process ":Copy"))
+            ;; Back to semi-char
+            (ghostel-semi-char-mode)
+            (should (null mode-line-process)))
+          ;; Char mode
+          (ghostel-char-mode)
+          (should (equal mode-line-process ":Char"))
+          (ghostel-semi-char-mode)
+          (should (null mode-line-process)))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-base-map-has-mode-switching ()
+  "Test that ghostel-mode-map has all mode switching bindings."
+  (should (eq (lookup-key ghostel-mode-map (kbd "C-c C-e")) #'ghostel-emacs-mode))
+  (should (eq (lookup-key ghostel-mode-map (kbd "C-c C-j")) #'ghostel-semi-char-mode))
+  (should (eq (lookup-key ghostel-mode-map (kbd "C-c M-d")) #'ghostel-char-mode))
+  (should (eq (lookup-key ghostel-mode-map (kbd "C-c C-t")) #'ghostel-copy-mode))
+  ;; Clear scrollback moved to C-c M-l
+  (should (eq (lookup-key ghostel-mode-map (kbd "C-c M-l")) #'ghostel-clear-scrollback)))
+
+(ert-deftest ghostel-test-delayed-redraw-skips-frozen ()
+  "Test that `ghostel--delayed-redraw' skips rendering in frozen modes."
+  (let ((buf (generate-new-buffer " *ghostel-test-redraw-frozen*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term 'fake-term)
+          (let ((redraw-called nil)
+                (write-input-called nil))
+            (cl-letf (((symbol-function 'ghostel--redraw)
+                       (lambda (&rest _) (setq redraw-called t)))
+                      ((symbol-function 'ghostel--flush-pending-output)
+                       #'ignore)
+                      ((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil)))
+              ;; In semi-char mode, redraw should be called
+              (setq ghostel--input-mode 'semi-char)
+              (ghostel--delayed-redraw buf)
+              (should redraw-called)
+              ;; In copy mode, redraw should be skipped
+              (setq redraw-called nil)
+              (setq ghostel--input-mode 'copy)
+              (ghostel--delayed-redraw buf)
+              (should-not redraw-called)
+              ;; In emacs mode, redraw should be skipped
+              (setq ghostel--input-mode 'emacs)
+              (ghostel--delayed-redraw buf)
+              (should-not redraw-called))))
+      (kill-buffer buf))))
+
 (defconst ghostel-test--elisp-tests
   '(ghostel-test-raw-key-sequences
     ghostel-test-modifier-number
@@ -1946,7 +2191,22 @@ cell, so the visual line width must equal the terminal column count."
     ghostel-test-send-next-key-function-key
     ghostel-test-local-host-p
     ghostel-test-update-directory-remote
-    ghostel-test-get-shell-local)
+    ghostel-test-get-shell-local
+    ghostel-test-frozen-p
+    ghostel-test-full-scrollback-p
+    ghostel-test-mode-starts-semi-char
+    ghostel-test-char-mode-binds-exceptions
+    ghostel-test-char-mode-escape-hatch
+    ghostel-test-semi-char-mode-inherits-base
+    ghostel-test-emacs-mode-map-exit-on-self-insert
+    ghostel-test-copy-mode-map-inherits-base
+    ghostel-test-switch-to-char-mode
+    ghostel-test-switch-to-emacs-mode
+    ghostel-test-copy-to-emacs-transition
+    ghostel-test-copy-mode-auto-load-goes-to-emacs
+    ghostel-test-mode-line-indicators
+    ghostel-test-base-map-has-mode-switching
+    ghostel-test-delayed-redraw-skips-frozen)
   "Tests that require only Elisp (no native module).")
 
 (defun ghostel-test-run-elisp ()


### PR DESCRIPTION
## Summary

Implements four input modes inspired by [eat.el](https://codeberg.org/akib/emacs-eat), addressing #40:

- **Semi-char** (default): most keys go to terminal, `C-c` prefix reserved for Emacs
- **Char** (`C-c M-d`): all keys sent to terminal, `M-RET` sole escape hatch
- **Copy** (`C-c C-t`): frozen viewport for text selection (existing, unchanged)
- **Emacs** (`C-c C-e`): full scrollback loaded as read-only Emacs buffer (isearch, occur, etc.)

`C-c C-j` returns to semi-char from any mode. Typing a character in copy/emacs mode auto-switches to semi-char and sends the key.

### Architecture changes

- Split `ghostel-mode-map` into base (C-c prefix only) + `ghostel-semi-char-mode-map` (terminal bindings, parent inheritance)
- New `ghostel-char-mode-map` (captures everything) and `ghostel-emacs-mode-map` (minimal, falls through to Emacs)
- Replace `ghostel--copy-mode-active` / `ghostel--copy-mode-full-buffer` with single `ghostel--input-mode` state variable
- `ghostel-copy-mode-load-all` now switches to emacs mode (full scrollback = emacs mode)
- Extract `ghostel--define-terminal-keys` / `ghostel--define-mouse-keys` helpers to share bindings
- Move clear-scrollback from `C-c C-l` to `C-c M-l` (reserving `C-c C-l` for future line mode)

### Line mode

Line mode (comint-like live terminal with editable input area) is planned as a separate follow-up PR due to its complexity.

## Test plan

- [x] All 48 existing tests pass
- [x] Clean byte-compile (no warnings)
- [ ] Manual: `M-x ghostel`, verify semi-char works as before
- [ ] Manual: `C-c M-d` enters char mode, all keys go to terminal, `M-RET` exits
- [ ] Manual: `C-c C-e` enters emacs mode, full scrollback loads, isearch works, `q` exits
- [ ] Manual: `C-c C-t` enters copy mode, `C-c C-e` from copy switches to emacs
- [ ] Manual: mode-line shows `:Char`, `:Copy`, `:Emacs` indicators
- [ ] Manual: `C-c C-j` returns to semi-char from all modes

Closes #40