### PR TITLE
Fix OSC 51;E eval crashing process filter (fixes #82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,8 +358,8 @@ if [[ "$INSIDE_EMACS" = 'ghostel' ]]; then
     # Open a file in Emacs from the terminal
     e()   { ghostel_cmd find-file-other-window "$@"; }
 
-    # Open dired in another window
-    dow() { ghostel_cmd dired-other-window "$@"; }
+    # Open dired in another window, defaulting to the current directory
+    dow() { ghostel_cmd dired-other-window "${1:-$PWD}"; }
 
     # Open magit for the current directory
     gst() { ghostel_cmd magit-status-setup-buffer "$(pwd)"; }

--- a/ghostel.el
+++ b/ghostel.el
@@ -1705,7 +1705,15 @@ Parses the command and arguments, looks up the command in
          (args (cdr parts))
          (entry (assoc command ghostel-eval-cmds)))
     (if entry
-        (apply (cadr entry) args)
+        ;; Catch errors from the dispatched function: this callback runs
+        ;; synchronously inside the native VT parser, so any unhandled
+        ;; error propagates back up through `ghostel--write-input' and
+        ;; crashes the process filter / redraw timer.
+        (condition-case err
+            (apply (cadr entry) args)
+          (error
+           (message "ghostel: error calling %s: %s"
+                    command (error-message-string err))))
       (message "ghostel: unknown eval command %S (add to `ghostel-eval-cmds' to allow)"
                command))))
 
