### PR TITLE
Add eat-style input modes (char, emacs, copy, line, semi-char)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,36 @@ string match -qr '^ghostel(,|$)' -- "$INSIDE_EMACS"; and source "$EMACS_GHOSTEL_
 ```
 </details>
 
-## Key Bindings
+## Input modes
 
-### Terminal mode
+Ghostel offers five eat.el-style input modes.  You enter a ghostel
+buffer in **semi-char mode**; switch modes with the key bindings below
+and watch `mode-line-process` for the current mode indicator.
+
+| Mode        | Indicator | Terminal | Buffer      | Purpose                                       |
+|-------------|-----------|----------|-------------|-----------------------------------------------|
+| semi-char   | *(none)*  | live     | editable    | default — type to terminal, `C-c` reserved    |
+| char        | `:Char`   | live     | editable    | TUI apps — *all* keys go to the terminal      |
+| Emacs       | `:Emacs`  | live     | read-only   | search/read while the terminal keeps running  |
+| copy        | `:Copy`   | frozen   | read-only   | precise text selection without scroll churn   |
+| line        | `:Line`   | live     | editable    | compose input with Emacs keys, send on `RET`  |
+
+### Mode-switch keybindings (available from every live mode)
+
+| Key       | Action                                    |
+|-----------|-------------------------------------------|
+| `C-c C-j` | Switch to semi-char mode (universal exit) |
+| `C-c M-d` | Switch to char mode                       |
+| `C-c C-e` | Switch to Emacs mode                      |
+| `C-c C-t` | Toggle copy mode                          |
+| `C-c C-l` | Switch to line mode                       |
+| `M-RET`   | Char mode only: return to semi-char       |
+
+### Semi-char mode (default)
+
+Most keys are sent to the terminal.  Keys in
+`ghostel-keymap-exceptions` (default: `C-c`, `C-x`, `C-u`, `C-h`,
+`C-g`, `M-x`, `M-o`, `M-:`, `C-\`) pass through to Emacs.
 
 | Key         | Action                                 |
 |-------------|----------------------------------------|
@@ -174,32 +201,60 @@ string match -qr '^ghostel(,|$)' -- "$INSIDE_EMACS"; and source "$EMACS_GHOSTEL_
 | `C-c C-z`   | Send suspend (C-z)                     |
 | `C-c C-d`   | Send EOF (C-d)                         |
 | `C-c C-\`   | Send quit (C-\)                        |
-| `C-c C-t`   | Enter copy mode                        |
 | `C-c M-w`   | Copy entire scrollback to kill ring    |
 | `C-y`       | Yank from kill ring (bracketed paste)  |
 | `M-y`       | Yank-pop (cycle through kill ring)     |
 | `C-c C-y`   | Paste from kill ring                   |
-| `C-c C-l`   | Clear scrollback                       |
+| `C-c M-l`   | Clear scrollback                       |
 | `C-c C-n`   | Jump to next hyperlink                 |
 | `C-c C-p`   | Jump to previous hyperlink             |
-| `C-c M-n`   | Jump to next prompt                    |
-| `C-c M-p`   | Jump to previous prompt                |
+| `C-c M-n`   | Enter Emacs mode and jump to next prompt |
+| `C-c M-p`   | Enter Emacs mode and jump to previous prompt |
 | `C-c C-q`   | Send next key literally (escape hatch) |
 | Mouse wheel | Scroll through scrollback              |
 
-Keys listed in `ghostel-keymap-exceptions` (default: `C-c`, `C-x`, `C-u`,
-`C-h`, `C-g`, `M-x`, `M-o`, `M-:`, `C-\`) pass through to Emacs.
+### Char mode
+
+Entered with `C-c M-d`.  **All** keys (including
+`ghostel-keymap-exceptions`) are sent to the terminal.  Useful for TUI
+apps that want to bind `C-x`, `M-x`, `C-h`, etc. themselves.  `M-RET`
+(or `C-M-m`) is the sole escape hatch.
+
+### Emacs mode
+
+Entered with `C-c C-e`.  **The terminal keeps running**, the buffer is
+read-only, and standard Emacs bindings fall through to the global map.
+`isearch-forward`, `occur`, `M-x`, `C-SPC` + `M-w`, arrow keys, wheel
+scroll — all work unmodified.  The terminal keeps producing output and
+the buffer keeps growing, but your point stays where you navigated it
+(the delayed-redraw path preserves point in Emacs mode).
+
+**Typed keys do not reach the shell** — Emacs mode is a "look but
+don't touch" view.  Self-insert, `RET`, `TAB`, `DEL` fall through to
+the read-only buffer and trigger `text-read-only`, so a stray
+keystroke can't accidentally land at the prompt.  Switch to semi-char
+mode (`C-c C-j`) when you want to type to the shell.  `C-y` is the
+exception: it pastes via bracketed paste as a deliberate action and
+snaps point back to the live cursor.
+
+Use this for searching through scrollback while a build is running,
+filtering streaming logs with `M-x occur`, marking and copying across
+the visible history, or running any buffer-based command over the
+terminal's output without having to freeze it.
 
 ### Copy mode
 
-Enter with `C-c C-t`. Standard Emacs navigation works.
-Normal letter keys exit copy mode and send the key to the terminal.
+Entered with `C-c C-t`.  The terminal is **frozen** — no live output
+updates the buffer until you exit.  Use this when you want to select
+text precisely without the terminal scrolling underneath your cursor.
+The aggressive copy-mode keymap exits on self-insert, so typing a
+letter sends it to the terminal and returns to semi-char mode.
 
 | Key           | Action                           |
 |---------------|----------------------------------|
 | `C-SPC`       | Set mark                         |
 | `M-w` / `C-w` | Copy selection and exit          |
-| `C-n` / `C-p` | Move line (scrolls at edges)     |
+| `C-n` / `C-p` | Move line                        |
 | `M-v` / `C-v` | Scroll page up / down            |
 | `M-<` / `M->` | Jump to top / bottom of buffer   |
 | `C-c C-n`     | Jump to next hyperlink           |
@@ -207,15 +262,61 @@ Normal letter keys exit copy mode and send the key to the terminal.
 | `C-c M-n`     | Jump to next prompt              |
 | `C-c M-p`     | Jump to previous prompt          |
 | `C-l`         | Recenter viewport                |
-| `C-c C-t`     | Exit without copying             |
+| `q`           | Exit without copying             |
 | `a`–`z`       | Exit and send key to terminal    |
 
 Soft-wrapped newlines are automatically stripped from copied text.
 
+### Line mode
+
+Entered with `C-c C-l`.  Line mode buffers the user's input locally in
+Emacs — **no keystrokes are forwarded to the shell** while composing.
+Full Emacs editing (`M-b`, `M-DEL`, `C-y` yank, `transpose-words`,
+etc.) works on the input region.  Pressing `RET` sends the whole line
+to the shell in one write; bash receives it atomically, echoes and
+executes it.
+
+The terminal stays live: output keeps streaming and the buffer keeps
+re-rendering while you compose.  A snapshot/restore step in the
+delayed-redraw path captures the in-progress input before each redraw
+and re-inserts it at the new prompt-end afterwards, so async output
+or a fresh prompt arriving mid-edit does not clobber what you typed.
+After `RET`, line mode stays active — the next prompt is found on the
+following redraw cycle and the input marker moves there.
+
+Line mode uses the terminal cursor as the input-area boundary, so
+REPLs without shell integration (python3, irb, sqlite3, …) work too.
+When OSC 133 prompt markers are present on the cursor's row, the
+prompt prefix is recognised and the input boundary lands right after
+it.
+
+Line mode and fullscreen TUIs (vim, less, htop, …) cannot share the
+same keystroke stream — the TUI needs every key forwarded raw, while
+line mode buffers them locally.  Ghostel handles this transparently:
+when an alt-screen TUI starts, line mode pauses (any in-progress
+input is stashed) and the buffer drops to semi-char so the TUI gets
+its keys.  When the TUI exits, line mode resumes at the new prompt
+and the stashed input is reinstated.  Pressing `C-c C-l` while a TUI
+is already running arms the same auto-resume so line mode activates
+when the TUI exits.  An explicit mode switch (`C-c C-j`,
+`ghostel-char-mode`, etc.) cancels the armed auto-resume.
+
+| Key         | Action                                   |
+|-------------|------------------------------------------|
+| *(letters)* | Edit local input (never sent char-by-char) |
+| `RET`       | Send the whole line to the shell, stay in line mode |
+| `C-c C-c`   | Discard input and send SIGINT, stay in line mode    |
+| `C-d`       | Delete char, or send EOF at empty input  |
+| `M-p` / `M-n` | History ring: previous / next entry    |
+| `C-a`       | Beginning of input on the prompt row, else `beginning-of-line` |
+| `C-c C-j`   | Exit to semi-char mode (discards input)  |
+
+### Scrollback search outside copy mode
+
 The full scrollback is always rendered into the buffer as styled text,
 so `isearch`, `consult-line`, `occur`, `M-x flush-lines`, `C-x h` to
 select all, and any other buffer-based command work across the full
-history — even outside copy mode.
+history in **any** mode that has a read-only buffer (Emacs or copy).
 
 ## Features
 
@@ -755,7 +856,11 @@ When `evil-ghostel-mode` is active:
 | `M-x ghostel-other`            | Switch to next terminal or create one        |
 | `M-x ghostel-clear`            | Clear screen and scrollback                  |
 | `M-x ghostel-clear-scrollback` | Clear scrollback only                        |
-| `M-x ghostel-copy-mode`        | Enter copy mode                              |
+| `M-x ghostel-semi-char-mode`   | Switch to semi-char input mode (default)     |
+| `M-x ghostel-char-mode`        | Switch to char input mode                    |
+| `M-x ghostel-emacs-mode`       | Switch to Emacs input mode (read-only, live) |
+| `M-x ghostel-copy-mode`        | Enter copy mode (frozen)                     |
+| `M-x ghostel-line-mode`        | Switch to line input mode                    |
 | `M-x ghostel-copy-all`         | Copy entire scrollback to kill ring          |
 | `M-x ghostel-paste`            | Paste from kill ring                         |
 | `M-x ghostel-send-next-key`    | Send next key literally                      |
@@ -1133,6 +1238,9 @@ powering Neovim's built-in terminal.
 | TRAMP remote terminals        | Yes       | Yes     |
 | OSC 52 clipboard              | Yes       | Yes     |
 | Copy mode                     | Yes       | Yes     |
+| Char mode (runtime toggle)    | Yes       | No      |
+| Line mode (local editing)     | Yes       | No      |
+| Emacs mode (read-only, live)  | Yes       | No      |
 | Drag-and-drop                 | Yes       | No      |
 | Auto module download          | Yes       | No      |
 | Scrollback default            | ~5,000    | 1,000   |
@@ -1151,6 +1259,24 @@ in protocol support.
 passes them through to the terminal via SGR mouse protocol.  TUI apps like
 htop or lazygit receive full mouse input.  vterm intercepts mouse clicks for
 Emacs point movement and does not forward them to the terminal.
+
+**Input modes.**  Ghostel offers five eat.el-style input modes (semi-char,
+char, Emacs, copy, line) selected from a single base keymap; see the
+[Input modes](#input-modes) section above.  vterm's default mode is
+roughly equivalent to ghostel's semi-char (a similar set of reserved
+prefixes via `vterm-keymap-exceptions`), and `vterm-copy-mode` lines up
+with our copy mode — both freeze incoming output (vterm via XOFF flow
+control, ghostel by cancelling the redraw timer).  Three of ghostel's
+modes have no vterm equivalent: **line mode** buffers input locally so
+full Emacs editing (`M-b`, `M-DEL`, yank, `transpose-words`, history
+ring) works on the in-progress line and `RET` sends it atomically;
+**Emacs mode** keeps the terminal streaming live but locks the buffer
+read-only, so `isearch`, `occur`, `M-x flush-lines`, and the rest of
+Emacs's vocabulary work over the live log without freezing it; **char
+mode** is a runtime toggle that bypasses the keymap exceptions and
+forwards every key (including `C-c`, `C-x`, `M-x`) to the terminal — vterm
+requires editing `vterm-keymap-exceptions` and reloading the buffer to
+get the same effect.
 
 **Rendering.**  Both use text properties (not overlays) and batch consecutive
 cells with identical styles.  Ghostel's engine provides three-level dirty

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -86,7 +86,18 @@ Sets the initial value of the buffer-local state.  Use
   (and evil-ghostel-mode
        ghostel--term
        (not (ghostel--mode-enabled ghostel--term 1049))
-       (not ghostel--copy-mode-active)))
+       (eq ghostel--input-mode 'semi-char)))
+
+(defun evil-ghostel--line-mode-active-p ()
+  "Return non-nil when line mode editing is in effect.
+Line mode buffers shell input as plain buffer text inside
+`[ghostel--line-input-start, ghostel--line-input-end]'.  evil's
+default editing operators (operating on buffer text) are exactly
+right there, so PTY-routing intercepts must stand down."
+  (and evil-ghostel-mode
+       (eq ghostel--input-mode 'line)
+       (markerp ghostel--line-input-start)
+       (markerp ghostel--line-input-end)))
 
 ;; ---------------------------------------------------------------------------
 ;; Cursor synchronization
