### PR TITLE
Fix: wrong number of argument for `ghostel-evil--around-delete` when calling `evil-delete-char`

### DIFF
--- a/ghostel-evil.el
+++ b/ghostel-evil.el
@@ -169,7 +169,8 @@ escape sequence is not bound in all shell configurations."
 ;; Advice for evil editing operators
 ;; ---------------------------------------------------------------------------
 
-(defun ghostel-evil--around-delete (orig-fn beg end type register yank-handler)
+(defun ghostel-evil--around-delete
+    (orig-fn beg end &optional type register yank-handler)
   "Intercept `evil-delete' in ghostel buffers.
 Yanks text to REGISTER, then deletes via PTY.
 Covers d, dd, D, x, X."

--- a/test/ghostel-evil-test.el
+++ b/test/ghostel-evil-test.el
@@ -351,6 +351,24 @@ Uses mocks for native functions."
        (should (cl-find '("u" . "ctrl") keys-sent :test #'equal))
        (should (cl-find '("e" . "ctrl") keys-sent :test #'equal))))))
 
+(ert-deftest ghostel-evil-test-delete-char ()
+  "Test that `evil-delete-char' (x) works without error.
+Regression: yank-handler arg was not optional in advice signature,
+so calls from `evil-delete-char' (which passes only 4 args to
+`evil-delete') raised `wrong-number-of-arguments'."
+  (ghostel-evil-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "hello")
+   (goto-char (point-min))
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0)))
+             ((symbol-function 'ghostel-evil--cursor-to-point) #'ignore)
+             ((symbol-function 'ghostel--send-encoded) #'ignore))
+     (evil-normal-state)
+     ;; evil-delete-char calls evil-delete without yank-handler
+     (evil-delete-char 1 2 'exclusive nil)
+     (should (eq evil-state 'normal)))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: evil-change advice
 ;; -----------------------------------------------------------------------
@@ -559,6 +577,7 @@ Prevents up/down arrows being sent as history navigation."
     ghostel-evil-test-advice-no-op-outside-ghostel
     ghostel-evil-test-delete-sends-backspace-keys
     ghostel-evil-test-delete-line-sends-ctrl-u
+    ghostel-evil-test-delete-char
     ghostel-evil-test-change-deletes-and-inserts
     ghostel-evil-test-replace-deletes-and-inserts
     ghostel-evil-test-paste-after


### PR DESCRIPTION
After loading `ghostel-evil`, calling `evil-delete-char` will result in error
```
apply: Wrong number of arguments: #[(orig-fn beg end type register yank-handler) ((if (ghostel-evil--active-p) (progn (if register nil (let ((text (filter-buffer-substring beg end))) (if (string-match-p "
" text) nil (evil-set-register 45 text)))) (let ((evil-was-yanked-without-register nil)) (evil-yank beg end type register yank-handler)) (if (eq type 'line) (progn (ghostel--send-encoded "e" "ctrl") (ghostel--send-encoded "u" "ctrl")) (ghostel-evil--delete-region beg end))) (funcall orig-fn beg end type register yank-handler))) (t) nil "Intercept `evil-delete' in ghostel buffers.
Yanks text to REGISTER, then deletes via PTY.
Covers d, dd, D, x, X."], 5
```
This is due to the fact that `evil-delete-char` is called with only 4 arguments `(evil-delete-char BEG END &optional TYPE REGISTER)`.

This PR fix this by setting the fifth argument, `yank-handler` as optional in the `ghostel-evil--around-delete` advice.
