### PR TITLE
Adopt useful changes from kiennq/ghostel fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ individual faces with `M-x customize-face`.
 | `ghostel-enable-osc52`           | `nil`                | Allow apps to set clipboard via OSC 52                   |
 | `ghostel-enable-url-detection`   | `t`                  | Linkify plain-text URLs in terminal output               |
 | `ghostel-enable-file-detection`  | `t`                  | Linkify file:line references in terminal output          |
+| `ghostel-ignore-cursor-change`   | `nil`                | Ignore terminal-driven cursor shape/visibility changes   |
 | `ghostel-keymap-exceptions`      | `("C-c" "C-x" ...)` | Keys passed through to Emacs                             |
 | `ghostel-exit-functions`         | `nil`                | Hook run when the shell process exits                    |
 

--- a/ghostel.el
+++ b/ghostel.el
@@ -416,7 +416,11 @@ Bump this only when the Elisp code requires a newer native module
 (defun ghostel--module-platform-tag ()
   "Return platform tag for the current system, e.g. \"x86_64-linux\".
 Returns nil if the platform is not recognized."
-  (let* ((arch (car (split-string system-configuration "-")))
+  (let* ((raw-arch (car (split-string system-configuration "-")))
+         (arch (pcase raw-arch
+                 ("amd64" "x86_64")
+                 ("arm64" "aarch64")
+                 (_ raw-arch)))
          (os (cond
               ((eq system-type 'darwin) "macos")
               ((eq system-type 'gnu/linux) "linux")

--- a/ghostel.el
+++ b/ghostel.el
@@ -266,6 +266,13 @@ When nil, falls back to `tramp-default-method'."
 These keys pass through to Emacs instead."
   :type '(repeat string))
 
+(defcustom ghostel-ignore-cursor-change nil
+  "When non-nil, ignore terminal requests to change cursor shape or visibility.
+Useful when editor-owned cursor behavior should take precedence over
+terminal-driven cursor changes.  Copy mode restores `cursor-type' to its
+default value."
+  :type 'boolean)
+
 (defcustom ghostel-scroll-on-input t
   "Automatically scroll to the bottom when typing in the terminal.
 When non-nil, any character typed while the viewport is scrolled
@@ -1707,8 +1714,10 @@ buffer has not been manually renamed by the user."
   "Set the cursor style based on terminal state.
 STYLE is one of: 0=bar, 1=block, 2=underline, 3=hollow-block.
 VISIBLE is t or nil.
-Skipped when copy mode is active because copy mode manages its own cursor."
-  (unless ghostel--copy-mode-active
+Skipped when copy mode is active because copy mode manages its own
+cursor, or when `ghostel-ignore-cursor-change' is non-nil."
+  (unless (or ghostel--copy-mode-active
+              ghostel-ignore-cursor-change)
     (setq cursor-type
           (if visible
               (pcase style

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1881,6 +1881,22 @@ buffer and hand nil to the native module."
             (should (null cursor-type))))                   ; cursor hidden again
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-ignore-cursor-change ()
+  "Test that `ghostel-ignore-cursor-change' suppresses cursor style updates."
+  (let ((buf (generate-new-buffer " *ghostel-test-ignore-cursor*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          ;; Default: cursor changes are applied
+          (let ((ghostel-ignore-cursor-change nil))
+            (ghostel--set-cursor-style 2 t)
+            (should (equal cursor-type '(hbar . 2))))
+          ;; With ignore: cursor changes are suppressed
+          (let ((ghostel-ignore-cursor-change t))
+            (ghostel--set-cursor-style 1 t)
+            (should (equal cursor-type '(hbar . 2)))))  ; unchanged
+      (kill-buffer buf))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: copy-mode hl-line-mode management
 ;; -----------------------------------------------------------------------
@@ -2998,6 +3014,7 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-osc51-eval-catches-errors
     ghostel-test-flush-pending-output-preserves-buffer
     ghostel-test-copy-mode-cursor
+    ghostel-test-ignore-cursor-change
     ghostel-test-copy-mode-hl-line
     ghostel-test-project-buffer-name
     ghostel-test-project-universal-arg

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -2239,6 +2239,29 @@ buffer and hand nil to the native module."
       (should-not warned))))
 
 ;; -----------------------------------------------------------------------
+;; Test: platform tag arch normalization
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-platform-tag-normalizes-arch ()
+  "Test that amd64/arm64 arch names are normalized in platform tags."
+  ;; amd64 -> x86_64
+  (let ((system-configuration "amd64-pc-linux-gnu")
+        (system-type 'gnu/linux))
+    (should (equal (ghostel--module-platform-tag) "x86_64-linux")))
+  ;; arm64 -> aarch64
+  (let ((system-configuration "arm64-apple-darwin23.1.0")
+        (system-type 'darwin))
+    (should (equal (ghostel--module-platform-tag) "aarch64-macos")))
+  ;; x86_64 unchanged
+  (let ((system-configuration "x86_64-pc-linux-gnu")
+        (system-type 'gnu/linux))
+    (should (equal (ghostel--module-platform-tag) "x86_64-linux")))
+  ;; aarch64 unchanged
+  (let ((system-configuration "aarch64-unknown-linux-gnu")
+        (system-type 'gnu/linux))
+    (should (equal (ghostel--module-platform-tag) "aarch64-linux"))))
+
+;; -----------------------------------------------------------------------
 ;; Test: immediate redraw for interactive echo
 ;; -----------------------------------------------------------------------
 
@@ -3031,6 +3054,7 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-module-version-match
     ghostel-test-module-version-mismatch
     ghostel-test-module-version-newer-than-minimum
+    ghostel-test-platform-tag-normalizes-arch
     ghostel-test-title-does-not-overwrite-manual-rename
     ghostel-test-title-tracking-disabled
     ghostel-test-immediate-redraw-triggers-on-small-echo


### PR DESCRIPTION
## Summary

Cherry-picks two useful improvements from the [kiennq/ghostel](https://github.com/kiennq/ghostel) fork, skipping Windows ConPTY, dyn-loader, and changes that conflict with our architecture.

- **`ghostel-ignore-cursor-change` defcustom**: When non-nil, terminal requests to change cursor shape/visibility are ignored. Useful when editor-owned cursor behavior should take precedence.
- **Platform tag arch normalization**: Normalizes `amd64` -> `x86_64` and `arm64` -> `aarch64` in `ghostel--module-platform-tag` so module auto-download works on systems where `system-configuration` uses non-Zig arch names.

### Changes reviewed and skipped

| Fork change | Reason skipped |
|---|---|
| Scroll primitives (`ghostel--scroll`, `ghostel--scroll-top`) | Already removed in 156a714 — dead code since scrollback is materialized |
| Copy mode viewport scrolling | Unnecessary with materialized scrollback |
| `pixel-scroll-precision-mode` suppression | Already solved better in 3b6c980 |
| Readonly-safe rendering | Cross-cutting; `inhibit-read-only` approach is more Emacs-conventional |
| `ghostel-cursor-follow` | Our viewport-start detection + marker save is superior |
| Face-remap caching | Benchmarked at ~1.5 us/redraw savings — not worth extra state |
| Title tracking removal | Regression |
| Windows ConPTY / dyn-loader | Out of scope |

## Test plan

- [x] `make -j4 all` passes (66/66 tests)
- [x] Verify `ghostel-ignore-cursor-change` blocks cursor shape changes when set to t
- [x] Verify `ghostel--module-platform-tag` returns correct tag on ARM systems