@@ -239,14 +250,18 @@ Set by the I/A advice which send Home/End directly.")
 (defun evil-ghostel--insert-state-entry ()
   "Sync terminal cursor to Emacs point when entering `emacs-state'.
 Skipped when `evil-ghostel--sync-inhibit' is set (by I/A advice
-which already sent Ctrl-a/Ctrl-e).
+which already sent Ctrl-a/Ctrl-e).  Also skipped outside semi-char:
+in line mode point and the terminal cursor are intentionally
+decoupled (the user is editing buffer text, not driving the shell
+cursor); in copy/Emacs/char modes the sync would either fight a
+read-only buffer or be redundant.
 When point is on a different row from the terminal cursor, snap
 back to the terminal cursor instead of sending up/down arrows
 which the shell would interpret as history navigation."
   (when (derived-mode-p 'ghostel-mode)
     (if evil-ghostel--sync-inhibit
         (setq evil-ghostel--sync-inhibit nil)
-      (when ghostel--term
+      (when (evil-ghostel--active-p)
         (let* ((tpos (ghostel--cursor-position ghostel--term))
                (trow (cdr tpos))
                (erow (- (line-number-at-pos (point) t) 1)))
@@ -264,17 +279,44 @@ cursor."
 ;; Advice for evil insert-line / append-line
 ;; ---------------------------------------------------------------------------
 
-(defun evil-ghostel--before-insert-line (&rest _)
-  "Send Ctrl-a to move terminal cursor to start of input."
-  (when (and evil-ghostel-mode ghostel--term)
+(defun evil-ghostel--around-insert-line (orig-fn &rest args)
+  "Route `evil-insert-line' according to the current input mode.
+ORIG-FN is the advised `evil-insert-line' called with ARGS.
+In semi-char, send Ctrl-a so the shell moves its readline cursor
+to the start of input — `orig-fn' then enters insert state and the
+buffer cursor is repositioned by the next redraw.
+In line mode, the input region is plain buffer text bounded by
+`ghostel--line-input-start' / `--line-input-end'; jump point there
+and enter insert state directly (`back-to-indentation' would land
+on the prompt, which is read-only).
+Outside ghostel, run unchanged."
+  (cond
+   ((evil-ghostel--active-p)
     (ghostel--send-encoded "a" "ctrl")
-    (setq evil-ghostel--sync-inhibit t)))
+    (setq evil-ghostel--sync-inhibit t)
+    (apply orig-fn args))
+   ((evil-ghostel--line-mode-active-p)
+    (goto-char (marker-position ghostel--line-input-start))
+    (setq evil-ghostel--sync-inhibit t)
+    (evil-insert-state 1))
+   (t (apply orig-fn args))))
 
-(defun evil-ghostel--before-append-line (&rest _)
-  "Send Ctrl-e to move terminal cursor to end of input."
-  (when (and evil-ghostel-mode ghostel--term)
+(defun evil-ghostel--around-append-line (orig-fn &rest args)
+  "Route `evil-append-line' according to the current input mode.
+ORIG-FN is the advised `evil-append-line' called with ARGS.
+Symmetric to `evil-ghostel--around-insert-line': Ctrl-e in
+semi-char, jump to `--line-input-end' in line mode, otherwise
+unchanged."
+  (cond
+   ((evil-ghostel--active-p)
     (ghostel--send-encoded "e" "ctrl")
-    (setq evil-ghostel--sync-inhibit t)))
+    (setq evil-ghostel--sync-inhibit t)
+    (apply orig-fn args))
+   ((evil-ghostel--line-mode-active-p)
+    (goto-char (marker-position ghostel--line-input-end))
+    (setq evil-ghostel--sync-inhibit t)
+    (evil-insert-state 1))
+   (t (apply orig-fn args))))
 
 ;; ---------------------------------------------------------------------------
 ;; Editing primitives
@@ -404,10 +446,18 @@ intercepted by evil's insert-state commands.")
 
 (defun evil-ghostel--passthrough-ctrl (key)
   "Send Ctrl+KEY to the terminal PTY, or fall back to evil's binding.
-Used for insert-state Ctrl keys that have readline/zle equivalents."
+Used for insert-state Ctrl keys that have readline/zle equivalents.
+Outside semi-char the local map is consulted first so line mode's
+own bindings (e.g. \\`C-a' → `ghostel-beginning-of-input-or-line',
+\\`C-d' → `ghostel-line-mode-delete-char-or-eof') win over evil's
+defaults; without that, the minor-mode aux map containing this
+passthrough would shadow line mode's local-map binding."
   (if (evil-ghostel--active-p)
       (ghostel--send-encoded key "ctrl")
-    (let ((cmd (lookup-key evil-insert-state-map (kbd (concat "C-" key)))))
+    (let* ((vec (kbd (concat "C-" key)))
+           (local (current-local-map))
+           (cmd (or (and local (lookup-key local vec))
+                    (lookup-key evil-insert-state-map vec))))
       (when (commandp cmd)
         (call-interactively cmd)))))
 
@@ -514,8 +564,8 @@ state transitions."
         ;; states expect point to follow the terminal cursor.
         (add-hook 'evil-emacs-state-entry-hook
                   #'evil-ghostel--insert-state-entry nil t)
-        (advice-add 'evil-insert-line :before #'evil-ghostel--before-insert-line)
-        (advice-add 'evil-append-line :before #'evil-ghostel--before-append-line)
+        (advice-add 'evil-insert-line :around #'evil-ghostel--around-insert-line)
+        (advice-add 'evil-append-line :around #'evil-ghostel--around-append-line)
         (advice-add 'evil-delete :around #'evil-ghostel--around-delete)
         (advice-add 'evil-change :around #'evil-ghostel--around-change)
         (advice-add 'evil-replace :around #'evil-ghostel--around-replace)
@@ -531,8 +581,8 @@ state transitions."
                  #'evil-ghostel--insert-state-entry t)
     (remove-hook 'evil-emacs-state-entry-hook
                  #'evil-ghostel--insert-state-entry t)
-    (advice-remove 'evil-insert-line #'evil-ghostel--before-insert-line)
-    (advice-remove 'evil-append-line #'evil-ghostel--before-append-line)
+    (advice-remove 'evil-insert-line #'evil-ghostel--around-insert-line)
+    (advice-remove 'evil-append-line #'evil-ghostel--around-append-line)
     (advice-remove 'evil-delete #'evil-ghostel--around-delete)
     (advice-remove 'evil-change #'evil-ghostel--around-change)
     (advice-remove 'evil-replace #'evil-ghostel--around-replace)

--- a/lisp/ghostel-debug.el
+++ b/lisp/ghostel-debug.el
@@ -548,7 +548,7 @@ omit it when the connection itself is the suspected fault."
             (insert "\n(not in a ghostel buffer — buffer/process/window/terminal sections skipped)\n")
           (let (buf-name maj-mode dir remote modes
                 proc cmd shell shell-integ tramp-integ detected
-                term term-rows term-cols force pending timer copy
+                term term-rows term-cols force pending timer input-mode
                 input-bytes input-timer
                 buf-size buf-lines pt dec2026 alt-scr
                 dln-on dln-style spawn-capture)
@@ -574,7 +574,7 @@ omit it when the connection itself is the suspected fault."
                     force ghostel--force-next-redraw
                     pending (length ghostel--pending-output)
                     timer (and ghostel--redraw-timer t)
-                    copy ghostel--copy-mode-active
+                    input-mode ghostel--input-mode
                     input-bytes (apply #'+ (mapcar #'length
                                                    ghostel--input-buffer))
                     input-timer (and ghostel--input-timer t)
@@ -682,8 +682,8 @@ omit it when the connection itself is the suspected fault."
                     (insert (format "Coalesce buffer:     %d bytes  timer: %s\n"
                                     input-bytes
                                     (if input-timer "pending" "none")))
-                    (insert (format "Copy mode:           %s\n"
-                                    (if copy "active" "off"))))
+                    (insert (format "Input mode:          %s\n"
+                                    (or input-mode "(unknown)"))))
                 (insert "Term handle:         nil (no terminal)\n"))
               ;; Size sync — surfaces #192-class bugs.
               ;; Compare term-rows against `floor(window-screen-lines)' (what

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -82,10 +82,14 @@
 (require 'ansi-color)
 (require 'cl-lib)
 (require 'project)
+(require 'shell)
 (require 'text-property-search)
 (require 'tramp)
 (require 'url-parse)
 (require 'face-remap)
+
+(declare-function bash-completion-capf-nonexclusive "bash-completion")
+(declare-function bash-completion-require-process "bash-completion")
 
 
 ;;; Customization
@@ -569,11 +573,93 @@ terminal-driven cursor changes.  Copy mode restores `cursor-type' to its
 default value."
   :type 'boolean)
 
+;; Forward declaration for the `ghostel-readonly-fast-exit' :set function.
+(defvar ghostel--input-mode)
+
+(defcustom ghostel-readonly-fast-exit t
+  "When non-nil, copy and Emacs modes exit on `q', `C-g', or any self-insert key.
+The triggering character is forwarded to the terminal when exiting
+returns to a mode that accepts terminal input (semi-char or char).
+
+When nil, exit only via an explicit input-mode switch
+\(`ghostel-semi-char-mode', `ghostel-char-mode', etc.).  Standard
+self-inserting keys still hit the read-only barrier and produce
+the usual \"Buffer is read-only\" signal.
+
+Toggling this through `customize-variable' or `setopt' rebinds
+the local map in every buffer currently in copy or Emacs mode, so
+the change takes effect immediately.  Plain `setq' bypasses the custom setter
+and affected buffers will pick up the new value on the next mode transition."
+  :type 'boolean
+  :initialize #'custom-initialize-default
+  :set (lambda (sym newval)
+         (set-default sym newval)
+         (dolist (buf (buffer-list))
+           (with-current-buffer buf
+             (when (memq ghostel--input-mode '(copy emacs))
+               (use-local-map (ghostel--readonly-keymap)))))))
+
 (defcustom ghostel-scroll-on-input t
   "Automatically scroll to the bottom when typing in the terminal.
 When non-nil, any character typed while the viewport is scrolled
 into the scrollback will first jump to the bottom of the terminal
 before sending the input."
+  :type 'boolean)
+
+(defcustom ghostel-github-release-url
+  "https://github.com/dakra/ghostel/releases"
+  "Base URL for Ghostel GitHub releases.
+Customize this when downloading pre-built modules from a fork or mirror."
+  :type 'string)
+
+(defcustom ghostel-line-mode-history-size 200
+  "Maximum number of lines kept in `ghostel--line-mode-history'."
+  :type 'integer)
+
+(defcustom ghostel-line-mode-completion-at-point-functions
+  '(comint-completion-at-point)
+  "Capfs activated for \\=`TAB\\=' in `ghostel-line-mode'.
+Each function is called inside a `save-restriction' narrowed to the
+editable input region, so it sees only the user's typed text — not
+the prompt or the surrounding scrollback.
+
+The default `comint-completion-at-point' dispatches through
+`comint-dynamic-complete-functions' (set up via
+`shell-completion-vars'), which gives filename completion, env-var
+completion, command completion from \\=`PATH\\=', `pcomplete'
+integration, and history expansion."
+  :type '(repeat function))
+
+(defcustom ghostel-line-mode-use-bash-completion 'auto
+  "Whether to layer bash programmable completion onto line-mode \\=`TAB\\='.
+When non-nil, `bash-completion-capf-nonexclusive' is prepended to
+`ghostel-line-mode-completion-at-point-functions' at completion
+time.  The capf is non-exclusive, so when bash returns no
+candidates the standard comint stack still runs.
+
+- `auto' (default): enable when the `bash-completion' package
+  loads cleanly; do nothing when it isn't installed.
+- t: require it; signal an error if it is missing.
+- nil: never use it.
+
+The bash-completion package spawns a hidden bash subprocess that
+sources the user's startup files, so registrations like
+\"complete -F _git git\" become available — TAB after \"git
+checkout \" lists branch names, etc."
+  :type '(choice (const :tag "Auto-detect" auto)
+                 (const :tag "Always (require)" t)
+                 (const :tag "Never" nil)))
+
+(defcustom ghostel-line-mode-bash-completion-prespawn nil
+  "When non-nil, eagerly start the bash-completion subprocess on line-mode entry.
+Off by default — the first \\=`TAB\\=' inside line mode pays the
+~500ms-1s cost of spawning the hidden bash process and sourcing
+the user's startup files; subsequent completions are fast.  Set
+this to t to amortise that cost at line-mode entry time so the
+first completion feels instant.
+
+Has no effect when `ghostel-line-mode-use-bash-completion' is nil
+or when the `bash-completion' package is not installed."
   :type 'boolean)
 
 
@@ -662,21 +748,11 @@ before sending the input."
    ghostel-color-bright-white]
   "Color palette for the terminal (vector of 16 face names).")
 
-(defcustom ghostel-github-release-url
-  "https://github.com/dakra/ghostel/releases"
-  "Base URL for Ghostel GitHub releases.
-Customize this when downloading pre-built modules from a fork or mirror."
-  :type 'string)
-
-(defconst ghostel--minimum-module-version "0.22.1"
-  "Minimum native module version required by this Elisp version.
-Bump this only when the Elisp code requires a newer native module
-\(e.g. new Zig-exported function or changed calling convention).")
-
 
 ;; Declare native module functions for the byte compiler
 
 (declare-function ghostel--cursor-position "ghostel-module")
+(declare-function ghostel--cursor-row-char-offset "ghostel-module")
 (declare-function ghostel--encode-key "ghostel-module")
 (declare-function ghostel--focus-event "ghostel-module")
 (declare-function ghostel--mode-enabled "ghostel-module")
@@ -698,6 +774,11 @@ Bump this only when the Elisp code requires a newer native module
 
 
 ;;; Automatic download and compilation of native module
+
+(defconst ghostel--minimum-module-version "0.22.1"
+  "Minimum native module version required by this Elisp version.
+Bump this only when the Elisp code requires a newer native module
+\(e.g. new Zig-exported function or changed calling convention).")
 
 (defun ghostel--module-platform-tag ()
   "Return platform tag for the current system, e.g. \"x86_64-linux\".
@@ -973,8 +1054,11 @@ Updated whenever the terminal is created or resized.")
   "Column count of the native terminal.
 Updated whenever the terminal is created or resized.")
 
-(defvar-local ghostel--copy-mode-active nil
-  "Non-nil when copy mode is active.")
+(defvar-local ghostel--input-mode 'semi-char
+  "Current input mode.
+One of `semi-char', `char', `copy', `emacs', or `line'.  See
+`ghostel-semi-char-mode', `ghostel-char-mode', `ghostel-copy-mode',
+`ghostel-emacs-mode', and `ghostel-line-mode'.")
 
 (defvar-local ghostel--process nil
   "The shell process.")
@@ -1096,6 +1180,12 @@ Used for prompt navigation and optional re-application after full redraws.")
   "Non-nil when ghostel's scroll-event intercept is active.
 Used as the activation key in `emulation-mode-map-alists'.")
 
+(defvar-local ghostel--spinner-active nil
+  "Non-nil when this buffer has a spinner started by `ghostel-spinner-progress'.
+The spinner object itself lives in spinner.el's buffer-local
+`spinner-current'; this flag is what ghostel inspects to keep
+`ghostel-spinner-progress' idempotent and to give the sentinel
+something to gate teardown on.")
 
 
 ;;; Scroll intercept via emulation-mode-map-alists
@@ -1169,76 +1259,109 @@ is non-nil.")
 
 
 
+;;; Input mode predicates
+
+(defsubst ghostel--buffer-editable-p ()
+  "Non-nil when typed keys are forwarded to the terminal.
+True in semi-char and char modes.  In Emacs, copy, and line modes
+the buffer is either read-only or consumes keys locally."
+  (memq ghostel--input-mode '(semi-char char)))
+
+(defsubst ghostel--terminal-live-p ()
+  "Non-nil when live output is propagated into the Emacs buffer.
+False only in copy mode, which freezes the terminal entirely.
+Line mode keeps redrawing — the snapshot/restore path in
+`ghostel--delayed-redraw' preserves the user's in-progress input
+across the rewrite."
+  (not (eq ghostel--input-mode 'copy)))
+
+(defsubst ghostel--terminal-frozen-p ()
+  "Non-nil when the terminal is frozen (copy mode)."
+  (eq ghostel--input-mode 'copy))
+
+
 ;;; Keymap
+
+(defun ghostel--define-terminal-keys (map &optional no-exceptions)
+  "Populate MAP with terminal key-sending bindings.
+When NO-EXCEPTIONS is non-nil, also bind the keys in
+`ghostel-keymap-exceptions' (used by char mode)."
+  ;; Self-insert characters
+  (define-key map [remap self-insert-command] #'ghostel--self-insert)
+  ;; Special keys — routed through the ghostty key encoder which
+  ;; respects terminal modes and handles all modifier combinations.
+  ;; Use angle-bracket forms so modifier prefixes compose correctly.
+  ;; Skip keys in `ghostel-keymap-exceptions' unless NO-EXCEPTIONS is
+  ;; non-nil (char mode binds everything).
+  (dolist (key '("<return>" "<tab>" "<backspace>" "<escape>"
+                 "<up>" "<down>" "<right>" "<left>"
+                 "<home>" "<end>" "<prior>" "<next>"
+                 "<deletechar>" "<insert>"
+                 "<f1>" "<f2>" "<f3>" "<f4>" "<f5>" "<f6>"
+                 "<f7>" "<f8>" "<f9>" "<f10>" "<f11>" "<f12>"))
+    (when (or no-exceptions (not (member key ghostel-keymap-exceptions)))
+      (define-key map (kbd key) #'ghostel--send-event))
+    (dolist (mod '("S-" "C-" "M-" "C-S-" "M-S-" "C-M-"))
+      (let ((key-str (concat mod key)))
+        (when (or no-exceptions
+                  (not (member key-str ghostel-keymap-exceptions)))
+          (ignore-errors
+            (define-key map (kbd key-str) #'ghostel--send-event))))))
+  ;; Bare aliases for unmodified keys (RET=\r, TAB=\t, DEL=\x7f)
+  (define-key map (kbd "RET") #'ghostel--send-event)
+  (define-key map (kbd "TAB") #'ghostel--send-event)
+  (define-key map (kbd "DEL") #'ghostel--send-event)
+  ;; Emacs reports S-TAB as <backtab>
+  (define-key map (kbd "<backtab>") #'ghostel--send-event)
+  ;; Control keys — bind all C-<letter> to send ASCII control codes.
+  ;; C-i = TAB and C-m = RET are equivalent to <tab>/<return> (bound above).
+  ;; C-y is reserved for ghostel-yank in semi-char mode.
+  (let ((skip (if no-exceptions '(?i ?m) '(?i ?m ?y))))
+    (dolist (c (number-sequence ?a ?z))
+      (let ((key-str (format "C-%c" c)))
+        (unless (or (memq c skip)
+                    (and (not no-exceptions)
+                         (member key-str ghostel-keymap-exceptions)))
+          (define-key map (kbd key-str)
+                      (let ((code (- c 96)))
+                        (lambda () (interactive)
+                          (ghostel--send-string (string code)))))))))
+  ;; Meta and Control-Meta keys - bind all (C-)M-<letter> so they reach
+  ;; the terminal instead of running Emacs commands like forward-word.
+  (dolist (c (number-sequence ?a ?z))
+    (let ((key-str (format "M-%c" c)))
+      (when (or no-exceptions
+                (not (member key-str ghostel-keymap-exceptions)))
+        (define-key map (kbd key-str) #'ghostel--send-event)))
+    (let ((key-str (format "C-M-%c" c)))
+      (when (or no-exceptions
+                (not (member key-str ghostel-keymap-exceptions)))
+        (define-key map (kbd key-str) #'ghostel--send-event))))
+  ;; M-DEL: TTY Emacs delivers Alt-Backspace as ESC + 0x7f, which
+  ;; resolves to ?\M-\d.  The `M-<backspace>' form above only covers
+  ;; the `[M-backspace]' symbol path; without this binding, TTY
+  ;; Alt-Backspace falls through to global `backward-kill-word'.
+  (define-key map (kbd "M-DEL") #'ghostel--send-event)
+  ;; C-@ (NUL, same as C-SPC) — used by programs like Emacs-in-terminal
+  (define-key map (kbd "C-@")
+              (lambda () (interactive) (ghostel--send-string "\x00")))
+  ;; Char mode extras: also bind non-letter exception keys so nothing
+  ;; gets stolen by Emacs while a TUI app runs.
+  (when no-exceptions
+    (define-key map (kbd "C-\\")
+                (lambda () (interactive) (ghostel--send-string "\x1c")))
+    (define-key map (kbd "M-:") #'ghostel--send-event)))
 
 (defvar ghostel-mode-map
   (let ((map (make-sparse-keymap)))
-    ;; Self-insert characters
-    (define-key map [remap self-insert-command] #'ghostel--self-insert)
-    ;; Special keys — routed through the ghostty key encoder which
-    ;; respects terminal modes and handles all modifier combinations.
-    ;; Use angle-bracket forms so modifier prefixes compose correctly.
-    (dolist (key '("<return>" "<tab>" "<backspace>" "<escape>"
-                   "<up>" "<down>" "<right>" "<left>"
-                   "<home>" "<end>" "<prior>" "<next>"
-                   "<deletechar>" "<insert>"
-                   "<f1>" "<f2>" "<f3>" "<f4>" "<f5>" "<f6>"
-                   "<f7>" "<f8>" "<f9>" "<f10>" "<f11>" "<f12>"))
-      (unless (member key ghostel-keymap-exceptions)
-        (define-key map (kbd key) #'ghostel--send-event))
-      (dolist (mod '("S-" "C-" "M-" "C-S-" "M-S-" "C-M-"))
-        (let ((key-str (concat mod key)))
-          (unless (member key-str ghostel-keymap-exceptions)
-            (ignore-errors
-              (define-key map (kbd key-str) #'ghostel--send-event))))))
-    ;; Bare aliases for unmodified keys (RET=\r, TAB=\t, DEL=\x7f)
-    (define-key map (kbd "RET") #'ghostel--send-event)
-    (define-key map (kbd "TAB") #'ghostel--send-event)
-    (define-key map (kbd "DEL") #'ghostel--send-event)
-    ;; Emacs reports S-TAB as <backtab>
-    (define-key map (kbd "<backtab>") #'ghostel--send-event)
-    ;; Control keys — bind all C-<letter> to send ASCII control codes,
-    ;; except keys in ghostel-keymap-exceptions and special cases.
-    ;; C-i = TAB and C-m = RET are equivalent to <tab>/<return> (bound above).
-    (let ((skip '(?i ?m ?y)))  ; i=TAB, m=RET already bound; y=ghostel-yank below
-      (dolist (c (number-sequence ?a ?z))
-        (let ((key-str (format "C-%c" c)))
-          (unless (or (member key-str ghostel-keymap-exceptions)
-                      (memq c skip))
-            (define-key map (kbd key-str)
-                        (let ((code (- c 96)))
-                          (lambda () (interactive)
-                            (ghostel--send-string (string code)))))))))
-    ;; Meta and Control-Meta keys - bind all (C-)M-<letter> so they reach
-    ;; the terminal instead of running Emacs commands like forward-word.
-    (dolist (c (number-sequence ?a ?z))
-      (let ((key-str (format "M-%c" c)))
-        (unless (member key-str ghostel-keymap-exceptions)
-          (define-key map (kbd key-str) #'ghostel--send-event)))
-      (let ((key-str (format "C-M-%c" c)))
-        (unless (member key-str ghostel-keymap-exceptions)
-          (define-key map (kbd key-str) #'ghostel--send-event))))
-    ;; M-DEL: TTY Emacs delivers Alt-Backspace as ESC + 0x7f, which
-    ;; resolves to ?\M-\d.  The `M-<backspace>' form above only covers
-    ;; the `[M-backspace]' symbol path; without this binding, TTY
-    ;; Alt-Backspace falls through to global `backward-kill-word'.
-    (define-key map (kbd "M-DEL") #'ghostel--send-event)
-    ;; C-@ (NUL, same as C-SPC) — used by programs like Emacs-in-terminal
-    (define-key map (kbd "C-@")
-                (lambda () (interactive) (ghostel--send-string "\x00")))
-    ;; C-y: yank from Emacs kill ring into the terminal
-    (define-key map (kbd "C-y")       #'ghostel-yank)
-    (when (eq system-type 'darwin)
-      (define-key map (kbd "s-v")     #'ghostel-yank))
-    ;; Clipboard media keys
+    ;; Clipboard media keys — useful in any mode.
     (define-key map (kbd "<XF86Paste>") #'ghostel-yank)
     (define-key map (kbd "<XF86Copy>")  #'kill-ring-save)
-    (define-key map (kbd "M-y")       #'ghostel-yank-pop)
     ;; Bracketed paste from the host terminal (TTY Emacs): forward the
     ;; paste payload to the subprocess instead of letting the default
     ;; `xterm-paste' insert it into the (renderer-owned) buffer.
     (define-key map [xterm-paste]     #'ghostel-xterm-paste)
-    ;; Terminal control via C-c prefix (pass through to Emacs, then handled here)
+    ;; Terminal control via C-c prefix
     (define-key map (kbd "C-c C-c")   #'ghostel-send-C-c)
     (define-key map (kbd "C-c C-z")   #'ghostel-send-C-z)
     (define-key map (kbd "C-c C-\\")  #'ghostel-send-C-backslash)
@@ -1247,14 +1370,21 @@ is non-nil.")
     (define-key map (kbd "C-c C-t")   #'ghostel-copy-mode)
     (define-key map (kbd "C-c M-w")   #'ghostel-copy-all)
     (define-key map (kbd "C-c C-y")   #'ghostel-paste)
-    (define-key map (kbd "C-c C-l")   #'ghostel-clear-scrollback)
+    (define-key map (kbd "C-c M-l")   #'ghostel-clear-scrollback)
     (define-key map (kbd "C-c C-q")   #'ghostel-send-next-key)
     ;; Hyperlink navigation (OSC 8, auto-detected URLs, file:line refs)
     (define-key map (kbd "C-c C-n")   #'ghostel-next-hyperlink)
     (define-key map (kbd "C-c C-p")   #'ghostel-previous-hyperlink)
-    ;; Prompt navigation (OSC 133)
+    ;; Prompt navigation (OSC 133) — `ghostel-next-prompt' and
+    ;; `ghostel-previous-prompt' switch to Emacs mode so the terminal
+    ;; keeps running while the user jumps between prompts.
     (define-key map (kbd "C-c M-n")   #'ghostel-next-prompt)
     (define-key map (kbd "C-c M-p")   #'ghostel-previous-prompt)
+    ;; Input mode switching (eat.el conventions)
+    (define-key map (kbd "C-c C-e")   #'ghostel-emacs-mode)
+    (define-key map (kbd "C-c C-j")   #'ghostel-semi-char-mode)
+    (define-key map (kbd "C-c M-d")   #'ghostel-char-mode)
+    (define-key map (kbd "C-c C-l")   #'ghostel-line-mode)
     ;; Mouse click events (for terminal mouse tracking)
     (define-key map (kbd "<down-mouse-1>")  #'ghostel--mouse-press)
     (define-key map (kbd "<mouse-1>")       #'ghostel--mouse-release)
@@ -1266,9 +1396,132 @@ is non-nil.")
     (define-key map (kbd "<drag-mouse-2>")  #'ghostel--mouse-drag)
     (define-key map (kbd "<drag-mouse-3>")  #'ghostel--mouse-drag)
     ;; Drag and drop
-    (define-key map [drag-n-drop]           #'ghostel--drop)
+    (define-key map [drag-n-drop]     #'ghostel--drop)
     map)
-  "Keymap for `ghostel-mode'.")
+  "Base keymap for `ghostel-mode'.
+Contains the \\`C-c' prefix commands available in every input mode.
+Input modes (`ghostel-semi-char-mode-map', `ghostel-char-mode-map',
+`ghostel-readonly-mode-map', `ghostel-readonly-fast-exit-mode-map',
+`ghostel-line-mode-map') inherit or extend this map.")
+
+(defvar ghostel-semi-char-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map ghostel-mode-map)
+    (ghostel--define-terminal-keys map)
+    ;; C-y: yank from Emacs kill ring into the terminal
+    (define-key map (kbd "C-y")       #'ghostel-yank)
+    (when (eq system-type 'darwin)
+      (define-key map (kbd "s-v")     #'ghostel-yank))
+    (define-key map (kbd "M-y")       #'ghostel-yank-pop)
+    map)
+  "Keymap for semi-char mode (the default input mode).
+Most keys are sent to the terminal.  Keys in
+`ghostel-keymap-exceptions' pass through to Emacs.  Inherits the
+\\`C-c' prefix from `ghostel-mode-map'.")
+
+(defvar ghostel-char-mode-map
+  (let ((map (make-sparse-keymap)))
+    ;; No parent — char mode captures everything, including C-c.
+    (ghostel--define-terminal-keys map 'no-exceptions)
+    ;; Mouse click/drag for terminal mouse tracking (no parent to
+    ;; inherit from; scroll wheel is handled by the emulation alist).
+    (define-key map (kbd "<down-mouse-1>")  #'ghostel--mouse-press)
+    (define-key map (kbd "<mouse-1>")       #'ghostel--mouse-release)
+    (define-key map (kbd "<down-mouse-2>")  #'ghostel--mouse-press)
+    (define-key map (kbd "<mouse-2>")       #'ghostel--mouse-release)
+    (define-key map (kbd "<down-mouse-3>")  #'ghostel--mouse-press)
+    (define-key map (kbd "<mouse-3>")       #'ghostel--mouse-release)
+    (define-key map (kbd "<drag-mouse-1>")  #'ghostel--mouse-drag)
+    (define-key map (kbd "<drag-mouse-2>")  #'ghostel--mouse-drag)
+    (define-key map (kbd "<drag-mouse-3>")  #'ghostel--mouse-drag)
+    ;; Sole escape hatch: exit char mode.  Graphical Emacs sends
+    ;; M-RET as the `<M-return>' symbol, terminal Emacs as the
+    ;; `\M-\r' character, and C-M-m is a synonym; bind all three
+    ;; so the user doesn't need to care which their setup uses.
+    (define-key map (kbd "M-RET")      #'ghostel-semi-char-mode)
+    (define-key map (kbd "M-<return>") #'ghostel-semi-char-mode)
+    (define-key map (kbd "C-M-m")      #'ghostel-semi-char-mode)
+    map)
+  "Keymap for char mode.
+All keys are sent to the terminal.
+\\<ghostel-char-mode-map>Only \\[ghostel-semi-char-mode] exits
+back to semi-char mode.")
+
+(defvar ghostel-readonly-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map ghostel-mode-map)
+    ;; Smart `C-a': on a line with a `ghostel-prompt' prefix, jump
+    ;; to the start of the input area; on any other line (scrollback,
+    ;; output) fall through to `move-beginning-of-line' so the user
+    ;; gets the standard column-0 behaviour they expect.
+    (define-key map (kbd "C-a")       #'ghostel-beginning-of-input-or-line)
+    ;; `C-y' pastes from the kill ring into the terminal via
+    ;; bracketed paste — an explicit, deliberate action, distinct
+    ;; from typing characters one by one (which read-only mode does
+    ;; not allow).
+    (define-key map (kbd "C-y")       #'ghostel-yank)
+    (when (eq system-type 'darwin)
+      (define-key map (kbd "s-v")     #'ghostel-yank))
+    ;; Selection helpers shared by both copy and Emacs modes.
+    (define-key map (kbd "M-w")       #'ghostel-readonly-copy)
+    (define-key map (kbd "C-w")       #'ghostel-readonly-copy)
+    (define-key map (kbd "M->")       #'ghostel-readonly-end-of-buffer)
+    (define-key map (kbd "C-e")       #'ghostel-readonly-end-of-line)
+    (define-key map (kbd "C-l")       #'ghostel-readonly-recenter)
+    ;; RET / <return> follows the link at point.  Bound here rather
+    ;; than on the text-property link map so a misdetected link inside
+    ;; a typed command in semi-char/char mode never hijacks the key
+    ;; away from the PTY.  When point is not on a link this is a no-op.
+    (define-key map (kbd "RET")       #'ghostel-open-link-at-point)
+    (define-key map (kbd "<return>")  #'ghostel-open-link-at-point)
+    map)
+  "Keymap shared by `ghostel-copy-mode' and `ghostel-emacs-mode'.
+The buffer is read-only in both modes; the only difference between
+them is whether live terminal output keeps streaming (Emacs mode)
+or is paused (copy mode).  Self-insert, RET, TAB, DEL and friends
+are NOT bound here — Emacs's standard `text-read-only' barrier
+keeps stray keystrokes from reaching the shell.  Pasting via
+\\[ghostel-yank] is allowed as an explicit input action; it
+forwards via bracketed paste and snaps point back to the live
+cursor.
+
+When `ghostel-readonly-fast-exit' is non-nil, the additional
+bindings in `ghostel-readonly-fast-exit-mode-map' are layered on
+top so that \\`q', \\`C-g', or any self-insert key exits.")
+
+(defvar ghostel-readonly-fast-exit-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map ghostel-readonly-mode-map)
+    ;; Normal letter keys exit and send the key to the terminal.
+    (define-key map [remap self-insert-command] #'ghostel-readonly-exit-and-send)
+    (define-key map (kbd "q")       #'ghostel-readonly-exit)
+    (define-key map (kbd "C-c C-t") #'ghostel-readonly-exit)
+    (define-key map (kbd "C-g")     #'ghostel-readonly-exit)
+    ;; C-c C-l overrides the parent's `ghostel-line-mode' binding so
+    ;; clearing scrollback from inside read-only mode also exits cleanly.
+    (define-key map (kbd "C-c C-l") #'ghostel-readonly-exit-and-clear)
+    map)
+  "Keymap layered on `ghostel-readonly-mode-map' when fast exit is on.
+See `ghostel-readonly-fast-exit'.")
+
+;; Char mode must override minor-mode keymaps.  Without this, a user
+;; config that binds, say, \\`C-c' as a prefix in a global minor mode
+;; steals the key before it reaches `ghostel-char-mode-map'.  Pushing
+;; an entry into `emulation-mode-map-alists' moves char mode's
+;; keymap ahead of `minor-mode-map-alist' in the lookup order, so a
+;; direct binding in `ghostel-char-mode-map' wins against any
+;; minor-mode prefix.
+
+(defvar-local ghostel--char-mode-override-active nil
+  "Non-nil in buffers where char mode is active.
+Drives the `emulation-mode-map-alists' entry that makes
+`ghostel-char-mode-map' override minor-mode keymaps.")
+
+(defvar ghostel--char-mode-override-alist
+  `((ghostel--char-mode-override-active . ,ghostel-char-mode-map))
+  "Alist entry registered in `emulation-mode-map-alists' for char mode.")
+
+(add-to-list 'emulation-mode-map-alists 'ghostel--char-mode-override-alist)
 
 
 ;;; Key sending
@@ -1455,7 +1708,14 @@ Resets the terminal engine's viewport out of scrollback and sets
 by `pixel-scroll-precision-mode' or similar scrollers).  No-op
 when `ghostel-scroll-on-input' is nil.  Call from any path where
 the user's action implies \"show me the prompt\" — typed input,
-paste, yank, drop."
+paste, yank, drop.
+
+Fires regardless of input mode: in semi-char/char/line modes
+each typed key calls this before forwarding; in Emacs mode
+typing is disabled but explicit paste (`\\`C-y'') still routes
+through `ghostel--paste-text' which calls this before sending.
+Pure-navigation commands do not call this, so reading scrollback
+without sending anything to the shell preserves point."
   (when (and ghostel-scroll-on-input ghostel--term)
     (setq ghostel--snap-requested t)
     (setq ghostel--force-next-redraw t)))
@@ -1660,8 +1920,8 @@ parity with `xterm-paste'."
   (interactive "e")
   (unless (eq (car-safe event) 'xterm-paste)
     (error "This command must be bound to an xterm-paste event"))
-  (when ghostel--copy-mode-active
-    (ghostel-copy-mode-exit))
+  (when (eq ghostel--input-mode 'copy)
+    (ghostel-readonly-exit))
   (when-let* ((text (nth 1 event)))
     (when (bound-and-true-p xterm-store-paste-on-kill-ring)
       (kill-new text))
@@ -1708,7 +1968,7 @@ pasted using bracketed paste."
     ;; `ghostel--snap-requested' here: nilling
     ;; `--last-anchor-position' makes `ghostel--window-anchored-p'
     ;; treat every window as anchored on the next redraw via its
-    ;; bootstrap branch.  (`ghostel-copy-mode-exit' uses the snap
+    ;; bootstrap branch.  (`ghostel-readonly-exit' uses the snap
     ;; flag instead because it preserves `--last-anchor-position'.)
     (setq ghostel--scroll-positions nil)
     (setq ghostel--last-anchor-position nil)
@@ -1735,7 +1995,7 @@ pasted using bracketed paste."
 Return non-nil if the event was forwarded (mouse tracking is active)."
   (when (and event ghostel--term ghostel--process
              (process-live-p ghostel--process)
-             (not ghostel--copy-mode-active))
+             (ghostel--buffer-editable-p))
     (let* ((posn (event-start event))
            (col-row (posn-col-row posn))
            (col (car col-row))
@@ -1746,19 +2006,19 @@ Return non-nil if the event was forwarded (mouse tracking is active)."
                             row col
                             (ghostel--mouse-mods event)))))
 
-(defun ghostel-copy-mode-end-of-buffer ()
-  "Move to the bottom of the buffer (current viewport) in copy mode."
+(defun ghostel-readonly-end-of-buffer ()
+  "Move to the bottom of the buffer (current viewport) in read-only mode."
   (interactive)
   (goto-char (point-max))
   (skip-chars-backward " \t\n"))
 
-(defun ghostel-copy-mode-end-of-line ()
+(defun ghostel-readonly-end-of-line ()
   "Move to the last non-whitespace character on the line."
   (interactive)
   (end-of-line)
   (skip-chars-backward " \t"))
 
-(defun ghostel-copy-mode-recenter ()
+(defun ghostel-readonly-recenter ()
   "Recenter the current line in the window."
   (interactive)
   (recenter))
@@ -1827,108 +2087,275 @@ Return non-nil if the event was forwarded (mouse tracking is active)."
                             (ghostel--mouse-mods event)))))
 
 
-;;; Copy mode
-
-(defvar ghostel-copy-mode-map
-  (let ((map (make-sparse-keymap)))
-    ;; Normal letter keys exit copy mode and send the key to the terminal
-    (define-key map [remap self-insert-command] #'ghostel-copy-mode-exit-and-send)
-    (define-key map (kbd "C-c C-t") #'ghostel-copy-mode-exit)
-    (define-key map (kbd "C-g") #'ghostel-copy-mode-exit)
-    (define-key map (kbd "M-w") #'ghostel-copy-mode-copy)
-    (define-key map (kbd "C-w") #'ghostel-copy-mode-copy)
-    ;; Hyperlink navigation works in copy mode too
-    (define-key map (kbd "C-c C-n") #'ghostel-next-hyperlink)
-    (define-key map (kbd "C-c C-p") #'ghostel-previous-hyperlink)
-    (define-key map (kbd "RET")      #'ghostel-open-link-at-point)
-    (define-key map (kbd "<return>") #'ghostel-open-link-at-point)
-    ;; Prompt navigation works in copy mode too
-    (define-key map (kbd "C-c M-n") #'ghostel-next-prompt)
-    (define-key map (kbd "C-c M-p") #'ghostel-previous-prompt)
-    (define-key map (kbd "M->")     #'ghostel-copy-mode-end-of-buffer)
-    (define-key map (kbd "C-e")     #'ghostel-copy-mode-end-of-line)
-    (define-key map (kbd "C-l")     #'ghostel-copy-mode-recenter)
-    (define-key map (kbd "C-c C-l") #'ghostel-copy-mode-exit-and-clear)
-    (define-key map [xterm-paste]   #'ghostel-xterm-paste)
-    map)
-  "Keymap for `ghostel-copy-mode'.
-Standard Emacs navigation works.
-Set mark, navigate to select, then \\[ghostel-copy-mode-copy] to copy.")
-
-(defvar-local ghostel--saved-local-map nil
-  "Saved keymap before entering copy mode.")
+;;; Input modes — state helpers
 
 (defvar-local ghostel--saved-cursor-type nil
-  "Saved `cursor-type' before entering copy mode.")
+  "Saved `cursor-type' before entering a read-only mode.")
 
 (defvar-local ghostel--saved-hl-line-mode nil
   "Non-nil if line highlighting was active when `ghostel-mode' suppressed it.
 Covers both `global-hl-line-mode' and buffer-local `hl-line-mode'.")
 
+(defvar-local ghostel--line-mode-paused nil
+  "Snapshot plist captured when alt-screen forced line mode to pause.
+Nil when not paused.  Set by `ghostel--line-mode-pause' (auto-pause
+when an alt-screen TUI starts) and by `ghostel--line-mode-defer-entry'
+\(when the user invokes `ghostel-line-mode' while a TUI is already
+running); consumed by `ghostel--line-mode-try-resume' once alt-screen
+has gone off and a prompt is locatable.  Cleared when the user
+manually switches input modes so a later alt-screen exit does not
+surprise them by force-resuming line mode.")
+
+(defvar-local ghostel--mode-line-tag nil
+  "Current input-mode label rendered in `mode-line-process'.
+String like \":Char\" / \":Line\" / \":Copy\" / \":Emacs\", or
+nil for semi-char.  Composed with `ghostel--mode-line-progress'
+\(and the spinner construct, when active) by
+`ghostel--mode-line-refresh' so OSC 9;4 progress updates do not
+clobber the input-mode label.")
+
+(defvar-local ghostel--mode-line-progress nil
+  "Current OSC 9;4 progress indicator for `mode-line-process'.
+Set by `ghostel-default-progress' / `ghostel-spinner-progress'.
+Composed with `ghostel--mode-line-tag' (and the spinner
+construct, when active) by `ghostel--mode-line-refresh'.")
+
+(defun ghostel--mode-line-refresh ()
+  "Recompute `mode-line-process' from tag + spinner + progress.
+Composes `ghostel--mode-line-tag', the spinner construct (when
+`ghostel--spinner-active' is non-nil), and
+`ghostel--mode-line-progress' so the input-mode label stays
+visible while a progress indicator or spinner is active.  When
+only one component is active the value is that component
+directly (so callers and tests that expect a plain string keep
+working); otherwise it is a list mode-line construct.
+
+Skips `setq' and `force-mode-line-update' when the composed value
+is unchanged — `ghostel-default-progress' calls this once per
+OSC 9;4 packet, and same-value packets must not fire FMLU."
+  (let* ((parts (delq nil
+                      (list ghostel--mode-line-tag
+                            (and ghostel--spinner-active
+                                 'spinner--mode-line-construct)
+                            ghostel--mode-line-progress)))
+         (new-val (pcase parts
+                    ('() nil)
+                    (`(,only) only)
+                    (_ parts))))
+    (unless (equal new-val mode-line-process)
+      (setq mode-line-process new-val)
+      (force-mode-line-update))))
+
+(defun ghostel--enter-readonly-state ()
+  "Common setup when entering a read-only mode (copy or Emacs).
+Saves the cursor style, re-enables `hl-line-mode' if it was
+suppressed, and sets the buffer read-only.  Does NOT cancel the
+redraw timer — that is the caller's job when freezing."
+  (setq ghostel--saved-cursor-type cursor-type)
+  (setq cursor-type (default-value 'cursor-type))
+  (when ghostel--saved-hl-line-mode
+    (hl-line-mode 1))
+  (setq buffer-read-only t))
+
+(defun ghostel--leave-readonly-state ()
+  "Common teardown when leaving a read-only mode.
+Restores the cursor style, deactivates the mark, disables
+`hl-line-mode' again, and clears `buffer-read-only'."
+  (setq cursor-type ghostel--saved-cursor-type)
+  (deactivate-mark)
+  (when ghostel--saved-hl-line-mode
+    (hl-line-mode -1))
+  (setq buffer-read-only nil))
+
+(defun ghostel--freeze-terminal ()
+  "Cancel the redraw timer so new output stops updating the buffer."
+  (when ghostel--redraw-timer
+    (cancel-timer ghostel--redraw-timer)
+    (setq ghostel--redraw-timer nil)))
+
+
+;;; Input mode switching commands
+
+(defun ghostel-semi-char-mode ()
+  "Switch to semi-char mode — the default terminal input mode.
+Most keys are sent to the terminal; keys in
+`ghostel-keymap-exceptions' pass through to Emacs."
+  (interactive)
+  (setq ghostel--line-mode-paused nil)
+  (unless (eq ghostel--input-mode 'semi-char)
+    (pcase ghostel--input-mode
+      ('copy  (ghostel--leave-readonly-state))
+      ('emacs (ghostel--leave-readonly-state))
+      ('line  (ghostel--line-mode-teardown)))
+    (setq ghostel--char-mode-override-active nil)
+    (setq ghostel--input-mode 'semi-char)
+    (use-local-map ghostel-semi-char-mode-map)
+    (setq ghostel--mode-line-tag nil)
+    (ghostel--mode-line-refresh)
+    (when ghostel--term
+      ;; Snap the next redraw to the live viewport so the user lands
+      ;; back at the prompt after exiting copy/emacs/line.  The render
+      ;; pipeline parks libghostty at `max_offset' on each pass, so
+      ;; setting these flags is the equivalent of the old
+      ;; `ghostel--scroll-bottom' call.
+      (setq ghostel--snap-requested t)
+      (setq ghostel--force-next-redraw t)
+      (goto-char (point-max))
+      (ghostel--invalidate))))
+
+(defun ghostel-char-mode ()
+  "Switch to char mode — send all keys to the terminal.
+Even keys listed in `ghostel-keymap-exceptions' (\\`C-c', \\`C-x',
+\\`C-h', \\`M-x', …) are sent to the terminal.
+\\<ghostel-char-mode-map>The only way to exit is
+\\[ghostel-semi-char-mode]."
+  (interactive)
+  ;; Manual mode switch — see `ghostel-semi-char-mode' for why.
+  (setq ghostel--line-mode-paused nil)
+  (unless (eq ghostel--input-mode 'char)
+    (pcase ghostel--input-mode
+      ('copy  (ghostel--leave-readonly-state))
+      ('emacs (ghostel--leave-readonly-state))
+      ('line  (ghostel--line-mode-teardown)))
+    (setq ghostel--input-mode 'char)
+    ;; Route char mode through `emulation-mode-map-alists' so it
+    ;; overrides minor-mode keymaps (without this, a minor mode that
+    ;; binds a prefix like \\`C-c' would steal those keys before
+    ;; `ghostel-char-mode-map' got a chance).
+    (setq ghostel--char-mode-override-active t)
+    (use-local-map ghostel-char-mode-map)
+    (setq ghostel--mode-line-tag ":Char")
+    (ghostel--mode-line-refresh)
+    (when ghostel--term
+      (setq ghostel--snap-requested t)
+      (setq ghostel--force-next-redraw t)
+      (goto-char (point-max))
+      (ghostel--invalidate))
+    (message "Char mode (%s to exit)"
+             (substitute-command-keys
+              "\\<ghostel-char-mode-map>\\[ghostel-semi-char-mode]"))))
+
+(defvar-local ghostel--pre-readonly-mode nil
+  "Input mode to restore when exiting a read-only mode.
+Set on every entry to copy or Emacs mode and cleared on exit.
+Tracks the mode the user was in immediately before the most
+recent read-only entry, so Emacs → copy → exit returns to Emacs
+mode and copy → Emacs → exit returns to copy.")
+
+(defun ghostel--readonly-keymap ()
+  "Return the keymap to use for the current read-only mode."
+  (if ghostel-readonly-fast-exit
+      ghostel-readonly-fast-exit-mode-map
+    ghostel-readonly-mode-map))
+
+(defun ghostel--enter-readonly (mode freeze label entry-message)
+  "Enter or transition between read-only modes.
+MODE is `copy' or `emacs'.  FREEZE non-nil pauses live terminal
+output (copy mode); nil keeps it streaming (Emacs mode).  LABEL is
+the `mode-line-process' tag.  ENTRY-MESSAGE is shown on entry from
+a non-read-only mode."
+  ;; Manual mode switch — see `ghostel-semi-char-mode' for why.
+  (setq ghostel--line-mode-paused nil)
+  (let ((from ghostel--input-mode))
+    ;; Track the mode we just left so a later exit returns to it.
+    ;; Line mode is stateful and not safely resumable — fall back
+    ;; to semi-char when exiting copy or Emacs in that case.
+    (setq ghostel--pre-readonly-mode
+          (pcase from
+            ('line 'semi-char)
+            (m m)))
+    (cond
+     ;; Toggle between the two read-only modes — buffer is already
+     ;; read-only, just adjust the freeze state, mode-line, and keymap.
+     ((memq from '(copy emacs)) nil)
+     ;; First entry from a non-read-only mode.
+     (t
+      (pcase from
+        ('line (ghostel--line-mode-teardown)
+               (ghostel--enter-readonly-state))
+        (_     (ghostel--enter-readonly-state)))
+      (setq ghostel--char-mode-override-active nil)
+      (message "%s" entry-message)))
+    (if freeze
+        (ghostel--freeze-terminal)
+      ;; Live mode: the redraw timer must be running so output keeps
+      ;; flowing.  `--invalidate' restarts it if a previous freeze
+      ;; cancelled it.
+      (when ghostel--term
+        (ghostel--invalidate)))
+    (setq ghostel--input-mode mode)
+    (use-local-map (ghostel--readonly-keymap))
+    (setq ghostel--mode-line-tag label)
+    (ghostel--mode-line-refresh)))
+
+(defun ghostel-emacs-mode ()
+  "Switch to Emacs mode — read-only buffer with the terminal still running.
+The terminal keeps running and scrollback keeps growing.  The
+buffer is read-only, so standard Emacs commands like `isearch',
+`occur', `M-x', `C-SPC' / `M-w', and regular navigation all work
+unmodified over the entire materialised scrollback.  Exit with an
+explicit mode-switch command (`\\[ghostel-semi-char-mode]'), or
+\\`q'/\\`C-g'/any self-insert key when `ghostel-readonly-fast-exit'
+is non-nil."
+  (interactive)
+  (unless (eq ghostel--input-mode 'emacs)
+    (ghostel--enter-readonly
+     'emacs nil ":Emacs"
+     (format "Emacs mode: terminal live, %s to exit"
+             (substitute-command-keys "\\[ghostel-semi-char-mode]")))))
+
 (defun ghostel-copy-mode ()
   "Enter copy mode for selecting and copying terminal text.
-Live terminal output is paused; standard Emacs navigation, search,
-and marking work across the full scrollback that is already rendered
-in the buffer."
+Freezes the terminal (live output is paused) and makes the buffer
+read-only.  Standard Emacs navigation, search, and marking work
+across the full scrollback.  When `ghostel-readonly-fast-exit' is
+non-nil press \\`q' or \\[ghostel-readonly-exit] to exit; exiting
+returns to whichever input mode was active before."
   (interactive)
-  (if ghostel--copy-mode-active
-      (ghostel-copy-mode-exit)
-    (setq ghostel--copy-mode-active t)
-    (when ghostel--redraw-timer
-      (cancel-timer ghostel--redraw-timer)
-      (setq ghostel--redraw-timer nil))
-    ;; Ensure cursor is visible for navigation
-    (setq ghostel--saved-cursor-type cursor-type)
-    (setq cursor-type (default-value 'cursor-type))
-    (setq ghostel--saved-local-map (current-local-map))
-    (use-local-map ghostel-copy-mode-map)
-    (when ghostel--saved-hl-line-mode
-      (hl-line-mode 1))
-    (setq buffer-read-only t)
-    (setq mode-line-process ":Copy")
-    (force-mode-line-update)
-    (message "Copy mode: Press any key to exit")))
+  (if (eq ghostel--input-mode 'copy)
+      (ghostel-readonly-exit)
+    (ghostel--enter-readonly 'copy t ":Copy"
+                             "Copy mode: Press any key to exit")))
 
-(defun ghostel-copy-mode-exit ()
-  "Exit copy mode and return to terminal mode."
+(defun ghostel-readonly-exit ()
+  "Exit copy or Emacs mode and return to the mode active before entry."
   (interactive)
   (setq quit-flag nil)
-  (when ghostel--copy-mode-active
-    (setq ghostel--copy-mode-active nil)
-    (setq cursor-type ghostel--saved-cursor-type)
-    (deactivate-mark)
-    (use-local-map ghostel--saved-local-map)
-    (when ghostel--saved-hl-line-mode
-      (hl-line-mode -1))
-    (setq buffer-read-only nil)
-    (setq mode-line-process nil)
-    (force-mode-line-update)
-    ;; Jump out of any scrollback position so the redraw is allowed to
-    ;; position point at the terminal cursor (otherwise
-    ;; `ghostel--delayed-redraw' would preserve our scrollback marker).
-    (goto-char (point-max))
-    ;; Drop stale scroll-state that was frozen while delayed-redraw was
-    ;; short-circuited during copy mode, and let the next redraw snap
-    ;; fresh to the viewport.  `force-next-redraw' is required so the
-    ;; snap fires even when DEC 2026 synchronized output is active.
-    (setq ghostel--scroll-positions nil)
-    (setq ghostel--snap-requested t)
-    (setq ghostel--force-next-redraw t)
-    (ghostel--invalidate)
-    (message "Copy mode exited")))
+  (when (memq ghostel--input-mode '(copy emacs))
+    (let ((target (or ghostel--pre-readonly-mode 'semi-char)))
+      (setq ghostel--pre-readonly-mode nil)
+      ;; Jump out of any scrollback position so the next redraw is
+      ;; free to position point at the terminal cursor.
+      (goto-char (point-max))
+      ;; Drop stale scroll-state that was frozen while delayed-redraw
+      ;; was short-circuited during copy mode, and let the next redraw
+      ;; snap fresh to the viewport.  `force-next-redraw' is required
+      ;; so the snap fires even when DEC 2026 synchronized output is
+      ;; active.
+      (setq ghostel--scroll-positions nil)
+      (setq ghostel--snap-requested t)
+      (setq ghostel--force-next-redraw t)
+      (pcase target
+        ('char  (ghostel-char-mode))
+        ('emacs (ghostel-emacs-mode))
+        (_      (ghostel-semi-char-mode))))
+    (message "Read-only mode exited")))
 
-(defun ghostel-copy-mode-exit-and-clear ()
-  "Exit copy mode and clear the scrollback."
+(defun ghostel-readonly-exit-and-clear ()
+  "Exit read-only mode and clear the scrollback."
   (interactive)
-  (ghostel-copy-mode-exit)
+  (ghostel-readonly-exit)
   (ghostel-clear-scrollback))
 
-(defun ghostel-copy-mode-exit-and-send ()
-  "Exit copy mode and send the key that triggered exit to the terminal."
+(defun ghostel-readonly-exit-and-send ()
+  "Exit read-only mode and send the triggering key to the terminal.
+Only forwards the key when the mode we are returning to actually
+accepts terminal input (semi-char or char)."
   (interactive)
-  (ghostel-copy-mode-exit)
-  (when ghostel--term
-    (ghostel--self-insert)))
+  (let ((target (or ghostel--pre-readonly-mode 'semi-char)))
+    (ghostel-readonly-exit)
+    (when (and ghostel--term (memq target '(semi-char char)))
+      (ghostel--self-insert))))
 
 (defun ghostel--filter-soft-wraps (text)
   "Remove newlines from TEXT that were inserted by soft line wrapping.
@@ -1951,8 +2378,8 @@ These are newlines with the `ghostel-wrap' text property."
          (trimmed (mapcar (lambda (line) (string-trim-right line)) lines)))
     (mapconcat #'identity trimmed "\n")))
 
-(defun ghostel-copy-mode-copy ()
-  "Copy the selected region and exit copy mode.
+(defun ghostel-readonly-copy ()
+  "Copy the selected region and exit read-only mode.
 Soft-wrapped newlines are removed and trailing whitespace is
 stripped so the copied text matches the original terminal content."
   (interactive)
@@ -1961,7 +2388,846 @@ stripped so the copied text matches the original terminal content."
                  (buffer-substring (region-beginning) (region-end)))))
       (kill-new text)
       (message "Copied to kill ring")))
-  (ghostel-copy-mode-exit))
+  (ghostel-readonly-exit))
+
+
+;;; Line mode
+
+(defvar-local ghostel--line-input-start nil
+  "Marker pointing at the start of the user's in-progress input line.
+Nil when line mode is not active.  Text between this marker and
+`ghostel--line-input-end' is the editable input line.")
+
+(defvar-local ghostel--line-input-end nil
+  "Marker pointing right after the last character of the in-progress input.
+Has insertion-type t so a self-insert at this position causes the
+marker to advance with the new character.  Bounding the input by an
+explicit marker (rather than `point-max') keeps content past the
+prompt — e.g. a status bar drawn below the prompt row — out of the
+snapshot read and out of the renderer's clobber path.")
+
+(defvar-local ghostel--line-mode-history nil
+  "History ring of inputs submitted via `ghostel-line-mode-send'.
+Most recent first.")
+
+(defvar-local ghostel--line-mode-history-index nil
+  "Current index into `ghostel--line-mode-history' while browsing history.
+Nil when not browsing.")
+
+(defvar-local ghostel--line-mode-saved-full-redraw nil
+  "Saved `ghostel-full-redraw' state from before line mode entry.
+Cons (BUFFER-LOCAL-P . VALUE).  Restored by
+`ghostel--line-mode-teardown' so toggling the mode does not
+permanently override the user's setting.")
+
+(defvar-local ghostel--line-mode-saved-cursor-type nil
+  "Saved `cursor-type' from before line mode entry, as a singleton list.
+A list (VALUE) when saved, nil when not — distinguishes \"not
+saved\" from \"saved nil\" (the value the terminal asks for after
+a CSI ?25l).  Line mode forces `cursor-type' to the editor's
+default so point stays visible while the user navigates and
+edits, and `ghostel--line-mode-teardown' restores VALUE so any
+terminal-driven cursor visibility resumes on exit.")
+
+(defvar-local ghostel--line-mode-adopted-count nil
+  "Characters of pre-existing input the shell's readline still holds.
+Set on line-mode entry to the length of input adopted from the
+renderer (chars typed via the PTY in a previous mode).  Cleared to
+0 by `ghostel--line-mode-clear-shell-readline' after sending that
+many backspaces to erase them — keeps a subsequent send from
+duplicating the prefix when the shell echoes our line back.")
+
+(defun ghostel--line-mode-cursor-buffer-pos ()
+  "Return the buffer position of the terminal cursor, or nil.
+Maps libghostty's viewport (COL . ROW) to a buffer position: walks
+ROW lines down from `ghostel--viewport-start' (the renderer
+guarantees one buffer line per viewport row), then advances by
+the cursor's char offset within its row.  The offset comes from
+`ghostel--cursor-row-char-offset' — it counts cells, not display
+columns, so it stays correct on pgtk where Emacs `char-width'
+disagrees with libghostty's grid width for box-drawing glyphs.
+Returns nil when the cursor has no value or the native module is
+not loaded — the caller falls back accordingly."
+  (when (and ghostel--term
+             (fboundp 'ghostel--cursor-position)
+             (fboundp 'ghostel--cursor-row-char-offset))
+    ;; `ignore-errors' protects line-mode entry on a non-user-ptr
+    ;; `ghostel--term' (which the unit-test fixtures pass via 'fake).
+    ;; A real getScrollbar failure deep in libghostty would also be
+    ;; swallowed here — accepted because the fallback path
+    ;; (OSC 133 walk-back, then the entry user-error) is harmless,
+    ;; whereas surfacing a Zig signal during line-mode entry would
+    ;; just abort the mode toggle with a confusing trace.
+    (let ((cursor (ignore-errors (ghostel--cursor-position ghostel--term)))
+          (offset (ignore-errors (ghostel--cursor-row-char-offset ghostel--term)))
+          (vp-start (ghostel--viewport-start)))
+      (when (and cursor offset vp-start)
+        (save-excursion
+          (goto-char vp-start)
+          (forward-line (cdr cursor))
+          (let ((row-end (line-end-position)))
+            (min (+ (point) offset) row-end)))))))
+
+(defun ghostel--line-mode-find-prompt-end ()
+  "Return the buffer position where line-mode input begins.
+The cursor's buffer position is the source of truth — whatever the
+terminal has written sits before it, and user input goes after.
+When the terminal cursor is unavailable (no `ghostel--term', tests),
+fall back to the rightmost `ghostel-prompt' text-property
+character.  When the cursor IS available and the cursor's row
+carries `ghostel-prompt' characters (OSC 133 shell integration),
+return the position right after the last contiguous
+`ghostel-prompt' char on that row; otherwise return the cursor
+position itself.  Returns nil when neither path can locate a
+position (no cursor and no prompt prop)."
+  (let ((cursor-pos (ghostel--line-mode-cursor-buffer-pos)))
+    (cond
+     (cursor-pos
+      (let* ((row-start (save-excursion
+                          (goto-char cursor-pos)
+                          (line-beginning-position)))
+             (pos cursor-pos))
+        ;; Walk back from the cursor on its row, looking for the
+        ;; rightmost `ghostel-prompt' character.  The first prompt
+        ;; char we hit (scanning right-to-left) is the end of the
+        ;; prompt prefix — so its position+1, which is the current
+        ;; `pos' when we stop, is the input boundary.
+        (while (and (> pos row-start)
+                    (not (get-text-property (1- pos) 'ghostel-prompt)))
+          (setq pos (1- pos)))
+        (if (and (> pos row-start)
+                 (get-text-property (1- pos) 'ghostel-prompt))
+            pos
+          ;; No prompt prop on the cursor's row — REPL with no shell
+          ;; integration, or a non-shell program that printed a
+          ;; prompt.  Cursor itself is the boundary.
+          cursor-pos)))
+     (t
+      ;; No live terminal — fall back to the OSC 133 walk-back so
+      ;; the helper stays useful in unit tests that exercise prompt
+      ;; markers in isolation.
+      (let ((pos (point-max))
+            (pmin (point-min)))
+        (while (and (> pos pmin)
+                    (not (get-text-property (1- pos) 'ghostel-prompt)))
+          (setq pos (1- pos)))
+        (when (and (> pos pmin)
+                   (get-text-property (1- pos) 'ghostel-prompt))
+          pos))))))
+
+(defvar ghostel-line-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map ghostel-mode-map)
+    (define-key map (kbd "RET") #'ghostel-line-mode-send-or-open-link)
+    (define-key map (kbd "<return>") #'ghostel-line-mode-send-or-open-link)
+    ;; Shift-Enter inserts a literal newline in the input
+    (define-key map (kbd "S-RET") #'ghostel-line-mode-newline)
+    (define-key map (kbd "<S-return>") #'ghostel-line-mode-newline)
+    (define-key map (kbd "C-c C-c") #'ghostel-line-mode-interrupt)
+    (define-key map (kbd "C-d") #'ghostel-line-mode-delete-char-or-eof)
+    (define-key map (kbd "M-p") #'ghostel-line-mode-history-previous)
+    (define-key map (kbd "M-n") #'ghostel-line-mode-history-next)
+    (define-key map (kbd "C-a") #'ghostel-beginning-of-input-or-line)
+    (define-key map (kbd "TAB") #'ghostel-line-mode-complete-at-point)
+    (define-key map (kbd "<tab>") #'ghostel-line-mode-complete-at-point)
+    (define-key map [remap self-insert-command] #'ghostel-line-mode-self-insert)
+    map)
+  "Keymap for `ghostel-line-mode'.
+Editing commands work on the input region;
+\\<ghostel-line-mode-map>\\[ghostel-line-mode-send-or-open-link]
+sends the whole line to the shell at once, or follows the link at
+point when one is there.  \\[ghostel-line-mode-newline] inserts a
+literal newline in the input for multi-line prompts.")
+
+(defun ghostel-line-mode-send-or-open-link ()
+  "Open the hyperlink at point, or send the input line if there is none."
+  (interactive)
+  (let ((url (ghostel--uri-at-pos (point))))
+    (if url
+        (ghostel--open-link url)
+      (ghostel-line-mode-send))))
+
+(defun ghostel-line-mode-self-insert (&optional n)
+  "Self-insert N times, snapping point back to the input region first.
+When point sits in the read-only scrollback portion of a line-mode
+buffer, jump to the end of the in-progress input
+\(`ghostel--line-input-end') and self-insert there.  When point is
+already inside `[ghostel--line-input-start, ghostel--line-input-end]'
+this is just `self-insert-command'.
+
+The prefix argument N is forwarded to `self-insert-command' so
+\\[universal-argument] still works as expected."
+  (interactive "p")
+  (let ((start (and (markerp ghostel--line-input-start)
+                    (marker-position ghostel--line-input-start)))
+        (end   (and (markerp ghostel--line-input-end)
+                    (marker-position ghostel--line-input-end))))
+    (when (and start end (or (< (point) start) (> (point) end)))
+      (deactivate-mark)
+      (goto-char end)))
+  (self-insert-command (or n 1)))
+
+(defun ghostel-line-mode-newline ()
+  "Insert a literal newline in the line-mode input region.
+Discoverable shortcut for `\\[quoted-insert]' followed by a newline: lets
+you compose multi-line prompts in apps that distinguish submit (Enter)
+from newline (Shift-Enter).  The newline goes through to the running app
+verbatim when `ghostel-line-mode-send' ships the input.
+
+Snaps point to the end of the input region first when point is in the
+read-only scrollback portion, mirroring `ghostel-line-mode-self-insert'."
+  (interactive)
+  (let ((start (and (markerp ghostel--line-input-start)
+                    (marker-position ghostel--line-input-start)))
+        (end   (and (markerp ghostel--line-input-end)
+                    (marker-position ghostel--line-input-end))))
+    (when (and start end (or (< (point) start) (> (point) end)))
+      (deactivate-mark)
+      (goto-char end)))
+  (insert "\n"))
+
+(defun ghostel--line-mode-alt-screen-p ()
+  "Return non-nil if libghostty is on its alternate screen.
+Checks DEC private modes 1049 and 1047 (the modern alt-screen
+modes used by less, htop, vim, etc.)."
+  (and ghostel--term
+       (or (ghostel--mode-enabled ghostel--term 1049)
+           (ghostel--mode-enabled ghostel--term 1047))))
+
+(defun ghostel--line-mode-apply-readonly (marker-pos)
+  "Mark `[point-min, MARKER-POS)' read-only with the rear-nonsticky trick.
+The non-sticky flag lands on the last protected character so
+insertion at MARKER-POS itself stays legal while edits inside the
+region still signal `text-read-only'.  Setting `rear-nonsticky' to
+t also stops typed input from inheriting the prompt char's `face'
+\(and any other rendered-style properties libghostty painted on
+it) — without this, text typed after a colored prompt picks up
+the prompt's color until RET."
+  (let ((inhibit-read-only t))
+    (put-text-property (point-min) marker-pos 'read-only t)
+    (when (> marker-pos (point-min))
+      (put-text-property (1- marker-pos) marker-pos
+                         'rear-nonsticky t))))
+
+(defun ghostel--line-mode-input-end-pos (start)
+  "Return the position right after the contiguous `ghostel-input' span at START.
+Returns START itself when there is no `ghostel-input' span there —
+the common case at a fresh prompt where libghostty has not seen
+any input bytes yet, so the renderer hasn't painted the property."
+  (if (get-text-property start 'ghostel-input)
+      (or (next-single-property-change start 'ghostel-input nil (point-max))
+          (point-max))
+    start))
+
+(defun ghostel--line-mode-trim-trailing-blank (start)
+  "Delete `[START, point-max)' if the region is pure whitespace.
+Used in line-mode entry/restore to scrub the renderer's trailing
+blank rows past the input region while leaving any non-blank
+content (a status bar drawn below the prompt, a multi-line UI from
+the shell, etc.) intact."
+  (when (string-match-p "\\`[[:space:]]*\\'"
+                        (buffer-substring-no-properties start (point-max)))
+    (let ((inhibit-read-only t))
+      (delete-region start (point-max)))))
+
+(defun ghostel--line-mode-snapshot ()
+  "Capture in-progress input plus point/mark offsets and clear the input region.
+Returns a plist (:input STR :point-offset N-or-nil :mark-offset N-or-nil)
+suitable for `ghostel--line-mode-restore', or nil when there is no
+live input marker.  The input region is bounded by
+`ghostel--line-input-start' and `ghostel--line-input-end' (not
+`point-max') so any content drawn past the input — e.g. a status
+bar below the prompt — stays untouched."
+  (let ((start-pos (and (markerp ghostel--line-input-start)
+                        (marker-position ghostel--line-input-start)))
+        (end-pos (and (markerp ghostel--line-input-end)
+                      (marker-position ghostel--line-input-end))))
+    (when (and start-pos end-pos)
+      (let* ((point-offset (and (>= (point) start-pos)
+                                (<= (point) end-pos)
+                                (- (point) start-pos)))
+             (mark-pos (and mark-active (mark)))
+             (mark-offset (and mark-pos
+                               (>= mark-pos start-pos)
+                               (<= mark-pos end-pos)
+                               (- mark-pos start-pos)))
+             (input (buffer-substring-no-properties start-pos end-pos)))
+        (let ((inhibit-read-only t))
+          (delete-region start-pos end-pos))
+        (list :input input
+              :point-offset point-offset
+              :mark-offset mark-offset)))))
+
+(defun ghostel--line-mode-restore (snapshot)
+  "Re-insert SNAPSHOT'd input after the new prompt and restore point/mark.
+Returns non-nil on success.  Returns nil when the prompt cannot be
+located (shell integration dropped out, or the prompt scrolled off
+because of async output during composition); callers fall back to
+forwarding the pending input raw.
+
+Trims pure-whitespace tails past the input but preserves any
+non-blank content the renderer wrote past the prompt row (e.g. a
+status bar)."
+  (when snapshot
+    (let ((prompt-end (ghostel--line-mode-find-prompt-end)))
+      (when prompt-end
+        (let ((inhibit-read-only t)
+              (input (plist-get snapshot :input)))
+          (ghostel--line-mode-trim-trailing-blank prompt-end)
+          (when (markerp ghostel--line-input-start)
+            (set-marker ghostel--line-input-start nil))
+          (when (markerp ghostel--line-input-end)
+            (set-marker ghostel--line-input-end nil))
+          (setq ghostel--line-input-start (copy-marker prompt-end nil))
+          (set-marker-insertion-type ghostel--line-input-start nil)
+          (setq ghostel--line-input-end (copy-marker prompt-end t))
+          (set-marker-insertion-type ghostel--line-input-end t)
+          (when (and input (> (length input) 0))
+            (goto-char (marker-position ghostel--line-input-start))
+            ;; Insertion advances `ghostel--line-input-end' (insertion
+            ;; type t) so end-marker tracks the tail of the input.
+            (insert input))
+          (let ((start-pos (marker-position ghostel--line-input-start))
+                (end-pos (marker-position ghostel--line-input-end)))
+            (ghostel--line-mode-apply-readonly start-pos)
+            ;; Mark the line-mode input region with `ghostel-input' so
+            ;; `ghostel--detect-urls-skip-p' skips it on the cursor's
+            ;; line — without this, a path the user typed locally
+            ;; (e.g. `cd src/main.rs') would get linkified and RET
+            ;; would open the file instead of running
+            ;; `ghostel-line-mode-send'.
+            (when (< start-pos end-pos)
+              (put-text-property start-pos end-pos 'ghostel-input t))
+            (let ((po (plist-get snapshot :point-offset))
+                  (mo (plist-get snapshot :mark-offset)))
+              (when po
+                (goto-char (+ start-pos po)))
+              (when mo
+                (set-mark (+ start-pos mo))))))
+        t))))
+
+(defun ghostel--line-mode-enter ()
+  "Set up line mode in the current buffer.
+Internal helper used by the interactive `ghostel-line-mode' entry
+path and the auto-resume path in
+`ghostel--line-mode-try-resume'.  Returns t on success, nil when
+the prompt cannot be located (no cursor and no OSC 133 marker —
+e.g. the prompt has not been redrawn yet after an alt-screen
+exit).  Caller decides whether \"no prompt\" is a user-error or a
+deferred retry.
+
+Assumes `ghostel--term' is non-nil and the buffer is not already
+in line mode (the interactive entry validates these)."
+  (let ((prompt-end (ghostel--line-mode-find-prompt-end))
+        (was-frozen (eq ghostel--input-mode 'copy)))
+    (when prompt-end
+      (pcase ghostel--input-mode
+        ('copy  (ghostel--leave-readonly-state))
+        ('emacs (ghostel--leave-readonly-state)))
+      ;; Copy mode froze the redraw timer; line mode is live, so the
+      ;; timer must be running again before we exit this function or
+      ;; the prompt sits there with no scheduled redraw until the next
+      ;; PTY byte arrives.  `ghostel--invalidate' is idempotent, so the
+      ;; emacs/semi-char paths (timer already live) are unaffected.
+      (when (and was-frozen ghostel--term)
+        (ghostel--invalidate))
+      ;; Save `cursor-type' and force the editor's default for the
+      ;; duration of line mode.  The user moves point freely here, so
+      ;; the cursor must be visible regardless of any CSI ?25l the
+      ;; running terminal app issued in semi-char/char mode.
+      ;; `ghostel--set-cursor-style' is a no-op in line mode, so
+      ;; further terminal requests are ignored until teardown.
+      (setq ghostel--line-mode-saved-cursor-type (list cursor-type))
+      (setq cursor-type (default-value 'cursor-type))
+      ;; Force full redraws while line mode is active so the
+      ;; snapshot/restore path always rebuilds the prompt row
+      ;; (otherwise dirty-row diff could skip it and the input would
+      ;; be re-inserted at a stale marker position).  Restore the
+      ;; previous setting on teardown.
+      (setq ghostel--line-mode-saved-full-redraw
+            (cons (local-variable-p 'ghostel-full-redraw)
+                  ghostel-full-redraw))
+      (setq-local ghostel-full-redraw t)
+      ;; If the user already typed something at this prompt via the
+      ;; PTY (e.g. before switching from semi-char to line mode), the
+      ;; renderer painted those cells with `ghostel-input'.  Adopt
+      ;; the span as the initial line-mode input so the user does not
+      ;; lose their typing.
+      (let ((input-end (ghostel--line-mode-input-end-pos prompt-end)))
+        ;; Trim only PURE-whitespace tails past the input.  Status
+        ;; bars / multi-line UI drawn below the prompt row stay put.
+        (ghostel--line-mode-trim-trailing-blank input-end)
+        (setq ghostel--line-input-start (copy-marker prompt-end nil))
+        (set-marker-insertion-type ghostel--line-input-start nil)
+        (setq ghostel--line-input-end (copy-marker input-end t))
+        (set-marker-insertion-type ghostel--line-input-end t)
+        ;; Remember how many chars the shell's readline currently
+        ;; holds for us — we'll erase them via backspaces before the
+        ;; next PTY write so the shell doesn't append our line to its
+        ;; existing input and echo a duplicated prefix.
+        (setq ghostel--line-mode-adopted-count (- input-end prompt-end)))
+      (setq ghostel--line-mode-history-index nil)
+      (setq ghostel--char-mode-override-active nil)
+      (setq ghostel--input-mode 'line)
+      (use-local-map ghostel-line-mode-map)
+      (setq ghostel--mode-line-tag ":Line")
+      (ghostel--mode-line-refresh)
+      ;; Protect everything before the input marker with a read-only
+      ;; text property so commands that would modify the buffer
+      ;; (self-insert, delete-char, yank, …) signal `text-read-only'
+      ;; when point is in the scrollback / previous output region.
+      ;; The redraw path binds `inhibit-read-only' so it is
+      ;; unaffected.
+      (ghostel--line-mode-apply-readonly
+       (marker-position ghostel--line-input-start))
+      ;; Make sure the adopted input carries `ghostel-input' (the
+      ;; renderer should have applied it for PTY-typed cells; reapply
+      ;; for consistency, and so URL detection skips the region even
+      ;; if the property was missed for some cells).
+      (let ((start-pos (marker-position ghostel--line-input-start))
+            (end-pos (marker-position ghostel--line-input-end)))
+        (when (< start-pos end-pos)
+          (let ((inhibit-read-only t))
+            (put-text-property start-pos end-pos 'ghostel-input t))))
+      ;; Place point at end of (any adopted) input so the user
+      ;; continues typing where the shell left them.
+      (goto-char (marker-position ghostel--line-input-end))
+      (ghostel--line-mode-maybe-prespawn-bash-completion)
+      t)))
+
+(defun ghostel-line-mode ()
+  "Switch to line mode — edit input locally, send to shell on RET.
+The user types into an editable region between the last prompt
+and `point-max'.  Full Emacs editing (yank, `kill-word',
+transpose, etc.) works.  Pressing \\[ghostel-line-mode-send]
+sends the entire line to the shell in one write; bash echoes and
+executes it normally.
+
+The terminal stays live: output streaming in around the prompt
+keeps rendering, and the snapshot/restore path in
+`ghostel--delayed-redraw' preserves the user's in-progress input
+across each redraw cycle.  After RET, line mode stays active so
+the user just keeps editing at the next prompt.
+
+\\<ghostel-line-mode-map>\\[ghostel-line-mode-complete-at-point]
+runs `completion-at-point' against the input region — filenames,
+env vars, executables on \\=`PATH\\=', and whatever \\=`pcomplete\\='
+extensions are loaded.  Install the `bash-completion' package and
+set `ghostel-line-mode-use-bash-completion' to layer real bash
+programmable completion (git subcommands, ssh hosts, …) on top.
+
+Uses the terminal cursor as the input-area boundary, so REPLs
+without OSC 133 (python3, irb, sqlite3, …) work too.  When OSC
+133 markers are present on the cursor's row, the prompt prefix is
+recognised and the input boundary lands right after it.
+
+While a fullscreen TUI is on the alt screen, line mode cannot
+edit (the TUI needs every keystroke raw); calling this command
+during an alt-screen session arms a deferred-activation sentinel
+instead, and line mode resumes automatically when the TUI exits."
+  (interactive)
+  (unless ghostel--term
+    (user-error "No terminal in this buffer"))
+  (cond
+   ((eq ghostel--input-mode 'line))
+   ((ghostel--line-mode-alt-screen-p)
+    (ghostel--line-mode-defer-entry))
+   ((ghostel--line-mode-enter)
+    (message "Line mode: RET sends the whole line; C-c C-j to exit"))
+   (t
+    (user-error "Line mode could not locate the cursor or a prompt"))))
+
+(defun ghostel--line-mode-input-text ()
+  "Return the current in-progress input text, or an empty string.
+Bounded by the start and end markers, not `point-max', so content
+past the input region (status bar, etc.) is never read."
+  (let ((start (and (markerp ghostel--line-input-start)
+                    (marker-position ghostel--line-input-start)))
+        (end (and (markerp ghostel--line-input-end)
+                  (marker-position ghostel--line-input-end))))
+    (if (and start end (< start end))
+        (buffer-substring-no-properties start end)
+      "")))
+
+(defun ghostel--line-mode-delete-input ()
+  "Delete the current in-progress input from the buffer.
+Removes only the region between the start and end markers; content
+past the end marker (status bar, etc.) stays put."
+  (let ((start (and (markerp ghostel--line-input-start)
+                    (marker-position ghostel--line-input-start)))
+        (end (and (markerp ghostel--line-input-end)
+                  (marker-position ghostel--line-input-end))))
+    (when (and start end (< start end))
+      (let ((inhibit-read-only t))
+        (delete-region start end)))))
+
+(defun ghostel--line-mode-clear-shell-readline ()
+  "Erase the adopted prefix from the shell's readline buffer.
+On line-mode entry we adopt any pre-existing input (chars the user
+already typed via the PTY) into the editable buffer, but the shell
+still holds those bytes in its own line-discipline / readline
+buffer.  Before our next write to the PTY, send that many
+backspaces so the upcoming line lands on an empty prompt — without
+this the shell concatenates and echoes a duplicated line.
+
+Backspaces work under any cooked-mode line discipline (bash, fish,
+zsh, vi-mode readline, python REPL); a readline-only kill like
+`C-u' would not.  Resets `ghostel--line-mode-adopted-count' to 0."
+  (when (and ghostel--line-mode-adopted-count
+             (> ghostel--line-mode-adopted-count 0)
+             ghostel--term
+             ghostel--process
+             (process-live-p ghostel--process))
+    (dotimes (_ ghostel--line-mode-adopted-count)
+      (ghostel--send-encoded "backspace" "")))
+  (setq ghostel--line-mode-adopted-count 0))
+
+(defun ghostel--line-mode-teardown (&optional pause)
+  "Clean up line-mode state and hand any pending input back to the shell.
+Any in-progress input is forwarded to the PTY raw (no newline) so
+the user can continue editing it at the shell's own prompt after
+the mode switch instead of losing what they typed.  Callers that
+have already handled the input themselves (like
+`ghostel-line-mode-send' and `ghostel-line-mode-interrupt') delete
+it from the buffer before calling this, so no double-send happens.
+
+Restores `ghostel-full-redraw' to the value captured on entry, and
+forces a final redraw so the buffer truncation done at entry is
+re-materialized from libghostty.
+
+When PAUSE is non-nil, skip forwarding pending input to the PTY,
+skip the readline-clearing backspaces (the alt-screen TUI would
+receive them), and skip the trailing redraw — used by
+`ghostel--line-mode-pause' which has already snapshotted the input
+and is running inside `ghostel--delayed-redraw'."
+  (unless pause
+    (let ((input (ghostel--line-mode-input-text)))
+      ;; Erase the adopted prefix from the shell's readline before
+      ;; handing back our (possibly edited) version, so the shell ends
+      ;; up holding exactly INPUT instead of "<adopted>INPUT".
+      (ghostel--line-mode-clear-shell-readline)
+      (when (and (> (length input) 0)
+                 ghostel--process
+                 (process-live-p ghostel--process))
+        (process-send-string ghostel--process input))))
+  (ghostel--line-mode-delete-input)
+  ;; Drop the `read-only' and `rear-nonsticky' properties that
+  ;; protected the scrollback region during line mode so the buffer
+  ;; is editable again.
+  (let ((inhibit-read-only t))
+    (remove-text-properties (point-min) (point-max)
+                            '(read-only nil rear-nonsticky nil)))
+  (when (markerp ghostel--line-input-start)
+    (set-marker ghostel--line-input-start nil))
+  (when (markerp ghostel--line-input-end)
+    (set-marker ghostel--line-input-end nil))
+  (setq ghostel--line-input-start nil)
+  (setq ghostel--line-input-end nil)
+  (setq ghostel--line-mode-history-index nil)
+  (setq ghostel--line-mode-adopted-count nil)
+  (when ghostel--line-mode-saved-full-redraw
+    (if (car ghostel--line-mode-saved-full-redraw)
+        (setq-local ghostel-full-redraw
+                    (cdr ghostel--line-mode-saved-full-redraw))
+      (kill-local-variable 'ghostel-full-redraw))
+    (setq ghostel--line-mode-saved-full-redraw nil))
+  (when ghostel--line-mode-saved-cursor-type
+    (setq cursor-type (car ghostel--line-mode-saved-cursor-type))
+    (setq ghostel--line-mode-saved-cursor-type nil))
+  (unless pause
+    (when ghostel--term
+      (let ((inhibit-read-only t))
+        (ghostel--redraw ghostel--term t)))))
+
+(defun ghostel--line-mode-pause ()
+  "Snapshot in-progress input, tear down line mode, switch to semi-char.
+Called by `ghostel--line-mode-pre-redraw' on a 1049/1047 transition
+into the alt screen.  Stashes the snapshot in
+`ghostel--line-mode-paused' so a later alt-screen-off cycle can
+re-enter line mode at the new prompt with the user's typing
+restored."
+  (let ((snapshot (or (ghostel--line-mode-snapshot)
+                      (list :input "" :point-offset nil :mark-offset nil))))
+    (ghostel--line-mode-teardown 'pause)
+    (setq ghostel--char-mode-override-active nil)
+    (setq ghostel--input-mode 'semi-char)
+    (use-local-map ghostel-semi-char-mode-map)
+    (setq ghostel--mode-line-tag nil)
+    (ghostel--mode-line-refresh)
+    (setq ghostel--line-mode-paused snapshot)))
+
+(defun ghostel--line-mode-try-resume ()
+  "Re-enter line mode and restore the paused snapshot, if possible.
+Called by `ghostel--line-mode-post-redraw' on a 1049/1047 exit.
+If `ghostel--line-mode-find-prompt-end' cannot locate a prompt
+yet (the renderer has not painted the post-TUI buffer yet), the
+paused snapshot is left in place so the next redraw can retry."
+  (when (ghostel--line-mode-find-prompt-end)
+    (let ((snapshot ghostel--line-mode-paused))
+      (setq ghostel--line-mode-paused nil)
+      (when (ghostel--line-mode-enter)
+        (ghostel--line-mode-restore snapshot)
+        t))))
+
+(defun ghostel--line-mode-defer-entry ()
+  "Arm auto-pause so line mode activates when the alt-screen TUI exits.
+Called by interactive `ghostel-line-mode' when an alt-screen TUI is
+already running.  Stashes an empty snapshot so the alt-screen-off
+transition picks it up and enters line mode for real.  Preserves
+any existing paused snapshot (the user re-arming should not clobber
+input captured by an earlier auto-pause)."
+  (unless ghostel--line-mode-paused
+    (setq ghostel--line-mode-paused
+          (list :input "" :point-offset nil :mark-offset nil)))
+  (message "Line mode armed — will activate when the TUI exits"))
+
+(defun ghostel--line-mode-pre-redraw ()
+  "Pause line mode if alt-screen is on while in line mode.
+Runs at the top of `ghostel--delayed-redraw' (after PTY flush, but
+before the renderer paints).  Pausing here lets us snapshot the
+in-progress input before libghostty's grid (which does not contain
+it) drives the renderer over the buffer.  After pausing,
+`ghostel--input-mode' is no longer `line', so subsequent calls
+fall through — there is no need for an explicit transition cache."
+  (when (and (eq ghostel--input-mode 'line)
+             (ghostel--line-mode-alt-screen-p))
+    (ghostel--line-mode-pause)))
+
+(defun ghostel--line-mode-post-redraw ()
+  "Resume line mode if alt-screen is off and a paused snapshot is armed.
+Runs at the bottom of `ghostel--delayed-redraw' (after the renderer
+paints) so `ghostel--line-mode-find-prompt-end' sees the
+post-TUI buffer state.  Re-attempts every redraw cycle until a
+prompt is locatable — covers the case where the shell prints its
+new prompt one or more redraws after libghostty leaves the alt
+screen."
+  (when (and ghostel--line-mode-paused
+             (not (ghostel--line-mode-alt-screen-p)))
+    (ghostel--line-mode-try-resume)))
+
+(defun ghostel-line-mode-send ()
+  "Send the current in-progress input line to the shell.
+Reads the text between the line-input marker and `point-max',
+deletes it locally, sends the input to the PTY as a single write,
+then submits via an encoded `return' keypress so the running app
+sees Enter the same way semi-char mode would have produced it.
+
+The encoded Return matters for TUI apps that distinguish a
+literal newline (Shift-Enter) from a submit (e.g. claude-code,
+pi).  They expect CR or a kitty-keyboard-protocol-encoded Enter,
+not a raw \\n; bash readline accepts CR as `accept-line' too, so
+the same code path works for shells.
+
+Stays in line mode: the next redraw cycle picks up the shell's
+echo and command output, and the snapshot/restore path moves the
+input marker to wherever the new prompt lands."
+  (interactive)
+  (unless (eq ghostel--input-mode 'line)
+    (user-error "Not in line mode"))
+  (let ((input (ghostel--line-mode-input-text)))
+    (ghostel--line-mode-delete-input)
+    (when (and (> (length input) 0)
+               (or (null ghostel--line-mode-history)
+                   (not (string= input (car ghostel--line-mode-history)))))
+      (push input ghostel--line-mode-history)
+      (when (> (length ghostel--line-mode-history)
+               ghostel-line-mode-history-size)
+        (setcdr (nthcdr (1- ghostel-line-mode-history-size)
+                        ghostel--line-mode-history)
+                nil)))
+    (setq ghostel--line-mode-history-index nil)
+    ;; Erase any prefix the shell already had in its readline buffer
+    ;; (adopted on line-mode entry) before sending — otherwise the
+    ;; shell would concatenate ours after that prefix and echo a
+    ;; duplicated line.
+    (ghostel--line-mode-clear-shell-readline)
+    (when (and ghostel--process (process-live-p ghostel--process))
+      (when (> (length input) 0)
+        (process-send-string ghostel--process input))
+      (ghostel--send-encoded "return" ""))))
+
+(defun ghostel-line-mode-interrupt ()
+  "Discard local input and send SIGINT (\\`C-c') to the shell.
+Stays in line mode; the next redraw cycle picks up the shell's
+new prompt and the snapshot/restore path repositions the input
+marker."
+  (interactive)
+  (ghostel--line-mode-delete-input)
+  (setq ghostel--line-mode-history-index nil)
+  ;; C-c discards readline's input buffer shell-side, so any adopted
+  ;; prefix is gone — just zero our count, no backspaces needed.
+  (setq ghostel--line-mode-adopted-count 0)
+  (when (and ghostel--process (process-live-p ghostel--process))
+    (process-send-string ghostel--process "\C-c")))
+
+(defun ghostel-line-mode-delete-char-or-eof ()
+  "Delete the next char, or send EOF at an empty input."
+  (interactive)
+  (let ((start (and (markerp ghostel--line-input-start)
+                    (marker-position ghostel--line-input-start)))
+        (end (and (markerp ghostel--line-input-end)
+                  (marker-position ghostel--line-input-end))))
+    (if (and start end (= start end) (= (point) start))
+        (when (and ghostel--process (process-live-p ghostel--process))
+          (process-send-string ghostel--process "\C-d"))
+      (delete-char 1))))
+
+(defun ghostel-beginning-of-input-or-line ()
+  "Move point to the start of input on a prompt row, else `beginning-of-line'.
+On a line that carries the `ghostel-prompt' text property over its
+leading characters, point moves to the position right after the
+last contiguous prompt character — i.e. where the user's input
+begins on that prompt row.  In line mode the active input marker
+\(`ghostel--line-input-start') wins over the property scan so an
+empty fresh prompt still goes to the marker position.
+
+On any other line — scrollback, output, a prompt-continuation row
+that has no content past the prefix — falls through to
+`move-beginning-of-line', so navigating up into history and
+pressing \\`C-a' gives the standard column-0 behaviour."
+  (interactive "^")
+  (let* ((bol (line-beginning-position))
+         (eol (line-end-position))
+         ;; Line-mode marker target — only meaningful when the
+         ;; marker is on the current line.
+         (line-mode-target
+          (and (eq ghostel--input-mode 'line)
+               (markerp ghostel--line-input-start)
+               (let ((m (marker-position ghostel--line-input-start)))
+                 (and m (>= m bol) (<= m eol) m))))
+         ;; Text-property fallback: walk forward from BOL while
+         ;; chars carry `ghostel-prompt'.  Only treat as input-start
+         ;; when there is real content past the prefix; an
+         ;; all-prompt line (multi-line prompt continuation) goes to
+         ;; BOL instead of jumping to EOL.
+         (prop-target
+          (unless line-mode-target
+            (save-excursion
+              (goto-char bol)
+              (let ((pos bol))
+                (while (and (< pos eol)
+                            (get-text-property pos 'ghostel-prompt))
+                  (setq pos (1+ pos)))
+                (and (> pos bol) (< pos eol) pos))))))
+    (cond
+     (line-mode-target (goto-char line-mode-target))
+     (prop-target      (goto-char prop-target))
+     (t                (move-beginning-of-line 1)))))
+
+(defun ghostel--line-mode-replace-input (text)
+  "Replace the current in-progress input with TEXT."
+  (ghostel--line-mode-delete-input)
+  (when (and ghostel--line-input-start
+             (marker-position ghostel--line-input-start))
+    (goto-char (marker-position ghostel--line-input-start))
+    ;; Insertion advances `ghostel--line-input-end' (insertion type
+    ;; t), so the end marker tracks the new input's tail.
+    (insert text)
+    (when (markerp ghostel--line-input-end)
+      (goto-char (marker-position ghostel--line-input-end)))))
+
+(defun ghostel-line-mode-history-previous ()
+  "Replace the input with the previous entry from history."
+  (interactive)
+  (when ghostel--line-mode-history
+    (let* ((len (length ghostel--line-mode-history))
+           (idx (if ghostel--line-mode-history-index
+                    (min (1- len) (1+ ghostel--line-mode-history-index))
+                  0)))
+      (setq ghostel--line-mode-history-index idx)
+      (ghostel--line-mode-replace-input
+       (nth idx ghostel--line-mode-history)))))
+
+(defun ghostel-line-mode-history-next ()
+  "Replace the input with the next entry from history."
+  (interactive)
+  (cond
+   ((null ghostel--line-mode-history-index)
+    (ghostel--line-mode-replace-input ""))
+   ((zerop ghostel--line-mode-history-index)
+    (setq ghostel--line-mode-history-index nil)
+    (ghostel--line-mode-replace-input ""))
+   (t
+    (setq ghostel--line-mode-history-index
+          (1- ghostel--line-mode-history-index))
+    (ghostel--line-mode-replace-input
+     (nth ghostel--line-mode-history-index ghostel--line-mode-history)))))
+
+(defun ghostel--line-mode-bash-completion-available-p ()
+  "Return non-nil when bash-completion should be used for line-mode TAB.
+Honours `ghostel-line-mode-use-bash-completion': loads the package
+when set to t, attempts a soft load when set to `auto', returns nil
+otherwise."
+  (pcase ghostel-line-mode-use-bash-completion
+    ('nil nil)
+    ('auto (require 'bash-completion nil 'noerror))
+    (_ (require 'bash-completion))))
+
+(defun ghostel--line-mode-effective-capfs ()
+  "Return the capf list used by `ghostel-line-mode-complete-at-point'.
+Starts from `ghostel-line-mode-completion-at-point-functions' and
+prepends `bash-completion-capf-nonexclusive' when bash-completion
+integration is enabled and available."
+  (let ((funs (copy-sequence
+               ghostel-line-mode-completion-at-point-functions)))
+    (when (and (ghostel--line-mode-bash-completion-available-p)
+               (not (memq #'bash-completion-capf-nonexclusive funs)))
+      (push #'bash-completion-capf-nonexclusive funs))
+    funs))
+
+(defun ghostel--line-mode-maybe-prespawn-bash-completion ()
+  "Spawn the bash-completion subprocess eagerly when configured.
+Honours `ghostel-line-mode-bash-completion-prespawn'.  No-op when
+the option is nil, when bash-completion is unavailable, or when
+the subprocess is already running (the bash-completion entry
+point is idempotent)."
+  (when (and ghostel-line-mode-bash-completion-prespawn
+             (ghostel--line-mode-bash-completion-available-p)
+             (fboundp 'bash-completion-require-process))
+    (ignore-errors (bash-completion-require-process))))
+
+(defun ghostel-line-mode-complete-at-point ()
+  "Complete the input at point against the line-mode capf stack.
+Narrows to `[ghostel--line-input-start, ghostel--line-input-end)'
+before delegating to `completion-at-point' so that comint/shell
+completion functions parse only the user's typed input — the
+prompt and surrounding scrollback are invisible to them.
+
+When point sits in the read-only scrollback, snaps to the input
+end first (mirrors `ghostel-line-mode-self-insert').
+
+Refreshes `comint-file-name-prefix' from `default-directory' on
+each call so completions follow OSC 7 / TRAMP directory tracking
+when it flips between local and remote.
+
+The capf list comes from `ghostel--line-mode-effective-capfs',
+which combines `ghostel-line-mode-completion-at-point-functions'
+with optional `bash-completion' integration controlled by
+`ghostel-line-mode-use-bash-completion'."
+  (interactive)
+  (let ((start (and (markerp ghostel--line-input-start)
+                    (marker-position ghostel--line-input-start)))
+        (end   (and (markerp ghostel--line-input-end)
+                    (marker-position ghostel--line-input-end))))
+    (cond
+     ((not (and start end))
+      ;; No live input markers — nothing to complete against.
+      (user-error "Line mode: no input region to complete"))
+     ((or (< (point) start) (> (point) end))
+      (deactivate-mark)
+      (goto-char end)
+      (ghostel-line-mode-complete-at-point))
+     (t
+      ;; Refresh in case directory tracking flipped between
+      ;; local/remote since `shell-completion-vars' first ran.
+      (setq-local comint-file-name-prefix
+                  (or (file-remote-p default-directory) ""))
+      (save-restriction
+        (narrow-to-region start end)
+        (let ((completion-at-point-functions
+               (ghostel--line-mode-effective-capfs)))
+          (completion-at-point)))))))
+
 
 (defun ghostel-copy-all ()
   "Copy the entire scrollback buffer to the kill ring."
@@ -2084,7 +3350,7 @@ A hyperlink is any OSC 8 link, auto-detected URL, or `file:line'
 reference in the buffer.  Wraps to `point-min' when no link is found
 after point.  Press RET to follow the link at point."
   (interactive "p")
-  (unless ghostel--copy-mode-active
+  (unless (eq ghostel--input-mode 'copy)
     (ghostel-copy-mode))
   (dotimes (_ (or n 1))
     (ghostel--goto-hyperlink 'next)))
@@ -2093,7 +3359,7 @@ after point.  Press RET to follow the link at point."
   "Enter copy mode and move point to the Nth previous hyperlink.
 Wraps to `point-max' when no link is found before point."
   (interactive "p")
-  (unless ghostel--copy-mode-active
+  (unless (eq ghostel--input-mode 'copy)
     (ghostel-copy-mode))
   (dotimes (_ (or n 1))
     (ghostel--goto-hyperlink 'previous)))
@@ -2208,7 +3474,6 @@ when called from the deferred-detection timer outside the redraw scope."
                               #'ghostel--run-queued-plain-link-detection
                               (current-buffer)))))))
 
-
 (defun ghostel--compensate-wide-chars ()
   "Shrink trailing spaces on lines where wide-char glyphs cause pixel overflow.
 Emoji glyphs often render wider than `char-width' times `frame-char-width'
@@ -2710,17 +3975,21 @@ the last non-whitespace+whitespace boundary (e.g. after `$ ' or `# ')."
       (ghostel--prompt-input-start))))
 
 (defun ghostel-next-prompt (&optional n)
-  "Enter copy mode and move to the Nth next prompt."
+  "Enter Emacs mode and move to the Nth next prompt.
+Emacs mode keeps the terminal running, so you can navigate between
+prompts while output continues streaming in."
   (interactive "p")
-  (unless ghostel--copy-mode-active
-    (ghostel-copy-mode))
+  (unless (memq ghostel--input-mode '(emacs copy))
+    (ghostel-emacs-mode))
   (ghostel--navigate-next-prompt n))
 
 (defun ghostel-previous-prompt (&optional n)
-  "Enter copy mode and move to the Nth previous prompt."
+  "Enter Emacs mode and move to the Nth previous prompt.
+Emacs mode keeps the terminal running, so you can navigate between
+prompts while output continues streaming in."
   (interactive "p")
-  (unless ghostel--copy-mode-active
-    (ghostel-copy-mode))
+  (unless (memq ghostel--input-mode '(emacs copy))
+    (ghostel-emacs-mode))
   (ghostel--navigate-previous-prompt n))
 
 
@@ -2781,9 +4050,12 @@ current, so `buffer-name' here gives the terminal buffer's name."
 
 (defun ghostel-default-progress (state progress)
   "Default handler for OSC 9;4 ConEmu progress reports.
-Updates `mode-line-process' to show the current STATE and
-PROGRESS (an integer 0-100 or nil).  STATE is one of the symbols
-`remove', `set', `error', `indeterminate', `pause'."
+Updates `ghostel--mode-line-progress' (and refreshes
+`mode-line-process') to show the current STATE and PROGRESS (an
+integer 0-100 or nil).  STATE is one of the symbols `remove',
+`set', `error', `indeterminate', `pause'.  The input-mode tag in
+`ghostel--mode-line-tag' is composed alongside, so progress
+updates do not clobber labels like \":Char\" or \":Line\"."
   (let ((new-val
          (pcase state
            ('remove        nil)
@@ -2796,29 +4068,24 @@ PROGRESS (an integer 0-100 or nil).  STATE is one of the symbols
            ('pause         (if progress
                                (format " [paused %d%%]" progress)
                              " [paused]"))
-           ;; Unknown state: keep the current mode-line value rather
+           ;; Unknown state: keep the current progress value rather
            ;; than silently clearing it, so a future Zig-side state is
            ;; visible-but-stale instead of disappearing.
-           (_              mode-line-process))))
-    (unless (equal new-val mode-line-process)
-      (setq mode-line-process new-val)
-      (force-mode-line-update))))
-
-(defvar-local ghostel--spinner-active nil
-  "Non-nil when this buffer has a spinner started by `ghostel-spinner-progress'.
-The spinner object itself lives in spinner.el's buffer-local
-`spinner-current'; this flag is what ghostel inspects to keep
-`ghostel-spinner-progress' idempotent and to give the sentinel
-something to gate teardown on.")
+           (_              ghostel--mode-line-progress))))
+    (unless (equal new-val ghostel--mode-line-progress)
+      (setq ghostel--mode-line-progress new-val)
+      (ghostel--mode-line-refresh))))
 
 (defun ghostel--spinner-stop ()
   "Stop this buffer's progress spinner, if any.
 Safe to call when no spinner is running.  Errors from spinner.el
 \(e.g. on a half-torn-down buffer) are swallowed — this is
-teardown.  Does not touch `mode-line-process'."
+teardown.  Refreshes `mode-line-process' so the spinner construct
+no longer renders alongside the input-mode tag."
   (when ghostel--spinner-active
     (ignore-errors (spinner-stop))
-    (setq ghostel--spinner-active nil)))
+    (setq ghostel--spinner-active nil)
+    (ghostel--mode-line-refresh)))
 
 (defun ghostel-spinner-progress (state progress)
   "Spinner-driven handler for OSC 9;4 ConEmu progress reports.
@@ -2829,25 +4096,30 @@ STATE is one of those symbols; PROGRESS is an integer 0-100 or nil.
 
 Requires spinner.el to be available; signals a `user-error' on
 the first call if it is not.  The spinner style is controlled by
-`ghostel-spinner-type'."
+`ghostel-spinner-type'.  The input-mode tag (`:Char', `:Line',
+…) is preserved across spinner transitions via
+`ghostel--mode-line-refresh'."
   (unless (require 'spinner nil t)
     (user-error
      "Cannot run `ghostel-spinner-progress' without spinner.el — install it \
 from MELPA or set `ghostel-progress-function' to #'ghostel-default-progress"))
   (if (eq state 'indeterminate)
       ;; Indeterminate: install spinner.el's mode-line construct.
-      ;; Clear any prior determinate text first so the spinner shows alone,
-      ;; not appended to a stale \" [50%]\".
+      ;; Clear any prior determinate text first so the spinner shows
+      ;; alone, not appended to a stale " [50%]".
       (unless ghostel--spinner-active
-        (setq mode-line-process nil)
+        (setq ghostel--mode-line-progress nil
+              ghostel--spinner-active t)
+        ;; spinner-start mutates `mode-line-process' directly; the
+        ;; refresh below overwrites it with the composed value so the
+        ;; input-mode tag stays visible alongside the spinner.
         (spinner-start ghostel-spinner-type)
-        (setq ghostel--spinner-active t))
-    ;; Any other state: stop the spinner and clear the (now-inert)
-    ;; mode-line construct it left behind, then defer to the text indicator.
-    (when ghostel--spinner-active
-      (spinner-stop)
-      (setq mode-line-process nil
-            ghostel--spinner-active nil))
+        (ghostel--mode-line-refresh))
+    ;; Any other state: stop the spinner and let the text indicator
+    ;; take over.  `ghostel--spinner-stop' refreshes the mode-line so
+    ;; the spinner construct disappears even if the new progress text
+    ;; happens to equal the old one.
+    (ghostel--spinner-stop)
     (ghostel-default-progress state progress)))
 
 (defun ghostel--handle-notification (title body)
@@ -2941,10 +4213,11 @@ Only acts when the buffer has not been manually renamed by the user."
   "Set the cursor style based on terminal state.
 STYLE is one of: 0=bar, 1=block, 2=underline, 3=hollow-block.
 VISIBLE is t or nil.
-Skipped when copy mode is active because copy mode manages its own
-cursor, or when `ghostel-ignore-cursor-change' is non-nil."
-  (unless (or ghostel--copy-mode-active
-              ghostel-ignore-cursor-change)
+Skipped in read-only input modes (copy, Emacs, line) where the
+user-facing cursor is managed by Emacs for navigation, or when
+`ghostel-ignore-cursor-change' is non-nil."
+  (when (and (ghostel--buffer-editable-p)
+             (not ghostel-ignore-cursor-change))
     (setq cursor-type
           (if visible
               (pcase style
@@ -3041,9 +4314,13 @@ Call this after changing the Emacs theme so terminals match."
     (with-current-buffer buf
       (when (and (derived-mode-p 'ghostel-mode) ghostel--term)
         (ghostel--apply-palette ghostel--term)
-        (when (not ghostel--copy-mode-active)
-          (let ((inhibit-read-only t))
+        (when (ghostel--terminal-live-p)
+          (let ((inhibit-read-only t)
+                (snap (and (eq ghostel--input-mode 'line)
+                           (ghostel--line-mode-snapshot))))
             (ghostel--redraw ghostel--term)
+            (when snap
+              (ghostel--line-mode-restore snap))
             (ghostel--schedule-link-detection)))))))
 
 (defun ghostel--on-theme-change (&rest _args)
@@ -3900,12 +5177,19 @@ left it following the viewport, so a drifted `window-start' below the
 anchor is Emacs redisplay (e.g. `keep-point-visible' when the
 minibuffer shrinks the window), not a user scroll."
   (let ((anchor ghostel--last-anchor-position))
+    ;; Snap-requested (the user just typed) overrides Emacs mode's
+    ;; usual no-anchor behaviour so typing forwards the keystroke
+    ;; AND brings the window back to the live cursor.  Emacs mode
+    ;; otherwise decouples buffer-point from the terminal cursor —
+    ;; treat every window as non-anchored so the scrollback restore
+    ;; preserves the user's window-point/window-start.
     (or ghostel--snap-requested
         (memq win ghostel--windows-needing-snap)
-        (null anchor)
-        (>= (window-start win) anchor)
-        (and ghostel--redraw-resize-active
-             (not (assq win ghostel--scroll-positions))))))
+        (and (not (eq ghostel--input-mode 'emacs))
+             (or (null anchor)
+                 (>= (window-start win) anchor)
+                 (and ghostel--redraw-resize-active
+                      (not (assq win ghostel--scroll-positions))))))))
 
 (defun ghostel--capture-window-state (win)
   "Return (WIN WS-KEY WP-KEY WP-COL) for WIN.
@@ -3995,15 +5279,24 @@ following the viewport.
 
 When a GUI input method is composing preedit text in BUFFER, leaves
 buffer point on the preedit anchor instead of the terminal cursor so
-the candidate window does not jump while text is streaming in."
+the candidate window does not jump while text is streaming in.
+
+In Emacs mode, the read-only buffer is decoupled from the terminal
+cursor — point is captured per-window via the standard scroll-state
+restore path so the user's navigation point is not yanked back when
+new output arrives."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (setq ghostel--redraw-timer nil)
-      (when (and ghostel--term (not ghostel--copy-mode-active))
+      (when (and ghostel--term (ghostel--terminal-live-p))
         (ghostel--flush-pending-output)
         ;; Skip during synchronized output unless forced by scroll/resize.
         (unless (and (not ghostel--force-next-redraw)
                      (ghostel--mode-enabled ghostel--term 2026))
+          ;; Pause line mode if alt-screen just turned on — must run
+          ;; before the line-snapshot block so that snapshot sees the
+          ;; post-pause input mode and skips its own capture.
+          (ghostel--line-mode-pre-redraw)
           (setq ghostel--force-next-redraw nil)
           (setq ghostel--has-wide-chars nil)
           (ghostel--correct-mangled-scroll-positions buffer)
@@ -4016,35 +5309,77 @@ the candidate window does not jump while text is streaming in."
                   (mapcar #'ghostel--capture-window-state
                           (cl-remove-if #'ghostel--window-anchored-p
                                         all-windows)))
+                 ;; In Emacs mode the buffer-point is normally
+                 ;; decoupled from the terminal cursor.  Stash a
+                 ;; marker so we can restore it after the renderer
+                 ;; rewrites the buffer (which moves point to the
+                 ;; live cursor).  Skip the stash when snap-requested
+                 ;; — the user just typed and wants point to land at
+                 ;; the live cursor where their input went, not
+                 ;; wherever they had navigated to.
+                 (emacs-saved-marker
+                  (and (eq ghostel--input-mode 'emacs)
+                       (not ghostel--snap-requested)
+                       (copy-marker (point) t)))
+                 ;; In line mode the user's in-progress input lives
+                 ;; in the buffer past the prompt and is not in
+                 ;; libghostty's grid; the renderer would otherwise
+                 ;; clobber it.  Snapshot the input region (and clear
+                 ;; it from the buffer) before the redraw, then
+                 ;; restore it after.
+                 (line-snapshot
+                  (and (eq ghostel--input-mode 'line)
+                       (ghostel--line-mode-snapshot)))
                  (inhibit-read-only t)
                  (inhibit-redisplay t)
                  (inhibit-modification-hooks t))
             (ghostel--redraw ghostel--term ghostel-full-redraw)
             (when ghostel--has-wide-chars
               (ghostel--compensate-wide-chars))
-            (let* ((pt (point))
-                   (vs (ghostel--viewport-start))
-                   (preedit-point
-                    (and preedit-state
-                         (ghostel--restore-preedit-state
-                          preedit-state vs))))
-              (setq ghostel--scroll-positions nil)
-              (dolist (win all-windows)
-                (if (and vs (memq win anchored))
-                    (let ((preedit-win-p
-                           (and preedit-point
-                                preedit-window
-                                (eq win preedit-window))))
-                      (ghostel--anchor-window
-                       win vs
-                       (if preedit-win-p preedit-point pt)))
-                  (ghostel--restore-scrollback-window
-                   win (assq win non-anchored-states))))
-              (when preedit-point
-                (goto-char preedit-point))
-              (when vs
-                (setq ghostel--last-anchor-position vs))
-              (ghostel--schedule-link-detection vs (point-max))))
+            (let ((line-restored
+                   (and line-snapshot
+                        (ghostel--line-mode-restore line-snapshot))))
+              (let* ((pt (point))
+                     (vs (ghostel--viewport-start))
+                     (preedit-point
+                      (and preedit-state
+                           (ghostel--restore-preedit-state
+                            preedit-state vs))))
+                (setq ghostel--scroll-positions nil)
+                (dolist (win all-windows)
+                  (if (and vs (memq win anchored))
+                      (let ((preedit-win-p
+                             (and preedit-point
+                                  preedit-window
+                                  (eq win preedit-window))))
+                        (ghostel--anchor-window
+                         win vs
+                         (if preedit-win-p preedit-point pt)))
+                    (ghostel--restore-scrollback-window
+                     win (assq win non-anchored-states))))
+                (cond
+                 (preedit-point      (goto-char preedit-point))
+                 (line-restored      nil) ; restore already moved point
+                 (emacs-saved-marker (goto-char emacs-saved-marker)))
+                (when emacs-saved-marker
+                  (set-marker emacs-saved-marker nil))
+                (when vs
+                  (setq ghostel--last-anchor-position vs))
+                (ghostel--schedule-link-detection vs (point-max)))
+              ;; Restore failed (prompt scrolled off / shell
+              ;; integration dropped out): the input was already
+              ;; deleted from the buffer in snapshot — forward it raw
+              ;; so the user does not lose what they typed.
+              (when (and line-snapshot (not line-restored))
+                (let ((input (plist-get line-snapshot :input)))
+                  (when (and input (> (length input) 0)
+                             ghostel--process
+                             (process-live-p ghostel--process))
+                    (process-send-string ghostel--process input))
+                  (message "ghostel: line-mode prompt lost; input forwarded raw")))
+              ;; Resume line mode if alt-screen just turned off, and
+              ;; update the alt-screen-prev cache for the next cycle.
+              (ghostel--line-mode-post-redraw)))
           (setq ghostel--snap-requested nil)
           (setq ghostel--windows-needing-snap nil))))))
 
@@ -4198,6 +5533,15 @@ output is arriving."
   (setq-local scroll-conservatively 101)
   (setq-local line-spacing 0)
   (setq-local list-buffers-directory (expand-file-name default-directory)) ; expose cwd to buffer-menu/ibuffer
+  ;; Set up the comint/shell completion plumbing once per buffer so
+  ;; `ghostel-line-mode-complete-at-point' has the right
+  ;; `comint-dynamic-complete-functions', `comint-file-name-chars',
+  ;; etc. ready when the user enters line mode.  The plumbing is
+  ;; cheap and harmless outside line mode (the capf is added to
+  ;; `completion-at-point-functions' but no one calls it).
+  (shell-completion-vars)
+  (setq ghostel--input-mode 'semi-char)
+  (use-local-map ghostel-semi-char-mode-map)
   (add-function :after after-focus-change-function #'ghostel--focus-change)
   (add-hook 'window-selection-change-functions #'ghostel--focus-change)
   (add-hook 'window-buffer-change-functions #'ghostel--focus-change)

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4184,15 +4184,29 @@ overtaking preceding single-byte self-insert input."
 (defvar-local ghostel--face-cookie nil
   "Cookie from `face-remap-add-relative' for the terminal default face.")
 
+(defvar-local ghostel--face-cookie-fg-bg nil
+  "Cached (FG . BG) pair backing `ghostel--face-cookie'.
+The native render path calls `ghostel--set-buffer-face' on every
+dirty redraw, even when the default colors have not changed.
+`face-remap-remove-relative' / `-add-relative' both call
+`force-mode-line-update' internally, so the unconditional remap
+generated a hundreds-of-Hz FMLU storm that starved the minibuffer
+of redisplay slots.  Comparing against this cache short-circuits
+the no-op case.")
+
 (defun ghostel--set-buffer-face (fg bg)
   "Set the buffer's default face to FG foreground and BG background.
-This ensures terminal text is visible regardless of the Emacs theme."
-  (when ghostel--face-cookie
-    (face-remap-remove-relative ghostel--face-cookie))
-  (setq ghostel--face-cookie
-        (face-remap-add-relative 'default
-                                 :foreground fg
-                                 :background bg)))
+This ensures terminal text is visible regardless of the Emacs theme.
+No-op when FG/BG match the cached values from the previous call."
+  (let ((pair (cons fg bg)))
+    (unless (equal pair ghostel--face-cookie-fg-bg)
+      (when ghostel--face-cookie
+        (face-remap-remove-relative ghostel--face-cookie))
+      (setq ghostel--face-cookie
+            (face-remap-add-relative 'default
+                                     :foreground fg
+                                     :background bg))
+      (setq ghostel--face-cookie-fg-bg pair))))
 
 (defun ghostel--set-title-default (title)
   "Update the buffer name with TITLE from the terminal.

--- a/src/module.zig
+++ b/src/module.zig
@@ -45,6 +45,7 @@ export fn emacs_module_init(runtime: *c.struct_emacs_runtime) callconv(.c) c_int
     env.bindFunction("ghostel--mode-enabled", 2, 2, &fnModeEnabled, "Return t if terminal DEC private MODE is enabled.\n\n(ghostel--mode-enabled TERM MODE)");
     env.bindFunction("ghostel--alt-screen-p", 1, 1, &fnAltScreen, "Return t if terminal is on the alternate screen buffer.\n\n(ghostel--alt-screen-p TERM)");
     env.bindFunction("ghostel--cursor-position", 1, 1, &fnCursorPosition, "Return terminal cursor position as (COL . ROW), 0-indexed.\n\n(ghostel--cursor-position TERM)");
+    env.bindFunction("ghostel--cursor-row-char-offset", 1, 1, &fnCursorRowCharOffset, "Return cursor's Emacs char offset from its row's start.\n\n(ghostel--cursor-row-char-offset TERM)");
     env.bindFunction("ghostel--debug-state", 1, 1, &fnDebugState, "Return debug info about terminal/render state.\n\n(ghostel--debug-state TERM)");
     env.bindFunction("ghostel--debug-feed", 2, 2, &fnDebugFeed, "Feed STR to terminal and return first row + cursor.\n\n(ghostel--debug-feed TERM STR)");
     env.bindFunction("ghostel--copy-all-text", 1, 1, &fnCopyAllText, "Return entire scrollback as plain text string.\n\n(ghostel--copy-all-text TERM)");
@@ -1178,6 +1179,91 @@ fn fnCursorPosition(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _
     _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_CURSOR_VIEWPORT_Y, @ptrCast(&cy));
 
     return env.call2(emacs.sym.cons, env.makeInteger(@as(i64, cx)), env.makeInteger(@as(i64, cy)));
+}
+
+/// (ghostel--cursor-row-char-offset TERM)
+/// Return the Emacs character offset of the cursor within its row,
+/// counted from the row's beginning.  Used by line-mode to find the
+/// input boundary without relying on `move-to-column', which uses
+/// `char-width' that disagrees with the terminal column model on
+/// pgtk for box-drawing glyphs (and for any wide cell whose Emacs
+/// width differs from libghostty's grid width).  Returns nil when
+/// the cursor has no value.
+fn fnCursorRowCharOffset(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
+    const env = emacs.Env.init(raw_env.?);
+    const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
+
+    const saved_offset = (term.getScrollbar() catch |err| {
+        env.signalErrorf("ghostel: getScrollbar failed: {s}", .{@errorName(err)});
+        return env.nil();
+    }).offset;
+    defer {
+        term.scrollViewport(gt.SCROLL_TOP, 0);
+        term.scrollViewport(gt.SCROLL_DELTA, @intCast(saved_offset));
+    }
+    term.scrollViewport(gt.SCROLL_BOTTOM, 0);
+
+    _ = gt.c.ghostty_render_state_update(term.render_state, term.terminal);
+
+    var cursor_has_value: bool = false;
+    _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_CURSOR_VIEWPORT_HAS_VALUE, @ptrCast(&cursor_has_value));
+    if (!cursor_has_value) return env.nil();
+
+    var cx: u16 = 0;
+    var cy: u16 = 0;
+    _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_CURSOR_VIEWPORT_X, @ptrCast(&cx));
+    _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_CURSOR_VIEWPORT_Y, @ptrCast(&cy));
+
+    if (cx == 0) return env.makeInteger(0);
+
+    gt.rs.read(term.render_state, gt.RS_DATA_ROW_ITERATOR, &term.row_iterator) catch |err| {
+        env.signalErrorf("ghostel: row-iterator read failed: {s}", .{@errorName(err)});
+        return env.nil();
+    };
+
+    // Advance iterator to cursor row.
+    {
+        var ri: u16 = 0;
+        while (ri <= cy) : (ri += 1) {
+            if (!gt.rs_row_next(term.row_iterator)) return env.nil();
+        }
+    }
+
+    gt.rs_row.read(term.row_iterator, gt.RS_ROW_DATA_CELLS, &term.row_cells) catch |err| {
+        env.signalErrorf("ghostel: row-cells read failed: {s}", .{@errorName(err)});
+        return env.nil();
+    };
+
+    // Walk cells 0..cx-1, counting Emacs characters.  Spacer tails of
+    // wide cells produce no Emacs character, empty cells map to a
+    // single space, and grapheme-bearing cells contribute their
+    // grapheme count.  Mirrors `positionCursorByCell' in render.zig.
+    var col: u16 = 0;
+    var char_count: i64 = 0;
+    while (col < cx) : (col += 1) {
+        if (!gt.rs_row_cells_next(term.row_cells)) break;
+
+        const graphemes_len = gt.rs_row_cells.get(u32, term.row_cells, gt.RS_CELLS_DATA_GRAPHEMES_LEN) catch |err| {
+            env.signalErrorf("ghostel: graphemes-len read failed: {s}", .{@errorName(err)});
+            return env.nil();
+        };
+        if (graphemes_len == 0) {
+            const raw_cell = gt.rs_row_cells.get(gt.c.GhosttyCell, term.row_cells, gt.c.GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_RAW) catch |err| {
+                env.signalErrorf("ghostel: raw-cell read failed: {s}", .{@errorName(err)});
+                return env.nil();
+            };
+            const wide = gt.cell.get(c_int, raw_cell, gt.c.GHOSTTY_CELL_DATA_WIDE) catch |err| {
+                env.signalErrorf("ghostel: cell-wide read failed: {s}", .{@errorName(err)});
+                return env.nil();
+            };
+            if (wide == gt.c.GHOSTTY_CELL_WIDE_SPACER_TAIL) continue;
+            char_count += 1;
+        } else {
+            char_count += @intCast(@min(graphemes_len, 16));
+        }
+    }
+
+    return env.makeInteger(char_count);
 }
 
 /// (ghostel--copy-all-text TERM)

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -752,6 +752,125 @@ Prevents up/down arrows being sent as history navigation."
        (should-not (member "down" keys-sent))))))
 
 ;; -----------------------------------------------------------------------
+;; Test: line mode + evil interaction
+;; -----------------------------------------------------------------------
+
+(defmacro evil-ghostel-test--with-line-mode (input-text input-start input-end &rest body)
+  "Set up a line-mode buffer for evil tests.
+INPUT-TEXT is inserted; INPUT-START / INPUT-END (1-indexed positions)
+become `ghostel--line-input-start' / `--line-input-end'."
+  (declare (indent 3) (debug t))
+  `(evil-ghostel-test--with-evil-buffer
+    (setq-local ghostel--term t)
+    (setq-local ghostel--input-mode 'line)
+    (insert ,input-text)
+    (setq-local ghostel--line-input-start (copy-marker ,input-start nil))
+    (setq-local ghostel--line-input-end (copy-marker ,input-end t))
+    (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil)))
+      ,@body)))
+
+(ert-deftest evil-ghostel-test-line-mode-active-p ()
+  "`evil-ghostel--line-mode-active-p' is true with markers in line mode."
+  (evil-ghostel-test--with-line-mode "$ echo hello" 3 13
+    (should (evil-ghostel--line-mode-active-p))
+    (should-not (evil-ghostel--active-p))))
+
+(ert-deftest evil-ghostel-test-line-mode-active-p-needs-markers ()
+  "Predicate returns nil in line mode if the input markers are unset."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--input-mode 'line)
+   (setq-local ghostel--line-input-start nil)
+   (setq-local ghostel--line-input-end nil)
+   (should-not (evil-ghostel--line-mode-active-p))))
+
+(ert-deftest evil-ghostel-test-insert-entry-skips-sync-in-line-mode ()
+  "Insert-state entry hook does not touch cursor sync in line mode.
+Point and the terminal cursor are intentionally decoupled there."
+  (evil-ghostel-test--with-line-mode "$ echo hi" 3 10
+    (cl-letf (((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0))))
+      (evil-normal-state)
+      (let ((sync-called nil))
+        (cl-letf (((symbol-function 'evil-ghostel--cursor-to-point)
+                   (lambda () (setq sync-called t)))
+                  ((symbol-function 'evil-ghostel--reset-cursor-point)
+                   (lambda () (setq sync-called t))))
+          (evil-insert-state))
+        (should-not sync-called)))))
+
+(ert-deftest evil-ghostel-test-insert-entry-skips-sync-in-copy-mode ()
+  "Insert-state entry hook does not sync the cursor in copy mode."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (setq-local ghostel--input-mode 'copy)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0))))
+     (evil-normal-state)
+     (let ((sync-called nil))
+       (cl-letf (((symbol-function 'evil-ghostel--cursor-to-point)
+                  (lambda () (setq sync-called t)))
+                 ((symbol-function 'evil-ghostel--reset-cursor-point)
+                  (lambda () (setq sync-called t))))
+         (evil-insert-state))
+       (should-not sync-called)))))
+
+(ert-deftest evil-ghostel-test-insert-line-jumps-to-input-start-in-line-mode ()
+  "I in line mode lands at `ghostel--line-input-start' and sends no PTY C-a."
+  (evil-ghostel-test--with-line-mode "$ echo hello" 3 13
+    (evil-normal-state)
+    (goto-char (point-max))
+    (let ((keys-sent '()))
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key _mods &rest _) (push key keys-sent))))
+        (evil-insert-line 1))
+      (should (= (point) 3))
+      (should (evil-insert-state-p))
+      (should-not (member "a" keys-sent)))))
+
+(ert-deftest evil-ghostel-test-append-line-jumps-to-input-end-in-line-mode ()
+  "A in line mode lands at `ghostel--line-input-end' and sends no PTY C-e."
+  (evil-ghostel-test--with-line-mode "$ echo hello" 3 13
+    (evil-normal-state)
+    (goto-char (point-min))
+    (let ((keys-sent '()))
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key _mods &rest _) (push key keys-sent))))
+        (evil-append-line 1))
+      (should (= (point) 13))
+      (should (evil-insert-state-p))
+      (should-not (member "e" keys-sent)))))
+
+(ert-deftest evil-ghostel-test-passthrough-ctrl-prefers-local-map-outside-semi-char ()
+  "Outside semi-char, the local map's binding wins over `evil-insert-state-map'.
+Without this, a passthrough handler in the minor-mode aux map would
+shadow line mode's own C-a (`ghostel-beginning-of-input-or-line') and
+C-d (`ghostel-line-mode-delete-char-or-eof')."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (setq-local ghostel--input-mode 'line)
+   (let* ((called nil)
+          (sentinel (lambda () (interactive) (setq called t)))
+          (map (make-sparse-keymap)))
+     (define-key map (kbd "C-a") sentinel)
+     (use-local-map map)
+     (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil)))
+       (evil-insert-state)
+       (evil-ghostel--passthrough-ctrl "a")
+       (should called)))))
+
+(ert-deftest evil-ghostel-test-delete-falls-through-in-line-mode ()
+  "evil-delete in line mode does not route to the PTY — runs evil's default."
+  (evil-ghostel-test--with-line-mode "hello world" 1 12
+    (goto-char (point-min))
+    (let ((bs-count 0))
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key _mods &rest _)
+                   (when (equal key "backspace") (cl-incf bs-count)))))
+        (evil-normal-state)
+        (evil-delete (point-min) (+ (point-min) 5) 'inclusive nil nil))
+      (should (= bs-count 0))
+      (should (equal " world" (buffer-string))))))
+
+;; -----------------------------------------------------------------------
 ;; Test: evil-undo advice
 ;; -----------------------------------------------------------------------
 

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -522,6 +522,140 @@ the URI in the buffer."
       (kill-buffer buf))))
 
 ;; -----------------------------------------------------------------------
+;; Test: emacs mode preserves point across a live redraw
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-emacs-mode-preserves-point ()
+  "In Emacs mode, point stays put while the terminal keeps running.
+The delayed redraw path always preserves point in Emacs mode,
+unlike semi-char mode where it tracks the terminal cursor."
+  (let ((buf (generate-new-buffer " *ghostel-test-emacs-pt*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term (ghostel--new 5 80 1000))
+          (setq ghostel--term-rows 5)
+          ;; Write some rows and redraw to populate the buffer.
+          (dotimes (i 10)
+            (ghostel--write-input ghostel--term
+                                  (format "row-%02d\r\n" i)))
+          (let ((inhibit-read-only t))
+            (ghostel--redraw ghostel--term t))
+          ;; Enter emacs mode and navigate to the top.
+          (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                    ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+            (ghostel-emacs-mode))
+          (goto-char (point-min))
+          (let ((mark (point)))
+            ;; More output streams in. Run the delayed redraw
+            ;; synchronously (as the timer would).
+            (dotimes (i 5)
+              (ghostel--write-input ghostel--term
+                                    (format "new-%02d\r\n" i)))
+            (ghostel--delayed-redraw buf)
+            ;; Point still at point-min — emacs mode preserved it.
+            (should (= (point) mark)))
+          ;; New rows are visible in the buffer.
+          (let ((content (buffer-substring-no-properties
+                          (point-min) (point-max))))
+            (should (string-match-p "new-04" content))))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+;; -----------------------------------------------------------------------
+;; Test: copy mode freezes redraws
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-copy-mode-freezes-redraws ()
+  "In copy mode, `ghostel--delayed-redraw' is a no-op."
+  (let ((buf (generate-new-buffer " *ghostel-test-copy-freeze*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term (ghostel--new 5 80 1000))
+          (setq ghostel--term-rows 5)
+          (dotimes (i 3)
+            (ghostel--write-input ghostel--term
+                                  (format "initial-%d\r\n" i)))
+          (let ((inhibit-read-only t))
+            (ghostel--redraw ghostel--term t))
+          (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                    ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+            (ghostel-copy-mode))
+          (let ((snapshot (buffer-substring-no-properties
+                           (point-min) (point-max))))
+            ;; Feed more output and attempt a redraw.
+            (dotimes (i 3)
+              (ghostel--write-input ghostel--term
+                                    (format "frozen-%d\r\n" i)))
+            (ghostel--delayed-redraw buf)
+            ;; Buffer is unchanged — copy mode gated the redraw.
+            (should (equal snapshot
+                           (buffer-substring-no-properties
+                            (point-min) (point-max)))))
+          ;; Exiting copy mode lets the redraw catch up.
+          (ghostel-readonly-exit)
+          (let ((inhibit-read-only t))
+            (ghostel--redraw ghostel--term t))
+          (let ((content (buffer-substring-no-properties
+                          (point-min) (point-max))))
+            (should (string-match-p "frozen-2" content))))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+;; -----------------------------------------------------------------------
+;; Test: line mode save/restore around redraw
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-line-mode-live-redraws-preserve-input ()
+  "Line mode redraws live; in-progress input survives via snapshot/restore.
+Output keeps streaming around the prompt while the user composes,
+and the snapshot/restore path in `ghostel--delayed-redraw' puts
+the input region back after each redraw so the user's typing is
+not clobbered."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-live*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term (ghostel--new 5 80 1000))
+          (setq ghostel--term-rows 5)
+          (setq ghostel--process 'fake-proc)
+          ;; First prompt with OSC 133 A/B markers.
+          (ghostel--write-input ghostel--term
+                                "\e]133;A\e\\$ \e]133;B\e\\")
+          (let ((inhibit-read-only t))
+            (ghostel--redraw ghostel--term t))
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string) #'ignore)
+                    ((symbol-function 'ghostel--invalidate) #'ignore)
+                    ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+            (ghostel-line-mode)
+            (should (eq ghostel--input-mode 'line))
+            (should (markerp ghostel--line-input-start))
+            ;; Type some input locally.
+            (insert "ls")
+            (should (equal (ghostel--line-mode-input-text) "ls"))
+            ;; Simulate the post-RET sequence: shell echoes the line,
+            ;; runs the command, prints output, then a new prompt
+            ;; with OSC 133 markers.  The redraw must preserve the
+            ;; user's input AND show the new output above the new
+            ;; prompt.
+            (ghostel--write-input ghostel--term
+                                  "ls\r\nfile1\r\n\e]133;A\e\\$ \e]133;B\e\\")
+            (ghostel--delayed-redraw buf)
+            ;; Input is still there.
+            (should (equal (ghostel--line-mode-input-text) "ls"))
+            ;; New output is in the buffer.
+            (let ((content (buffer-substring-no-properties
+                            (point-min) (point-max))))
+              (should (string-match-p "file1" content)))
+            ;; Marker now points at the NEW prompt-end, not the old
+            ;; one — find-prompt-end picks the last prompt char.
+            ;; Exit cleans up state.
+            (ghostel-semi-char-mode)
+            (should-not (text-property-any (point-min) (point-max)
+                                           'read-only t))))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+;; -----------------------------------------------------------------------
 ;; Test: clear screen (ghostel-clear)
 ;; -----------------------------------------------------------------------
 
@@ -2039,6 +2173,72 @@ exits, so a regression here would leak the timer past the buffer's life."
         (ghostel--spinner-stop)
         (should (= 1 stop-calls))))))
 
+(ert-deftest ghostel-test-progress-preserves-input-mode-tag ()
+  "Progress updates compose with `ghostel--mode-line-tag', not clobber it.
+Regression test: the previous implementation overwrote
+`mode-line-process' directly, so OSC 9;4 progress reports erased
+input-mode labels like \":Char\" or \":Line\".  The composed
+`mode-line-process' must contain both the tag and the progress."
+  (with-temp-buffer
+    (setq ghostel--mode-line-tag ":Line")
+    (ghostel--mode-line-refresh)
+    (should (equal ":Line" mode-line-process))
+    (ghostel-default-progress 'set 42)
+    (should (equal '(":Line" " [42%]") mode-line-process))
+    (ghostel-default-progress 'remove nil)
+    (should (equal ":Line" mode-line-process))))
+
+(ert-deftest ghostel-test-spinner-preserves-input-mode-tag ()
+  "Spinner transitions preserve `ghostel--mode-line-tag'.
+The composed `mode-line-process' must list both the tag and the
+spinner construct so the input-mode label keeps rendering while
+the spinner is active."
+  (cl-letf (((symbol-function #'require)
+             (lambda (&rest _) t))
+            ((symbol-function #'spinner-start) #'ignore)
+            ((symbol-function #'spinner-stop) #'ignore))
+    (with-temp-buffer
+      (setq ghostel--mode-line-tag ":Char")
+      (ghostel--mode-line-refresh)
+      (should (equal ":Char" mode-line-process))
+      (ghostel-spinner-progress 'indeterminate nil)
+      (should (equal '(":Char" spinner--mode-line-construct) mode-line-process))
+      (ghostel-spinner-progress 'set 75)
+      (should (equal '(":Char" " [75%]") mode-line-process))
+      (ghostel-spinner-progress 'remove nil)
+      (should (equal ":Char" mode-line-process)))))
+
+(ert-deftest ghostel-test-mode-line-refresh-skips-fmlu-when-unchanged ()
+  "Refresh skips FMLU when the composed mode-line value is unchanged.
+Regression: the previous `ghostel--mode-line-refresh' always
+fired `force-mode-line-update', defeating the no-spam contract
+that motivated the face-cache fix on the progress callpath."
+  (let ((fmlu-calls 0))
+    (cl-letf (((symbol-function #'force-mode-line-update)
+               (lambda (&rest _) (cl-incf fmlu-calls))))
+      (with-temp-buffer
+        (setq ghostel--mode-line-tag ":Char")
+        (ghostel--mode-line-refresh)
+        (should (= 1 fmlu-calls))
+        ;; Same composed value — FMLU must not fire again.
+        (ghostel--mode-line-refresh)
+        (ghostel--mode-line-refresh)
+        (should (= 1 fmlu-calls))
+        ;; Tag actually changes → FMLU fires.
+        (setq ghostel--mode-line-tag ":Line")
+        (ghostel--mode-line-refresh)
+        (should (= 2 fmlu-calls))
+        ;; Same again → still no extra FMLU.
+        (ghostel--mode-line-refresh)
+        (should (= 2 fmlu-calls))
+        ;; Progress changes the composed list → FMLU fires.
+        (setq ghostel--mode-line-progress " [42%]")
+        (ghostel--mode-line-refresh)
+        (should (= 3 fmlu-calls))
+        ;; Identical progress packet → no FMLU.
+        (ghostel--mode-line-refresh)
+        (should (= 3 fmlu-calls))))))
+
 (ert-deftest ghostel-test-osc-partial-does-not-starve-later ()
   "A partial OSC must not cannibalize or starve a following complete OSC.
 Input \"\\e]7;PARTIAL\\e]52;c;aGVsbG8=\\a\" would, under a naive
@@ -2528,12 +2728,18 @@ first real focus event."
   ;; RET is intentionally NOT bound in the text-property link map: a
   ;; binding there outranks the local map and hijacks RET away from the
   ;; PTY when a typed substring is misdetected as a link.  The
-  ;; RET-follows-link affordance lives in `ghostel-copy-mode-map' only.
+  ;; RET-follows-link affordance lives in the read-only and line-mode
+  ;; maps so it works in copy, Emacs, and line modes without
+  ;; intercepting RET in semi-char/char.
   (should (null (lookup-key ghostel-link-map (kbd "RET"))))
   (should (eq #'ghostel-open-link-at-point
-              (lookup-key ghostel-copy-mode-map (kbd "RET"))))
+              (lookup-key ghostel-readonly-mode-map (kbd "RET"))))
   (should (eq #'ghostel-open-link-at-point
-              (lookup-key ghostel-copy-mode-map (kbd "<return>"))))
+              (lookup-key ghostel-readonly-mode-map (kbd "<return>"))))
+  (should (eq #'ghostel-line-mode-send-or-open-link
+              (lookup-key ghostel-line-mode-map (kbd "RET"))))
+  (should (eq #'ghostel-line-mode-send-or-open-link
+              (lookup-key ghostel-line-mode-map (kbd "<return>"))))
   (should (commandp #'ghostel-open-link-at-point))         ; open-link-at-point is interactive
   (should (null (ghostel--open-link nil)))                 ; open-link returns nil for empty
   (should (null (ghostel--open-link 42))))                 ; open-link returns nil for non-string
@@ -6177,7 +6383,7 @@ and requests a snap so the next redraw lands at the live viewport."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (setq ghostel--copy-mode-active t)
+          (setq ghostel--input-mode 'copy)
           (setq ghostel--scroll-positions
                 (list (cons (selected-window)
                             (list '("stale") '("stale") 0))))
@@ -6185,7 +6391,7 @@ and requests a snap so the next redraw lands at the live viewport."
           (setq ghostel--force-next-redraw nil)
           (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
                     ((symbol-function 'message) #'ignore))
-            (ghostel-copy-mode-exit))
+            (ghostel-readonly-exit))
           (should-not ghostel--scroll-positions)
           (should ghostel--snap-requested)
           ;; `force-next-redraw' must also be set so the snap fires
@@ -6657,7 +6863,7 @@ rendered by `ghostel--delayed-redraw'.  This is the exact real-world path."
               (with-current-buffer buf
                 (ghostel-mode)
                 (setq ghostel--term 'fake-term)
-                (setq ghostel--copy-mode-active nil)
+                (setq ghostel--input-mode 'semi-char)
                 (setq ghostel-enable-url-detection t))
               ;; `other' is not a ghostel buffer and should be ignored.
               (ghostel-sync-theme)
@@ -6665,16 +6871,27 @@ rendered by `ghostel--delayed-redraw'.  This is the exact real-world path."
               (should (memq 'fake-term redraw-calls))
               (should (= post-process-calls 1))
 
-              ;; Verify copy-mode skips redraw.
+              ;; Verify copy mode (frozen) skips redraw
               (setq palette-calls nil
                     redraw-calls nil
                     post-process-calls 0)
               (with-current-buffer buf
-                (setq ghostel--copy-mode-active t))
+                (setq ghostel--input-mode 'copy))
+              (ghostel-sync-theme)
+              (should (memq 'fake-term palette-calls))    ; palette still applied in copy mode
+              (should-not (memq 'fake-term redraw-calls)) ; redraw skipped in copy mode
+              (should (= post-process-calls 0))
+
+              ;; Verify emacs mode (unfrozen) still redraws
+              (setq palette-calls nil
+                    redraw-calls nil
+                    post-process-calls 0)
+              (with-current-buffer buf
+                (setq ghostel--input-mode 'emacs))
               (ghostel-sync-theme)
               (should (memq 'fake-term palette-calls))
-              (should-not (memq 'fake-term redraw-calls))
-              (should (= post-process-calls 0)))
+              (should (memq 'fake-term redraw-calls))     ; redraw runs in emacs mode
+              (should (= post-process-calls 1)))
           (kill-buffer buf)
           (kill-buffer other))))))
 
@@ -6801,15 +7018,14 @@ hand nil to the native module."
           (ghostel--set-cursor-style 1 nil)
           (should (null cursor-type))                       ; cursor hidden
           ;; Enter copy mode — cursor should become visible
-          (let ((ghostel--copy-mode-active nil)
-                (ghostel--redraw-timer nil))
+          (let ((ghostel--redraw-timer nil))
             (ghostel-copy-mode)
-            (should ghostel--copy-mode-active)              ; in copy mode
+            (should (eq ghostel--input-mode 'copy))         ; in copy mode
             (should cursor-type)                            ; cursor visible
             (should (equal cursor-type (default-value 'cursor-type))) ; uses user default
             ;; Exit copy mode — cursor should be hidden again
-            (ghostel-copy-mode-exit)
-            (should-not ghostel--copy-mode-active)          ; exited copy mode
+            (ghostel-readonly-exit)
+            (should (eq ghostel--input-mode 'semi-char))    ; exited copy mode
             (should (null cursor-type))))                   ; cursor hidden again
       (kill-buffer buf))))
 
@@ -6851,12 +7067,11 @@ hand nil to the native module."
             ;; post-command-hook) from creating overlays in this buffer.
             (should-not global-hl-line-mode))
           ;; Enter copy mode — local hl-line-mode should be enabled
-          (let ((ghostel--copy-mode-active nil)
-                (ghostel--redraw-timer nil))
+          (let ((ghostel--redraw-timer nil))
             (ghostel-copy-mode)
             (should (bound-and-true-p hl-line-mode))
             ;; Exit copy mode — local hl-line-mode disabled again
-            (ghostel-copy-mode-exit)
+            (ghostel-readonly-exit)
             (should-not (bound-and-true-p hl-line-mode))))
       (when (buffer-live-p buf)
         (with-current-buffer buf
@@ -7088,18 +7303,18 @@ hand nil to the native module."
 ;; -----------------------------------------------------------------------
 
 (ert-deftest ghostel-test-copy-mode-buffer-navigation ()
-  "`ghostel-copy-mode-end-of-buffer' skips trailing blank rows."
+  "`ghostel-readonly-end-of-buffer' skips trailing blank rows."
   (let ((buf (generate-new-buffer " *ghostel-test-copy-nav*")))
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (let ((ghostel--copy-mode-active t)
+          (let ((ghostel--input-mode 'copy)
                 (ghostel--term 'fake-term)
                 (inhibit-read-only t))
             (insert (mapconcat #'number-to-string (number-sequence 1 20) "\n"))
             (insert "   \n\n")
             (goto-char (point-min))
-            (ghostel-copy-mode-end-of-buffer)
+            (ghostel-readonly-end-of-buffer)
             (should (looking-back "20" (line-beginning-position)))))
       (kill-buffer buf))))
 
@@ -7668,7 +7883,7 @@ redraw and produce visible flicker, so point is left alone."
   "Scroll intercept forwards events when mouse tracking is active."
   (let ((ghostel--term 'fake)
         (ghostel--process 'fake)
-        (ghostel--copy-mode-active nil)
+        (ghostel--input-mode 'semi-char)
         (ghostel--scroll-intercept-active t)
         (mouse-event-args nil)
         ;; Fake wheel-up event at row 5, col 10
@@ -7711,7 +7926,7 @@ redraw and produce visible flicker, so point is left alone."
     (with-current-buffer event-buf
       (setq-local ghostel--term 'fake)
       (setq-local ghostel--process 'fake)
-      (setq-local ghostel--copy-mode-active nil)
+      (setq-local ghostel--input-mode 'semi-char)
       (setq-local ghostel--scroll-intercept-active t)
       (setq-local pre-command-hook nil))
     (unwind-protect
@@ -7743,7 +7958,7 @@ redraw and produce visible flicker, so point is left alone."
       (with-current-buffer event-buf
         (kill-local-variable 'ghostel--term)
         (kill-local-variable 'ghostel--process)
-        (kill-local-variable 'ghostel--copy-mode-active)
+        (kill-local-variable 'ghostel--input-mode)
         (kill-local-variable 'ghostel--scroll-intercept-active)
         (kill-local-variable 'pre-command-hook)))))
 
@@ -7766,7 +7981,7 @@ Emacs until `C-g'."
                  (_ (with-current-buffer ghostel-buf
                       (setq-local ghostel--term 'fake)
                       (setq-local ghostel--process 'fake)
-                      (setq-local ghostel--copy-mode-active nil)
+                      (setq-local ghostel--input-mode 'semi-char)
                       (setq-local ghostel--scroll-intercept-active t)))
                  ;; Simulate a wheel event on an unselected ghostel window:
                  ;; current-buffer is the *other* buffer while the event's
@@ -7809,7 +8024,7 @@ rather than the selected window's buffer."
                  (_ (with-current-buffer ghostel-buf
                       (setq-local ghostel--term 'fake)
                       (setq-local ghostel--process 'fake)
-                      (setq-local ghostel--copy-mode-active nil)
+                      (setq-local ghostel--input-mode 'semi-char)
                       (setq-local ghostel--scroll-intercept-active t)))
                  (fake-event `(wheel-up (,ghostel-win 1 (10 . 5) 0)))
                  (unread-command-events nil))
@@ -7834,16 +8049,16 @@ rather than the selected window's buffer."
       (kill-buffer other-buf))))
 
 (ert-deftest ghostel-test-control-key-bindings ()
-  "All non-exception C-<letter> keys should be bound in ghostel-mode-map."
+  "All non-exception C-<letter> keys should be bound in semi-char-mode-map."
   (dolist (c (number-sequence ?a ?z))
     (let* ((key-str (format "C-%c" c))
            (key-vec (kbd key-str))
-           (binding (lookup-key ghostel-mode-map key-vec)))
+           (binding (lookup-key ghostel-semi-char-mode-map key-vec)))
       ;; Skip exceptions (may have sub-keymaps like C-c C-c)
       (unless (member key-str ghostel-keymap-exceptions)
         (should binding))))
   ;; C-@ should also be bound (sends NUL)
-  (should (lookup-key ghostel-mode-map (kbd "C-@"))))
+  (should (lookup-key ghostel-semi-char-mode-map (kbd "C-@"))))
 
 (ert-deftest ghostel-test-c-g-binding ()
   "`ghostel-mode-map' binds the quit key to a dedicated send handler."
@@ -7851,9 +8066,9 @@ rather than the selected window's buffer."
               #'ghostel-send-C-g)))
 
 (ert-deftest ghostel-test-c-g-exits-copy-mode ()
-  "The quit key is bound in `ghostel-copy-mode-map' to exit copy mode."
-  (should (eq (lookup-key ghostel-copy-mode-map (kbd "C-g"))
-              #'ghostel-copy-mode-exit)))
+  "The quit key is bound in the fast-exit map to exit read-only mode."
+  (should (eq (lookup-key ghostel-readonly-fast-exit-mode-map (kbd "C-g"))
+              #'ghostel-readonly-exit)))
 
 (ert-deftest ghostel-test-inhibit-quit ()
   "`ghostel-mode' should set `inhibit-quit' buffer-locally."
@@ -7892,20 +8107,19 @@ side effects have to happen explicitly inside the command."
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-meta-key-bindings ()
-  "All non-exception M-<letter> keys should be bound in ghostel-mode-map."
+  "All non-exception M-<letter> keys should be bound in semi-char-mode-map."
   (dolist (c (number-sequence ?a ?z))
     (let* ((key-str (format "M-%c" c))
            (key-vec (kbd key-str))
-           (binding (lookup-key ghostel-mode-map key-vec)))
+           (binding (lookup-key ghostel-semi-char-mode-map key-vec)))
       (unless (eq c ?y)  ; M-y is ghostel-yank-pop
         (if (member key-str ghostel-keymap-exceptions)
             (should-not (eq binding #'ghostel--send-event))
           (should (eq binding #'ghostel--send-event))))))
-  ;; M-y should be bound to ghostel-yank-pop, not send-event
-  (should (eq (lookup-key ghostel-mode-map (kbd "M-y")) #'ghostel-yank-pop))
+  (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "M-y")) #'ghostel-yank-pop))
   ;; M-DEL must be bound so TTY Alt-Backspace ([27 127]) routes through
   ;; ghostel--send-event instead of global backward-kill-word.
-  (should (eq (lookup-key ghostel-mode-map (kbd "M-DEL")) #'ghostel--send-event)))
+  (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "M-DEL")) #'ghostel--send-event)))
 
 (ert-deftest ghostel-test-control-meta-key-bindings ()
   "Every non-exception Control-Meta letter chord routes to `ghostel--send-event'.
@@ -7914,7 +8128,7 @@ control byte so readline `.inputrc' rules like \"\\e\\<C-letter>\" can fire,
 instead of running Emacs commands like `forward-sexp'."
   (dolist (c (number-sequence ?a ?z))
     (let* ((key-str (format "C-M-%c" c))
-           (binding (lookup-key ghostel-mode-map (kbd key-str))))
+           (binding (lookup-key ghostel-semi-char-mode-map (kbd key-str))))
       (if (member key-str ghostel-keymap-exceptions)
           (should-not (eq binding #'ghostel--send-event))
         (should (eq binding #'ghostel--send-event))))))
@@ -8000,6 +8214,24 @@ but `this-command-keys-vector' retains the ESC prefix."
         ;; Already-meta event (shouldn't double-add meta)
         (sim-tty (vector 27 ?b)   (aref (kbd "M-b") 0) "b" "meta")))))
 
+(ert-deftest ghostel-test-char-mode-key-bindings ()
+  "Char mode map should bind even keys in `ghostel-keymap-exceptions'."
+  ;; Every C-<letter>, M-<letter>, and C-M-<letter> is bound in char
+  ;; mode, including ones that semi-char mode reserves for Emacs.
+  (dolist (c (number-sequence ?a ?z))
+    (unless (memq c '(?i ?m))  ; C-i = TAB, C-m = RET handled separately
+      (should (lookup-key ghostel-char-mode-map (kbd (format "C-%c" c))))))
+  (dolist (c (number-sequence ?a ?z))
+    (should (lookup-key ghostel-char-mode-map (kbd (format "M-%c" c))))
+    (unless (eq c ?m)  ; C-M-m is the escape hatch (asserted below)
+      (should (eq (lookup-key ghostel-char-mode-map (kbd (format "C-M-%c" c)))
+                  #'ghostel--send-event))))
+  ;; The escape hatch is M-RET / C-M-m → semi-char.
+  (should (eq (lookup-key ghostel-char-mode-map (kbd "M-RET"))
+              #'ghostel-semi-char-mode))
+  (should (eq (lookup-key ghostel-char-mode-map (kbd "C-M-m"))
+              #'ghostel-semi-char-mode)))
+
 ;; -----------------------------------------------------------------------
 ;; Test: ghostel-yank-pop DWIM
 ;; -----------------------------------------------------------------------
@@ -8047,7 +8279,7 @@ but `this-command-keys-vector' retains the ESC prefix."
 (ert-deftest ghostel-test-xterm-paste-forwards-to-paste-text ()
   "`ghostel-xterm-paste' forwards the event payload via `ghostel--paste-text'."
   (let ((pasted nil)
-        (ghostel--copy-mode-active nil)
+        (ghostel--input-mode 'semi-char)
         (xterm-store-paste-on-kill-ring nil))
     (cl-letf (((symbol-function 'ghostel--paste-text)
                (lambda (text) (push text pasted))))
@@ -8056,7 +8288,7 @@ but `this-command-keys-vector' retains the ESC prefix."
 
 (ert-deftest ghostel-test-xterm-paste-rejects-wrong-event ()
   "`ghostel-xterm-paste' signals when the event isn't an xterm-paste."
-  (let ((ghostel--copy-mode-active nil))
+  (let ((ghostel--input-mode 'semi-char))
     (should-error (ghostel-xterm-paste '(mouse-1 "oops")))))
 
 (ert-deftest ghostel-test-xterm-paste-no-text-is-noop ()
@@ -8064,7 +8296,7 @@ but `this-command-keys-vector' retains the ESC prefix."
   (let ((called nil)
         (kill-ring '("preexisting"))
         (kill-ring-yank-pointer nil)
-        (ghostel--copy-mode-active nil)
+        (ghostel--input-mode 'semi-char)
         (xterm-store-paste-on-kill-ring t))
     (cl-letf (((symbol-function 'ghostel--paste-text)
                (lambda (_text) (setq called t))))
@@ -8077,7 +8309,7 @@ but `this-command-keys-vector' retains the ESC prefix."
   (let ((pasted nil)
         (kill-ring nil)
         (kill-ring-yank-pointer nil)
-        (ghostel--copy-mode-active nil)
+        (ghostel--input-mode 'semi-char)
         (xterm-store-paste-on-kill-ring t))
     (cl-letf (((symbol-function 'ghostel--paste-text)
                (lambda (text) (push text pasted))))
@@ -8090,7 +8322,7 @@ but `this-command-keys-vector' retains the ESC prefix."
   (let ((pasted nil)
         (kill-ring '("preexisting"))
         (kill-ring-yank-pointer nil)
-        (ghostel--copy-mode-active nil)
+        (ghostel--input-mode 'semi-char)
         (xterm-store-paste-on-kill-ring nil))
     (cl-letf (((symbol-function 'ghostel--paste-text)
                (lambda (text) (push text pasted))))
@@ -8102,11 +8334,11 @@ but `this-command-keys-vector' retains the ESC prefix."
   "`ghostel-xterm-paste' exits copy mode before forwarding."
   (let ((pasted nil)
         (exit-called nil)
-        (ghostel--copy-mode-active t)
+        (ghostel--input-mode 'copy)
         (xterm-store-paste-on-kill-ring nil))
     (cl-letf (((symbol-function 'ghostel--paste-text)
                (lambda (text) (push text pasted)))
-              ((symbol-function 'ghostel-copy-mode-exit)
+              ((symbol-function 'ghostel-readonly-exit)
                (lambda () (setq exit-called t))))
       (ghostel-xterm-paste '(xterm-paste "payload"))
       (should exit-called)
@@ -8116,7 +8348,8 @@ but `this-command-keys-vector' retains the ESC prefix."
   "`ghostel-xterm-paste' is bound to the [xterm-paste] event in both keymaps."
   (should (eq (lookup-key ghostel-mode-map [xterm-paste])
               #'ghostel-xterm-paste))
-  (should (eq (lookup-key ghostel-copy-mode-map [xterm-paste])
+  ;; Inherited from `ghostel-mode-map' through the readonly map chain.
+  (should (eq (lookup-key ghostel-readonly-fast-exit-mode-map [xterm-paste])
               #'ghostel-xterm-paste)))
 
 (ert-deftest ghostel-test-xterm-paste-copy-mode-and-kill-ring ()
@@ -8125,11 +8358,11 @@ but `this-command-keys-vector' retains the ESC prefix."
         (exit-called nil)
         (kill-ring nil)
         (kill-ring-yank-pointer nil)
-        (ghostel--copy-mode-active t)
+        (ghostel--input-mode 'copy)
         (xterm-store-paste-on-kill-ring t))
     (cl-letf (((symbol-function 'ghostel--paste-text)
                (lambda (text) (push text pasted)))
-              ((symbol-function 'ghostel-copy-mode-exit)
+              ((symbol-function 'ghostel-readonly-exit)
                (lambda () (setq exit-called t))))
       (ghostel-xterm-paste '(xterm-paste "combo"))
       (should exit-called)
@@ -8137,7 +8370,7 @@ but `this-command-keys-vector' retains the ESC prefix."
       (should (equal (car kill-ring) "combo")))))
 
 ;; -----------------------------------------------------------------------
-;; Test: ghostel-copy-mode-recenter
+;; Test: ghostel-readonly-recenter
 ;; -----------------------------------------------------------------------
 
 (ert-deftest ghostel-test-copy-mode-recenter ()
@@ -8145,8 +8378,1813 @@ but `this-command-keys-vector' retains the ESC prefix."
   (let ((called nil))
     (cl-letf (((symbol-function 'recenter)
                (lambda (&rest _) (setq called t))))
-      (ghostel-copy-mode-recenter)
+      (ghostel-readonly-recenter)
       (should called))))
+
+;; -----------------------------------------------------------------------
+;; Test: input mode state + predicates
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-input-mode-default-is-semi-char ()
+  "A fresh `ghostel-mode' buffer starts in semi-char mode."
+  (let ((buf (generate-new-buffer " *ghostel-test-mode-default*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (should (eq ghostel--input-mode 'semi-char))
+          (should (eq (current-local-map) ghostel-semi-char-mode-map))
+          (should (null mode-line-process))
+          (should (ghostel--buffer-editable-p))
+          (should (ghostel--terminal-live-p))
+          (should-not (ghostel--terminal-frozen-p)))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-input-mode-predicates ()
+  "The ghostel--*-p predicates reflect the current `ghostel--input-mode'."
+  (let ((ghostel--input-mode 'semi-char))
+    (should (ghostel--buffer-editable-p))
+    (should (ghostel--terminal-live-p))
+    (should-not (ghostel--terminal-frozen-p)))
+  (let ((ghostel--input-mode 'char))
+    (should (ghostel--buffer-editable-p))
+    (should (ghostel--terminal-live-p)))
+  (let ((ghostel--input-mode 'emacs))
+    (should-not (ghostel--buffer-editable-p))
+    (should (ghostel--terminal-live-p)))
+  (let ((ghostel--input-mode 'copy))
+    (should-not (ghostel--buffer-editable-p))
+    (should-not (ghostel--terminal-live-p))
+    (should (ghostel--terminal-frozen-p)))
+  ;; Line mode keeps the terminal live: redraws still run, with the
+  ;; snapshot/restore path preserving the user's in-progress input.
+  (let ((ghostel--input-mode 'line))
+    (should-not (ghostel--buffer-editable-p))
+    (should (ghostel--terminal-live-p))
+    (should-not (ghostel--terminal-frozen-p))))
+
+;; -----------------------------------------------------------------------
+;; Test: char mode
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-char-mode-enter-exit ()
+  "Char mode swaps the local map, sets mode-line, and \\`M-RET' exits."
+  (let ((buf (generate-new-buffer " *ghostel-test-char-mode*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-char-mode)
+              (should (eq ghostel--input-mode 'char))
+              (should (eq (current-local-map) ghostel-char-mode-map))
+              (should (equal mode-line-process ":Char"))
+              ;; Switch back via the same function that M-RET invokes.
+              (ghostel-semi-char-mode)
+              (should (eq ghostel--input-mode 'semi-char))
+              (should (eq (current-local-map) ghostel-semi-char-mode-map))
+              (should (null mode-line-process)))))
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
+;; Test: emacs mode
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-emacs-mode-enter-exit ()
+  "Emacs mode sets read-only, swaps map, and exits cleanly."
+  (let ((buf (generate-new-buffer " *ghostel-test-emacs-mode*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-emacs-mode)
+              (should (eq ghostel--input-mode 'emacs))
+              (should (eq (current-local-map)
+                          (if ghostel-readonly-fast-exit
+                              ghostel-readonly-fast-exit-mode-map
+                            ghostel-readonly-mode-map)))
+              (should (equal mode-line-process ":Emacs"))
+              (should buffer-read-only)
+              (ghostel-semi-char-mode)
+              (should (eq ghostel--input-mode 'semi-char))
+              (should-not buffer-read-only)
+              (should (null mode-line-process)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-emacs-mode-is-unfrozen ()
+  "Emacs mode leaves the terminal live so redraws keep running."
+  (let ((buf (generate-new-buffer " *ghostel-test-emacs-live*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-emacs-mode)
+              ;; Terminal is live in emacs mode — unlike copy mode.
+              (should (ghostel--terminal-live-p))
+              (should-not (ghostel--terminal-frozen-p)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-emacs-mode-does-not-forward-typing ()
+  "Sticky read-only modes do NOT forward typed chars to the shell.
+With `ghostel-readonly-fast-exit' set to nil, self-insert, `RET',
+`TAB', `DEL' fall through to the global map; the buffer's
+`read-only' state then signals `text-read-only'.  This makes Emacs
+mode a true \"look but don't touch\" view — keystrokes cannot
+accidentally reach the shell while you read or search the
+scrollback."
+  (let ((buf (generate-new-buffer " *ghostel-test-emacs-noforward*"))
+        (ghostel-readonly-fast-exit nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-emacs-mode)
+              (should (eq ghostel--input-mode 'emacs))
+              ;; Self-insert is NOT remapped to the ghostel version.
+              (should-not (eq (key-binding "a") #'ghostel--self-insert))
+              ;; TAB, DEL fall through to the read-only barrier.  RET
+              ;; is bound to follow links at point but is a no-op
+              ;; everywhere else — typing RET on a non-link cell does
+              ;; not reach the shell.
+              (should (eq (lookup-key ghostel-readonly-mode-map (kbd "RET"))
+                          #'ghostel-open-link-at-point))
+              (should-not (lookup-key ghostel-readonly-mode-map (kbd "TAB")))
+              (should-not (lookup-key ghostel-readonly-mode-map (kbd "DEL")))
+              ;; Navigation keys fall through to the global map —
+              ;; `C-n' etc. are not bound locally.
+              (should-not (lookup-key ghostel-readonly-mode-map (kbd "C-n")))
+              (should-not (lookup-key ghostel-readonly-mode-map (kbd "C-p")))
+              ;; C-y (paste) is allowed — explicit, deliberate action.
+              (should (eq (lookup-key ghostel-readonly-mode-map (kbd "C-y"))
+                          #'ghostel-yank))
+              ;; Still reachable via C-c C-j (inherited from `ghostel-mode-map').
+              (should (eq (lookup-key ghostel-readonly-mode-map (kbd "C-c C-j"))
+                          #'ghostel-semi-char-mode)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-emacs-mode-snap-on-input ()
+  "`ghostel--snap-to-input' fires in Emacs mode (e.g. on paste).
+Emacs mode no longer forwards typed characters, but explicit
+input actions like `\\`C-y'' still go through `ghostel--paste-text'
+which calls `snap-to-input' before sending — so the next redraw
+brings the window back to the live cursor where the paste lands,
+instead of leaving it parked wherever the user had navigated."
+  (with-temp-buffer
+    (let ((ghostel--input-mode 'emacs)
+          (ghostel--term 'fake)
+          (ghostel--snap-requested nil)
+          (ghostel-scroll-on-input t))
+      (ghostel--snap-to-input)
+      (should ghostel--snap-requested)
+      (should ghostel--force-next-redraw))))
+
+(ert-deftest ghostel-test-emacs-mode-window-anchored-when-snap-requested ()
+  "`ghostel--window-anchored-p' returns t in Emacs mode when snap-requested.
+Otherwise the window stays where the user navigated."
+  (with-temp-buffer
+    (let ((ghostel--input-mode 'emacs)
+          (ghostel--term 'fake)
+          (ghostel--last-anchor-position 1)
+          (ghostel--snap-requested nil))
+      ;; No snap → not anchored (user navigates freely).
+      (should-not (ghostel--window-anchored-p (selected-window)))
+      ;; Snap requested (user just typed) → anchored.
+      (let ((ghostel--snap-requested t))
+        (should (ghostel--window-anchored-p (selected-window)))))))
+
+;; -----------------------------------------------------------------------
+;; Test: copy ↔ emacs transitions preserve read-only state
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-copy-mode-restores-previous-mode ()
+  "Exiting copy mode returns to whatever mode the user was in beforehand."
+  (let ((buf (generate-new-buffer " *ghostel-test-copy-restore*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake)
+                (ghostel--redraw-timer nil))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              ;; semi-char → copy → semi-char
+              (ghostel-copy-mode)
+              (should (eq ghostel--input-mode 'copy))
+              (ghostel-readonly-exit)
+              (should (eq ghostel--input-mode 'semi-char))
+              ;; char → copy → char
+              (ghostel-char-mode)
+              (ghostel-copy-mode)
+              (should (eq ghostel--input-mode 'copy))
+              (ghostel-readonly-exit)
+              (should (eq ghostel--input-mode 'char))
+              ;; emacs → copy → emacs
+              (ghostel-emacs-mode)
+              (ghostel-copy-mode)
+              (should (eq ghostel--input-mode 'copy))
+              (ghostel-readonly-exit)
+              (should (eq ghostel--input-mode 'emacs)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-copy-to-emacs-transition ()
+  "Copy → Emacs unfreezes the terminal without re-toggling read-only."
+  (let ((buf (generate-new-buffer " *ghostel-test-copy-to-emacs*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake)
+                (ghostel--redraw-timer nil))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-copy-mode)
+              (should (eq ghostel--input-mode 'copy))
+              (should buffer-read-only)
+              (ghostel-emacs-mode)
+              (should (eq ghostel--input-mode 'emacs))
+              (should buffer-read-only)               ; still read-only
+              (should (ghostel--terminal-live-p))     ; but now unfrozen
+              (ghostel-semi-char-mode)
+              (should (eq ghostel--input-mode 'semi-char))
+              (should-not buffer-read-only))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-emacs-to-copy-transition ()
+  "Emacs → copy freezes the terminal without re-toggling read-only."
+  (let ((buf (generate-new-buffer " *ghostel-test-emacs-to-copy*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake)
+                (ghostel--redraw-timer (run-at-time 999 nil #'ignore)))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (unwind-protect
+                  (progn
+                    (ghostel-emacs-mode)
+                    (should (eq ghostel--input-mode 'emacs))
+                    (should buffer-read-only)
+                    (ghostel-copy-mode)
+                    (should (eq ghostel--input-mode 'copy))
+                    (should buffer-read-only)
+                    (should (ghostel--terminal-frozen-p))
+                    (should (null ghostel--redraw-timer)))
+                (when (and ghostel--redraw-timer
+                           (timerp ghostel--redraw-timer))
+                  (cancel-timer ghostel--redraw-timer))))))
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
+;; Test: mode switching keybindings live on the base map
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-mode-switch-keybindings ()
+  "Mode-switch keys are bound to the right mode commands."
+  (should (eq (lookup-key ghostel-mode-map (kbd "C-c C-e"))
+              #'ghostel-emacs-mode))
+  (should (eq (lookup-key ghostel-mode-map (kbd "C-c C-j"))
+              #'ghostel-semi-char-mode))
+  (should (eq (lookup-key ghostel-mode-map (kbd "C-c M-d"))
+              #'ghostel-char-mode))
+  (should (eq (lookup-key ghostel-mode-map (kbd "C-c C-l"))
+              #'ghostel-line-mode))
+  (should (eq (lookup-key ghostel-mode-map (kbd "C-c M-l"))
+              #'ghostel-clear-scrollback))
+  (should (eq (lookup-key ghostel-mode-map (kbd "C-c C-t"))
+              #'ghostel-copy-mode)))
+
+;; -----------------------------------------------------------------------
+;; Test: prompt navigation enters emacs mode (not copy mode)
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-prompt-nav-enters-emacs-mode ()
+  "`ghostel-next-prompt' auto-enters Emacs mode, not copy mode."
+  (let ((buf (generate-new-buffer " *ghostel-test-prompt-nav*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore)
+                      ((symbol-function 'ghostel--navigate-next-prompt)
+                       (lambda (_n) nil))
+                      ((symbol-function 'ghostel--navigate-previous-prompt)
+                       (lambda (_n) nil)))
+              (ghostel-next-prompt 1)
+              (should (eq ghostel--input-mode 'emacs))
+              (ghostel-semi-char-mode)
+              (ghostel-previous-prompt 1)
+              (should (eq ghostel--input-mode 'emacs)))))
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
+;; Test: mode mutual exclusivity
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-mode-mutual-exclusivity ()
+  "Entering any mode exits the others cleanly."
+  (let ((buf (generate-new-buffer " *ghostel-test-mutex*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              ;; A round-trip through every mode returns to semi-char.
+              (ghostel-char-mode)  (should (eq ghostel--input-mode 'char))
+              (ghostel-emacs-mode) (should (eq ghostel--input-mode 'emacs))
+              (ghostel-copy-mode)  (should (eq ghostel--input-mode 'copy))
+              (ghostel-char-mode)  (should (eq ghostel--input-mode 'char))
+              (ghostel-semi-char-mode)
+              (should (eq ghostel--input-mode 'semi-char))
+              ;; Read-only flag is consistently off after returning.
+              (should-not buffer-read-only))))
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
+;; Test: line mode
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-line-mode-find-prompt-end ()
+  "`ghostel--line-mode-find-prompt-end' walks back from `point-max'.
+Exercises the fallback path used when no live terminal cursor is
+available (unit tests, native module not loaded)."
+  (with-temp-buffer
+    ;; No prompt property anywhere → nil
+    (insert "plain text")
+    (should-not (ghostel--line-mode-find-prompt-end))
+    ;; With prompt property
+    (erase-buffer)
+    (insert (propertize "$ " 'ghostel-prompt t))
+    (insert "")  ; cursor right after prompt
+    (should (= (ghostel--line-mode-find-prompt-end) 3))
+    ;; With prompt property followed by user-typed content
+    (erase-buffer)
+    (insert (propertize "$ " 'ghostel-prompt t))
+    (insert "ls -la")
+    (should (= (ghostel--line-mode-find-prompt-end) 3))))
+
+(ert-deftest ghostel-test-line-mode-find-prompt-end-uses-cursor ()
+  "When a terminal cursor is available, it anchors the input boundary.
+Mimics a python3-style REPL: no `ghostel-prompt' anywhere, but the
+cursor sits at the end of the `>>> ' prompt the REPL printed."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-cursor*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (insert ">>> \n")
+          (setq ghostel--term 'fake)
+          (setq ghostel--term-rows 1)
+          (cl-letf (((symbol-function 'ghostel--cursor-position)
+                     (lambda (_term) (cons 4 0)))
+                    ((symbol-function 'ghostel--cursor-row-char-offset)
+                     (lambda (_term) 4)))
+            ;; Cursor at col 4 of row 0 → buffer position right
+            ;; after `>>> ', i.e. position 5 (1-indexed).
+            (should (= (ghostel--line-mode-find-prompt-end) 5))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-find-prompt-end-prefers-cursor-over-stale-prompt ()
+  "A stale `ghostel-prompt' above the cursor row is ignored.
+When bash printed an OSC-133 prompt and then the user launched
+python3 (which doesn't speak OSC 133), the only `ghostel-prompt'
+chars in the buffer are above the python session.  The cursor row
+takes precedence so input is sent to python3, not concatenated
+onto the bash prompt."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-stale-prompt*")))
+    (unwind-protect
+        (with-current-buffer buf
+          ;; 3 renderer rows: bash row + 2 python rows.
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (insert "python3\n")
+          (insert "Python 3.x\n")
+          (insert ">>> \n")
+          (setq ghostel--term 'fake)
+          (setq ghostel--term-rows 3)
+          (cl-letf (((symbol-function 'ghostel--cursor-position)
+                     (lambda (_term) (cons 4 2)))
+                    ((symbol-function 'ghostel--cursor-row-char-offset)
+                     (lambda (_term) 4)))
+            (let ((pos (ghostel--line-mode-find-prompt-end)))
+              (should pos)
+              (should (string= ">>> "
+                               (buffer-substring-no-properties
+                                (- pos 4) pos))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-find-prompt-end-uses-char-offset ()
+  "Cursor → buffer-pos uses cell-walking offset, not display columns.
+Regression for the pgtk wide-char case where Emacs `char-width'
+of e.g. a box-drawing glyph reports 2 but libghostty's grid
+treats it as 1 column.  The Zig-side `cursor-row-char-offset' is
+the source of truth so the Emacs/terminal width disagreement
+cannot misplace the input boundary."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-wide*")))
+    (unwind-protect
+        (with-current-buffer buf
+          ;; Pretend a wide cell is on the row.  We don't need a real
+          ;; wide char in the buffer for this test — only that the
+          ;; offset returned by Zig drives the math (not the display
+          ;; column which `move-to-column' would use).
+          (insert "AB$ ")  ; 4 chars in buffer
+          (setq ghostel--term 'fake)
+          (setq ghostel--term-rows 1)
+          (cl-letf (((symbol-function 'ghostel--cursor-position)
+                     ;; Pretend libghostty says cursor at grid col 5
+                     ;; (e.g. 2 grid cols for `A' as a wide cell, 1
+                     ;; for `B', 1 for `$', 1 for ` ').
+                     (lambda (_term) (cons 5 0)))
+                    ((symbol-function 'ghostel--cursor-row-char-offset)
+                     ;; Cell-walking gives the actual char count: 4.
+                     (lambda (_term) 4)))
+            ;; Should land at position 5 (after the 4 buffer chars),
+            ;; matching the Zig offset — NOT what `move-to-column 5'
+            ;; would yield (which depends on `char-width').
+            (should (= (ghostel--line-mode-find-prompt-end) 5))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-find-prompt-end-osc133-on-cursor-row ()
+  "When `ghostel-prompt' covers the cursor row's prefix, use its end.
+This is the canonical bash-with-shell-integration path: `$ '
+carries `ghostel-prompt', cursor sits right after it (or after
+input already typed at the prompt)."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-osc133*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (insert "ls -la")
+          (setq ghostel--term 'fake)
+          (setq ghostel--term-rows 1)
+          (cl-letf (((symbol-function 'ghostel--cursor-position)
+                     ;; Cursor at end of typed input.
+                     (lambda (_term) (cons 8 0)))
+                    ((symbol-function 'ghostel--cursor-row-char-offset)
+                     (lambda (_term) 8)))
+            ;; Prompt prefix ends at position 3 (after "$ ").
+            (should (= (ghostel--line-mode-find-prompt-end) 3))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-requires-anchor ()
+  "Line mode refuses to enter when neither cursor nor prompt mark exists."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-noprompt*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil)))
+              (should-error (ghostel-line-mode) :type 'user-error))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-enters-without-osc133 ()
+  "Line mode enters successfully in a REPL with no shell integration.
+Reproduces the python3 case: no `ghostel-prompt' chars anywhere,
+but the cursor is at the end of the REPL's prompt."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-nointegration*"))
+        (sent nil)
+        (encoded nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert ">>> \n")
+          (setq ghostel--term 'fake)
+          (setq ghostel--term-rows 1)
+          (setq ghostel--process 'fake-proc)
+          (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'ghostel--cursor-position)
+                     (lambda (_term) (cons 4 0)))
+                    ((symbol-function 'ghostel--cursor-row-char-offset)
+                     (lambda (_term) 4))
+                    ((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'process-send-string)
+                     (lambda (_p s) (setq sent s)))
+                    ((symbol-function 'ghostel--send-encoded)
+                     (lambda (key _mods &optional _utf8)
+                       (setq encoded key)))
+                    ((symbol-function 'ghostel--redraw) #'ignore)
+                    ((symbol-function 'ghostel--invalidate) #'ignore)
+                    ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+            (ghostel-line-mode)
+            (should (eq ghostel--input-mode 'line))
+            (goto-char (marker-position ghostel--line-input-end))
+            (insert "1+1")
+            (ghostel-line-mode-send)
+            (should (equal sent "1+1"))
+            (should (equal encoded "return"))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-copy-to-line-restarts-redraw-timer ()
+  "Copy → line transition re-arms the redraw timer.
+Copy mode froze the timer via `ghostel--freeze-terminal'; line
+mode is live, so the redraw cycle must be running again on exit
+or the prompt sits stuck until the next PTY byte arrives.
+Regression: `ghostel--line-mode-enter' previously cleared
+`buffer-read-only' but never called `ghostel--invalidate'."
+  (let ((buf (generate-new-buffer " *ghostel-test-copy-to-line*"))
+        (invalidate-calls 0))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert ">>> \n")
+          (setq ghostel--term 'fake)
+          (setq ghostel--term-rows 1)
+          (setq ghostel--process 'fake-proc)
+          (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'ghostel--cursor-position)
+                     (lambda (_term) (cons 4 0)))
+                    ((symbol-function 'ghostel--cursor-row-char-offset)
+                     (lambda (_term) 4))
+                    ((symbol-function 'ghostel--invalidate)
+                     (lambda (&rest _) (cl-incf invalidate-calls)))
+                    ((symbol-function 'ghostel--scroll-bottom) #'ignore)
+                    ((symbol-function 'ghostel--redraw) #'ignore))
+            ;; Enter copy mode — freezes the redraw timer.
+            (ghostel-copy-mode)
+            (should (eq ghostel--input-mode 'copy))
+            (should (ghostel--terminal-frozen-p))
+            (let ((before invalidate-calls))
+              ;; Copy → line must call invalidate so the timer is live again.
+              (ghostel-line-mode)
+              (should (eq ghostel--input-mode 'line))
+              (should (> invalidate-calls before)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-emacs-to-line-does-not-double-invalidate ()
+  "Emacs → line transition does not need the extra invalidate call.
+The redraw timer is already running in Emacs mode (the terminal
+is unfrozen), so `ghostel--line-mode-enter' must skip the
+copy-only `ghostel--invalidate' call to avoid pointless work on
+the hot path."
+  (let ((buf (generate-new-buffer " *ghostel-test-emacs-to-line*"))
+        (invalidate-calls 0))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert ">>> \n")
+          (setq ghostel--term 'fake)
+          (setq ghostel--term-rows 1)
+          (setq ghostel--process 'fake-proc)
+          (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'ghostel--cursor-position)
+                     (lambda (_term) (cons 4 0)))
+                    ((symbol-function 'ghostel--cursor-row-char-offset)
+                     (lambda (_term) 4))
+                    ((symbol-function 'ghostel--invalidate)
+                     (lambda (&rest _) (cl-incf invalidate-calls)))
+                    ((symbol-function 'ghostel--scroll-bottom) #'ignore)
+                    ((symbol-function 'ghostel--redraw) #'ignore))
+            (ghostel-emacs-mode)
+            (should (eq ghostel--input-mode 'emacs))
+            ;; Reset counter: any invalidates from the emacs-mode entry
+            ;; itself are not the subject of this test.
+            (setq invalidate-calls 0)
+            (ghostel-line-mode)
+            (should (eq ghostel--input-mode 'line))
+            ;; No invalidate call from the copy-only branch.
+            (should (= 0 invalidate-calls))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-defers-entry-on-alt-screen ()
+  "Calling `ghostel-line-mode' in alt-screen arms deferred activation.
+The user's intent (\"I want line mode\") is preserved; the
+auto-resume path in `ghostel--line-mode-post-redraw' picks up the
+sentinel and enters line mode for real once the TUI exits."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-defer*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (_term mode) (= mode 1049))))
+              ;; Buffer is in semi-char, alt-screen is on.
+              (should (eq ghostel--input-mode 'semi-char))
+              (ghostel-line-mode)
+              ;; Mode is unchanged (the TUI keeps getting raw keys),
+              ;; but the paused sentinel is armed so a later
+              ;; alt-screen-off cycle re-enters line mode.
+              (should (eq ghostel--input-mode 'semi-char))
+              (should ghostel--line-mode-paused)
+              (should (equal (plist-get ghostel--line-mode-paused :input)
+                             "")))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-pauses-on-alt-screen-on ()
+  "1049 ON while in line-mode snapshots input and drops to semi-char.
+The in-progress input lands in `ghostel--line-mode-paused' so a
+later alt-screen exit can restore it."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-pause*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((alt-on nil)
+                (ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (_term mode)
+                         (and alt-on (memq mode '(1049 1047)) t)))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string) #'ignore)
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (should (eq ghostel--input-mode 'line))
+              (insert "ls")
+              (should (equal (ghostel--line-mode-input-text) "ls"))
+              ;; Alt-screen turns on; pre-redraw fires the pause.
+              (setq alt-on t)
+              (ghostel--line-mode-pre-redraw)
+              (should (eq ghostel--input-mode 'semi-char))
+              (should ghostel--line-mode-paused)
+              (should (equal (plist-get ghostel--line-mode-paused :input)
+                             "ls"))
+              ;; Input region was extracted from the buffer.
+              (should-not (markerp ghostel--line-input-start))
+              ;; Read-only props from line-mode entry are gone.
+              (should-not (text-property-any (point-min) (point-max)
+                                             'read-only t)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-resumes-on-alt-screen-off ()
+  "1049 OFF with a prompt in the buffer re-enters line mode + restores input.
+Drives the pause, then the resume; the snapshotted input lands at
+the new prompt-end and the buffer is back in line mode."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-resume*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((alt-on nil)
+                (ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (_term mode)
+                         (and alt-on (memq mode '(1049 1047)) t)))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string) #'ignore)
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              ;; Enter line mode and type some input.
+              (ghostel-line-mode)
+              (insert "ls -la")
+              ;; Alt-screen ON → pause via pre-redraw.
+              (setq alt-on t)
+              (ghostel--line-mode-pre-redraw)
+              (should (eq ghostel--input-mode 'semi-char))
+              (should ghostel--line-mode-paused)
+              ;; Post-redraw with alt-screen still on does NOT resume.
+              (ghostel--line-mode-post-redraw)
+              (should (eq ghostel--input-mode 'semi-char))
+              ;; Alt-screen OFF → next post-redraw resumes.
+              (setq alt-on nil)
+              (ghostel--line-mode-pre-redraw)  ; no-op (not in line mode)
+              (ghostel--line-mode-post-redraw)
+              (should (eq ghostel--input-mode 'line))
+              (should-not ghostel--line-mode-paused)
+              (should (equal (ghostel--line-mode-input-text) "ls -la")))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-resume-defers-without-prompt ()
+  "Resume with no prompt in the buffer keeps the paused snapshot for next cycle."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-resume-defer*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((alt-on nil)
+                (ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (_term mode)
+                         (and alt-on (memq mode '(1049 1047)) t)))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string) #'ignore)
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (insert "echo hi")
+              (setq alt-on t)
+              (ghostel--line-mode-pre-redraw)
+              (ghostel--line-mode-post-redraw)
+              ;; Drop the prompt before alt-screen-off — simulates
+              ;; a redraw cycle where the new post-TUI prompt has
+              ;; not been painted yet.
+              (let ((inhibit-read-only t)) (erase-buffer))
+              (setq alt-on nil)
+              (ghostel--line-mode-post-redraw)
+              ;; Still paused, snapshot intact, mode still semi-char.
+              (should (eq ghostel--input-mode 'semi-char))
+              (should ghostel--line-mode-paused)
+              (should (equal (plist-get ghostel--line-mode-paused :input)
+                             "echo hi"))
+              ;; Add the new prompt and run another post-redraw —
+              ;; resume succeeds.
+              (insert (propertize "$ " 'ghostel-prompt t))
+              (ghostel--line-mode-post-redraw)
+              (should (eq ghostel--input-mode 'line))
+              (should-not ghostel--line-mode-paused)
+              (should (equal (ghostel--line-mode-input-text) "echo hi")))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-paused-cleared-on-manual-switch ()
+  "An explicit mode switch drops the paused sentinel — no force-resume later."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-clear-paused*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((alt-on t)
+                (ghostel--term 'fake))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (_term mode)
+                         (and alt-on (memq mode '(1049 1047)) t)))
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              ;; Defer entry while alt-screen is on — paused armed.
+              (ghostel-line-mode)
+              (should ghostel--line-mode-paused)
+              ;; User explicitly switches modes — paused is dropped.
+              (ghostel-char-mode)
+              (should-not ghostel--line-mode-paused)
+              (should (eq ghostel--input-mode 'char)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-send ()
+  "Line-mode-send ships the input as one write then an encoded return.
+The trailing key is encoded via `ghostel--send-encoded' so apps
+that distinguish CR/LF (claude-code, pi) get a real submit, not
+a literal newline."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-send*"))
+        (events nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string)
+                       (lambda (_p s) (push (cons 'send s) events)))
+                      ((symbol-function 'ghostel--send-encoded)
+                       (lambda (key _mods &optional _utf8)
+                         (push (cons 'encoded key) events)))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (should (eq ghostel--input-mode 'line))
+              (should (markerp ghostel--line-input-start))
+              ;; Type some input.
+              (insert "ls -la")
+              (ghostel-line-mode-send)
+              ;; Input written first, then a separately-encoded Enter.
+              (should (equal (reverse events)
+                             '((send . "ls -la")
+                               (encoded . "return"))))
+              ;; Send stays in line mode; the next redraw / prompt
+              ;; cycle will reposition the marker via
+              ;; snapshot/restore.  The input region is empty after
+              ;; send.
+              (should (eq ghostel--input-mode 'line))
+              (should (markerp ghostel--line-input-start))
+              (should (equal (ghostel--line-mode-input-text) ""))
+              ;; History retains the sent line.
+              (should (member "ls -la" ghostel--line-mode-history)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-send-or-open-link-opens-link-at-point ()
+  "RET on a link in line-mode opens the link instead of sending."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-link*"))
+        (sent nil)
+        (opened nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          ;; Scrollback line carrying a help-echo (linkified).
+          (insert (propertize "see ./README.md\n" 'help-echo "fileref:./README.md"))
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string)
+                       (lambda (_p s) (setq sent s)))
+                      ((symbol-function 'ghostel--open-link)
+                       (lambda (url) (setq opened url)))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              ;; Park point on the linkified text in the scrollback.
+              (goto-char (point-min))
+              (forward-char 4)
+              (ghostel-line-mode-send-or-open-link)
+              (should (equal opened "fileref:./README.md"))
+              (should (null sent)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-newline-inserts-and-sends-multiline ()
+  "Shift-Enter inserts \\n; the multi-line input ships verbatim on send.
+For chat apps that distinguish submit from newline (claude-code,
+pi), the trailing encoded `return' is the submit and any embedded
+\\n stays in the input as a literal newline."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-newline*"))
+        (events nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string)
+                       (lambda (_p s) (push (cons 'send s) events)))
+                      ((symbol-function 'ghostel--send-encoded)
+                       (lambda (key _mods &optional _utf8)
+                         (push (cons 'encoded key) events)))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (insert "first line")
+              (ghostel-line-mode-newline)
+              (insert "second line")
+              (should (equal (ghostel--line-mode-input-text)
+                             "first line\nsecond line"))
+              (ghostel-line-mode-send)
+              (should (equal (reverse events)
+                             '((send . "first line\nsecond line")
+                               (encoded . "return")))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-newline-snaps-from-scrollback ()
+  "Shift-Enter from the read-only scrollback snaps point to input end first."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-newline-snap*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert "scrollback line\n")
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string) #'ignore)
+                      ((symbol-function 'ghostel--send-encoded) #'ignore)
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (insert "abc")
+              ;; Park point in the scrollback line.
+              (goto-char (point-min))
+              (ghostel-line-mode-newline)
+              ;; Input now contains "abc\n", scrollback untouched.
+              (should (equal (ghostel--line-mode-input-text) "abc\n"))
+              (should (= (point) (marker-position ghostel--line-input-end))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-send-or-open-link-sends-without-link ()
+  "RET in the input region with no link at point sends the line."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-nolink*"))
+        (sent nil)
+        (encoded nil)
+        (opened nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string)
+                       (lambda (_p s) (setq sent s)))
+                      ((symbol-function 'ghostel--send-encoded)
+                       (lambda (key _mods &optional _utf8)
+                         (setq encoded key)))
+                      ;; No native URI lookup with a fake terminal handle.
+                      ((symbol-function 'ghostel--uri-at-pos)
+                       (lambda (_pos) nil))
+                      ((symbol-function 'ghostel--open-link)
+                       (lambda (url) (setq opened url)))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (insert "echo hi")
+              (ghostel-line-mode-send-or-open-link)
+              (should (equal sent "echo hi"))
+              (should (equal encoded "return"))
+              (should (null opened)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-send-clears-adopted-prefix ()
+  "RET in line mode erases the shell's adopted prefix before sending.
+When the user typed input via the PTY in a previous mode and then
+switched to line mode, the shell's readline still holds those
+chars.  `ghostel-line-mode-send' must send one backspace per
+adopted char first — otherwise the shell concatenates and echoes
+a duplicated line."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-send-dedup*"))
+        (events nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          ;; Adopted input as the renderer would have painted it for
+          ;; chars typed via the PTY in a previous mode.
+          (insert (propertize "ls -la" 'ghostel-input t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string)
+                       (lambda (_p s) (push (cons 'send s) events)))
+                      ((symbol-function 'ghostel--send-encoded)
+                       (lambda (key _mods &optional _utf8)
+                         (push (cons 'encoded key) events)))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              ;; Entry adopts the rendered prefix into the editable
+              ;; buffer and remembers the shell still has it.
+              (should (= ghostel--line-mode-adopted-count 6))
+              (should (equal (ghostel--line-mode-input-text) "ls -la"))
+              (ghostel-line-mode-send)
+              ;; Six "backspace" key encodes happen first, in order,
+              ;; then the line is sent in a single write, then an
+              ;; encoded "return" submits.  Asserting the full event
+              ;; sequence locks down the ordering — a future
+              ;; regression that re-introduced the duplication would
+              ;; either drop the backspaces or send the line before
+              ;; them, and a regression to a literal "\\n" submitter
+              ;; would replace the trailing encoded return.
+              (should (equal (reverse events)
+                             (append (make-list 6 '(encoded . "backspace"))
+                                     '((send . "ls -la")
+                                       (encoded . "return")))))
+              ;; Counter is zero after send so the next prompt cycle
+              ;; (with empty readline) doesn't trigger spurious
+              ;; backspaces.
+              (should (= ghostel--line-mode-adopted-count 0)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-history ()
+  "Line mode \\`M-p' / \\`M-n' cycle through the history ring."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-history*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string) #'ignore)
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (setq ghostel--line-mode-history '("third" "second" "first"))
+              (ghostel-line-mode-history-previous)
+              (should (equal (ghostel--line-mode-input-text) "third"))
+              (ghostel-line-mode-history-previous)
+              (should (equal (ghostel--line-mode-input-text) "second"))
+              (ghostel-line-mode-history-previous)
+              (should (equal (ghostel--line-mode-input-text) "first"))
+              (ghostel-line-mode-history-next)
+              (should (equal (ghostel--line-mode-input-text) "second"))
+              (ghostel-line-mode-history-next)
+              (should (equal (ghostel--line-mode-input-text) "third"))
+              (ghostel-line-mode-history-next)
+              (should (equal (ghostel--line-mode-input-text) "")))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-beginning-of-input-or-line-on-prompt-row ()
+  "On the prompt row, `C-a' jumps to the start of input.
+Both line mode (where the marker pinpoints the input) and Emacs
+mode (where only the `ghostel-prompt' text property is available)
+should land at the position right after the prompt prefix."
+  (let ((buf (generate-new-buffer " *ghostel-test-c-a-prompt*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (insert "ls -la")
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              ;; Line mode: end of buffer, then C-a → input-start.
+              (ghostel-line-mode)
+              (goto-char (point-max))
+              (ghostel-beginning-of-input-or-line)
+              (should (= (point)
+                         (marker-position ghostel--line-input-start)))
+              (ghostel-semi-char-mode))
+            ;; Emacs mode: text-property scan finds same position.
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore))
+              (ghostel-emacs-mode)
+              (goto-char (point-max))
+              (ghostel-beginning-of-input-or-line)
+              ;; "$ " is 2 chars (positions 1-2), input starts at 3.
+              (should (= (point) 3)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-beginning-of-input-or-line-in-scrollback ()
+  "On a non-prompt line, `C-a' falls through to `beginning-of-line'.
+This covers both modes: navigating up into scrollback and pressing
+`C-a' should give the standard column-0 behaviour, not snap point
+back to the active prompt's input area."
+  (let ((buf (generate-new-buffer " *ghostel-test-c-a-bol*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert "scrollback line one\nscrollback line two\n")
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              ;; Line mode: navigate up to scrollback, C-a → BOL of
+              ;; that line, NOT the active prompt's input marker.
+              (ghostel-line-mode)
+              (goto-char (point-min))
+              (search-forward "line two")  ; cursor mid-line in scrollback
+              (let ((expected-bol (line-beginning-position)))
+                (ghostel-beginning-of-input-or-line)
+                (should (= (point) expected-bol))
+                (should-not
+                 (= (point)
+                    (marker-position ghostel--line-input-start))))
+              (ghostel-semi-char-mode))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore))
+              (ghostel-emacs-mode)
+              ;; Emacs mode: same on a scrollback line.
+              (goto-char (point-min))
+              (search-forward "line one")
+              (let ((expected-bol (line-beginning-position)))
+                (ghostel-beginning-of-input-or-line)
+                (should (= (point) expected-bol))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-interrupt ()
+  "Line-mode interrupt discards input, sends SIGINT, and exits."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-interrupt*"))
+        (sent nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string)
+                       (lambda (_p s) (setq sent s)))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (insert "half-typed")
+              (ghostel-line-mode-interrupt)
+              (should (equal sent "\C-c"))
+              ;; Interrupt stays in line mode; the next redraw /
+              ;; prompt cycle picks up the shell's new prompt and
+              ;; snapshot/restore repositions the marker.  The input
+              ;; region is empty after interrupt.
+              (should (eq ghostel--input-mode 'line))
+              (should (markerp ghostel--line-input-start))
+              (should (equal (ghostel--line-mode-input-text) "")))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-exit-sends-pending ()
+  "Exiting line mode via a mode-switch sends the in-progress input raw.
+The user's in-progress characters should not be lost when the
+mode changes — they get forwarded to the shell's readline so the
+user can continue editing at the shell prompt."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-exit*"))
+        (sent-log nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string)
+                       (lambda (_p s) (push s sent-log)))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (insert "ls -la")
+              ;; Exit via a mode switch.  The teardown should ship the
+              ;; partially-typed input to the PTY raw (no newline).
+              (ghostel-semi-char-mode)
+              (should (eq ghostel--input-mode 'semi-char))
+              (should (member "ls -la" sent-log)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-eof-on-empty ()
+  "Line mode \\`C-d' at an empty input sends EOF; otherwise deletes forward."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-eof*"))
+        (sent nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string)
+                       (lambda (_p s) (setq sent s)))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              ;; Empty input → EOF.
+              (ghostel-line-mode-delete-char-or-eof)
+              (should (equal sent "\C-d")))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-teardown-on-exit ()
+  "Exiting line mode cleans up the marker and deletes in-progress input."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-teardown*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (insert "abandoned")
+              (ghostel-semi-char-mode)
+              (should (eq ghostel--input-mode 'semi-char))
+              (should (null ghostel--line-input-start))
+              ;; The abandoned input is gone from the buffer.
+              (should-not (string-match-p "abandoned"
+                                          (buffer-string)))
+              ;; The read-only property is cleared too.
+              (should-not (text-property-any (point-min) (point-max)
+                                             'read-only t)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-scrollback-read-only ()
+  "Line mode makes everything before the input marker read-only.
+Typing in the middle of the scrollback / previous-output region
+signals `text-read-only', while typing after the marker works
+normally."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-ro*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          ;; Buffer: some previous output, then a prompt.
+          (insert "earlier output\n")
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              ;; The scrollback region carries the read-only property.
+              (should (get-text-property (point-min) 'read-only))
+              ;; Attempting to edit in the MIDDLE of the scrollback
+              ;; region errors.  (Emacs allows insertion right at
+              ;; point-min because the new text goes "before" the
+              ;; read-only region, not inside it — that is a known
+              ;; property-read-only quirk and we do not fight it.)
+              (goto-char 5)
+              (should-error (insert "x") :type 'text-read-only)
+              ;; Typing at the marker (inside the input region) works.
+              (goto-char (marker-position ghostel--line-input-start))
+              (insert "ls")
+              (should (equal (ghostel--line-mode-input-text) "ls"))
+              ;; Exit: the read-only property goes away.
+              (ghostel-semi-char-mode)
+              (should-not (text-property-any (point-min) (point-max)
+                                             'read-only t)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-self-insert-snaps-from-scrollback ()
+  "Typing while point sits in the scrollback snaps to the input end."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-snap-insert*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert "earlier output\n")
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              ;; Type some input first so the input region has content.
+              (goto-char (marker-position ghostel--line-input-start))
+              (insert "ls")
+              (let ((input-end (marker-position ghostel--line-input-end)))
+                ;; Navigate up into the read-only scrollback.
+                (goto-char (point-min))
+                (should (< (point) (marker-position ghostel--line-input-start)))
+                ;; Self-insert via the snap wrapper.
+                (let ((last-command-event ?x))
+                  (ghostel-line-mode-self-insert 1))
+                ;; Point landed just past where input-end used to be,
+                ;; the `x' was appended to the input region.
+                (should (equal (ghostel--line-mode-input-text) "lsx"))
+                (should (= (point) (1+ input-end)))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-self-insert-no-jump-when-inside ()
+  "When point is already inside the input region, self-insert stays put."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-no-snap*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (goto-char (marker-position ghostel--line-input-start))
+              (insert "hello")
+              ;; Move point to the middle of the input ("hel|lo").
+              (let ((mid (- (point) 2)))
+                (goto-char mid)
+                (let ((last-command-event ?X))
+                  (ghostel-line-mode-self-insert 1))
+                ;; Inserted at the cursor, no jump to end.
+                (should (equal (ghostel--line-mode-input-text) "helXlo"))
+                (should (= (point) (1+ mid)))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-self-insert-prefix-arg ()
+  "Numeric prefix repeats the self-insert."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-prefix*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert "earlier output\n")
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (goto-char (point-min))
+              (let ((last-command-event ?a))
+                (ghostel-line-mode-self-insert 5))
+              (should (equal (ghostel--line-mode-input-text) "aaaaa")))))
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
+;; Test: line mode TAB completion
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-line-mode-tab-binding ()
+  "Both \\`TAB' and \\`<tab>' in line-mode-map call the completion command."
+  (should (eq #'ghostel-line-mode-complete-at-point
+              (lookup-key ghostel-line-mode-map (kbd "TAB"))))
+  (should (eq #'ghostel-line-mode-complete-at-point
+              (lookup-key ghostel-line-mode-map (kbd "<tab>")))))
+
+(ert-deftest ghostel-test-line-mode-complete-narrows-to-input ()
+  "Completion sees only the input region, not prompt or scrollback."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-complete-narrow*"))
+        recorded)
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert "earlier output\n")
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc)
+                (ghostel-line-mode-completion-at-point-functions
+                 (list (lambda ()
+                         (setq recorded
+                               (list :pmin (point-min)
+                                     :pmax (point-max)
+                                     :content
+                                     (buffer-substring-no-properties
+                                      (point-min) (point-max))))
+                         nil)))
+                ;; Skip bash-completion in this test regardless of host config.
+                (ghostel-line-mode-use-bash-completion nil))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (goto-char (marker-position ghostel--line-input-end))
+              (insert "ls fo")
+              (ghostel-line-mode-complete-at-point)
+              (should recorded)
+              (should (equal (plist-get recorded :content) "ls fo"))
+              (should (= (plist-get recorded :pmin)
+                         (marker-position ghostel--line-input-start)))
+              (should (= (plist-get recorded :pmax)
+                         (marker-position ghostel--line-input-end))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-complete-filename ()
+  "Filename completion expands a unique prefix in the buffer's `default-directory'.
+Restricts the capf list to `comint-filename-completion' so the test
+isn't perturbed by whatever \\=`ap*\\=' commands happen to live in
+\\=`$PATH\\=' on the host (`shell-command-completion' fires for the
+first word and would add e.g. \\=`apropos\\=', making the result
+ambiguous)."
+  (let* ((tmpdir (file-name-as-directory (make-temp-file "ghostel-cmp" 'dir)))
+         (buf (generate-new-buffer " *ghostel-test-line-complete-fname*")))
+    (unwind-protect
+        (progn
+          (with-temp-file (expand-file-name "apple.txt" tmpdir))
+          (with-temp-file (expand-file-name "banana.txt" tmpdir))
+          (with-current-buffer buf
+            (setq default-directory tmpdir)
+            (ghostel-mode)
+            (insert (propertize "$ " 'ghostel-prompt t))
+            (let ((ghostel--term 'fake)
+                  (ghostel--process 'fake-proc)
+                  (ghostel-line-mode-use-bash-completion nil)
+                  (ghostel-line-mode-completion-at-point-functions
+                   '(comint-filename-completion)))
+              (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                         (lambda (&rest _) nil))
+                        ((symbol-function 'ghostel--redraw) #'ignore)
+                        ((symbol-function 'ghostel--invalidate) #'ignore)
+                        ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+                (ghostel-line-mode)
+                (goto-char (marker-position ghostel--line-input-end))
+                (insert "ap")
+                (ghostel-line-mode-complete-at-point)
+                ;; Unique prefix `ap' resolves to `apple.txt'.  Comint's
+                ;; filename completion may add a trailing space — just
+                ;; check the expansion happened.
+                (should (string-match-p "\\`apple\\.txt"
+                                        (ghostel--line-mode-input-text)))))))
+      (when (buffer-live-p buf) (kill-buffer buf))
+      (delete-directory tmpdir 'recursive))))
+
+(ert-deftest ghostel-test-line-mode-complete-empty-input ()
+  "TAB on empty input does not error."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-complete-empty*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc)
+                (ghostel-line-mode-use-bash-completion nil)
+                (ghostel-line-mode-completion-at-point-functions
+                 ;; A capf that would crash if called on a non-string —
+                 ;; ensures empty-input path doesn't blow up.
+                 (list (lambda () nil))))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              ;; Should complete without raising.
+              (ghostel-line-mode-complete-at-point))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-complete-snaps-from-scrollback ()
+  "TAB pressed in scrollback snaps point to the input end before completing."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-complete-snap*"))
+        snapped-point)
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert "earlier output\n")
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc)
+                (ghostel-line-mode-use-bash-completion nil)
+                (ghostel-line-mode-completion-at-point-functions
+                 (list (lambda ()
+                         (setq snapped-point (point))
+                         nil))))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (goto-char (marker-position ghostel--line-input-end))
+              (insert "ls")
+              (let ((input-end (marker-position ghostel--line-input-end)))
+                (goto-char (point-min))
+                (ghostel-line-mode-complete-at-point)
+                (should (= snapped-point input-end))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-complete-refreshes-tramp-prefix ()
+  "Each TAB updates `comint-file-name-prefix' from `default-directory'."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-complete-tramp*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc)
+                (ghostel-line-mode-use-bash-completion nil)
+                (ghostel-line-mode-completion-at-point-functions
+                 (list (lambda () nil))))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (let ((default-directory "/ssh:host:/tmp/"))
+                (goto-char (marker-position ghostel--line-input-end))
+                (ghostel-line-mode-complete-at-point)
+                (should (equal comint-file-name-prefix "/ssh:host:"))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-bash-completion-disabled-by-default-in-test ()
+  "`ghostel--line-mode-effective-capfs' omits bash-completion when option is nil."
+  (let ((ghostel-line-mode-use-bash-completion nil)
+        (ghostel-line-mode-completion-at-point-functions
+         '(comint-completion-at-point)))
+    (should-not (memq 'bash-completion-capf-nonexclusive
+                      (ghostel--line-mode-effective-capfs)))))
+
+(ert-deftest ghostel-test-line-mode-bash-completion-prepended-when-available ()
+  "`ghostel--line-mode-effective-capfs' prepends bash-completion when enabled."
+  (skip-unless (require 'bash-completion nil 'noerror))
+  (let ((ghostel-line-mode-use-bash-completion t)
+        (ghostel-line-mode-completion-at-point-functions
+         '(comint-completion-at-point)))
+    (let ((funs (ghostel--line-mode-effective-capfs)))
+      (should (eq (car funs) #'bash-completion-capf-nonexclusive))
+      (should (memq #'comint-completion-at-point funs)))))
+
+(ert-deftest ghostel-test-line-mode-bash-completion-no-double-add ()
+  "Bash-completion is not added twice when the user has it in the defcustom."
+  (skip-unless (require 'bash-completion nil 'noerror))
+  (let ((ghostel-line-mode-use-bash-completion t)
+        (ghostel-line-mode-completion-at-point-functions
+         '(bash-completion-capf-nonexclusive comint-completion-at-point)))
+    (let ((funs (ghostel--line-mode-effective-capfs)))
+      (should (= 1 (cl-count #'bash-completion-capf-nonexclusive funs))))))
+
+(ert-deftest ghostel-test-line-mode-bash-completion-prespawn-defaults-off ()
+  "The prespawn defcustom is off by default."
+  (should (eq nil (default-value
+                   'ghostel-line-mode-bash-completion-prespawn))))
+
+(ert-deftest ghostel-test-line-mode-snapshot-captures-input ()
+  "`ghostel--line-mode-snapshot' returns a plist and clears the input region."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-snap*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (insert "hello")
+              (let* ((marker-pos (marker-position
+                                  ghostel--line-input-start))
+                     (snap (ghostel--line-mode-snapshot)))
+                (should (equal (plist-get snap :input) "hello"))
+                (should (equal (plist-get snap :point-offset) 5))
+                (should-not (plist-get snap :mark-offset))
+                ;; Input region was cleared from the buffer.
+                (should (= (point-max) marker-pos))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-snapshot-no-marker-returns-nil ()
+  "`ghostel--line-mode-snapshot' returns nil when no input marker is live."
+  (with-temp-buffer
+    (let ((ghostel--line-input-start nil))
+      (should-not (ghostel--line-mode-snapshot)))))
+
+(ert-deftest ghostel-test-line-mode-snapshot-captures-mark-offset ()
+  "`ghostel--line-mode-snapshot' records mark offset when an active region overlaps the input."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-snap-mark*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (insert "abcdef")
+              ;; Place mark at +2, point at +5.
+              (let ((marker-pos (marker-position
+                                 ghostel--line-input-start)))
+                (set-mark (+ marker-pos 2))
+                (goto-char (+ marker-pos 5)))
+              (let ((snap (ghostel--line-mode-snapshot)))
+                (should (equal (plist-get snap :input) "abcdef"))
+                (should (equal (plist-get snap :point-offset) 5))
+                (should (equal (plist-get snap :mark-offset) 2))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-restore-reinserts-input ()
+  "`ghostel--line-mode-restore' re-inserts SNAPSHOT after the new prompt."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-restore*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (insert "command")
+              (let ((snap (ghostel--line-mode-snapshot)))
+                ;; Simulate a redraw rewriting the buffer: the renderer
+                ;; would re-emit the prompt at a (potentially new)
+                ;; position.  Erase and rebuild with a longer
+                ;; preamble.
+                (let ((inhibit-read-only t))
+                  (erase-buffer)
+                  (insert "background line\n")
+                  (insert (propertize "$ " 'ghostel-prompt t)))
+                (should (ghostel--line-mode-restore snap))
+                ;; Input is back, marker points at the new prompt-end.
+                (should (equal (ghostel--line-mode-input-text) "command"))
+                ;; Point is at the original :point-offset (end of
+                ;; "command" = 7) past the new marker.
+                (should (= (- (point) (marker-position
+                                       ghostel--line-input-start))
+                           7))
+                ;; Read-only re-applied to the new scrollback region.
+                (should (get-text-property (point-min) 'read-only))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-restore-no-prompt-returns-nil ()
+  "`ghostel--line-mode-restore' returns nil when the prompt cannot be found."
+  (with-temp-buffer
+    ;; No `ghostel-prompt' property anywhere → restore reports failure.
+    (insert "no prompt here")
+    (let ((snap '(:input "x" :point-offset 1 :mark-offset nil)))
+      (should-not (ghostel--line-mode-restore snap)))))
+
+(ert-deftest ghostel-test-line-mode-restore-marks-ghostel-input ()
+  "`ghostel--line-mode-restore' marks the input region with `ghostel-input'.
+This makes `ghostel--detect-urls-skip-p' skip the user's typed
+input on the cursor's line so a path the user typed locally does
+not get linkified (which would steal RET from line-mode-send)."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-input-prop*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (insert "cd src/main.rs")
+              (let ((snap (ghostel--line-mode-snapshot)))
+                ;; Simulate redraw rewriting buffer with same prompt.
+                (let ((inhibit-read-only t))
+                  (erase-buffer)
+                  (insert (propertize "$ " 'ghostel-prompt t)))
+                (should (ghostel--line-mode-restore snap))
+                ;; Every char in the input region carries `ghostel-input'.
+                (let ((start (marker-position
+                              ghostel--line-input-start)))
+                  (should (< start (point-max)))
+                  (should (eq (get-text-property start 'ghostel-input) t))
+                  (should (eq (get-text-property (1- (point-max))
+                                                 'ghostel-input)
+                              t)))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-end-marker-bounds-snapshot ()
+  "Snapshot reads `[start, end)' — content past the end marker is preserved.
+Simulates a status bar drawn below the prompt row.  The renderer
+would normally write past the prompt, then a redraw cycle of
+snapshot/restore must leave the status-bar text untouched."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-end-marker*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (insert "\n--- status ---\n")
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              ;; Both markers exist.
+              (should (markerp ghostel--line-input-start))
+              (should (markerp ghostel--line-input-end))
+              ;; The status bar is non-blank, so the trailing trim
+              ;; left it alone — buffer still contains it.
+              (should (string-match-p "--- status ---" (buffer-string)))
+              ;; Markers coincide (no input typed yet).
+              (should (= (marker-position ghostel--line-input-start)
+                         (marker-position ghostel--line-input-end)))
+              ;; Type some input — end marker advances, start stays.
+              (insert "ls -la")
+              (should (= (- (marker-position ghostel--line-input-end)
+                            (marker-position ghostel--line-input-start))
+                         6))
+              ;; Snapshot reads only [start, end), leaving the status
+              ;; bar untouched.
+              (let ((snap (ghostel--line-mode-snapshot)))
+                (should (equal (plist-get snap :input) "ls -la"))
+                (should (string-match-p "--- status ---"
+                                        (buffer-string)))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-adopts-existing-input-on-entry ()
+  "Line mode entry adopts a pre-existing `ghostel-input' span as initial input.
+This covers the workflow where the user typed at the shell in
+semi-char mode, then switched to line mode partway through — the
+already-typed chars in libghostty's INPUT cells (marked
+`ghostel-input' by the renderer) become the line-mode input
+instead of being discarded."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-adopt*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          ;; Pre-existing typed chars marked with `ghostel-input'.
+          (insert (propertize "cd src" 'ghostel-input t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              ;; Adopted chars become the initial line-mode input.
+              (should (equal (ghostel--line-mode-input-text) "cd src"))
+              ;; Point sits at end of input so user keeps typing.
+              (should (= (point)
+                         (marker-position ghostel--line-input-end)))
+              ;; The adopted span carries `ghostel-input'.
+              (let ((start (marker-position ghostel--line-input-start)))
+                (should (eq (get-text-property start 'ghostel-input) t))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-preserves-status-below-prompt ()
+  "Line-mode entry does not delete non-blank content past the prompt row.
+A status bar (or any non-whitespace content) drawn below the prompt
+row by the shell or another app survives entering line mode and
+running through a redraw cycle."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-status*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (insert "\n[status: ok]\n")
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (ghostel-line-mode)
+              (should (string-match-p "\\[status: ok\\]" (buffer-string)))
+              (insert "ls")
+              (should (equal (ghostel--line-mode-input-text) "ls"))
+              (should (string-match-p "\\[status: ok\\]"
+                                      (buffer-string))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-saves-restores-full-redraw ()
+  "Entering line mode forces full redraws; teardown restores the prior setting."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-fullredraw*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc)
+                (ghostel-full-redraw nil))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              ;; Was nil, no buffer-local override.
+              (should-not (local-variable-p 'ghostel-full-redraw))
+              (ghostel-line-mode)
+              ;; Entry sets buffer-local override to t.
+              (should (local-variable-p 'ghostel-full-redraw))
+              (should (eq ghostel-full-redraw t))
+              ;; Saved-state cons records "was not buffer-local".
+              (should (equal ghostel--line-mode-saved-full-redraw
+                             '(nil . nil)))
+              (ghostel-semi-char-mode)
+              ;; Teardown killed the buffer-local override.
+              (should-not (local-variable-p 'ghostel-full-redraw))
+              (should-not ghostel--line-mode-saved-full-redraw))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-restores-cursor-when-terminal-hid-it ()
+  "Line mode shows the editor's cursor regardless of CSI ?25l from the TUI.
+Bug: a TUI that hides the cursor (e.g. claude-code) leaves
+`cursor-type' nil, and line mode previously inherited that — so
+moving point produced no visible cursor.  Entering line mode must
+force the editor default; teardown must restore the saved value."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-cursor*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              ;; Simulate a TUI that hid the cursor in semi-char mode.
+              (ghostel--set-cursor-style 1 nil)
+              (should (null cursor-type))
+              ;; Enter line mode — cursor must be visible (default).
+              (ghostel-line-mode)
+              (should (eq ghostel--input-mode 'line))
+              (should (equal cursor-type (default-value 'cursor-type)))
+              (should (equal ghostel--line-mode-saved-cursor-type '(nil)))
+              ;; Exit line mode — cursor returns to terminal-hidden state.
+              (ghostel-semi-char-mode)
+              (should (null cursor-type))
+              (should-not ghostel--line-mode-saved-cursor-type))))
+      (kill-buffer buf))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: ghostel-send-next-key
@@ -10228,6 +12266,9 @@ slip past the unit tests."
     ghostel-test-spinner-progress-set-stops-and-shows-percent
     ghostel-test-spinner-progress-remove-clears-modeline
     ghostel-test-spinner-stop-helper-clears-state
+    ghostel-test-progress-preserves-input-mode-tag
+    ghostel-test-spinner-preserves-input-mode-tag
+    ghostel-test-mode-line-refresh-skips-fmlu-when-unchanged
     ghostel-test-flush-pending-output-preserves-buffer
     ghostel-test-copy-mode-cursor
     ghostel-test-ignore-cursor-change
@@ -10292,7 +12333,74 @@ slip past the unit tests."
     ghostel-test-xterm-paste-exits-copy-mode
     ghostel-test-xterm-paste-bound-in-keymaps
     ghostel-test-xterm-paste-copy-mode-and-kill-ring
+    ghostel-test-char-mode-key-bindings
     ghostel-test-copy-mode-recenter
+    ghostel-test-input-mode-default-is-semi-char
+    ghostel-test-input-mode-predicates
+    ghostel-test-char-mode-enter-exit
+    ghostel-test-emacs-mode-enter-exit
+    ghostel-test-emacs-mode-is-unfrozen
+    ghostel-test-emacs-mode-does-not-forward-typing
+    ghostel-test-emacs-mode-snap-on-input
+    ghostel-test-emacs-mode-window-anchored-when-snap-requested
+    ghostel-test-line-mode-scrollback-read-only
+    ghostel-test-line-mode-self-insert-snaps-from-scrollback
+    ghostel-test-line-mode-self-insert-no-jump-when-inside
+    ghostel-test-line-mode-self-insert-prefix-arg
+    ghostel-test-line-mode-tab-binding
+    ghostel-test-line-mode-complete-narrows-to-input
+    ghostel-test-line-mode-complete-filename
+    ghostel-test-line-mode-complete-empty-input
+    ghostel-test-line-mode-complete-snaps-from-scrollback
+    ghostel-test-line-mode-complete-refreshes-tramp-prefix
+    ghostel-test-line-mode-bash-completion-disabled-by-default-in-test
+    ghostel-test-line-mode-bash-completion-prepended-when-available
+    ghostel-test-line-mode-bash-completion-no-double-add
+    ghostel-test-line-mode-bash-completion-prespawn-defaults-off
+    ghostel-test-copy-mode-restores-previous-mode
+    ghostel-test-copy-to-emacs-transition
+    ghostel-test-emacs-to-copy-transition
+    ghostel-test-mode-switch-keybindings
+    ghostel-test-prompt-nav-enters-emacs-mode
+    ghostel-test-mode-mutual-exclusivity
+    ghostel-test-line-mode-find-prompt-end
+    ghostel-test-line-mode-find-prompt-end-uses-cursor
+    ghostel-test-line-mode-find-prompt-end-prefers-cursor-over-stale-prompt
+    ghostel-test-line-mode-find-prompt-end-uses-char-offset
+    ghostel-test-line-mode-find-prompt-end-osc133-on-cursor-row
+    ghostel-test-line-mode-requires-anchor
+    ghostel-test-line-mode-enters-without-osc133
+    ghostel-test-copy-to-line-restarts-redraw-timer
+    ghostel-test-emacs-to-line-does-not-double-invalidate
+    ghostel-test-line-mode-defers-entry-on-alt-screen
+    ghostel-test-line-mode-pauses-on-alt-screen-on
+    ghostel-test-line-mode-resumes-on-alt-screen-off
+    ghostel-test-line-mode-resume-defers-without-prompt
+    ghostel-test-line-mode-paused-cleared-on-manual-switch
+    ghostel-test-line-mode-send
+    ghostel-test-line-mode-newline-inserts-and-sends-multiline
+    ghostel-test-line-mode-newline-snaps-from-scrollback
+    ghostel-test-line-mode-send-or-open-link-opens-link-at-point
+    ghostel-test-line-mode-send-or-open-link-sends-without-link
+    ghostel-test-line-mode-send-clears-adopted-prefix
+    ghostel-test-line-mode-history
+    ghostel-test-beginning-of-input-or-line-on-prompt-row
+    ghostel-test-beginning-of-input-or-line-in-scrollback
+    ghostel-test-line-mode-interrupt
+    ghostel-test-line-mode-exit-sends-pending
+    ghostel-test-line-mode-eof-on-empty
+    ghostel-test-line-mode-teardown-on-exit
+    ghostel-test-line-mode-snapshot-captures-input
+    ghostel-test-line-mode-snapshot-no-marker-returns-nil
+    ghostel-test-line-mode-snapshot-captures-mark-offset
+    ghostel-test-line-mode-restore-reinserts-input
+    ghostel-test-line-mode-restore-no-prompt-returns-nil
+    ghostel-test-line-mode-restore-marks-ghostel-input
+    ghostel-test-line-mode-end-marker-bounds-snapshot
+    ghostel-test-line-mode-adopts-existing-input-on-entry
+    ghostel-test-line-mode-preserves-status-below-prompt
+    ghostel-test-line-mode-saves-restores-full-redraw
+    ghostel-test-line-mode-restores-cursor-when-terminal-hid-it
     ghostel-test-send-next-key-control-x
     ghostel-test-send-next-key-control-h
     ghostel-test-send-next-key-regular-char


### PR DESCRIPTION
## Summary

Adds five eat.el-inspired input modes for ghostel. Closes #40.

- **semi-char** (default): terminal input, `C-c` prefix reserved
- **char** (`C-c M-d`): all keys to terminal, `M-RET` exits — for TUI apps that want `C-x`, `M-x`, `C-h`
- **Emacs** (`C-c C-e`): **unfrozen** — terminal keeps running, buffer is read-only, standard Emacs keys (`isearch`, `occur`, `M-x`, `C-SPC`+`M-w`) fall through to the global map. Lets you search across a live log
- **copy** (`C-c C-t`): frozen + read-only + aggressive copy keymap (`M-w` copies and exits)
- **line** (`C-c C-l`): buffers input locally in Emacs; `RET` sends the whole line to the shell in one write. Full Emacs editing (yank, transpose, kill-word…) works. Requires OSC 133 shell integration

## Mechanics

- Single state variable `ghostel--input-mode`; `ghostel--copy-mode-active` removed
- Keymap split: slim base `ghostel-mode-map` (C-c prefix + drag-n-drop) with per-mode child maps
- New predicates `ghostel--buffer-editable-p`, `ghostel--terminal-live-p`, `ghostel--terminal-frozen-p` — all five check sites that used `copy-mode-active` migrated
- Emacs mode reuses the existing `inhibit-read-only`/`inhibit-redisplay` bindings around `ghostel--redraw`, so nothing in the Zig layer changes; the delayed-redraw path now preserves point unconditionally in Emacs mode
- Line mode suppresses redraws while composing and forces a full catch-up redraw on exit — no save/restore-around-redraw race
- Prompt nav (`C-c C-n`/`C-c C-p`) now auto-enters Emacs mode instead of copy mode so the terminal keeps running during navigation

## Base

This PR targets `scrollback-in-buffer` (PR #73) since it depends on the always-materialized-scrollback model. Once #73 merges to main, this can be rebased onto main.

## Test plan

- [x] `make build` — native module compiles (no Zig changes, sanity check)
- [x] `make test-all` — 120 ghostel tests pass (93 existing + 27 new mode tests)
- [x] `make test-evil` — 30 evil-integration tests still pass
- [x] `make lint` — package-lint + checkdoc clean
- [x] Manual smoke test: `C-c M-d` char mode, `C-c C-e` Emacs mode + isearch across streaming output, `C-c C-t` copy mode, `C-c C-l` line mode with bash + `ls -la` + RET
- [x] CI green (all matrix jobs)