### PR TITLE
Use per-process property for window resize handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,11 @@ EMACS ?= emacs
 XDG_CACHE_HOME ?= $(HOME)/.cache
 MELPAZOID_DIR  ?= $(XDG_CACHE_HOME)/melpazoid
 
-.PHONY: all build check test lint melpazoid byte-compile bench bench-quick clean
+ELC := ghostel.elc ghostel-debug.elc
 
-all: build test lint
+.PHONY: all build check test test-all lint melpazoid byte-compile bench bench-quick clean
+
+all: build test-all lint
 
 build:
 	./build.sh
@@ -13,8 +15,20 @@ build:
 check:
 	zig build check
 
-test:
+# Pattern rule: rebuild .elc whenever its .el source is newer.
+# Make's timestamp tracking keeps the byte-compiled files in sync, so
+# test targets never load stale .elc (Emacs prefers .elc over .el
+# even when the source is newer, which silently masks edits).
+%.elc: %.el
+	$(EMACS) --batch -Q -L . --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile $<
+
+test: $(ELC)
 	$(EMACS) --batch -Q -L . -l ert -l test/ghostel-test.el -f ghostel-test-run-elisp
+
+test-all: build $(ELC)
+	$(EMACS) --batch -Q -L . -l ert -l test/ghostel-test.el -f ghostel-test-run
+
+byte-compile: $(ELC)
 
 lint: byte-compile package-lint checkdoc
 
@@ -50,9 +64,6 @@ melpazoid:
 		LOCAL_REPO=$(CURDIR) \
 		make -C "$(MELPAZOID_DIR)"
 
-byte-compile:
-	$(EMACS) --batch -Q -L . --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile ghostel.el ghostel-debug.el
-
 bench:
 	bash bench/run-bench.sh
 
@@ -61,5 +72,5 @@ bench-quick:
 
 clean:
 	rm -f ghostel-module.dylib ghostel-module.so
-	rm -f ghostel.elc ghostel-debug.elc
+	rm -f $(ELC)
 	rm -rf zig-out .zig-cache

