### PR TITLE
Defer buffer erasure on resize to eliminate blank flash

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -2218,8 +2218,23 @@ interrupted by live output updating the terminal cursor."
           ;; `find-file-other-window'), the ghostel window's
           ;; window-point is stale and the terminal cursor will display
           ;; at the wrong place when the user reselects it.  Sync it.
-          (let ((pt (point)))
+          ;;
+          ;; Also anchor window-start to the viewport origin when point
+          ;; is in the viewport.  Without this, a resize (which erases
+          ;; and rebuilds the buffer inside redraw) leaves window-start
+          ;; clamped to 1 and Emacs's auto-scroll produces a visible
+          ;; jump.  Skip the anchor when point is in scrollback so that
+          ;; users reading history are not yanked back to the bottom.
+          (let* ((pt (point))
+                 (tr (or ghostel--term-rows 0))
+                 (vs (when (> tr 0)
+                       (save-excursion
+                         (goto-char (point-max))
+                         (forward-line (- (1- tr)))
+                         (line-beginning-position)))))
             (dolist (win (get-buffer-window-list buffer nil t))
+              (when (and vs (>= pt vs))
+                (set-window-start win vs t))
               (set-window-point win pt))))))))
 
 (defun ghostel-force-redraw ()
@@ -2254,7 +2269,12 @@ PROCESS is the shell process, WINDOWS is the list of windows."
           (ghostel--set-size ghostel--term (max 1 height) (max 1 width))
           (setq ghostel--term-rows height)
           (setq ghostel--force-next-redraw t)
-          (ghostel--invalidate))))
+          ;; Redraw synchronously so the buffer is updated before
+          ;; Emacs displays the stale content at the new window size.
+          (when ghostel--redraw-timer
+            (cancel-timer ghostel--redraw-timer)
+            (setq ghostel--redraw-timer nil))
+          (ghostel--delayed-redraw buffer))))
     ;; Return size — Emacs calls set-process-window-size (SIGWINCH)
     ;; after this function returns, matching eat/vterm timing.
     size))

--- a/src/module.zig
+++ b/src/module.zig
@@ -486,9 +486,9 @@ fn fnSetSize(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*any
         env.signalError("ghostel: resize failed");
         return env.nil();
     };
-    // Reflow invalidates the materialized scrollback region — wipe the
-    // buffer so the next full redraw rebuilds it from libghostty state.
-    env.eraseBuffer();
+    // Reflow invalidates the materialized scrollback — terminal.resize()
+    // sets resize_pending so the next redraw() erases and rebuilds under
+    // inhibit-redisplay, avoiding a visible blank frame.
 
     return env.nil();
 }

--- a/src/render.zig
+++ b/src/render.zig
@@ -781,6 +781,17 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
         return;
     }
 
+    // ---- Deferred resize buffer reset ----------------------------------------
+    // terminal.resize() sets resize_pending instead of immediately erasing the
+    // buffer, so the old frame stays visible until this redraw replaces it
+    // (the caller binds inhibit-redisplay around us).  Erase now and force a
+    // full rebuild of scrollback + viewport.
+    if (term.resize_pending) {
+        env.eraseBuffer();
+        term.resize_pending = false;
+        force_full = true;
+    }
+
     // Resolve default colors once — used for both the scrollback append
     // path and the viewport render path.
     var default_fg = gt.ColorRgb{ .r = 204, .g = 204, .b = 204 };

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -42,6 +42,13 @@ scrollback_in_buffer: usize = 0,
 /// activity" from "writes happened but total_rows plateaued".
 wrote_since_redraw: bool = false,
 
+/// Set by `resize`, cleared at the start of `redraw`. When true, the
+/// next redraw will erase the buffer and force a full rebuild.  This
+/// defers the buffer erasure from the synchronous resize call (which
+/// would leave the buffer visibly empty until the timer-driven redraw)
+/// into the redraw pass where `inhibit-redisplay` prevents flicker.
+resize_pending: bool = false,
+
 /// Hash of the first scrollback row's content, sampled at the end of
 /// each redraw that touched scrollback. Used to detect rotation
 /// (libghostty evicting the oldest row in lockstep with new ones being
@@ -207,8 +214,9 @@ pub fn vtWrite(self: *Self, data: []const u8) void {
 ///
 /// Resets `scrollback_in_buffer` because libghostty reflows wrapped rows
 /// on resize and the row count above the viewport no longer matches what
-/// we have in the Emacs buffer. The caller is responsible for erasing the
-/// buffer so the next redraw rebuilds scrollback from scratch.
+/// we have in the Emacs buffer.  Sets `resize_pending` so the next
+/// `redraw()` erases the buffer under `inhibit-redisplay` and rebuilds
+/// scrollback from scratch — avoiding a visible blank frame.
 pub fn resize(self: *Self, cols: u16, rows: u16) !void {
     if (gt.c.ghostty_terminal_resize(self.terminal, cols, rows, 1, 1) != gt.SUCCESS) {
         return error.ResizeFailed;
@@ -217,6 +225,7 @@ pub fn resize(self: *Self, cols: u16, rows: u16) !void {
     self.rows = rows;
     self.scrollback_in_buffer = 0;
     self.first_scrollback_row_hash = 0;
+    self.resize_pending = true;
 }
 
 /// Scroll the viewport.

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1448,6 +1448,94 @@ for new size inside BSU/ESU → verify buffer shows new content."
       (kill-buffer buf))))
 
 ;; -----------------------------------------------------------------------
+;; Test: resize preserves old frame until redraw replaces it
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-resize-no-blank-flash ()
+  "Buffer keeps old content after resize; redraw replaces it atomically.
+Regression test: fnSetSize used to call erase-buffer synchronously,
+leaving the buffer visibly empty until the next timer-driven redraw.
+Now the erasure is deferred into redraw() under inhibit-redisplay."
+  (let ((buf (generate-new-buffer " *ghostel-test-resize-no-blank*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 10 40 100))
+                 (ghostel--term term)
+                 (ghostel--term-rows 10)
+                 (inhibit-read-only t))
+            ;; Fill the viewport with identifiable content.
+            (dotimes (i 10)
+              (ghostel--write-input term (format "LINE-%02d\r\n" i)))
+            (ghostel--redraw term t)
+            (let ((pre-content (buffer-substring-no-properties
+                                (point-min) (point-max))))
+              (should (string-match-p "LINE-00" pre-content))
+              (should (string-match-p "LINE-09" pre-content))
+
+              ;; Resize — old content must survive in the buffer.
+              (ghostel--set-size term 6 40)
+              (setq ghostel--term-rows 6)
+              (let ((mid-content (buffer-substring-no-properties
+                                  (point-min) (point-max))))
+                (should (> (length mid-content) 0))
+                (should (string-match-p "LINE-" mid-content)))
+
+              ;; Redraw rebuilds the buffer from the new terminal state.
+              (ghostel--redraw term t)
+              (let ((post-content (buffer-substring-no-properties
+                                   (point-min) (point-max))))
+                (should (> (length post-content) 0))
+                ;; Viewport should have the new row count; extra lines
+                ;; above are scrollback from the old viewport rows.
+                (should (>= (count-lines (point-min) (point-max)) 6))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-resize-redraw-anchors-window-start ()
+  "After resize + redraw, window-start is at the viewport origin.
+Without explicit anchoring, erase+rebuild inside redraw() clamps
+window-start to 1 (top of scrollback), causing a visible jump when
+Emacs auto-scrolls to make point visible."
+  (let ((buf (generate-new-buffer " *ghostel-test-resize-anchor*"))
+        (orig-buf (window-buffer (selected-window))))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 10 40 200))
+                 (ghostel--term term)
+                 (ghostel--term-rows 10)
+                 (ghostel--force-next-redraw nil)
+                 (inhibit-read-only t))
+            ;; Build up scrollback so the viewport is not at buffer start.
+            (dotimes (i 30)
+              (ghostel--write-input term (format "scroll-%02d\r\n" i)))
+            (ghostel--write-input term "prompt> ")
+            (ghostel--redraw term t)
+            (should (> (line-number-at-pos (point-max)) 10))
+
+            ;; Display in a real window so we can test window-start.
+            (set-window-buffer (selected-window) buf)
+
+            ;; Resize + redraw via delayed-redraw (simulates the real path).
+            (ghostel--set-size term 6 40)
+            (setq ghostel--term-rows 6)
+            (setq ghostel--force-next-redraw t)
+            (ghostel--delayed-redraw buf)
+
+            ;; window-start should be at the viewport, not at buffer start.
+            (let* ((ws (window-start (selected-window)))
+                   (wp (window-point (selected-window)))
+                   (vp-start (save-excursion
+                               (goto-char (point-max))
+                               (forward-line -5)
+                               (line-beginning-position))))
+              (should (= ws vp-start))
+              (should (>= wp vp-start)))))
+      (when (buffer-live-p orig-buf)
+        (set-window-buffer (selected-window) orig-buf))
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
 ;; Test: resize with real process — verify PTY and buffer content
 ;; -----------------------------------------------------------------------
 
@@ -2398,12 +2486,12 @@ ncurses apps like htop at start-up size and breaks live resize."
     (let ((ghostel--term 'fake)
           (ghostel--force-next-redraw nil)
           (set-size-args nil)
-          (invalidate-called nil))
+          (redraw-called nil))
       (let ((cur-buf (current-buffer)))
         (cl-letf (((symbol-function 'ghostel--set-size)
                    (lambda (_term h w) (setq set-size-args (list h w))))
-                  ((symbol-function 'ghostel--invalidate)
-                   (lambda () (setq invalidate-called t)))
+                  ((symbol-function 'ghostel--delayed-redraw)
+                   (lambda (_buf) (setq redraw-called t)))
                   ((symbol-function 'process-buffer)
                    (lambda (_proc) cur-buf))
                   ((default-value 'window-adjust-process-window-size-function)
@@ -2413,7 +2501,7 @@ ncurses apps like htop at start-up size and breaks live resize."
             (should (equal '(120 . 40) result))
             (should (equal '(40 120) set-size-args))
             (should ghostel--force-next-redraw)
-            (should invalidate-called)))))))
+            (should redraw-called)))))))
 
 (ert-deftest ghostel-test-resize-nil-size ()
   "When default function returns nil, no resize happens."
@@ -2564,7 +2652,7 @@ while :; do sleep 0.1; done'\n")
             (let ((ghostel--term 'fake-term))
               (cl-letf (((symbol-function 'ghostel--set-size)
                          (lambda (_t _h _w) nil))
-                        ((symbol-function 'ghostel--invalidate) #'ignore)
+                        ((symbol-function 'ghostel--delayed-redraw) #'ignore)
                         ((default-value 'window-adjust-process-window-size-function)
                          (lambda (_p _w) (cons 120 30))))
                 ;; Invoke the handler as Emacs would.


### PR DESCRIPTION
## Summary

- `fnSetSize` used to call `erase-buffer` synchronously during resize, leaving the buffer visibly empty for ~16ms until the timer-driven redraw rebuilt it
- Move the erasure into `redraw()` where it runs under `inhibit-redisplay`, so the old frame stays visible until the new one atomically replaces it
- `terminal.resize()` now sets a `resize_pending` flag; `redraw()` checks it and does erase + full rebuild in one pass

## Test plan

- [x] `zig build check` compiles cleanly
- [x] `make all` passes (101 tests + 30 evil tests + byte-compile + lint)
- [x] Manual: resize Emacs frame with active terminal — no visible blank flash
- [x] Manual: pop open minibuffer during Claude Code session — no scrollback jump

Ref: #85