### PR TITLE
Remove dead scroll commands and add C-c C-l to copy mode

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -397,9 +397,7 @@ Bump this only when the Elisp code requires a newer native module
 (declare-function ghostel--mouse-event "ghostel-module")
 (declare-function ghostel--new "ghostel-module")
 (declare-function ghostel--redraw "ghostel-module" (term &optional full))
-(declare-function ghostel--scroll "ghostel-module")
 (declare-function ghostel--scroll-bottom "ghostel-module")
-(declare-function ghostel--scroll-top "ghostel-module")
 (declare-function ghostel--set-default-colors "ghostel-module")
 (declare-function ghostel--set-palette "ghostel-module")
 (declare-function ghostel--set-size "ghostel-module")
@@ -1129,15 +1127,6 @@ scroll event to the running application instead."
   (unless (ghostel--forward-scroll-event event 5) ; button 5 = scroll down
     (scroll-up 3)))
 
-(defun ghostel-copy-mode-scroll-up ()
-  "Scroll the Emacs window up by a page in copy mode."
-  (interactive)
-  (scroll-down-command))
-
-(defun ghostel-copy-mode-scroll-down ()
-  "Scroll the Emacs window down by a page in copy mode."
-  (interactive)
-  (scroll-up-command))
 
 (defun ghostel-copy-mode-previous-line ()
   "Move to the previous line in copy mode."
@@ -1256,14 +1245,13 @@ scroll event to the running application instead."
     (define-key map (kbd "<mouse-5>")       #'ghostel--scroll-down)
     (define-key map (kbd "<wheel-up>")      #'ghostel--scroll-up)
     (define-key map (kbd "<wheel-down>")    #'ghostel--scroll-down)
-    (define-key map (kbd "M-v")             #'ghostel-copy-mode-scroll-up)
-    (define-key map (kbd "C-v")             #'ghostel-copy-mode-scroll-down)
     (define-key map (kbd "C-n")             #'ghostel-copy-mode-next-line)
     (define-key map (kbd "C-p")             #'ghostel-copy-mode-previous-line)
     (define-key map (kbd "M-<")             #'ghostel-copy-mode-beginning-of-buffer)
     (define-key map (kbd "M->")             #'ghostel-copy-mode-end-of-buffer)
     (define-key map (kbd "C-e")             #'ghostel-copy-mode-end-of-line)
     (define-key map (kbd "C-l")             #'ghostel-copy-mode-recenter)
+    (define-key map (kbd "C-c C-l")         #'ghostel-copy-mode-exit-and-clear)
     map)
   "Keymap for `ghostel-copy-mode'.
 Standard Emacs navigation works.
@@ -1322,6 +1310,12 @@ in the buffer.  Press \\`q' or \\[ghostel-copy-mode-exit] to exit."
     (goto-char (point-max))
     (ghostel--invalidate)
     (message "Copy mode exited")))
+
+(defun ghostel-copy-mode-exit-and-clear ()
+  "Exit copy mode and clear the scrollback."
+  (interactive)
+  (ghostel-copy-mode-exit)
+  (ghostel-clear-scrollback))
 
 (defun ghostel-copy-mode-exit-and-send ()
   "Exit copy mode and send the key that triggered exit to the terminal."

--- a/src/module.zig
+++ b/src/module.zig
@@ -35,8 +35,6 @@ export fn emacs_module_init(runtime: *c.struct_emacs_runtime) callconv(.c) c_int
     env.bindFunction("ghostel--get-title", 1, 1, &fnGetTitle, "Get the terminal title.\n\n(ghostel--get-title TERM)");
     env.bindFunction("ghostel--get-pwd", 1, 1, &fnGetPwd, "Get the terminal's working directory from OSC 7.\n\n(ghostel--get-pwd TERM)");
     env.bindFunction("ghostel--redraw", 1, 2, &fnRedraw, "Redraw the terminal into the current buffer.\n\n(ghostel--redraw TERM &optional FULL)");
-    env.bindFunction("ghostel--scroll", 2, 2, &fnScroll, "Scroll the terminal viewport by DELTA lines.\n\n(ghostel--scroll TERM DELTA)");
-    env.bindFunction("ghostel--scroll-top", 1, 1, &fnScrollTop, "Scroll the terminal viewport to the top of scrollback.\n\n(ghostel--scroll-top TERM)");
     env.bindFunction("ghostel--scroll-bottom", 1, 1, &fnScrollBottom, "Scroll the terminal viewport to the bottom.\n\n(ghostel--scroll-bottom TERM)");
     env.bindFunction("ghostel--encode-key", 3, 4, &fnEncodeKey, "Encode a key event using the terminal's key encoder.\n\n(ghostel--encode-key TERM KEY MODS &optional UTF8)");
     env.bindFunction("ghostel--mouse-event", 6, 6, &fnMouseEvent, "Send a mouse event to the terminal.\n\n(ghostel--mouse-event TERM ACTION BUTTON ROW COL MODS)");
@@ -533,25 +531,6 @@ fn fnRedraw(raw_env: ?*c.emacs_env, nargs: isize, args: [*c]c.emacs_value, _: ?*
         defer vt_log_env = null;
     }
     render.redraw(env, term, force_full);
-    return env.nil();
-}
-
-/// (ghostel--scroll TERM DELTA)
-fn fnScroll(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
-    const env = emacs.Env.init(raw_env.?);
-    const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
-
-    const delta = env.extractInteger(args[1]);
-    term.scrollViewport(gt.SCROLL_DELTA, @intCast(delta));
-
-    return env.nil();
-}
-
-/// (ghostel--scroll-top TERM)
-fn fnScrollTop(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
-    const env = emacs.Env.init(raw_env.?);
-    const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
-    term.scrollViewport(gt.SCROLL_TOP, 0);
     return env.nil();
 }
 

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -176,21 +176,6 @@ succeeds."
       (should (string-match-p "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" state))))) ; 40 x's on row
 
 ;; -----------------------------------------------------------------------
-;; Test: scrollback
-;; -----------------------------------------------------------------------
-
-(ert-deftest ghostel-test-scrollback ()
-  "Test scrollback by overflowing visible rows."
-  (let ((term (ghostel--new 5 80 100)))
-    (dotimes (i 10)
-      (ghostel--write-input term (format "line %d\r\n" i)))
-    (let ((state (ghostel--debug-state term)))
-      (should (string-match-p "line [6-9]" state)))       ; recent lines visible
-    (ghostel--scroll term -5)
-    (let ((state (ghostel--debug-state term)))
-      (should (string-match-p "line [0-4]" state)))))     ; scrollback shows earlier lines
-
-;; -----------------------------------------------------------------------
 ;; Test: scrollback is materialized into the Emacs buffer (vterm parity)
 ;; -----------------------------------------------------------------------
 
@@ -427,25 +412,21 @@ scrolling libghostty's viewport."
         (with-current-buffer buf
           (ghostel-mode)
           (setq ghostel--term (ghostel--new 5 80 100))
-          ;; Fill screen + scrollback with 10 lines
-          (dotimes (i 10)
-            (ghostel--write-input ghostel--term (format "line %d\r\n" i)))
-          ;; Verify content on screen and in scrollback
-          (let ((state (ghostel--debug-state ghostel--term)))
-            (should (string-match-p "line [6-9]" state)))      ; recent lines on screen
-          (ghostel--scroll ghostel--term -5)
-          (let ((state (ghostel--debug-state ghostel--term)))
-            (should (string-match-p "line [0-4]" state)))      ; early lines in scrollback
-          ;; Return to bottom and call the actual function
-          (ghostel--scroll-bottom ghostel--term)
-          (ghostel-clear-scrollback)
-          ;; Screen should be empty
-          (let ((state (ghostel--debug-state ghostel--term)))
-            (should-not (string-match-p "line [6-9]" state)))  ; screen cleared
-          ;; Scrollback should also be empty
-          (ghostel--scroll ghostel--term -10)
-          (let ((state (ghostel--debug-state ghostel--term)))
-            (should-not (string-match-p "line [0-4]" state)))) ; scrollback cleared
+          (let ((inhibit-read-only t))
+            ;; Fill screen + scrollback with 10 lines
+            (dotimes (i 10)
+              (ghostel--write-input ghostel--term (format "line %d\r\n" i)))
+            (ghostel--redraw ghostel--term t)
+            ;; Verify lines materialized in the buffer
+            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+              (should (string-match-p "line 0" content))
+              (should (string-match-p "line 9" content)))
+            ;; Clear scrollback (sends CSI 3J to libghostty)
+            (ghostel-clear-scrollback)
+            (ghostel--redraw ghostel--term t)
+            ;; Screen and scrollback should be empty
+            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+              (should-not (string-match-p "line [0-9]" content)))))
       (kill-buffer buf))))
 
 ;; -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove `ghostel--scroll` and `ghostel--scroll-top` Zig functions (dead code since scrollback materialization)
- Remove `ghostel-copy-mode-scroll-up/down` wrappers (`M-v`/`C-v` inherit from global keymap)
- Remove old viewport-scrolling test, update clear-scrollback test to verify via buffer content
- Add `C-c C-l` binding in copy mode to exit and clear scrollback

## Test plan
- [x] `make -j4 all` passes (build + 139 tests + lint)
- [ ] Mouse wheel scrolling works in terminal mode and copy mode
- [ ] Mouse wheel forwards to TUI apps with mouse tracking (vim, less)
- [ ] Typing while scrolled into history triggers scroll-on-input
- [ ] `C-c C-l` clears scrollback from both terminal and copy mode