### PR TITLE
Use _get_multi for render state queries and add VT log callback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ELC := ghostel.elc ghostel-debug.elc
 all: build test-all test-evil lint
 
 build:
-	zig build
+	zig build -Doptimize=ReleaseFast -Dcpu=baseline
 
 # Pattern rule: rebuild .elc whenever its .el source is newer.
 # Make's timestamp tracking keeps the byte-compiled files in sync, so

--- a/ghostel-debug.el
+++ b/ghostel-debug.el
@@ -45,6 +45,8 @@
   (advice-add 'ghostel--filter :before #'ghostel-debug--log-filter)
   (advice-add 'ghostel--send-key :before #'ghostel-debug--log-send)
   (advice-add 'ghostel--send-encoded :before #'ghostel-debug--log-encoded)
+  (when (fboundp 'ghostel--enable-vt-log)
+    (ghostel--enable-vt-log))
   (message "ghostel-debug: logging started, check *ghostel-debug* buffer"))
 
 (defun ghostel-debug-stop ()
@@ -53,7 +55,21 @@
   (advice-remove 'ghostel--filter #'ghostel-debug--log-filter)
   (advice-remove 'ghostel--send-key #'ghostel-debug--log-send)
   (advice-remove 'ghostel--send-encoded #'ghostel-debug--log-encoded)
+  (when (fboundp 'ghostel--disable-vt-log)
+    (ghostel--disable-vt-log))
   (message "ghostel-debug: logging stopped"))
+
+(defun ghostel--debug-log-vt (level scope message)
+  "Log a libghostty-vt internal message.
+LEVEL is the severity (error/warning/info/debug).
+SCOPE is the subsystem name.  MESSAGE is the log text.
+Called from the native module's log callback."
+  (when ghostel-debug--log-buffer
+    (with-current-buffer ghostel-debug--log-buffer
+      (goto-char (point-max))
+      (insert (format "[%s] VT [%s](%s): %s\n"
+                      (format-time-string "%T.%3N")
+                      level scope message)))))
 
 (defun ghostel-debug--log-filter (_proc output)
   "Log process filter call with OUTPUT length and preview.

--- a/ghostel.el
+++ b/ghostel.el
@@ -459,8 +459,7 @@ Runs synchronously and returns non-nil on success."
     (message "ghostel: compiling native module with zig build (this may take a moment)...")
     (condition-case err
         (let ((ret (process-file "zig" nil "*ghostel-build*" nil
-                                 "build" "-Doptimize=ReleaseFast"
-                                 "-Dcpu=baseline")))
+                                 "build" "-Doptimize=ReleaseFast" "-Dcpu=baseline")))
           (if (eq ret 0)
               (progn (message "ghostel: native module compiled successfully") t)
             (display-warning 'ghostel

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -313,6 +313,7 @@ pub const Sym = struct {
     @"ghostel--osc133-marker": Value,
     @"ghostel--flush-output": Value,
     @"ghostel--set-title": Value,
+    @"ghostel--debug-log-vt": Value,
     ding: Value,
 };
 

--- a/src/module.zig
+++ b/src/module.zig
@@ -49,6 +49,8 @@ export fn emacs_module_init(runtime: *c.struct_emacs_runtime) callconv(.c) c_int
     env.bindFunction("ghostel--debug-feed", 2, 2, &fnDebugFeed, "Feed STR to terminal and return first row + cursor.\n\n(ghostel--debug-feed TERM STR)");
     env.bindFunction("ghostel--copy-all-text", 1, 1, &fnCopyAllText, "Return entire scrollback as plain text string.\n\n(ghostel--copy-all-text TERM)");
     env.bindFunction("ghostel--module-version", 0, 0, &fnModuleVersion, "Return the native module version string.\n\n(ghostel--module-version)");
+    env.bindFunction("ghostel--enable-vt-log", 0, 0, &fnEnableVtLog, "Enable libghostty internal log routing to *ghostel-debug*.\n\n(ghostel--enable-vt-log)");
+    env.bindFunction("ghostel--disable-vt-log", 0, 0, &fnDisableVtLog, "Disable libghostty internal log routing.\n\n(ghostel--disable-vt-log)");
 
     emacs.initSymbols(env);
     env.provide("ghostel-module");
@@ -133,9 +135,13 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
         return env.nil();
     }
 
-    // Stash env for callbacks
+    // Stash env for callbacks (and for the VT log callback)
     term.env = env;
     defer term.env = null;
+    if (vt_log_active) {
+        vt_log_env = env;
+        defer vt_log_env = null;
+    }
 
     // Normalize CRLF: Emacs PTYs lack ONLCR, so bare \n arrives
     // without \r.  Insert \r before every bare \n.
@@ -522,6 +528,10 @@ fn fnRedraw(raw_env: ?*c.emacs_env, nargs: isize, args: [*c]c.emacs_value, _: ?*
     const env = emacs.Env.init(raw_env.?);
     const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
     const force_full = nargs > 1 and env.isNotNil(args[1]);
+    if (vt_log_active) {
+        vt_log_env = env;
+        defer vt_log_env = null;
+    }
     render.redraw(env, term, force_full);
     return env.nil();
 }
@@ -989,4 +999,82 @@ fn titleChangedCallback(_: gt.Terminal, userdata: ?*anyopaque) callconv(.c) void
     if (term.getTitle()) |title| {
         _ = env.call1(emacs.sym.@"ghostel--set-title", env.makeString(title));
     }
+}
+
+// ---------------------------------------------------------------------------
+// libghostty log callback
+// ---------------------------------------------------------------------------
+
+/// Global Emacs env stashed during any Elisp→Zig call where logging is
+/// active.  Only valid on the main thread while a Zig function is
+/// executing; set to null at all other times.
+///
+/// Thread safety: the GhosttySysLogFn contract requires thread safety,
+/// but ghostel only drives libghostty from Emacs's main thread, so the
+/// callback always fires on the same thread that stashed the env.  If
+/// libghostty ever uses background threads, this would need a mutex or
+/// a lock-free message queue.
+var vt_log_env: ?emacs.Env = null;
+
+/// Log callback matching GhosttySysLogFn.  Formats the message and
+/// forwards it to `ghostel--debug-log-vt' in Elisp.
+fn vtLogCallback(
+    _: ?*anyopaque,
+    level: gt.c.GhosttySysLogLevel,
+    scope: [*c]const u8,
+    scope_len: usize,
+    message: [*c]const u8,
+    message_len: usize,
+) callconv(.c) void {
+    const env = vt_log_env orelse return;
+    const level_str: []const u8 = switch (level) {
+        gt.c.GHOSTTY_SYS_LOG_LEVEL_ERROR => "error",
+        gt.c.GHOSTTY_SYS_LOG_LEVEL_WARNING => "warning",
+        gt.c.GHOSTTY_SYS_LOG_LEVEL_INFO => "info",
+        gt.c.GHOSTTY_SYS_LOG_LEVEL_DEBUG => "debug",
+        else => "unknown",
+    };
+    const scope_slice: []const u8 = if (scope_len > 0) scope[0..scope_len] else "default";
+    const msg_slice: []const u8 = if (message_len > 0) message[0..message_len] else "";
+
+    _ = env.call3(
+        emacs.sym.@"ghostel--debug-log-vt",
+        env.makeString(level_str),
+        env.makeString(scope_slice),
+        env.makeString(msg_slice),
+    );
+
+    // If the Elisp call signaled an error (e.g. ghostel--debug-log-vt is
+    // void-function because ghostel-debug.el isn't loaded), clear it so it
+    // doesn't leak into the calling context and disable logging to prevent
+    // repeated errors.
+    if (env.nonLocalExitCheck() != c.emacs_funcall_exit_return) {
+        env.nonLocalExitClear();
+        _ = gt.c.ghostty_sys_set(gt.c.GHOSTTY_SYS_OPT_LOG, null);
+        vt_log_active = false;
+    }
+}
+
+/// Whether the VT log callback is installed.
+var vt_log_active: bool = false;
+
+/// (ghostel--enable-vt-log)
+fn fnEnableVtLog(raw_env: ?*c.emacs_env, _: isize, _: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
+    const env = emacs.Env.init(raw_env.?);
+    if (!vt_log_active) {
+        const cb: gt.c.GhosttySysLogFn = &vtLogCallback;
+        _ = gt.c.ghostty_sys_set(gt.c.GHOSTTY_SYS_OPT_LOG, @ptrCast(cb));
+        vt_log_active = true;
+    }
+    return env.t();
+}
+
+/// (ghostel--disable-vt-log)
+fn fnDisableVtLog(raw_env: ?*c.emacs_env, _: isize, _: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
+    const env = emacs.Env.init(raw_env.?);
+    if (vt_log_active) {
+        _ = gt.c.ghostty_sys_set(gt.c.GHOSTTY_SYS_OPT_LOG, null);
+        vt_log_active = false;
+    }
+    return env.t();
 }

--- a/src/render.zig
+++ b/src/render.zig
@@ -857,11 +857,21 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
     }
 
     // Resolve default colors once — used for both the scrollback append
