### PR TITLE
Fix blank first page of scrollback after initial output burst

### DIFF
--- a/src/render.zig
+++ b/src/render.zig
@@ -941,33 +941,46 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
         //    `insertScrollbackRange` for the remainder.
         var delta = libghostty_sb - term.scrollback_in_buffer;
 
-        env.gotoCharN(viewport_start_int);
-        const remaining_lines = env.forwardLine(@as(i64, @intCast(delta)));
-        var promoted: usize = delta - @as(usize, @intCast(remaining_lines));
-
-        // forward-line counts the position right after the last buffer
-        // char as a moveable "line N+1" even when the buffer doesn't
-        // end in \n. That position corresponds to our terminal cursor
-        // row — a stale snapshot, NOT a real libghostty scrollback row.
-        // If we landed at pointMax with no trailing newline, peel one
-        // off the promoted count so we don't promote the cursor row.
-        if (promoted > 0 and env.extractInteger(env.point()) == env.extractInteger(env.pointMax())) {
-            const cb = env.call0(emacs.sym.@"char-before");
-            if (env.isNotNil(cb) and env.extractInteger(cb) != '\n') {
-                promoted -= 1;
-            }
-        }
-
-        if (promoted > 0) {
-            term.scrollback_in_buffer += promoted;
-            // forward-line may have left point at pointMax even when it
-            // partially walked past complete lines, so always re-walk
-            // exactly `promoted` newline-bounded lines to anchor the new
-            // viewport_start at the start of the first un-promoted row.
+        // Skip promotion when the entire previous viewport scrolled off
+        // during first materialization.  The buffer still contains the
+        // initial viewport (often mostly empty rows from before any
+        // output) which was overwritten at the cursor before scrolling
+        // off — promoted rows would be stale.  When delta < rows only
+        // the topmost rows scrolled off; those sat above the cursor and
+        // were not overwritten, so promotion is safe even on the first
+        // burst.  The stale old viewport tail gets cleaned up by the
+        // deleteRegion(viewport_start, pointMax) in the viewport
+        // renderer below.
+        var promoted: usize = 0;
+        if (term.scrollback_in_buffer > 0 or delta < term.rows) {
             env.gotoCharN(viewport_start_int);
-            _ = env.forwardLine(@as(i64, @intCast(promoted)));
-            viewport_start_int = env.extractInteger(env.point());
-            delta -= promoted;
+            const remaining_lines = env.forwardLine(@as(i64, @intCast(delta)));
+            promoted = delta - @as(usize, @intCast(remaining_lines));
+
+            // forward-line counts the position right after the last buffer
+            // char as a moveable "line N+1" even when the buffer doesn't
+            // end in \n. That position corresponds to our terminal cursor
+            // row — a stale snapshot, NOT a real libghostty scrollback row.
+            // If we landed at pointMax with no trailing newline, peel one
+            // off the promoted count so we don't promote the cursor row.
+            if (promoted > 0 and env.extractInteger(env.point()) == env.extractInteger(env.pointMax())) {
+                const cb = env.call0(emacs.sym.@"char-before");
+                if (env.isNotNil(cb) and env.extractInteger(cb) != '\n') {
+                    promoted -= 1;
+                }
+            }
+
+            if (promoted > 0) {
+                term.scrollback_in_buffer += promoted;
+                // forward-line may have left point at pointMax even when it
+                // partially walked past complete lines, so always re-walk
+                // exactly `promoted` newline-bounded lines to anchor the new
+                // viewport_start at the start of the first un-promoted row.
+                env.gotoCharN(viewport_start_int);
+                _ = env.forwardLine(@as(i64, @intCast(promoted)));
+                viewport_start_int = env.extractInteger(env.point());
+                delta -= promoted;
+            }
         }
 
         if (delta > 0) {

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -205,6 +205,43 @@ This is the vterm-style growing-buffer model that lets `isearch' and
             (should (= 12 (count-lines (point-min) (point-max))))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-scrollback-bootstrap-not-blank ()
+  "First-time scrollback materialization must contain actual content.
+Regression test: when the initial (mostly empty) viewport was rendered
+and then a burst of output overflowed the screen, the promotion
+optimisation incorrectly kept the stale empty rows as scrollback
+instead of fetching the real content from libghostty."
+  (let ((buf (generate-new-buffer " *ghostel-test-sb-bootstrap*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 80 1000))
+                 (inhibit-read-only t))
+            ;; Render the initial (nearly empty) viewport so the buffer
+            ;; has 5 rows of stale content — simulates a fresh terminal.
+            (ghostel--write-input term "$ \r\n")
+            (ghostel--redraw term t)
+            ;; Now a burst of output overflows the viewport.
+            (dotimes (i 15)
+              (ghostel--write-input term (format "line-%02d\r\n" i)))
+            (ghostel--redraw term t)
+            ;; The scrollback region (above the viewport) must contain
+            ;; the actual output, not blank lines from the old viewport.
+            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+              (should (string-match-p "\\$ " content))   ; prompt survived
+              (should (string-match-p "line-00" content)) ; first output line
+              (should (string-match-p "line-05" content)) ; middle output line
+              ;; No blank lines in the scrollback region: every line
+              ;; before the viewport should have visible content.
+              (goto-char (point-min))
+              (let ((blank-count 0))
+                (while (and (not (eobp))
+                            (< (line-number-at-pos) (- (line-number-at-pos (point-max)) 4)))
+                  (when (looking-at-p "^$")
+                    (setq blank-count (1+ blank-count)))
+                  (forward-line 1))
+                (should (= 0 blank-count))))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-render-trims-trailing-whitespace ()
   "Rendered rows do not carry libghostty's full-width padding.
 The renderer should only keep cells the terminal actually wrote to,


### PR DESCRIPTION
## Summary
- When a fresh terminal received a burst of output, scrolling up in copy mode showed blank lines for the first page instead of actual content
- The scrollback promotion optimisation incorrectly reused stale empty viewport rows from the initial render
- Skip promotion when `scrollback_in_buffer == 0` and `delta >= rows` (entire viewport scrolled off during bootstrap)
- Small deltas (`delta < rows`) still promote — the top rows sat above the cursor and weren't overwritten, preserving text properties (URLs, prompt markers)

## Test plan
- [x] New test `ghostel-test-scrollback-bootstrap-not-blank` — fails without fix, passes with it
- [x] Existing `ghostel-test-scrollback-preserves-url-properties` still passes (promotion preserved for small deltas)
- [x] `make -j4 all` — 140 tests pass
- [x] Manual: start fresh ghostel, run `ls -l /usr`, enter copy mode, scroll to top — should show actual content