### PR TITLE
Add ghostel-enable-title-tracking defcustom

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -173,6 +173,12 @@ aggressive partial screen updates, but may use more CPU."
   "Default buffer name for ghostel terminals."
   :type 'string)
 
+(defcustom ghostel-enable-title-tracking t
+  "Automatically rename the buffer when the terminal title changes.
+When non-nil, OSC 2 title sequences update the buffer name to
+\"*ghostel: TITLE*\".  Set to nil to keep the buffer name fixed."
+  :type 'boolean)
+
 (defcustom ghostel-kill-buffer-on-exit t
   "Kill the buffer when the shell process exits."
   :type 'boolean)
@@ -1629,10 +1635,12 @@ This ensures terminal text is visible regardless of the Emacs theme."
 
 (defun ghostel--set-title (title)
   "Update the buffer name with TITLE from the terminal.
-Do not overwrite a manual buffer rename."
-  (let ((new-name (format "*ghostel: %s*" title)))
-    (when (or (null ghostel--managed-buffer-name)
-              (equal (buffer-name) ghostel--managed-buffer-name))
+Only acts when `ghostel-enable-title-tracking' is non-nil and the
+buffer has not been manually renamed by the user."
+  (when (and ghostel-enable-title-tracking
+             (or (null ghostel--managed-buffer-name)
+                 (equal (buffer-name) ghostel--managed-buffer-name)))
+    (let ((new-name (format "*ghostel: %s*" title)))
       (rename-buffer new-name t)
       ;; Keep the actual name because `rename-buffer' may uniquify it.
       (setq ghostel--managed-buffer-name (buffer-name)))))

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -553,6 +553,28 @@ than the full terminal `cols'."
       (when (buffer-live-p buf)
         (kill-buffer buf)))))
 
+(ert-deftest ghostel-test-title-tracking-disabled ()
+  "Test that title updates are ignored when `ghostel-enable-title-tracking' is nil."
+  (let (buf)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--new)
+                   (lambda (&rest _args) 'fake-term))
+                  ((symbol-function 'ghostel--apply-palette)
+                   (lambda (&rest _args) nil))
+                  ((symbol-function 'ghostel--start-process)
+                   (lambda () nil)))
+          (let ((ghostel--buffer-counter 0)
+                (ghostel-enable-title-tracking nil))
+            (ghostel)
+            (setq buf (current-buffer))
+            (with-current-buffer buf
+              (should (equal "*ghostel*" (buffer-name)))
+              (ghostel--set-title "Ignored Title")
+              (should (equal "*ghostel*" (buffer-name)))
+              (should (equal "*ghostel*" ghostel--managed-buffer-name)))))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: CRLF normalization in Zig
 ;; -----------------------------------------------------------------------
@@ -2628,6 +2650,7 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-module-version-mismatch
     ghostel-test-module-version-newer-than-minimum
     ghostel-test-title-does-not-overwrite-manual-rename
+    ghostel-test-title-tracking-disabled
     ghostel-test-immediate-redraw-triggers-on-small-echo
     ghostel-test-immediate-redraw-skips-large-output
     ghostel-test-immediate-redraw-skips-stale-send


### PR DESCRIPTION
## Summary
- Add `ghostel-enable-title-tracking` defcustom (default `t`) to control whether OSC 2 title sequences rename the buffer
- When set to `nil`, the buffer keeps its original `ghostel-buffer-name` instead of being renamed to `*ghostel: TITLE*`
- The Zig callback still fires (cheap no-op) so `ghostel--get-title` remains usable for programmatic access

## Test plan
- [x] New `ghostel-test-title-tracking-disabled` test verifies buffer name stays fixed when the option is nil
- [x] All 56 Elisp tests pass
- [x] Byte-compile and lint clean