-    // path and the viewport render path.
+    // path and the viewport render path.  These always succeed (the
+    // render state always has resolved default colors), so batching is safe.
     var default_fg = gt.ColorRgb{ .r = 204, .g = 204, .b = 204 };
     var default_bg = gt.ColorRgb{ .r = 0, .g = 0, .b = 0 };
-    _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_COLOR_FOREGROUND, @ptrCast(&default_fg));
-    _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_COLOR_BACKGROUND, @ptrCast(&default_bg));
+    {
+        const color_keys = [_]gt.c.GhosttyRenderStateData{
+            gt.RS_DATA_COLOR_FOREGROUND,
+            gt.RS_DATA_COLOR_BACKGROUND,
+        };
+        var color_values = [_]?*anyopaque{
+            @ptrCast(&default_fg),
+            @ptrCast(&default_bg),
+        };
+        _ = gt.c.ghostty_render_state_get_multi(term.render_state, color_keys.len, &color_keys, @ptrCast(&color_values), null);
+    }
 
     // ---- Scrollback rotation detection ------------------------------------
     // When libghostty's scrollback is at its byte cap, sustained writes
@@ -1115,7 +1125,6 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
             const row_start = env.extractInteger(env.point());
             insertAndStyle(env, &text_buf, content, &runs, run_count, default_fg, default_bg);
 
