### PR TITLE
build: pass -Dcpu=baseline for native x86_64 builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ if [ -n "$ZIG_TARGET" ]; then
      zig build -Demit-lib-vt=true -Doptimize=ReleaseFast $ZIG_TARGET_FLAG)
     SEARCH_DIRS="$GHOSTTY_CACHE"
 else
-    (cd vendor/ghostty && zig build -Demit-lib-vt=true -Doptimize=ReleaseFast)
+    (cd vendor/ghostty && zig build -Demit-lib-vt=true -Doptimize=ReleaseFast -Dcpu=baseline)
     SEARCH_DIRS="vendor/ghostty/.zig-cache"
     [ -n "$ZIG_LOCAL_CACHE_DIR" ] && SEARCH_DIRS="$SEARCH_DIRS $ZIG_LOCAL_CACHE_DIR"
     [ -n "$ZIG_GLOBAL_CACHE_DIR" ] && SEARCH_DIRS="$SEARCH_DIRS $ZIG_GLOBAL_CACHE_DIR"
@@ -76,7 +76,11 @@ echo "  libhighway.a <- $HIGHWAY"
 
 # Build ghostel module
 echo "Building ghostel module..."
-zig build -Doptimize=ReleaseFast $ZIG_TARGET_FLAG
+if [ -n "$ZIG_TARGET" ]; then
+    zig build -Doptimize=ReleaseFast $ZIG_TARGET_FLAG
+else
+    zig build -Doptimize=ReleaseFast -Dcpu=baseline
+fi
 
 # Determine output suffix from target or host OS
 if [ -n "$ZIG_TARGET" ]; then


### PR DESCRIPTION
Without this, Zig targets the build machine's native CPU. The CI
runners are modern enough to have AVX2, so the released x86_64
binary ends up with AVX2 instructions baked into compiler_rt
(rem_pio2_large, __divei4, sqrtf) via auto-vectorization. Those
are unconditional code paths with no runtime dispatch guard, so
they SIGILL immediately on Sandy Bridge and other pre-Haswell CPUs
that have AVX but not AVX2.

The Highway and simdutf SIMD paths are unaffected — they use
per-function target attributes and runtime CPUID dispatch, so they
still select AVX2 on capable CPUs. This matches what ghostty's own
nix package already does.

Tested with an AVX only Intel Sandybridge CPU.

Co-authored-by: Claude Sonnet 4.6 <claude@anthropic.com>
Signed-off-by: Arthur Heymans <arthur@aheymans.xyz>