### PR TITLE
Make TRAMP method for OSC 7 directory tracking configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ login shell via `getent passwd`.  `FALLBACK` is used when detection fails.
 OSC 7 directory tracking is TRAMP-aware: when the shell reports a remote
 hostname, `default-directory` is set to the corresponding TRAMP path,
 reusing the existing TRAMP prefix (method, user, multi-hop) when available.
+When no prefix exists, the method defaults to `tramp-default-method`; set
+`ghostel-tramp-default-method` to override it for ghostel specifically
+(e.g. `"scp"`, or `"rpc"` with [emacs-tramp-rpc](https://github.com/ArthurHeymans/emacs-tramp-rpc)).
 
 #### Remote Shell Integration
 
@@ -389,6 +392,7 @@ individual faces with `M-x customize-face`.
 | `ghostel-shell`                  | `$SHELL`             | Shell program to run                                     |
 | `ghostel-tramp-shells`           | `(see below)`        | Shell to use per TRAMP method (with login-shell detection) |
 | `ghostel-shell-integration`      | `t`                  | Auto-inject shell integration                            |
+| `ghostel-tramp-default-method`   | `nil`                | TRAMP method for new remote paths from OSC 7 (nil uses `tramp-default-method`) |
 | `ghostel-tramp-shell-integration` | `nil`               | Auto-inject shell integration for remote TRAMP sessions  |
 | `ghostel-buffer-name`            | `"*ghostel*"`        | Default buffer name                                      |
 | `ghostel-max-scrollback`         | `20MB`               | Maximum scrollback size in bytes                         |

--- a/ghostel.el
+++ b/ghostel.el
@@ -239,6 +239,15 @@ Set to t for all supported shells, or a list of symbols
                  (repeat :tag "Specific shells"
                          (choice (const bash) (const zsh) (const fish)))))
 
+(defcustom ghostel-tramp-default-method nil
+  "TRAMP method for constructing remote paths from OSC 7 directory reports.
+When directory tracking (OSC 7) reports a hostname that does not match
+the local machine and `default-directory' has no existing remote prefix,
+this method is used to build the TRAMP path (e.g. \"/ssh:host:/path\").
+When nil, falls back to `tramp-default-method'."
+  :type '(choice (const :tag "Use tramp-default-method" nil)
+                 string))
+
 (defcustom ghostel-keymap-exceptions
   '("C-c" "C-x" "C-u" "C-h" "C-g" "M-x" "M-o" "M-:" "C-\\")
   "Key sequences that should not be sent to the terminal.
@@ -1775,7 +1784,10 @@ file:// URL does not match the local machine, construct a TRAMP path."
               (let ((prefix (file-remote-p default-directory)))
                 (setq path (if prefix
                                (concat prefix filename)
-                             (format "/ssh:%s:%s" host filename))))))
+                             (format "/%s:%s:%s"
+                                     (or ghostel-tramp-default-method
+                                         tramp-default-method)
+                                     host filename))))))
         (setq path dir))
       (when (and path (not (string= path "")))
         (if (file-remote-p path)

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -2180,11 +2180,20 @@ rendered by `ghostel--delayed-redraw'.  This is the exact real-world path."
 
 (ert-deftest ghostel-test-update-directory-remote ()
   "Test TRAMP path construction from remote OSC 7."
-  ;; Remote hostname -> TRAMP ssh path
+  ;; Remote hostname -> TRAMP path using tramp-default-method fallback
   (let ((ghostel--last-directory nil)
-        (default-directory "/tmp/"))
+        (default-directory "/tmp/")
+        (ghostel-tramp-default-method nil)
+        (tramp-default-method "ssh"))
     (ghostel--update-directory "file://remote-host/home/user")
     (should (equal "/ssh:remote-host:/home/user/" default-directory)))
+  ;; ghostel-tramp-default-method takes precedence over tramp-default-method
+  (let ((ghostel--last-directory nil)
+        (default-directory "/tmp/")
+        (ghostel-tramp-default-method "rsync")
+        (tramp-default-method "ssh"))
+    (ghostel--update-directory "file://remote-host/home/user")
+    (should (equal "/rsync:remote-host:/home/user/" default-directory)))
   ;; Preserves method from existing TRAMP default-directory
   (let ((ghostel--last-directory nil)
         (default-directory "/scp:server:/"))


### PR DESCRIPTION
Add `ghostel-tramp-default-method' to control the TRAMP method used
when constructing remote paths from OSC 7 directory reports.  Defaults
to nil, which falls back to `tramp-default-method' instead of the
previously hardcoded "ssh".

Co-authored-by: Claude Opus 4.6 <claude@anthropic.com>
Signed-off-by: Arthur Heymans <arthur@aheymans.xyz>