--- a/ghostel.el
+++ b/ghostel.el
@@ -2175,7 +2175,9 @@ on the remote host."
                       (t "erase '^?' iutf8")))
          (shell-command
           (list "/bin/sh" "-c"
-                (concat "stty " stty-flags " 2>/dev/null; "
+                (concat "stty " stty-flags
+                        (format " rows %d columns %d" height width)
+                        " 2>/dev/null; "
                         "printf '\\033[H\\033[2J'; exec "
                         (shell-quote-argument shell)
                         (and shell-args
@@ -2187,9 +2189,7 @@ on the remote host."
            (list
             "INSIDE_EMACS=ghostel"
             "TERM=xterm-256color"
-            "COLORTERM=truecolor"
-            (format "COLUMNS=%d" width)
-            (format "LINES=%d" height))
+            "COLORTERM=truecolor")
            (unless remote-p
              (list (format "EMACS_GHOSTEL_PATH=%s" ghostel-dir)))
            integration-env

--- a/ghostel.el
+++ b/ghostel.el
@@ -613,8 +613,6 @@ DIR is the module directory."
 Cleared before each redraw; checked afterwards to decide whether
 pixel-based trailing-space compensation is needed.")
 
-(defvar-local ghostel--resize-timer nil
-  "Timer for debounced SIGWINCH on alt screen.")
 
 (defvar-local ghostel--last-send-time nil
   "Time of the last `ghostel--send-key' call, for immediate-redraw detection.")
@@ -1913,9 +1911,6 @@ PROCESS is the shell process, EVENT describes the state change."
         (when ghostel--redraw-timer
           (cancel-timer ghostel--redraw-timer)
           (setq ghostel--redraw-timer nil))
-        (when ghostel--resize-timer
-          (cancel-timer ghostel--resize-timer)
-          (setq ghostel--resize-timer nil))
         (when ghostel--input-timer
           (cancel-timer ghostel--input-timer)
           (setq ghostel--input-timer nil))
@@ -2207,6 +2202,8 @@ on the remote host."
     ;; the shell's line editor (readline/ZLE) can render properly.
     (set-process-window-size proc height width)
     (set-process-query-on-exit-flag proc nil)
+    (process-put proc 'adjust-window-size-function
+                 #'ghostel--window-adjust-process-window-size)
     proc))
 
 
@@ -2279,46 +2276,26 @@ frame after idle to improve interactive responsiveness."
 (defun ghostel--window-adjust-process-window-size (process windows)
   "Resize the terminal to match the new Emacs window dimensions.
 PROCESS is the shell process, WINDOWS is the list of windows."
-  (let* ((window (car windows))
-         (width (window-max-chars-per-line window))
-         (height (window-body-height window)))
-    (when ghostel--term
-      (if (ghostel--mode-enabled ghostel--term 1049)
-          ;; Alt screen: debounce the entire resize (terminal + SIGWINCH)
-          ;; so we never interrupt a BSU/ESU cycle mid-render.
-          (progn
-            (when ghostel--resize-timer
-              (cancel-timer ghostel--resize-timer))
-            (setq ghostel--resize-timer
-                  (run-with-timer 0.05 nil
-                                  #'ghostel--resize-settled
-                                  (current-buffer) process height width)))
-        ;; Primary screen: resize + SIGWINCH + render immediately.
-        (ghostel--set-size ghostel--term height width)
-        (when (process-live-p process)
-          (set-process-window-size process height width))
-        (setq ghostel--force-next-redraw t)
-        (ghostel--invalidate)))
-    (cons width height)))
+  (let* ((adjust-fn (default-value 'window-adjust-process-window-size-function))
+         (adjust-fn (if (and (functionp adjust-fn)
+                             (not (eq adjust-fn
+                                      #'ghostel--window-adjust-process-window-size)))
+                        adjust-fn
+                      #'window-adjust-process-window-size-smallest))
+         (size (funcall adjust-fn process windows))
+         (width (car size))
+         (height (cdr size))
+         (buffer (process-buffer process)))
+    (when (and size (buffer-live-p buffer))
+      (with-current-buffer buffer
+        (when ghostel--term
+          (ghostel--set-size ghostel--term height width)
+          (setq ghostel--force-next-redraw t)
+          (ghostel--invalidate))))
+    ;; Return size — Emacs calls set-process-window-size (SIGWINCH)
+    ;; after this function returns, matching eat/vterm timing.
+    size))
 
-(defun ghostel--resize-settled (buffer process height width)
-  "Resize terminal in BUFFER and send SIGWINCH after debounce settles.
-Renders synchronously before returning to the event loop so the
-reflowed content is visible before the app's BSU can arrive.
-PROCESS is the shell, HEIGHT and WIDTH the final dimensions."
-  (when (buffer-live-p buffer)
-    (with-current-buffer buffer
-      (setq ghostel--resize-timer nil)
-      (when ghostel--term
-        (ghostel--set-size ghostel--term height width)
-        (when (and process (process-live-p process))
-          (set-process-window-size process height width))
-        ;; Render NOW, before returning to the event loop.
-        ;; The app's BSU response can't arrive until we return.
-        (let ((inhibit-read-only t)
-              (inhibit-redisplay t)
-              (inhibit-modification-hooks t))
-          (ghostel--redraw ghostel--term ghostel-full-redraw))))))
 
 
 ;;; Major mode
@@ -2333,8 +2310,6 @@ PROCESS is the shell, HEIGHT and WIDTH the final dimensions."
   (setq-local truncate-lines t)
   (setq-local scroll-conservatively 101)
   (setq-local line-spacing 0)
-  (setq-local window-adjust-process-window-size-function
-              #'ghostel--window-adjust-process-window-size)
   (add-function :after after-focus-change-function #'ghostel--focus-change)
   (ghostel--suppress-interfering-modes))
 

--- a/ghostel.el
+++ b/ghostel.el
@@ -1985,11 +1985,21 @@ When `default-directory' is a remote TRAMP path, consult
     (insert content)
     (write-region (point-min) (point-max) tramp-path nil 'silent)))
 
+(defun ghostel--cleanup-temp-paths (files dirs)
+  "Delete temporary FILES and DIRS created for remote shell integration.
+Directories are removed recursively so any contents written into them,
+such as a per-session `.zshenv', are cleaned up as well."
+  (dolist (f files)
+    (ignore-errors (delete-file f)))
+  (dolist (d dirs)
+    (ignore-errors (delete-directory d t))))
+
 (defun ghostel--setup-remote-integration (shell-type)
   "Set up shell integration on the remote host for SHELL-TYPE.
 Reads the local integration script, writes it (with any necessary
 preamble) to a temporary file on the remote host, and returns a
-plist (:env :args :stty :temp-files) for `ghostel--start-process'.
+plist (:env :args :stty :temp-files :temp-dirs) for
+`ghostel--start-process'.
 Returns nil on failure."
   (condition-case err
       (let* ((remote-prefix (file-remote-p default-directory))
@@ -2054,7 +2064,7 @@ Returns nil on failure."
                                           "}\n"))
              (list :env (list (format "ZDOTDIR=%s" remote-dir))
                    :args nil :stty "erase '^?' iutf8"
-                   :temp-files (list temp-zshenv temp-dir))))
+                   :temp-dirs (list temp-dir))))
           ;; Fish: -C runs after config, so just source the script.
           ('fish
            (let* ((temp (make-temp-file
@@ -2193,8 +2203,9 @@ on the remote host."
                 :filter #'ghostel--filter
                 :sentinel #'ghostel--sentinel)))
     (when remote-integration
-      (dolist (f (plist-get remote-integration :temp-files))
-        (ignore-errors (delete-file f))))
+      (ghostel--cleanup-temp-paths
+       (plist-get remote-integration :temp-files)
+       (plist-get remote-integration :temp-dirs)))
     (setq ghostel--process proc)
     ;; Raw binary I/O — no encoding/decoding by Emacs
     (set-process-coding-system proc 'binary 'binary)

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -13,6 +13,8 @@
 (require 'ert)
 (require 'ghostel)
 
+(declare-function ghostel--cleanup-temp-paths "ghostel")
+
 ;;; Helper: read first N rows from render state via debug-state
 
 (defun ghostel-test--row0 (term)
@@ -535,6 +537,26 @@ cell, so the visual line width must equal the terminal column count."
 
             (delete-process proc)))
       (kill-buffer buf))))
+
+(ert-deftest ghostel-test-cleanup-temp-paths-handles-files-and-dirs ()
+  "`ghostel--cleanup-temp-paths' deletes files and recursively deletes dirs.
+Mirrors the real zsh case where the directory still contains a
+`.zshenv' at cleanup time."
+  (let* ((dir (make-temp-file "ghostel-test-" t))
+         (nested (expand-file-name ".zshenv" dir))
+         (standalone (make-temp-file "ghostel-test-")))
+    (unwind-protect
+        (progn
+          (with-temp-file nested (insert "# test"))
+          (should (file-exists-p nested))
+          (should (file-directory-p dir))
+          (should (file-exists-p standalone))
+          (ghostel--cleanup-temp-paths (list standalone) (list dir))
+          (should-not (file-exists-p standalone))
+          (should-not (file-exists-p nested))
+          (should-not (file-directory-p dir)))
+      (ignore-errors (delete-file standalone))
+      (ignore-errors (delete-directory dir t)))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: encode-key with kitty keyboard protocol active

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1063,6 +1063,179 @@ cell, so the visual line width must equal the terminal column count."
       (kill-buffer buf))))
 
 ;; -----------------------------------------------------------------------
+;; Test: resize + app redraw produces correct buffer content
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-resize-redraw-alt-screen ()
+  "After resize on alt screen, the app's SIGWINCH-triggered redraw renders correctly.
+Simulates: alt-screen TUI fills screen → window resize → app redraws
+for new size inside BSU/ESU → verify buffer shows new content."
+  (let ((buf (generate-new-buffer " *ghostel-test-resize-redraw*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 10 40 100))
+                 (ghostel--term term)
+                 (ghostel--force-next-redraw nil)
+                 (inhibit-read-only t))
+            ;; 1) Enter alt screen and fill with "old" content using
+            ;;    cursor positioning (like a TUI app would).
+            (ghostel--write-input term "\e[?1049h")  ; alt screen on
+            (dotimes (i 10)
+              (ghostel--write-input term (format "\e[%d;1HOLD-LINE-%02d" (1+ i) i)))
+            (ghostel--redraw term t)
+            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+              (should (string-match-p "OLD-LINE-00" content))
+              (should (string-match-p "OLD-LINE-09" content)))
+
+            ;; 2) Simulate what ghostel--window-adjust-process-window-size does:
+            ;;    resize VT, synchronous redraw, set force flag.
+            (ghostel--set-size term 6 40)
+            (ghostel--redraw term t)
+            (setq ghostel--force-next-redraw t)
+
+            ;; 3) Simulate the app's SIGWINCH-triggered redraw with BSU/ESU.
+            ;;    The app clears screen and redraws for the new 6-row size.
+            (ghostel--write-input term "\e[?2026h")     ; BSU
+            (ghostel--write-input term "\e[H\e[2J")     ; clear
+            (dotimes (i 6)
+              (ghostel--write-input term (format "\e[%d;1HNEW-LINE-%02d" (1+ i) i)))
+            (ghostel--write-input term "\e[?2026l")     ; ESU
+
+            ;; 4) Simulate what ghostel--delayed-redraw does:
+            ;;    check BSU gate, flush, redraw.
+            (ghostel--delayed-redraw buf)
+
+            ;; 5) Verify: buffer must show NEW content, not OLD.
+            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+              (should (string-match-p "NEW-LINE-00" content))
+              (should (string-match-p "NEW-LINE-05" content))
+              (should-not (string-match-p "OLD-LINE" content)))))
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
+;; Test: resize with real process — verify PTY and buffer content
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-resize-width-change-full-repaint ()
+  "After width change on alt screen, all rows repainted correctly.
+Matches the real htop scenario: width changes from wide to narrow,
+app redraws all rows at new width via the filter pipeline."
+  (let ((buf (generate-new-buffer " *ghostel-test-width-change*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term (ghostel--new 6 80 100))
+          (let* ((proc (start-process "ghostel-test-w" buf "sleep" "60"))
+                 (ghostel--process proc)
+                 (inhibit-read-only t))
+            (set-process-coding-system proc 'binary 'binary)
+            (set-process-window-size proc 6 80)
+            (set-process-query-on-exit-flag proc nil)
+            (unwind-protect
+                (progn
+                  ;; Alt screen, fill all rows at 80 columns.
+                  (ghostel--write-input ghostel--term "\e[?1049h\e[H\e[2J")
+                  (dotimes (i 6)
+                    (ghostel--write-input ghostel--term
+                                          (format "\e[%d;1H%-80s" (1+ i) (format "WIDE-R%02d" i))))
+                  (ghostel--redraw ghostel--term t)
+                  (let ((c (buffer-substring-no-properties (point-min) (point-max))))
+                    (should (string-match-p "WIDE-R00" c))
+                    ;; Verify rows are 80 chars wide.
+                    (should (= 80 (length (car (split-string c "\n"))))))
+
+                  ;; Simulate what the resize function does.
+                  (ghostel--set-size ghostel--term 6 40)
+                  (set-process-window-size proc 6 40)
+                  (setq ghostel--force-next-redraw t)
+
+                  ;; App redraws ALL rows at new width, through filter pipeline.
+                  (let ((response (concat
+                                   "\e[H\e[2J"
+                                   (mapconcat
+                                    (lambda (i) (format "\e[%d;1HNARROW-R%02d" (1+ i) i))
+                                    (number-sequence 0 5) ""))))
+                    (ghostel--filter proc response))
+                  (ghostel--delayed-redraw buf)
+
+                  (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+                    ;; All rows must have new narrow content.
+                    (should (string-match-p "NARROW-R00" content))
+                    (should (string-match-p "NARROW-R05" content))
+                    ;; No old wide content.
+                    (should-not (string-match-p "WIDE-R" content))
+                    ;; Rows should be 40 chars wide (new terminal width).
+                    (should (= 40 (length (car (split-string content "\n")))))))
+              (when (process-live-p proc)
+                (delete-process proc)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-resize-through-filter-pipeline ()
+  "Full pipeline test: resize, then app response goes through filter path.
+The app's output enters via `ghostel--filter' (pending-output) and is
+rendered by `ghostel--delayed-redraw'.  This is the exact real-world path."
+  (let ((buf (generate-new-buffer " *ghostel-test-pipeline*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term (ghostel--new 10 40 100))
+          (let* ((process-environment
+                  (append (list "TERM=xterm-256color" "COLUMNS=40" "LINES=10")
+                          process-environment))
+                 (proc (start-process "ghostel-test-pipe" buf "sleep" "60")))
+            (setq ghostel--process proc)
+            (set-process-coding-system proc 'binary 'binary)
+            (set-process-window-size proc 10 40)
+            (set-process-query-on-exit-flag proc nil)
+            (unwind-protect
+                (let ((inhibit-read-only t))
+                  ;; Initial content on alt screen (written directly to VT).
+                  (ghostel--write-input ghostel--term "\e[?1049h\e[H\e[2J")
+                  (dotimes (i 10)
+                    (ghostel--write-input ghostel--term
+                                          (format "\e[%d;1H%-40s" (1+ i) (format "OLD-%02d" i))))
+                  (ghostel--redraw ghostel--term t)
+                  (should (string-match-p "OLD-00"
+                                          (buffer-substring-no-properties (point-min) (point-max))))
+
+                  ;; Resize (as our resize function does).
+                  (ghostel--set-size ghostel--term 6 40)
+                  (set-process-window-size proc 6 40)
+                  (ghostel--redraw ghostel--term t)
+                  (setq ghostel--force-next-redraw t)
+
+                  ;; Simulate app's SIGWINCH response arriving through the filter.
+                  ;; This is the real pipeline: filter → pending-output → delayed-redraw.
+                  ;; Use BSU/ESU like htop does.
+                  (let ((response (concat
+                                   "\e[?2026h"      ; BSU
+                                   "\e[?25l"         ; hide cursor
+                                   "\e[H\e[2J"       ; clear
+                                   (mapconcat
+                                    (lambda (i)
+                                      (format "\e[%d;1HNEW-%02d%s" (1+ i) i
+                                              (make-string (- 40 6) ?\s)))
+                                    (number-sequence 0 5) "")
+                                   "\e[6;7H"         ; position cursor
+                                   "\e[?25h"         ; show cursor
+                                   "\e[?2026l")))    ; ESU
+                    ;; Feed through the filter to accumulate as pending output.
+                    (ghostel--filter proc response))
+
+                  ;; Now call delayed-redraw (as the timer would).
+                  (ghostel--delayed-redraw buf)
+
+                  (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+                    (should (string-match-p "NEW-00" content))
+                    (should (string-match-p "NEW-05" content))
+                    (should-not (string-match-p "OLD-" content))
+                    (should (equal 6 (count-lines (point-min) (point-max))))))
+              (when (process-live-p proc)
+                (delete-process proc)))))
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
 ;; Test: theme synchronization
 ;; -----------------------------------------------------------------------
 
@@ -1840,7 +2013,7 @@ cell, so the visual line width must equal the terminal column count."
 (ert-deftest ghostel-test-send-next-key-meta-x ()
   "send-next-key routes M-x through the encoder with meta modifier."
   (let (captured-key captured-mods
-        (ghostel--term 'fake))
+                     (ghostel--term 'fake))
     (cl-letf (((symbol-function 'ghostel--send-encoded)
                (lambda (key mods &optional _utf8)
                  (setq captured-key key captured-mods mods))))
@@ -1852,7 +2025,7 @@ cell, so the visual line width must equal the terminal column count."
 (ert-deftest ghostel-test-send-next-key-function-key ()
   "send-next-key routes function keys through the encoder."
   (let (captured-key captured-mods
-        (ghostel--term 'fake))
+                     (ghostel--term 'fake))
     (cl-letf (((symbol-function 'ghostel--send-encoded)
                (lambda (key mods &optional _utf8)
                  (setq captured-key key captured-mods mods))))
@@ -1897,6 +2070,49 @@ cell, so the visual line width must equal the terminal column count."
   (let ((default-directory "/tmp/")
         (ghostel-shell "/bin/zsh"))
     (should (equal "/bin/zsh" (ghostel--get-shell)))))
+
+;; -----------------------------------------------------------------------
+;; Tests: window resize
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-resize-window-adjust ()
+  "Window adjust resizes the VT, marks redraw state, and returns dimensions."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--force-next-redraw nil)
+          (set-size-args nil)
+          (invalidate-called nil))
+      (let ((cur-buf (current-buffer)))
+        (cl-letf (((symbol-function 'ghostel--set-size)
+                   (lambda (_term h w) (setq set-size-args (list h w))))
+                  ((symbol-function 'ghostel--invalidate)
+                   (lambda () (setq invalidate-called t)))
+                  ((symbol-function 'process-buffer)
+                   (lambda (_proc) cur-buf))
+                  ((default-value 'window-adjust-process-window-size-function)
+                   (lambda (_proc _wins) '(120 . 40))))
+          (let ((result (ghostel--window-adjust-process-window-size
+                         'fake-proc '(fake-win))))
+            (should (equal '(120 . 40) result))
+            (should (equal '(40 120) set-size-args))
+            (should ghostel--force-next-redraw)
+            (should invalidate-called)))))))
+
+(ert-deftest ghostel-test-resize-nil-size ()
+  "When default function returns nil, no resize happens."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (set-size-called nil))
+      (cl-letf (((symbol-function 'ghostel--set-size)
+                 (lambda (_term _h _w) (setq set-size-called t)))
+                ((symbol-function 'process-buffer)
+                 (lambda (_proc) nil))
+                ((default-value 'window-adjust-process-window-size-function)
+                 (lambda (_proc _wins) nil)))
+        (let ((result (ghostel--window-adjust-process-window-size
+                       'fake-proc nil)))
+          (should (null result))
+          (should-not set-size-called))))))
 
 (defconst ghostel-test--elisp-tests
   '(ghostel-test-raw-key-sequences
@@ -1946,7 +2162,9 @@ cell, so the visual line width must equal the terminal column count."
     ghostel-test-send-next-key-function-key
     ghostel-test-local-host-p
     ghostel-test-update-directory-remote
-    ghostel-test-get-shell-local)
+    ghostel-test-get-shell-local
+    ghostel-test-resize-window-adjust
+    ghostel-test-resize-nil-size)
   "Tests that require only Elisp (no native module).")
 
 (defun ghostel-test-run-elisp ()

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -2093,6 +2093,42 @@ rendered by `ghostel--delayed-redraw'.  This is the exact real-world path."
         (ghostel-shell "/bin/zsh"))
     (should (equal "/bin/zsh" (ghostel--get-shell)))))
 
+(ert-deftest ghostel-test-start-process-sets-size-via-stty-not-env ()
+  "Initial terminal size must be baked into the `stty' wrapper, not
+into `LINES'/`COLUMNS' env vars.  Setting those env vars freezes
+ncurses apps like htop at start-up size and breaks live resize."
+  (let ((captured-env nil)
+        (orig-make-process (symbol-function #'make-process)))
+    (cl-letf (((symbol-function #'window-body-height)
+               (lambda (&optional _w) 43))
+              ((symbol-function #'window-max-chars-per-line)
+               (lambda (&optional _w) 137))
+              ((symbol-function #'make-process)
+               (lambda (&rest plist)
+                 (setq captured-env process-environment)
+                 (apply orig-make-process plist))))
+      (with-temp-buffer
+        (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+               (ghostel-shell "/bin/sh")
+               (ghostel-shell-integration nil)
+               (default-directory "/tmp/")
+               (proc (ghostel--start-process)))
+          (unwind-protect
+              (let ((cmd (process-command proc)))
+                (should (equal #'ghostel--window-adjust-process-window-size
+                               (process-get proc 'adjust-window-size-function)))
+                (should (equal '("/bin/sh" "-c") (seq-take cmd 2)))
+                (should (string-match-p "stty .* rows 43 columns 137"
+                                        (nth 2 cmd)))
+                (should-not (seq-some (lambda (s) (string-prefix-p "LINES=" s))
+                                      captured-env))
+                (should-not (seq-some (lambda (s) (string-prefix-p "COLUMNS=" s))
+                                      captured-env))
+                (should (member "TERM=xterm-256color" captured-env))
+                (should (member "COLORTERM=truecolor" captured-env)))
+            (when (process-live-p proc)
+              (delete-process proc))))))))
+
 ;; -----------------------------------------------------------------------
 ;; Tests: window resize
 ;; -----------------------------------------------------------------------

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -2114,6 +2114,193 @@ rendered by `ghostel--delayed-redraw'.  This is the exact real-world path."
           (should (null result))
           (should-not set-size-called))))))
 
+;;; SIGWINCH delivery tests — verify the PTY actually sends the signal
+
+(defun ghostel-test--sigwinch-wait-for (proc pred timeout)
+  "Wait up to TIMEOUT seconds for PRED to become non-nil on PROC output."
+  (let ((deadline (+ (float-time) timeout)))
+    (while (and (not (funcall pred))
+                (< (float-time) deadline))
+      (accept-process-output proc 0.05))))
+
+(ert-deftest ghostel-test-sigwinch-reaches-shell-basic ()
+  "Verify `set-process-window-size' delivers SIGWINCH to a PTY shell.
+This is the baseline: if this fails, the Emacs PTY mechanism itself
+is broken on this system."
+  (skip-unless (not (eq system-type 'windows-nt)))
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf (generate-new-buffer " *sigwinch-basic*"))
+         (output "")
+         (proc nil))
+    (unwind-protect
+        (progn
+          (setq proc
+                (make-process
+                 :name "sigwinch-basic"
+                 :buffer buf
+                 :command '("/bin/sh")
+                 :connection-type 'pty
+                 :noquery t
+                 :coding 'binary
+                 :filter (lambda (_p s) (setq output (concat output s)))))
+          (set-process-window-size proc 24 80)
+          ;; Install a SIGWINCH trap that prints a marker to stdout.
+          (process-send-string
+           proc "trap 'printf \"__WINCH__\\n\"' WINCH\n")
+          ;; Wait a bit for shell to consume the trap command.
+          (sleep-for 0.3)
+          ;; Clear output so we only see post-resize output.
+          (setq output "")
+          ;; Now trigger a resize — this is what Emacs does after
+          ;; adjust-window-size-function returns a (width . height).
+          (set-process-window-size proc 30 120)
+          ;; Wait up to 2 seconds for trap to fire.
+          (ghostel-test--sigwinch-wait-for
+           proc (lambda () (string-match-p "__WINCH__" output)) 2.0)
+          (should (string-match-p "__WINCH__" output)))
+      (when (and proc (process-live-p proc))
+        (delete-process proc))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-sigwinch-reaches-shell-ghostel-style ()
+  "Verify SIGWINCH delivery using ghostel's exact shell-invocation pattern.
+Ghostel starts the shell via `/bin/sh -c \"stty ...; exec <shell>\"',
+which could affect process group setup and SIGWINCH delivery."
+  (skip-unless (not (eq system-type 'windows-nt)))
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf (generate-new-buffer " *sigwinch-ghostel*"))
+         (output "")
+         (proc nil))
+    (unwind-protect
+        (progn
+          (setq proc
+                (make-process
+                 :name "sigwinch-ghostel"
+                 :buffer buf
+                 :command '("/bin/sh" "-c"
+                            "stty erase '^?' iutf8 2>/dev/null; \
+printf '\\033[H\\033[2J'; exec /bin/sh")
+                 :connection-type 'pty
+                 :noquery t
+                 :coding 'binary
+                 :filter (lambda (_p s) (setq output (concat output s)))))
+          (set-process-window-size proc 24 80)
+          ;; Wait for the exec to complete and shell to be ready.
+          (sleep-for 0.5)
+          (process-send-string
+           proc "trap 'printf \"__WINCH__\\n\"' WINCH\n")
+          (sleep-for 0.3)
+          (setq output "")
+          (set-process-window-size proc 30 120)
+          (ghostel-test--sigwinch-wait-for
+           proc (lambda () (string-match-p "__WINCH__" output)) 2.0)
+          (should (string-match-p "__WINCH__" output)))
+      (when (and proc (process-live-p proc))
+        (delete-process proc))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-sigwinch-via-ghostel-resize-handler ()
+  "Verify SIGWINCH reaches child processes when resize goes through
+`ghostel--window-adjust-process-window-size'.  This is the full path
+Emacs takes: call the adjust-window-size-function, get (width . height),
+then call `set-process-window-size'."
+  (skip-unless (not (eq system-type 'windows-nt)))
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf (generate-new-buffer " *sigwinch-gh-handler*"))
+         (output "")
+         (proc nil))
+    (unwind-protect
+        (progn
+          (setq proc
+                (make-process
+                 :name "sigwinch-gh-handler"
+                 :buffer buf
+                 :command '("/bin/sh" "-c"
+                            "stty erase '^?' iutf8 2>/dev/null; \
+printf '\\033[H\\033[2J'; exec /bin/sh")
+                 :connection-type 'pty
+                 :noquery t
+                 :coding 'binary
+                 :filter (lambda (_p s) (setq output (concat output s)))))
+          (set-process-window-size proc 24 80)
+          (sleep-for 0.5)
+          (setq output "")
+          ;; Start a foreground child that traps SIGWINCH (simulates htop).
+          (process-send-string
+           proc "/bin/sh -c 'trap \"printf __CHILD_WINCH__\\\\n\" WINCH; \
+while :; do sleep 0.1; done'\n")
+          (sleep-for 0.5)
+          ;; Now simulate Emacs's window--adjust-process-windows path:
+          ;; register the adjust-window-size-function and trigger the handler.
+          (process-put proc 'adjust-window-size-function
+                       #'ghostel--window-adjust-process-window-size)
+          (with-current-buffer buf
+            (let ((ghostel--term 'fake-term))
+              (cl-letf (((symbol-function 'ghostel--set-size)
+                         (lambda (_t _h _w) nil))
+                        ((symbol-function 'ghostel--invalidate) #'ignore)
+                        ((default-value 'window-adjust-process-window-size-function)
+                         (lambda (_p _w) (cons 120 30))))
+                ;; Invoke the handler as Emacs would.
+                (let ((size (ghostel--window-adjust-process-window-size
+                             proc (list))))
+                  ;; Emacs calls set-process-window-size with the returned size.
+                  (should (equal size (cons 120 30)))
+                  (set-process-window-size proc (cdr size) (car size))))))
+          (ghostel-test--sigwinch-wait-for
+           proc (lambda () (string-match-p "__CHILD_WINCH__" output)) 2.0)
+          (should (string-match-p "__CHILD_WINCH__" output)))
+      (when (and proc (process-live-p proc))
+        (delete-process proc))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-sigwinch-reaches-child-process ()
+  "Verify SIGWINCH reaches a foreground child of the shell (mimicking htop).
+When htop runs, it is a child process of the shell.  Since ghostel's
+shell is non-interactive (no job control), the child inherits the
+shell's process group and should receive SIGWINCH sent to the PTY's
+foreground process group."
+  (skip-unless (not (eq system-type 'windows-nt)))
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf (generate-new-buffer " *sigwinch-child*"))
+         (output "")
+         (proc nil))
+    (unwind-protect
+        (progn
+          (setq proc
+                (make-process
+                 :name "sigwinch-child"
+                 :buffer buf
+                 :command '("/bin/sh" "-c" "exec /bin/sh")
+                 :connection-type 'pty
+                 :noquery t
+                 :coding 'binary
+                 :filter (lambda (_p s) (setq output (concat output s)))))
+          (set-process-window-size proc 24 80)
+          (sleep-for 0.3)
+          (setq output "")
+          ;; Start a child sh in the foreground with its own SIGWINCH trap,
+          ;; sleeping forever.  This child simulates htop waiting for SIGWINCH.
+          ;; We can't send more commands after this because the outer shell
+          ;; is blocked on wait() for the child — but that's fine, we only
+          ;; need the resize to fire and the child's trap to print the marker.
+          (process-send-string
+           proc "/bin/sh -c 'trap \"printf __CHILD_WINCH__\\\\n\" WINCH; \
+while :; do sleep 0.1; done'\n")
+          (sleep-for 0.5)
+          (set-process-window-size proc 30 120)
+          (ghostel-test--sigwinch-wait-for
+           proc (lambda () (string-match-p "__CHILD_WINCH__" output)) 2.0)
+          (should (string-match-p "__CHILD_WINCH__" output)))
+      (when (and proc (process-live-p proc))
+        (delete-process proc))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
+
 (defconst ghostel-test--elisp-tests
   '(ghostel-test-raw-key-sequences
     ghostel-test-modifier-number
@@ -2164,7 +2351,11 @@ rendered by `ghostel--delayed-redraw'.  This is the exact real-world path."
     ghostel-test-update-directory-remote
     ghostel-test-get-shell-local
     ghostel-test-resize-window-adjust
-    ghostel-test-resize-nil-size)
+    ghostel-test-resize-nil-size
+    ghostel-test-sigwinch-reaches-shell-basic
+    ghostel-test-sigwinch-reaches-shell-ghostel-style
+    ghostel-test-sigwinch-reaches-child-process
+    ghostel-test-sigwinch-via-ghostel-resize-handler)
   "Tests that require only Elisp (no native module).")
 
 (defun ghostel-test-run-elisp ()


### PR DESCRIPTION
## Summary
- Register resize handler via per-process `adjust-window-size-function` property instead of buffer-local variable, matching eat/vterm and ensuring reliable invocation by Emacs's C-level `window--adjust-process-windows`
- Delegate dimension calculation to the default `window-adjust-process-window-size-smallest` for proper multi-window handling
- Unify primary/alt screen resize paths, removing the debounce timer and `ghostel--resize-settled`

## Test plan
- [x] `make all` passes (build + 50 tests + lint)
- [x] Open ghostel, split window, close split — terminal resizes for shell prompt
- [x] Verify resize works with vertical split (C-x 3) as well
- [x] Test with TUI app on alt screen (e.g. `less`, `vim`)

Note: htop has a known rendering issue after resize (#67) that appears related to ncurses optimized diff assumptions vs libghostty render state dirty tracking — this needs further investigation.

Ref: #67