@@ -2269,7 +2277,13 @@ frame after idle to improve interactive responsiveness."
   (when ghostel--pending-output
     (let ((combined (apply #'concat (nreverse ghostel--pending-output))))
       (setq ghostel--pending-output nil)
-      (ghostel--write-input ghostel--term combined))))
+      ;; An OSC 51;E callback dispatched synchronously from the native
+      ;; parser (e.g. `find-file-other-window') can change the current
+      ;; buffer via `select-window'.  Isolate that so callers keep
+      ;; reading buffer-locals — notably `ghostel--term' — from the
+      ;; ghostel buffer after this returns.
+      (save-current-buffer
+        (ghostel--write-input ghostel--term combined)))))
 
 (defun ghostel--delayed-redraw (buffer)
   "Perform the actual redraw in BUFFER."
@@ -2289,7 +2303,16 @@ frame after idle to improve interactive responsiveness."
                 (inhibit-modification-hooks t))
             (ghostel--redraw ghostel--term ghostel-full-redraw))
           (when ghostel--has-wide-chars
-            (ghostel--compensate-wide-chars)))))))
+            (ghostel--compensate-wide-chars))
+          ;; Native redraw updates buffer-point via `goto-char', which
+          ;; only propagates to `window-point' for the selected window.
+          ;; If an OSC 51;E callback moved selection elsewhere (e.g.
+          ;; `find-file-other-window'), the ghostel window's
+          ;; window-point is stale and the terminal cursor will display
+          ;; at the wrong place when the user reselects it.  Sync it.
+          (let ((pt (point)))
+            (dolist (win (get-buffer-window-list buffer nil t))
+              (set-window-point win pt))))))))
 
 (defun ghostel-force-redraw ()
   "Force a full terminal redraw (for debugging)."

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1454,6 +1454,48 @@ rendered by `ghostel--delayed-redraw'.  This is the exact real-world path."
       (should (car messages))
       (should (string-match-p "unknown eval command" (car messages))))))
 
+(ert-deftest ghostel-test-osc51-eval-catches-errors ()
+  "Errors signaled by a dispatched OSC 51;E function must not
+propagate out of `ghostel--osc51-eval' — otherwise they crash the
+process filter / redraw timer that invoked the native parser.
+Regression for a follow-up to #82 where `dow' with no args called
+`dired-other-window' with 0 arguments and signaled up through the
+filter."
+  (let* ((ghostel-eval-cmds
+          `(("boom" ,(lambda (&rest _) (error "kaboom")))))
+         (messages nil))
+    (cl-letf (((symbol-function 'message)
+               (lambda (fmt &rest args) (push (apply #'format fmt args) messages))))
+      ;; Must not raise.
+      (ghostel--osc51-eval "\"boom\"")
+      (should (car messages))
+      (should (string-match-p "error calling boom" (car messages)))
+      (should (string-match-p "kaboom" (car messages))))))
+
+(ert-deftest ghostel-test-flush-pending-output-preserves-buffer ()
+  "Regression for #82: a buffer switch performed by a synchronous
+native callback (as OSC 51;E dispatch does when it calls
+`find-file-other-window') must not leak out of
+`ghostel--flush-pending-output'.  Otherwise callers such as
+`ghostel--delayed-redraw' read `ghostel--term' from the wrong
+buffer and hand nil to the native module."
+  (let ((ghostel-buf (generate-new-buffer " *ghostel-test-flush-buf*"))
+        (other-buf (generate-new-buffer " *ghostel-test-flush-other*")))
+    (unwind-protect
+        (with-current-buffer ghostel-buf
+          (setq-local ghostel--term 'fake-handle)
+          (setq-local ghostel--pending-output (list "payload"))
+          (cl-letf (((symbol-function 'ghostel--write-input)
+                     (lambda (_term _data)
+                       ;; Simulate `find-file-other-window' flipping
+                       ;; the current buffer via `select-window'.
+                       (set-buffer other-buf))))
+            (ghostel--flush-pending-output))
+          (should (eq (current-buffer) ghostel-buf))
+          (should (null ghostel--pending-output)))
+      (kill-buffer ghostel-buf)
+      (kill-buffer other-buf))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: copy-mode cursor visibility
 ;; -----------------------------------------------------------------------
@@ -2496,6 +2538,8 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-apply-palette-default-colors
     ghostel-test-osc51-eval
     ghostel-test-osc51-eval-unknown
+    ghostel-test-osc51-eval-catches-errors
+    ghostel-test-flush-pending-output-preserves-buffer
     ghostel-test-copy-mode-cursor
     ghostel-test-copy-mode-hl-line
     ghostel-test-project-buffer-name


### PR DESCRIPTION
## Summary

Three fixes for #82, all stemming from the fact that `ghostel--osc51-eval` is dispatched synchronously from the native VT parser inside `fnWriteInput` — anything the whitelisted callback does (or any error it signals) unwinds back through `ghostel--write-input` into the caller that drove the flush:

- **Buffer leak.** `find-file-other-window` / `dired-other-window` call `select-window` on the new window, which flips `current-buffer` as a side effect. Control returns mid-`with-current-buffer` inside `ghostel--delayed-redraw`, subsequent statements read `ghostel--term` from the wrong buffer (nil), and the native module signals \`Wrong type argument: user-ptrp, nil\`. Fixed by wrapping the \`ghostel--write-input\` call inside \`ghostel--flush-pending-output\` with \`save-current-buffer\` — single site, protects every caller (delayed-redraw, filter color-query fast path, \`ghostel-clear\`, \`ghostel-clear-scrollback\`, sentinel). User-visible window selection still sticks because \`save-current-buffer\` only restores the elisp current buffer, not \`selected-window\`.
- **Unhandled errors.** \`dow\` with no args ran \`dired-other-window\` with zero arguments, which signals \`Wrong number of arguments\` and crashes the filter/timer the same way. Wrapped the \`apply\` in \`ghostel--osc51-eval\` with \`condition-case\` so any error a whitelisted function raises is reported via \`message\` instead of escaping up through the native parser. Also updated the README's \`dow()\` example to default to \`\${1:-\$PWD}\` so the bare invocation does the sensible thing.
- **Stale window-point.** After \`find-file-other-window\` deselected the ghostel window, the native redraw updated \`buffer-point\` via \`goto-char\` but \`window-point\` only propagates for the *selected* window — so when the user switched back, the terminal cursor displayed at a stale position. Fixed by pushing the post-redraw \`(point)\` into every window showing the buffer via \`set-window-point\` at the end of \`ghostel--delayed-redraw\`.

## Test plan

- [x] \`emacs --batch -Q -L . -l test/ghostel-test.el -f ghostel-test-run-elisp\` — 56/56 pass (2 new regression tests added)
- [x] \`make lint\` — clean
- [x] \`zig build check\` — clean (no Zig changes but sanity)
- [x] New regression test \`ghostel-test-flush-pending-output-preserves-buffer\` verified to fail on \`main\` and pass with the fix (stashed \`ghostel.el\`, recompiled, reran)
- [x] Manual smoke in a live ghostel session: \`e README.md\` and \`dow .\` should open the target and leave \`*Messages*\` clean, and switching back to the ghostel window should leave the terminal cursor at the latest prompt position, not a stale one

New tests:

- \`ghostel-test-flush-pending-output-preserves-buffer\` — stubs \`ghostel--write-input\` via \`cl-letf\` to \`set-buffer\` on another buffer (simulating \`find-file-other-window\`'s \`select-window\` side effect) and asserts the flush restores the ghostel buffer and clears \`ghostel--pending-output\`.
- \`ghostel-test-osc51-eval-catches-errors\` — dispatches a whitelisted lambda that raises, asserts the error is messaged and does not propagate out of \`ghostel--osc51-eval\`.