### PR TITLE
Disable XON/XOFF flow control so C-q and C-s reach the shell

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -1961,7 +1961,7 @@ Returns nil on failure."
                                           "fi\n"
                                           integration))
              (list :env nil :args (list "--rcfile" path)
-                   :stty "erase '^?' iutf8 echo" :temp-files (list temp))))
+                   :stty "erase '^?' iutf8 -ixon echo" :temp-files (list temp))))
           ;; Zsh: ZDOTDIR replaces .zshenv search, so we restore it,
           ;; source the user's .zshenv, then load integration.
           ('zsh
@@ -1990,7 +1990,7 @@ Returns nil on failure."
                                           "    'builtin' 'unset' '_ghostel_file'\n"
                                           "}\n"))
              (list :env (list (format "ZDOTDIR=%s" remote-dir))
-                   :args nil :stty "erase '^?' iutf8"
+                   :args nil :stty "erase '^?' iutf8 -ixon"
                    :temp-dirs (list temp-dir))))
           ;; Fish: -C runs after config, so just source the script.
           ('fish
@@ -2001,7 +2001,7 @@ Returns nil on failure."
              (list :env nil
                    :args (list "-C" (format "source %s"
                                             (shell-quote-argument path)))
-                   :stty "erase '^?' iutf8" :temp-files (list temp))))))
+                   :stty "erase '^?' iutf8 -ixon" :temp-files (list temp))))))
     (error
      (message "ghostel: remote shell integration failed: %s"
               (error-message-string err))
@@ -2082,6 +2082,9 @@ on the remote host."
          ;;    whether \x7f means backspace.
          ;;  - iutf8: kernel-level UTF-8 awareness so backspace
          ;;    correctly erases multi-byte characters.
+         ;;  - -ixon: disable XON/XOFF flow control so C-q and C-s
+         ;;    pass through to the application instead of being
+         ;;    swallowed by the PTY line discipline.
          ;;  - echo: bash-only — readline buffers its own echo, so
          ;;    we need PTY-level echo.  When bash integration is
          ;;    active, the integration script handles echo.
@@ -2098,8 +2101,8 @@ on the remote host."
                        (plist-get remote-integration :stty))
                       ((and (eq (ghostel--detect-shell shell) 'bash)
                             (not integration-env))
-                       "erase '^?' iutf8 echo")
-                      (t "erase '^?' iutf8")))
+                       "erase '^?' iutf8 -ixon echo")
+                      (t "erase '^?' iutf8 -ixon")))
          (shell-command
           (list "/bin/sh" "-c"
                 (concat "stty " stty-flags

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -2630,6 +2630,7 @@ ncurses apps like htop at start-up size and breaks live resize."
                 (should (equal '("/bin/sh" "-c") (seq-take cmd 2)))
                 (should (string-match-p "stty .* rows 43 columns 137"
                                         (nth 2 cmd)))
+                (should (string-match-p "-ixon" (nth 2 cmd)))
                 (should-not (seq-some (lambda (s) (string-prefix-p "LINES=" s))
                                       captured-env))
                 (should-not (seq-some (lambda (s) (string-prefix-p "COLUMNS=" s))
@@ -2721,8 +2722,9 @@ is broken on this system."
           ;; Install a SIGWINCH trap that prints a marker to stdout.
           (process-send-string
            proc "trap 'printf \"__WINCH__\\n\"' WINCH\n")
-          ;; Wait a bit for shell to consume the trap command.
-          (sleep-for 0.3)
+          ;; Wait for shell to start and consume the trap command.
+          ;; Bash with readline needs more startup time than /bin/sh.
+          (sleep-for 0.5)
           ;; Clear output so we only see post-resize output.
           (setq output "")
           ;; Now trigger a resize — this is what Emacs does after


### PR DESCRIPTION
## Summary
- Add `-ixon` to all stty flag strings (local and remote) to disable XON/XOFF flow control on the PTY, allowing C-q and C-s to pass through to the shell
- Bump sleep in bare-bash SIGWINCH test from 0.3s to 0.5s for reliable bash/readline startup

## Test plan
- [x] `make all` passes (110/110 tests, build, lint)
- [x] Launch `M-x ghostel`, run `cat`, press C-q → should see `^Q`
- [x] Press C-s → should see `^S`