### PR TITLE
Use executable-find to locate bash in SIGWINCH tests

### DIFF
--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -2181,9 +2181,7 @@ ncurses apps like htop at start-up size and breaks live resize."
                 (< (float-time) deadline))
       (accept-process-output proc 0.05))))
 
-(defconst ghostel-test--bash
-  (cond ((file-executable-p "/bin/bash") "/bin/bash")
-        ((file-executable-p "/usr/bin/bash") "/usr/bin/bash"))
+(defconst ghostel-test--bash (executable-find "bash")
   "Absolute path to bash, or nil if not found.
 The baseline SIGWINCH tests explicitly use bash because trap-on-signal
 behavior for an idle shell reading stdin differs across implementations


### PR DESCRIPTION
## Summary
Follow-up to #69. Replaces the hardcoded `/bin/bash` / `/usr/bin/bash` cond with `(executable-find "bash")` so non-standard installs (Nix, Homebrew) are also picked up.

## Test plan
- [x] Local macOS: all 54 Elisp tests pass (3 consecutive runs)
- [x] CI green