-            // Mark prompt portion so Elisp navigation can find it
             // Mark prompt portion (cell-level boundary), or entire row (row-level fallback).
             if (content.prompt_char_len > 0) {
                 env.putTextProperty(
@@ -1186,7 +1195,24 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
         }
     }
 
-    // Position cursor (viewport-relative row -> absolute line)
+    // Batch-fetch cursor style/visibility (always available).
+    var cursor_visible: bool = true;
+    var cursor_style: c_int = gt.CURSOR_BLOCK;
+    {
+        const cursor_keys = [_]gt.c.GhosttyRenderStateData{
+            gt.RS_DATA_CURSOR_VISIBLE,
+            gt.RS_DATA_CURSOR_VISUAL_STYLE,
+        };
+        var cursor_values = [_]?*anyopaque{
+            @ptrCast(&cursor_visible),
+            @ptrCast(&cursor_style),
+        };
+        _ = gt.c.ghostty_render_state_get_multi(term.render_state, cursor_keys.len, &cursor_keys, @ptrCast(&cursor_values), null);
+    }
+
+    // Position cursor (viewport-relative row -> absolute line).
+    // X/Y are only valid when HAS_VALUE is true, so query separately
+    // to avoid stopping the style batch above on NO_VALUE.
     var cursor_has_value: bool = false;
     _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_CURSOR_VIEWPORT_HAS_VALUE, @ptrCast(&cursor_has_value));
     if (cursor_has_value) {
@@ -1201,13 +1227,6 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
             env.moveToColumn(@as(i64, cx));
         }
     }
-
-    // Update cursor style
-    var cursor_visible: bool = true;
-    _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_CURSOR_VISIBLE, @ptrCast(&cursor_visible));
-
-    var cursor_style: c_int = gt.CURSOR_BLOCK;
-    _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_CURSOR_VISUAL_STYLE, @ptrCast(&cursor_style));
 
     _ = env.call2(
         emacs.sym.@"ghostel--set-cursor-style",


### PR DESCRIPTION
## Summary

- Batch default-color and cursor-style render state queries into `ghostty_render_state_get_multi` calls (2 keys each), taking advantage of the new batched query API in libghostty
- Add a log callback that routes libghostty internal log messages through the `*ghostel-debug*` buffer when `ghostel-debug-start` is active, via `ghostty_sys_set(GHOSTTY_SYS_OPT_LOG, callback)`
- Fix `make build` to pass `-Doptimize=ReleaseFast -Dcpu=baseline` so that `make all` produces a release binary

## Notes

Cell-level and row-level `_get_multi` batching was explored but reverted:
- `FG_COLOR`/`BG_COLOR` return `NO_VALUE` for default-colored cells, stopping the batch before `STYLE` is fetched
- `ROW_DATA_CELLS` populates a pre-allocated handle rather than writing a new one, requiring `&term.row_cells` instead of a local variable
- Benchmarks showed no measurable performance gain from batching (FFI overhead between statically-linked Zig functions is negligible)
- The render-state-level batches (colors, cursor) are kept as clean groupings of always-succeeding queries

## Test plan

- [x] `make all` passes (105 native tests, 30 evil tests, lint)
- [x] Manual test: `ghostel-debug-start`, verify VT log messages appear in `*ghostel-debug*`
- [x] Manual test: verify no performance regression with `find` or similar rapid-output commands