### PR TITLE
Add ghostel-compile for compilation-mode integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ XDG_CACHE_HOME ?= $(HOME)/.cache
 MELPAZOID_DIR  ?= $(XDG_CACHE_HOME)/melpazoid
 EVIL_DIR       ?= $(XDG_CACHE_HOME)/evil
 
-ELC := ghostel.elc ghostel-debug.elc
+ELC := ghostel.elc ghostel-debug.elc ghostel-compile.elc
 
 .PHONY: all build test test-native test-all test-evil lint melpazoid byte-compile bench bench-quick clean
 
@@ -53,7 +53,7 @@ checkdoc:
 		              (checkdoc-proper-noun-list nil) \
 		              (checkdoc-verb-check-experimental-flag nil) \
 		              (ok t)) \
-		  (dolist (f '(\"ghostel.el\" \"ghostel-debug.el\")) \
+		  (dolist (f '(\"ghostel.el\" \"ghostel-debug.el\" \"ghostel-compile.el\")) \
 		    (ignore-errors (kill-buffer \"*Warnings*\")) \
 		    (let ((inhibit-message t)) \
 		      (checkdoc-file f)) \
@@ -67,7 +67,7 @@ melpazoid:
 	@if [ ! -d "$(MELPAZOID_DIR)" ]; then \
 		git clone https://github.com/riscy/melpazoid.git "$(MELPAZOID_DIR)"; \
 	fi
-	RECIPE='(ghostel :fetcher github :repo "dakra/ghostel" :files ("ghostel.el" "ghostel-debug.el" "ghostel-module.*"))' \
+	RECIPE='(ghostel :fetcher github :repo "dakra/ghostel" :files ("ghostel.el" "ghostel-debug.el" "ghostel-compile.el" "ghostel-module.*"))' \
 		LOCAL_REPO=$(CURDIR) \
 		make -C "$(MELPAZOID_DIR)"
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ process, keymap, and buffer.
   - [TRAMP (Remote Terminals)](#tramp-remote-terminals)
 - [Configuration](#configuration)
 - [Commands](#commands)
+  - [Compilation mode](#compilation-mode)
 - [Running Tests](#running-tests)
 - [Performance](#performance)
 - [Ghostel vs vterm](#ghostel-vs-vterm)
@@ -456,6 +457,110 @@ with a project-prefixed buffer name.  To make it available from
 ```elisp
 (add-to-list 'project-switch-commands '(ghostel-project "Ghostel") t)
 ```
+
+### Compilation mode
+
+`ghostel-compile` runs a shell command in a ghostel buffer and presents
+the result like `M-x compile` — `compilation-mode`-style header,
+footer, error highlighting, and `next-error` navigation — but backed by
+a real TTY so programs that probe `isatty(3)` (coloured output, progress
+bars, curses tools) behave as they do in a normal shell.
+
+```elisp
+(require 'ghostel-compile)
+
+(global-set-key (kbd "C-c c") #'ghostel-compile)
+```
+
+Commands:
+
+| Command                 | Description                                         |
+|-------------------------|-----------------------------------------------------|
+| `M-x ghostel-compile`   | Prompt for a command and run it (uses `compile-command`) |
+| `M-x ghostel-recompile` | Re-run the last command in its original directory   |
+
+What a run looks like — the buffer text matches `M-x compile`:
+
+```
+-*- mode: ghostel-compile -*-
+Compilation started at Wed Apr 15 08:30:11
+
+make -j4 test
+
+...command output (live, with full TTY)...
+
+Compilation finished at Wed Apr 15 08:30:19, duration 8.20 s
+```
+
+When the command finishes, the live shell and ghostel renderer are torn
+down and the buffer's major mode is switched to `ghostel-compile-view-mode`
+(derived from `compilation-mode`).  The buffer becomes a regular,
+read-only Emacs buffer with compile-mode's coloured error / line-number
+faces; the buffer never returns to an interactive ghostel terminal —
+a recompile discards it and starts fresh in the original directory.
+Point stays at the end of the output (where the renderer left it) so
+you see the latest output and the footer rather than jumping to the
+top.  `mode-line-process` shows `:run` while the command is running
+and `:exit [N]` afterwards, using the same faces `M-x compile` uses.
+
+Keybindings (in `ghostel-compile-view-mode`):
+
+| Key             | Action                                                  |
+|-----------------|---------------------------------------------------------|
+| `g`             | Re-run via `ghostel-recompile`                          |
+| `n` / `p`       | Move point to next / previous error (no auto-open)      |
+| `RET` / `mouse-2` | Jump to the source of the error under point           |
+| `M-g n` / `M-g p` | Standard `next-error` / `previous-error`              |
+| `C-c C-c`       | `compile-goto-error` (same as RET)                      |
+
+These standard `compile` options are honoured:
+
+- **`compile-command` / `compile-history`** — shared with `M-x compile`.
+  The prompt defaults to `compile-command`, the chosen command is
+  written back, and the history list is `compile-history`, so recent
+  commands round-trip between the two commands.
+- **`compilation-read-command`** — when nil, `ghostel-compile` runs
+  `compile-command` silently; pass a prefix arg to force the prompt.
+- **`compilation-ask-about-save`** — modified buffers are offered for
+  saving before launching.
+- **`compilation-auto-jump-to-first-error`** — jumps to the first error
+  after parsing.
+- **`compilation-finish-functions`** — runs with `(buffer msg)` just
+  like with `M-x compile`.
+- Output scrolling is always on (terminal behaviour — equivalent to
+  `compilation-scroll-output` non-nil).
+
+`ghostel-recompile` runs in the directory the original `ghostel-compile`
+was invoked from, regardless of which buffer you're in when you press
+`g`.
+
+Ghostel-specific customisation:
+
+| Option                                | Effect                                                                                                          |
+|---------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| `ghostel-compile-buffer-name`         | Buffer name (default `*ghostel-compile*`)                                                                        |
+| `ghostel-compile-finished-major-mode` | Major mode to switch to after each run (default `ghostel-compile-view-mode`; set to nil to stay in `ghostel-mode`) |
+| `ghostel-compile-hide-prompts`        | Hide surrounding shell prompts (default `t`)                                                                     |
+| `ghostel-compile-clear-buffer`        | Clear the buffer before each run (default `t`)                                                                   |
+| `ghostel-compile-finish-functions`    | Ghostel-specific finish hook (runs alongside `compilation-finish-functions`)                                     |
+| `ghostel-compile-debug`               | Log every OSC 133 C/D event to `*Messages*` (default `nil`)                                                      |
+
+Completion is detected via the OSC 133 `D;<exit>` semantic prompt
+marker, so shell integration (`ghostel-shell-integration`, enabled by
+default) must be active.
+
+#### Hooks for your own integrations
+
+Outside of a compile buffer, two hooks let you react to *any* shell
+command in *any* ghostel buffer:
+
+- `ghostel-command-start-functions` — called with `(BUFFER)` when the
+  shell emits OSC 133 `C` (a command starts running).
+- `ghostel-command-finish-functions` — called with `(BUFFER EXIT-STATUS)`
+  when the shell emits OSC 133 `D` (a command finishes).
+
+Errors raised by individual hook functions are caught and logged so
+one bad consumer can't break the rest.
 
 ## Running Tests
 

--- a/etc/ghostel.bash
+++ b/etc/ghostel.bash
@@ -17,11 +17,6 @@ __ghostel_osc7() {
 
 # --- Semantic prompt markers (OSC 133) ---
 
-# Save exit status before PROMPT_COMMAND overwrites $?.
-__ghostel_save_status() {
-    __ghostel_last_status="$?"
-}
-
 # Emit "command finished" (D) for the previous command, then "prompt start" (A).
 # D is skipped on the very first prompt (no previous command).
 __ghostel_prompt_start() {
@@ -46,8 +41,15 @@ __ghostel_preexec() {
 }
 
 __ghostel_wrapped_prompt_command() {
+    # Capture $? FIRST.  A bare assignment such as
+    # `__ghostel_in_prompt_command=1' on its own line counts as a
+    # successful command and resets $? to 0 in bash, so any later
+    # `$?' read here would always see 0 and we'd report `:exit [0]'
+    # for every command.  `local' with `=$?' evaluates `$?' before
+    # invoking the local builtin, preserving the real exit status.
+    local __ghostel_status=$?
     __ghostel_in_prompt_command=1
-    __ghostel_save_status
+    __ghostel_last_status=$__ghostel_status
     __ghostel_prompt_start
     __ghostel_osc7
     eval "${__ghostel_original_prompt_command:-}"

--- a/ghostel-compile.el
+++ b/ghostel-compile.el
@@ -1,0 +1,647 @@
+;;; ghostel-compile.el --- Compilation integration for ghostel -*- lexical-binding: t; -*-
+
+;; Author: Daniel Kraus <daniel@kraus.my>
+;; Keywords: processes, tools, convenience
+;; Package-Requires: ((emacs "28.1"))
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; Run `compile'-style shell commands inside a ghostel terminal
+;; buffer.  Unlike \\[compile] (which runs commands through comint),
+;; `ghostel-compile' runs them in a real TTY via ghostel so programs
+;; that detect a terminal (progress bars, colours, curses tools)
+;; behave as they would in an interactive shell.
+;;
+;; The buffer mimics `compilation-mode': a "Compilation started at"
+;; header, a "Compilation finished at ..., duration ..." footer (with
+;; the same plain-text format and duration formula `M-x compile'
+;; uses), and surrounding shell prompts are hidden so only the
+;; command's own output is visible.  `mode-line-process' reflects
+;; run/exit state with the same faces `M-x compile' uses.
+;;
+;; When the command finishes, the live shell and ghostel renderer are
+;; torn down and the buffer's major mode is switched to
+;; `ghostel-compile-view-mode' (derived from `compilation-mode').  At
+;; that point the buffer is a regular, read-only Emacs buffer with
+;; standard error highlighting and `next-error' navigation.  It will
+;; not return to an interactive ghostel terminal — a recompile (`g',
+;; `M-x ghostel-recompile') discards it and starts fresh in the
+;; original `default-directory'.
+;;
+;; Completion is detected via the OSC 133 D semantic prompt marker,
+;; so shell integration (`ghostel-shell-integration') must be
+;; enabled — bundled bash, zsh and fish scripts emit those markers
+;; automatically.  `ghostel-compile-debug' logs every OSC 133 C/D
+;; event and the finalize call to *Messages* for diagnostics.
+;;
+;; Standard `compile' options honoured:
+;;   `compile-command' / `compile-history' (shared with \\[compile])
+;;   `compilation-read-command'
+;;   `compilation-ask-about-save'
+;;   `compilation-auto-jump-to-first-error'
+;;   `compilation-finish-functions' (runs alongside
+;;     `ghostel-compile-finish-functions')
+;;   `compilation-scroll-output' (effectively always on)
+;;
+;; Keys in the finished buffer:
+;;   g           — ghostel-recompile
+;;   n / p       — compilation-next-error / -previous-error (no auto-open)
+;;   RET         — compile-goto-error (open the source)
+;;   M-g n / M-g p — standard `next-error' / `previous-error'
+
+;;; Code:
+
+(require 'ghostel)
+(require 'compile)
+
+
+;;; Customization
+
+(defgroup ghostel-compile nil
+  "Run `compile'-style commands in a ghostel terminal."
+  :group 'ghostel)
+
+(defcustom ghostel-compile-buffer-name "*ghostel-compile*"
+  "Buffer name used by `ghostel-compile'."
+  :type 'string)
+
+(defcustom ghostel-compile-finished-major-mode 'ghostel-compile-view-mode
+  "Major mode to switch to after a `ghostel-compile' run finishes.
+
+The default `ghostel-compile-view-mode' derives from `compilation-mode',
+making the buffer a regular read-only Emacs buffer with `next-error'
+navigation and colored error text.
+
+Set to nil to skip the major-mode switch and leave the buffer in
+`ghostel-mode'.  Either way, finalization always tears down the live
+shell and ghostel rendering — the buffer never returns to an
+interactive terminal."
+  :type '(choice (const :tag "Compilation view (default)" ghostel-compile-view-mode)
+                 (const :tag "Don't switch" nil)
+                 (function :tag "Custom major mode")))
+
+(defcustom ghostel-compile-hide-prompts t
+  "When non-nil, hide OSC 133 prompt regions inside the scan range.
+The command echo line and the trailing prompt printed by the shell
+are marked invisible so only the command's own output is shown,
+similar to `M-x compile'."
+  :type 'boolean)
+
+(defcustom ghostel-compile-clear-buffer t
+  "When non-nil, clear the buffer (screen and scrollback) before each run.
+Mirrors `M-x compile's behaviour of starting each compilation with a
+fresh buffer.  Set to nil to keep previous runs visible above the
+new one."
+  :type 'boolean)
+
+(defcustom ghostel-compile-debug nil
+  "When non-nil, log OSC 133 C/D events from `ghostel-compile' to *Messages*.
+Useful for diagnosing wrong exit codes, missed events, or shell
+integration mismatches."
+  :type 'boolean)
+
+(defcustom ghostel-compile-finish-functions nil
+  "Functions to call when a `ghostel-compile' command finishes.
+Each function receives two arguments: the compilation buffer and a
+status message string (e.g. \"finished\\n\" or
+\"exited abnormally with code 2\\n\"), matching the convention of
+`compilation-finish-functions'.
+
+`compilation-finish-functions' is also run with the same arguments."
+  :type 'hook)
+
+
+;;; Internal variables
+
+(defvar-local ghostel-compile--command nil
+  "The command most recently launched by `ghostel-compile' here.")
+
+(defvar-local ghostel-compile--scan-marker nil
+  "Marker at the buffer position where the current command's output began.")
+
+(defvar-local ghostel-compile--last-exit nil
+  "Exit status of the most recent `ghostel-compile' command.")
+
+(defvar-local ghostel-compile--start-time nil
+  "`current-time' when the most recent command was launched.")
+
+(defvar-local ghostel-compile--directory nil
+  "`default-directory' captured at `ghostel-compile' invocation time.
+Used by `ghostel-recompile' so the command re-runs in the same
+directory regardless of where the user is when they press `g'.")
+
+(defvar-local ghostel-compile--running nil
+  "State of the in-flight `ghostel-compile' command.
+- nil      : no command in flight (or finalize already ran)
+- `pending': command was sent, but no OSC 133 C marker seen yet
+- `armed'  : C marker seen; the next D marker will trigger finalize
+- `fired'  : a D was accepted, finalize is scheduled; later Ds ignored")
+
+(defvar-local ghostel-compile--header-marker nil
+  "Marker at the end of the inserted compilation header.")
+
+(defvar-local ghostel-compile--footer-marker nil
+  "Marker at the start of the inserted compilation footer.")
+
+(defvar-local ghostel-compile--finalize-timer nil
+  "Pending finalize timer scheduled by `ghostel-compile--on-finish'.
+Set when the first D marker after C is accepted; subsequent D
+markers within the deferred window are ignored (first-D-wins) so
+the real command's exit isn't overwritten by a follow-up prompt's
+D;0.  Cleared by `ghostel-compile--finalize' once it actually
+runs, or by `ghostel-compile-mode' on disable.")
+
+(defvar-local ghostel-compile--owns-compilation-minor-mode nil
+  "Non-nil if `ghostel-compile-mode' enabled `compilation-minor-mode'.
+Tracked so disabling our mode only turns off `compilation-minor-mode'
+when we were the ones who turned it on — never when the user (or
+some other minor mode) had it enabled independently.")
+
+(defvar ghostel-compile-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "g") #'ghostel-recompile)
+    map)
+  "Keymap for `ghostel-compile-mode'.
+Shadows `compilation-minor-mode-map' bindings that clash.")
+
+(defvar ghostel-compile-view-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map compilation-mode-map)
+    ;; `n'/`p' navigate within the compile buffer only (no auto-open).
+    ;; RET / mouse-2 still jump to the source like in `compilation-mode'.
+    (define-key map "n" #'compilation-next-error)
+    (define-key map "p" #'compilation-previous-error)
+    (define-key map "g" #'ghostel-recompile)
+    map)
+  "Keymap for `ghostel-compile-view-mode'.
+Inherits from `compilation-mode-map'; rebinds `n'/`p' to
+`compilation-next-error' / `compilation-previous-error' so they
+just move point through errors without opening the source file
+in another window.  `g' runs `ghostel-recompile' instead of
+`recompile'.  RET still opens the error like in `compilation-mode'.")
+
+
+;;; Helper functions
+(define-derived-mode ghostel-compile-view-mode
+  compilation-mode "Compilation"
+  "Major mode for a finished `ghostel-compile' buffer.
+
+A regular, read-only Emacs buffer.  `g' re-runs the command via
+`ghostel-recompile', `n'/`p' walk errors in the buffer (without
+opening files), RET jumps to the source.  The live shell and
+ghostel rendering have been torn down; the buffer will not return
+to a ghostel terminal."
+  :group 'ghostel-compile
+  ;; Make sure our keymap actually parents `compilation-mode-map' even
+  ;; if it was created earlier — `define-derived-mode' won't reset an
+  ;; already-set parent.
+  (set-keymap-parent ghostel-compile-view-mode-map compilation-mode-map)
+  (setq-local next-error-function #'compilation-next-error-function)
+  ;; Make sure point lands at the top after a successful recompile (and
+  ;; that future input doesn't inherit ghostel's terminal-style behaviour).
+  (setq-local window-point-insertion-type nil))
+
+(defun ghostel-compile--format-duration (seconds)
+  "Format SECONDS (float) as a compilation-style duration string.
+Matches the format used by `M-x compile'."
+  (cond
+   ((< seconds 10) (format "%.2f s" seconds))
+   ((< seconds 60) (format "%.1f s" seconds))
+   (t              (format-seconds "%h:%02m:%02s" seconds))))
+
+(defun ghostel-compile--status-message (exit)
+  "Return the compile-style status message string for EXIT status."
+  (cond
+   ((and (numberp exit) (= exit 0)) "finished\n")
+   ((numberp exit) (format "exited abnormally with code %d\n" exit))
+   (t              "finished\n")))
+
+(defun ghostel-compile--hide-prompts (start end)
+  "Hide OSC 133 prompt regions and echoed command lines in START..END.
+A buffer line is marked invisible (together with its trailing
+newline) when either condition holds:
+
+1. Any character on the line carries the `ghostel-prompt' text
+   property — the OSC 133 A..B prompt region rendered by the
+   native renderer.
+
+2. The line ends with `ghostel-compile--command' — the shell's
+   PTY-echo of what we typed.  The native renderer applies
+   `ghostel-prompt' only to the prompt glyph itself (A..B), not
+   to the echoed command that follows on the same row, so without
+   this second check the user would see the header's command
+   followed by a duplicated `~/dir λ <cmd>' line right below it."
+  (save-excursion
+    (let ((cmd ghostel-compile--command))
+      (goto-char start)
+      (while (< (point) end)
+        (let* ((bol (line-beginning-position))
+               (eol (min end (line-end-position)))
+               (hide (or
+                      ;; 1. Prompt property anywhere on this line?
+                      (text-property-not-all bol eol
+                                             'ghostel-prompt nil)
+                      ;; 2. Line ends with the echoed command?
+                      (and cmd (not (string-empty-p cmd))
+                           (let ((tail-start
+                                  (max bol (- eol (length cmd)))))
+                             (string= cmd
+                                      (buffer-substring-no-properties
+                                       tail-start eol)))))))
+          (when hide
+            (add-text-properties bol eol '(invisible t))
+            (when (and (< eol end) (eq (char-after eol) ?\n))
+              (add-text-properties eol (1+ eol) '(invisible t)))))
+        (forward-line 1)))))
+
+(defun ghostel-compile--clear-markers ()
+  "Reset header/footer markers."
+  (when (markerp ghostel-compile--header-marker)
+    (set-marker ghostel-compile--header-marker nil))
+  (when (markerp ghostel-compile--footer-marker)
+    (set-marker ghostel-compile--footer-marker nil))
+  (setq ghostel-compile--header-marker nil
+        ghostel-compile--footer-marker nil))
+
+(defun ghostel-compile--header-text (command start-time)
+  "Return the header string for COMMAND started at START-TIME.
+Plain text, matching the `M-x compile' header format."
+  (format "-*- mode: ghostel-compile -*-\nCompilation started at %s\n\n%s\n"
+          (substring (current-time-string start-time) 0 19)
+          command))
+
+(defun ghostel-compile--footer-text (exit start-time end-time)
+  "Return the footer string for EXIT between START-TIME and END-TIME.
+Plain text, matching the `M-x compile' footer format."
+  (let* ((duration (float-time (time-subtract end-time start-time)))
+         (ts (substring (current-time-string end-time) 0 19))
+         (status-word (cond
+                       ((and (numberp exit) (= exit 0)) "finished")
+                       ((numberp exit)
+                        (format "exited abnormally with code %d" exit))
+                       (t "finished"))))
+    (format "\nCompilation %s at %s, duration %s\n"
+            status-word ts (ghostel-compile--format-duration duration))))
+
+(defun ghostel-compile--set-mode-line-running ()
+  "Set `mode-line-process' to the running indicator."
+  (setq mode-line-process
+        (list '(:propertize ":run" face compilation-mode-line-run)
+              'compilation-mode-line-errors))
+  (force-mode-line-update))
+
+(defun ghostel-compile--set-mode-line-exit (exit)
+  "Set `mode-line-process' to reflect the terminal EXIT status."
+  (let* ((ok (and (numberp exit) (= exit 0)))
+         (face (if ok 'compilation-mode-line-exit 'compilation-mode-line-fail))
+         (text (format ":exit [%s]" (if (numberp exit) exit "?"))))
+    (setq mode-line-process
+          (list (propertize text 'face face)
+                'compilation-mode-line-errors))
+    (force-mode-line-update)))
+
+(defun ghostel-compile--auto-jump (buffer)
+  "Jump to the first error in BUFFER if `compilation-auto-jump-to-first-error'."
+  (when (and compilation-auto-jump-to-first-error
+             (buffer-live-p buffer))
+    (with-current-buffer buffer
+      (let ((next-error-last-buffer buffer))
+        (condition-case _
+            (first-error)
+          (error nil))))))
+
+(defun ghostel-compile--teardown-terminal ()
+  "Tear down the live shell and ghostel renderer in the current buffer.
+Replaces the sentinel and filter with no-ops before deleting the
+process.  Passing nil to `set-process-sentinel' restores the
+*default* sentinel, which writes \"Process NAME killed: N\" into
+the process buffer — exactly what we don't want."
+  (when (and (bound-and-true-p ghostel--process)
+             (process-live-p ghostel--process))
+    (set-process-sentinel ghostel--process #'ignore)
+    (set-process-filter ghostel--process #'ignore)
+    (set-process-query-on-exit-flag ghostel--process nil)
+    (delete-process ghostel--process)
+    (setq ghostel--process nil))
+  (when (bound-and-true-p ghostel--redraw-timer)
+    (cancel-timer ghostel--redraw-timer)
+    (setq ghostel--redraw-timer nil))
+  (when (bound-and-true-p ghostel--input-timer)
+    (cancel-timer ghostel--input-timer)
+    (setq ghostel--input-timer nil)))
+
+(defun ghostel-compile--finalize (buffer exit end-time)
+  "Insert header/footer, hide prompts, parse errors for BUFFER.
+EXIT is the command exit status; END-TIME its completion time.
+Switches the buffer's major mode to
+`ghostel-compile-finished-major-mode' (by default
+`ghostel-compile-view-mode') so the buffer becomes a regular,
+read-only Emacs buffer that can never transition back to
+interactive terminal mode.
+
+Header and footer are inserted as plain buffer text (matching
+`M-x compile') rather than overlays, so cursor motion behaves the
+same as in any compilation buffer."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let* ((start (and ghostel-compile--scan-marker
+                         (marker-position ghostel-compile--scan-marker)))
+             (start-time ghostel-compile--start-time)
+             (command ghostel-compile--command)
+             (directory ghostel-compile--directory)
+             (header (ghostel-compile--header-text command start-time))
+             (footer (ghostel-compile--footer-text exit start-time end-time))
+             (inhibit-read-only t))
+        (setq ghostel-compile--last-exit exit
+              ghostel-compile--running nil
+              ghostel-compile--finalize-timer nil)
+        (when ghostel-compile-debug
+          (message "ghostel-compile: finalizing exit=%S buffer=%S"
+                   exit (buffer-name buffer)))
+        (when (and start ghostel-compile-hide-prompts)
+          (ghostel-compile--hide-prompts start (point-max)))
+        (ghostel-compile--clear-markers)
+        (ghostel-compile--teardown-terminal)
+        ;; Switch major mode now that the shell is dead.  Preserve state
+        ;; that `kill-all-local-variables' would otherwise wipe.
+        (let ((saved-command command)
+              (saved-start-time start-time)
+              (saved-directory directory))
+          (when ghostel-compile-finished-major-mode
+            (funcall ghostel-compile-finished-major-mode))
+          (setq-local ghostel-compile--command saved-command
+                      ghostel-compile--directory saved-directory
+                      ghostel-compile--start-time saved-start-time
+                      ghostel-compile--last-exit exit)
+          ;; Pin the buffer's `default-directory' to the directory the
+          ;; user invoked `ghostel-compile' from, so it doesn't drift if
+          ;; the shell happened to `cd' elsewhere during the run.
+          (when saved-directory
+            (setq default-directory saved-directory)))
+        ;; Anchor header at the start of THIS run's output, not at
+        ;; point-min — when `ghostel-compile-clear-buffer' is nil and
+        ;; older output remains in the buffer, the header should still
+        ;; bracket the right region.  Track the resulting parse-start
+        ;; so jit-lock doesn't pick up stale matches above the run.
+        (let* ((inhibit-read-only t)
+               (header-anchor (or start (point-min)))
+               (parse-start (copy-marker header-anchor)))
+          (save-excursion
+            (goto-char header-anchor)
+            (insert header)
+            (setq ghostel-compile--header-marker (point-marker))
+            (set-marker-insertion-type ghostel-compile--header-marker nil))
+          ;; Append footer at end-of-buffer; ensure separation from output.
+          (save-excursion
+            (goto-char (point-max))
+            (unless (or (= (point) (point-min)) (bolp))
+              (insert "\n"))
+            (setq ghostel-compile--footer-marker (point-marker))
+            (set-marker-insertion-type ghostel-compile--footer-marker nil)
+            (insert footer))
+          ;; Parse only this run's output.  Seed `compilation--parsed'
+          ;; at the start of the run so `compilation--ensure-parse'
+          ;; (and any later jit-lock pass) skip everything above it —
+          ;; otherwise old output left over by `--clear-buffer nil'
+          ;; would leak into `next-error' and the error count.  Note:
+          ;; `compilation-mode' initialises `compilation--parsed' to
+          ;; -1 (not a marker), so we set the marker ourselves.
+          (save-excursion
+            (save-restriction
+              (widen)
+              (setq-local compilation--parsed (copy-marker parse-start))
+              (condition-case err
+                  (compilation--ensure-parse (point-max))
+                (error
+                 (message "ghostel-compile: error scanning output: %s"
+                          (error-message-string err)))))))
+        ;; Put point at `point-max' — past the footer — so the user
+        ;; actually sees the "Compilation finished at ..., duration ..."
+        ;; line instead of having it scroll below the window bottom.
+        ;; Recenter each window on this buffer so that line is flush
+        ;; with the bottom of the window.
+        (goto-char (point-max))
+        (dolist (win (get-buffer-window-list buffer nil t))
+          (set-window-point win (point-max))
+          (with-selected-window win (recenter -1))))
+      (ghostel-compile--set-mode-line-exit exit)
+      (setq next-error-last-buffer buffer)
+      (ghostel-compile--auto-jump buffer)
+      (let ((msg (ghostel-compile--status-message exit)))
+        (run-hook-with-args 'compilation-finish-functions buffer msg)
+        (run-hook-with-args 'ghostel-compile-finish-functions buffer msg)))))
+
+(defun ghostel-compile--on-start (buffer)
+  "Hook function: arm finalize gating for BUFFER on OSC 133 C marker.
+A D marker is only treated as the user command's exit when a C
+marker has been seen since `ghostel-compile' was invoked.  This
+filters out spurious D markers from prompt redraws (e.g. shell
+clear-screen handlers after we send `\\f' to refresh the display).
+
+When we transition from `pending' to `armed', snap the scan
+marker to the current `point-max'.  The scan marker must land
+*after* any content the shell rendered in response to our clear
+(the fresh prompt re-echo), which arrives asynchronously through
+the process filter — not synchronously during `ghostel-compile'.
+The C marker is emitted by the shell's preexec / DEBUG trap right
+before the user's command starts producing output, so point-max
+at that moment is exactly the boundary between \"pre-command
+noise\" and the command's real output."
+  (when (and (buffer-live-p buffer)
+             (buffer-local-value 'ghostel-compile-mode buffer))
+    (with-current-buffer buffer
+      (when ghostel-compile-debug
+        (message "ghostel-compile: OSC 133 C — running=%S"
+                 ghostel-compile--running))
+      (when (eq ghostel-compile--running 'pending)
+        (setq ghostel-compile--running 'armed
+              ghostel-compile--scan-marker (copy-marker (point-max)))))))
+
+(defun ghostel-compile--on-finish (buffer exit)
+  "Hook function: schedule finalize for BUFFER with EXIT status.
+
+Runs deferred so any rendering from the same output batch settles
+first.  Only acts when `ghostel-compile--running' is `armed' (i.e.
+a C marker has been seen) — D markers from prompt redraws or other
+shell activity that haven't been preceded by a C are ignored.
+
+The first D after C wins.  Subsequent Ds before finalize actually
+fires are ignored, so a follow-up prompt's D;0 cannot overwrite
+the real command's exit status."
+  (when (and (buffer-live-p buffer)
+             (buffer-local-value 'ghostel-compile-mode buffer))
+    (with-current-buffer buffer
+      (when ghostel-compile-debug
+        (message "ghostel-compile: OSC 133 D;%S — running=%S"
+                 exit ghostel-compile--running))
+      (when (eq ghostel-compile--running 'armed)
+        (setq ghostel-compile--running 'fired
+              ghostel-compile--finalize-timer
+              (run-at-time 0.05 nil
+                           #'ghostel-compile--finalize
+                           buffer exit (current-time)))))))
+
+(define-minor-mode ghostel-compile-mode
+  "Minor mode that turns a ghostel buffer into a compilation buffer.
+
+When enabled, an OSC 133 D marker triggers an error scan over the
+command's output, a compilation-style header/footer is inserted,
+surrounding prompts are hidden, and the buffer's major mode is
+switched to `ghostel-compile-finished-major-mode' (by default
+`ghostel-compile-view-mode' — derived from `compilation-mode').
+Pressing \\<ghostel-compile-mode-map>\\[ghostel-recompile] re-runs
+the last command."
+  :lighter " gh-compile"
+  :keymap ghostel-compile-mode-map
+  (cond
+   (ghostel-compile-mode
+    (unless (derived-mode-p 'ghostel-mode)
+      (setq ghostel-compile-mode nil)
+      (user-error "`ghostel-compile-mode' can only be enabled in a ghostel buffer"))
+    ;; Only adopt `compilation-minor-mode' if it isn't already on, and
+    ;; remember whether we turned it on so we don't yank it from under
+    ;; some other consumer when our mode is disabled.
+    (setq ghostel-compile--owns-compilation-minor-mode
+          (not (bound-and-true-p compilation-minor-mode)))
+    (compilation-minor-mode 1)
+    (setq-local next-error-function #'compilation-next-error-function)
+    ;; Ensure our `g' binding wins over `compilation-minor-mode-map'.
+    (setq-local minor-mode-overriding-map-alist
+                (cons (cons 'ghostel-compile-mode ghostel-compile-mode-map)
+                      (assq-delete-all
+                       'ghostel-compile-mode
+                       minor-mode-overriding-map-alist)))
+    (add-hook 'ghostel-command-start-functions
+              #'ghostel-compile--on-start nil t)
+    (add-hook 'ghostel-command-finish-functions
+              #'ghostel-compile--on-finish nil t))
+   (t
+    (setq-local minor-mode-overriding-map-alist
+                (assq-delete-all
+                 'ghostel-compile-mode
+                 minor-mode-overriding-map-alist))
+    (remove-hook 'ghostel-command-start-functions
+                 #'ghostel-compile--on-start t)
+    (remove-hook 'ghostel-command-finish-functions
+                 #'ghostel-compile--on-finish t)
+    ;; Cancel any pending finalize and reset the in-flight state so
+    ;; turning the mode off mid-command doesn't leak `pending'/`armed'
+    ;; into the next enable cycle.
+    (when (timerp ghostel-compile--finalize-timer)
+      (cancel-timer ghostel-compile--finalize-timer))
+    (setq ghostel-compile--finalize-timer nil
+          ghostel-compile--running nil)
+    ;; Only turn off `compilation-minor-mode' (and the `next-error'
+    ;; wiring that goes with it) if WE turned it on; otherwise the
+    ;; user's pre-existing `compilation-minor-mode' would be left
+    ;; with its `next-error-function' yanked out from under it.
+    (when (and ghostel-compile--owns-compilation-minor-mode
+               (bound-and-true-p compilation-minor-mode))
+      (compilation-minor-mode -1)
+      (kill-local-variable 'next-error-function))
+    (setq ghostel-compile--owns-compilation-minor-mode nil))))
+
+(defun ghostel-compile--get-or-create-buffer ()
+  "Return a live ghostel-compile buffer, creating one if needed.
+Uses the caller's `default-directory' as the new buffer's working
+directory — captured before any buffer kill, so that
+`ghostel-recompile' (which kills the previous `view-mode' buffer)
+runs in the directory bound by its caller, not whatever buffer
+happens to be current after the kill."
+  (let ((existing (get-buffer ghostel-compile-buffer-name))
+        (dir default-directory))
+    (if (and existing
+             (with-current-buffer existing
+               (and (derived-mode-p 'ghostel-mode)
+                    ghostel--process
+                    (process-live-p ghostel--process))))
+        existing
+      (when existing
+        (kill-buffer existing))
+      (let ((ghostel-buffer-name ghostel-compile-buffer-name)
+            (default-directory dir))
+        (ghostel))
+      (get-buffer ghostel-compile-buffer-name))))
+
+
+;;; Public `ghostel-compile' entry point
+
+;;;###autoload
+(defun ghostel-compile (command)
+  "Run COMMAND in a ghostel terminal with compilation integration.
+
+Like \\[compile], but uses a ghostel buffer so programs that require
+a real TTY work correctly.  The buffer gets a compilation-mode-like
+header and footer, surrounding prompts are hidden, and when the
+command finishes (detected via the OSC 133 D semantic prompt marker)
+the major mode is switched to `ghostel-compile-finished-major-mode'
+\(by default `ghostel-compile-view-mode', derived from
+`compilation-mode').  Error locations become available through
+`next-error'.
+
+Output always scrolls as it arrives (equivalent to
+`compilation-scroll-output' being non-nil).  `compilation-ask-about-save'
+and `compilation-auto-jump-to-first-error' are honoured.  The command
+default and history are shared with \\[compile] via `compile-command'
+and `compile-history'.
+
+Requires shell integration; see `ghostel-shell-integration'."
+  (interactive
+   (list
+    (let ((default (eval compile-command t)))
+      (if (or compilation-read-command current-prefix-arg)
+          (read-shell-command "Ghostel compile: " default
+                              (if (equal (car compile-history) default)
+                                  '(compile-history . 1)
+                                'compile-history))
+        default))))
+  (unless (equal command (eval compile-command t))
+    (setq compile-command command))
+  (save-some-buffers (not compilation-ask-about-save)
+                     compilation-save-buffers-predicate)
+  (let ((buffer (ghostel-compile--get-or-create-buffer)))
+    (with-current-buffer buffer
+      (when (bound-and-true-p ghostel--copy-mode-active)
+        (ghostel-copy-mode-exit))
+      (unless ghostel-compile-mode
+        (ghostel-compile-mode 1))
+      (ghostel-compile--clear-markers)
+      (when ghostel-compile-clear-buffer
+        (ghostel-clear-scrollback))
+      ;; The scan marker is snapped by `ghostel-compile--on-start' when
+      ;; the shell emits OSC 133 C — by then any async output from our
+      ;; clear-scrollback's `\\f' (the re-echoed prompt) has already
+      ;; landed, so the marker lands exactly at the command's own
+      ;; output boundary instead of above that noise.
+      (setq ghostel-compile--command command
+            ghostel-compile--directory default-directory
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--last-exit nil
+            ghostel-compile--running 'pending
+            ghostel-compile--scan-marker nil)
+      (ghostel-compile--set-mode-line-running)
+      (ghostel--flush-output (concat command "\n")))
+    (pop-to-buffer buffer (append display-buffer--same-window-action
+                                  '((category . comint))))))
+
+(defun ghostel-recompile ()
+  "Re-run the last `ghostel-compile' command in its original directory.
+Falls back to `compile-command' (and the current `default-directory')
+when no ghostel compile has run yet."
+  (interactive)
+  (let* ((buf (get-buffer ghostel-compile-buffer-name))
+         (cmd (or (and (buffer-live-p buf)
+                       (buffer-local-value 'ghostel-compile--command buf))
+                  (eval compile-command t)))
+         (dir (or (and (buffer-live-p buf)
+                       (buffer-local-value 'ghostel-compile--directory buf))
+                  default-directory)))
+    (unless (and cmd (not (string-blank-p cmd)))
+      (user-error "No previous `ghostel-compile' command to re-run"))
+    (let ((default-directory dir))
+      (ghostel-compile cmd))))
+
+(provide 'ghostel-compile)
+
+;;; ghostel-compile.el ends here

--- a/ghostel.el
+++ b/ghostel.el
@@ -188,6 +188,38 @@ Each function is called with two arguments: the buffer and the
 exit event string."
   :type 'hook)
 
+(defcustom ghostel-command-finish-functions nil
+  "Hook run when a shell command finishes (OSC 133 D marker).
+Each function is called with two arguments: the buffer and the
+exit status (an integer, or nil if the shell did not report one).
+
+Requires the shell to emit OSC 133 semantic prompt markers.  Bash,
+zsh, and fish shell integration bundled with ghostel emits these
+markers automatically when `ghostel-shell-integration' is enabled.
+
+The hook fires synchronously from the terminal parser, so consumers
+that need a fully rendered buffer should defer their own work via
+`run-at-time'.  Errors in hook functions are demoted to messages
+via `with-demoted-errors', so a misbehaving hook does not break
+the parser or stop later hooks — except when `debug-on-error' is
+non-nil, in which case the error is re-signalled so the debugger
+can fire (standard `with-demoted-errors' semantics)."
+  :type 'hook)
+
+(defcustom ghostel-command-start-functions nil
+  "Hook run when a shell command starts running (OSC 133 C marker).
+Each function is called with one argument: the buffer.
+
+Requires shell integration; this fires from the shell's
+preexec/DEBUG hook just before the user's command runs.  Useful
+for distinguishing a real command's lifecycle from prompt
+redraws (which emit D markers without a preceding C).
+
+Errors in hook functions are demoted to messages via
+`with-demoted-errors' (re-signalled when `debug-on-error' is
+non-nil so the debugger can fire)."
+  :type 'hook)
+
 (defcustom ghostel-eval-cmds '(("find-file" find-file)
                                ("find-file-other-window" find-file-other-window)
                                ("dired" dired)
@@ -620,6 +652,7 @@ DIR is the module directory."
                        (concat "Native module not found: " mod
                                "\nRun M-x ghostel-download-module or M-x ghostel-module-compile")))))
 
+
 ;;; Internal variables
 
 (defvar-local ghostel--term nil
@@ -1569,11 +1602,31 @@ not here.  This handler only tracks prompt positions and exit status."
      ;; Prompt start — record line number.
      (push (cons (count-lines (point-min) (point-max)) nil)
            ghostel--prompt-positions))
+    ("C"
+     ;; Command output start — notify `ghostel-command-start-functions'.
+     (ghostel--run-hook-safely 'ghostel-command-start-functions
+                               (current-buffer)))
     ("D"
-     ;; Command finished — store exit status on the most recent entry.
-     (when (and ghostel--prompt-positions param)
-       (setcdr (car ghostel--prompt-positions)
-               (string-to-number param))))))
+     ;; Command finished — store exit status on the most recent entry
+     ;; and notify `ghostel-command-finish-functions'.
+     (let ((exit (and param (string-to-number param))))
+       (when (and ghostel--prompt-positions param)
+         (setcdr (car ghostel--prompt-positions) exit))
+       (ghostel--run-hook-safely 'ghostel-command-finish-functions
+                                 (current-buffer) exit)))))
+
+(defun ghostel--run-hook-safely (hook &rest args)
+  "Run HOOK with ARGS, isolating errors per handler.
+Each handler is wrapped in `with-demoted-errors' so a raising
+handler logs and the remaining hooks still run.  As with the rest
+of Emacs, `with-demoted-errors' re-signals when `debug-on-error'
+is non-nil so the debugger fires for hook authors who want it."
+  (run-hook-wrapped
+   hook
+   (lambda (fn)
+     (with-demoted-errors "ghostel: error in hook: %S"
+       (apply fn args))
+     nil)))
 
 (defun ghostel--prompt-input-start ()
   "From the start of a prompt line, move past the prompt marker to user input.

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -12,6 +12,7 @@
 
 (require 'ert)
 (require 'ghostel)
+(require 'ghostel-compile)
 
 (declare-function ghostel--cleanup-temp-paths "ghostel")
 
@@ -1371,6 +1372,932 @@ the reply waits for the redraw timer."
             (when ghostel--prompt-positions
               (should (equal 0 (cdr (car ghostel--prompt-positions))))))) ; exit status stored
       (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
+;; Test: ghostel-command-finish-functions hook
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-command-finish-hook ()
+  "Test that OSC 133 D fires `ghostel-command-finish-functions'."
+  (with-temp-buffer
+    (let* ((calls nil)
+           (ghostel-command-finish-functions
+            (list (lambda (buf exit) (push (cons buf exit) calls)))))
+      (ghostel--osc133-marker "A" nil)
+      (ghostel--osc133-marker "D" "0")
+      (should (equal 1 (length calls)))                       ; hook fired once
+      (should (eq (caar calls) (current-buffer)))             ; buffer passed
+      (should (equal 0 (cdar calls)))                         ; exit 0 as integer
+
+      (setq calls nil)
+      (ghostel--osc133-marker "A" nil)
+      (ghostel--osc133-marker "D" "2")
+      (should (equal 2 (cdar calls)))                         ; non-zero exit parsed
+
+      ;; Missing param -> exit is nil, hook still fires
+      (setq calls nil)
+      (ghostel--osc133-marker "A" nil)
+      (ghostel--osc133-marker "D" nil)
+      (should (equal 1 (length calls)))                       ; hook fired with nil param
+      (should (null (cdar calls))))))                         ; exit is nil
+
+(ert-deftest ghostel-test-command-finish-hook-via-vt ()
+  "End-to-end: OSC 133 D bytes through VT parser fires the hook."
+  (let ((buf (generate-new-buffer " *ghostel-test-finish-vt*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 40 100))
+                 (calls nil)
+                 (ghostel-command-finish-functions
+                  (list (lambda (_buf exit) (push exit calls)))))
+            (ghostel--write-input term "\e]133;A\e\\$ \e]133;B\e\\")
+            (ghostel--write-input term "echo hi\r\nhi\r\n")
+            (ghostel--write-input term "\e]133;D;0\e\\")
+            (should (equal '(0) calls))                       ; exit code flows through
+            (ghostel--write-input term "\e]133;A\e\\$ \e]133;B\e\\")
+            (ghostel--write-input term "\e]133;D;127\e\\")
+            (should (equal '(127 0) calls))))                  ; non-zero exit flows through
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-command-finish-hook-error-caught ()
+  "Errors in `ghostel-command-finish-functions' are demoted to messages.
+Bind `debug-on-error' to nil so we test the production code path
+\(under `--batch -Q' Emacs sets `debug-on-error' to t, which
+intentionally makes `with-demoted-errors' re-signal so a hook
+author's debugger can fire)."
+  (with-temp-buffer
+    (let ((inhibit-message t)
+          (debug-on-error nil)
+          (ghostel-command-finish-functions
+           (list (lambda (_buf _exit) (error "boom")))))
+      (ghostel--osc133-marker "A" nil)
+      (should-not (condition-case _ (progn (ghostel--osc133-marker "D" "0") nil)
+                    (error t))))))
+
+(ert-deftest ghostel-test-command-finish-hook-error-isolated ()
+  "A raising hook must not prevent later hooks from running.
+See `ghostel-test-command-finish-hook-error-caught' for why we
+bind `debug-on-error' to nil."
+  (with-temp-buffer
+    (let ((inhibit-message t)
+          (debug-on-error nil)
+          (later-ran nil))
+      (let ((ghostel-command-finish-functions
+             (list (lambda (_buf _exit) (error "first boom"))
+                   (lambda (_buf _exit) (setq later-ran t)))))
+        (ghostel--osc133-marker "A" nil)
+        (ghostel--osc133-marker "D" "0")
+        (should later-ran)))))                                 ; second hook still fired
+
+;; -----------------------------------------------------------------------
+;; Test: ghostel-compile-mode
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-compile-mode-requires-ghostel-buffer ()
+  "`ghostel-compile-mode' must refuse to enable outside a ghostel buffer."
+  (with-temp-buffer
+    (should-error (ghostel-compile-mode 1) :type 'user-error)
+    (should-not ghostel-compile-mode)))                       ; mode stayed off
+
+(ert-deftest ghostel-test-compile-mode-sets-up-finish-hook ()
+  "Enabling `ghostel-compile-mode' adds the finish hook locally."
+  (let ((buf (generate-new-buffer " *ghostel-test-compile-mode*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (ghostel-compile-mode 1)
+          (should ghostel-compile-mode)                       ; mode on
+          (should (memq #'ghostel-compile--on-finish
+                        ghostel-command-finish-functions))    ; hook installed
+          (ghostel-compile-mode -1)
+          (should-not (memq #'ghostel-compile--on-finish
+                            ghostel-command-finish-functions)))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-compile-mode-disable-is-reversible ()
+  "Disabling `ghostel-compile-mode' tears down its side effects."
+  (let ((buf (generate-new-buffer " *ghostel-test-compile-teardown*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (ghostel-compile-mode 1)
+          (should compilation-minor-mode)                      ; compile-minor on
+          (should (eq next-error-function
+                      #'compilation-next-error-function))      ; next-error installed
+          (should (assq 'ghostel-compile-mode
+                        minor-mode-overriding-map-alist))      ; map override in
+          (ghostel-compile-mode -1)
+          (should-not compilation-minor-mode)                  ; compile-minor off
+          (should-not (local-variable-p 'next-error-function)) ; restored
+          (should-not (assq 'ghostel-compile-mode
+                            minor-mode-overriding-map-alist))) ; map override out
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-compile-mode-respects-prior-compilation-minor ()
+  "Disabling our mode must NOT turn off `compilation-minor-mode' (or
+yank its `next-error-function' out from under it) when the user
+enabled `compilation-minor-mode' independently before us."
+  (let ((buf (generate-new-buffer " *ghostel-test-compile-coexist*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          ;; User enables compilation-minor-mode independently first.
+          (compilation-minor-mode 1)
+          (should compilation-minor-mode)
+          (should (eq next-error-function
+                      #'compilation-next-error-function))
+          ;; Now enable, then disable, our mode.
+          (ghostel-compile-mode 1)
+          (ghostel-compile-mode -1)
+          ;; Independent compilation-minor-mode and its next-error
+          ;; wiring must both still be active.
+          (should compilation-minor-mode)                       ; preserved
+          (should (eq next-error-function
+                      #'compilation-next-error-function)))      ; preserved
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-compile-mode-disable-cancels-pending ()
+  "Disabling the mode mid-flight must reset state and cancel any
+pending finalize timer, so a subsequent enable starts clean."
+  (let ((buf (generate-new-buffer " *ghostel-test-compile-cancel*"))
+        (cancelled 0))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (ghostel-compile-mode 1)
+          ;; Pretend a command is in flight with a pending timer.
+          (cl-letf (((symbol-function 'cancel-timer)
+                     (lambda (_t) (setq cancelled (1+ cancelled))))
+                    ((symbol-function 'timerp) (lambda (_t) t)))
+            (setq ghostel-compile--running 'armed
+                  ghostel-compile--finalize-timer :stub-timer)
+            (ghostel-compile-mode -1)
+            (should (= 1 cancelled))                            ; cancelled
+            (should-not ghostel-compile--running)                ; reset
+            (should-not ghostel-compile--finalize-timer)))      ; cleared
+      (kill-buffer buf))))
+
+(defmacro ghostel-test--with-compile-buffer (var &rest body)
+  "Run BODY in a fresh ghostel-mode buffer bound to VAR with compile-mode on."
+  (declare (indent 1))
+  `(let ((,var (generate-new-buffer " *ghostel-test-compile*"))
+         (inhibit-message t))
+     (unwind-protect
+         (with-current-buffer ,var
+           (ghostel-mode)
+           (ghostel-compile-mode 1)
+           ,@body)
+       (kill-buffer ,var))))
+
+(ert-deftest ghostel-test-compile-finalize-scans-errors ()
+  "ghostel-compile--finalize parses errors in the scan region."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (insert "pre-existing line\n")
+      (setq ghostel-compile--command "make"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--running 'armed
+            ghostel-compile--scan-marker (copy-marker (point)))
+      (insert "/tmp/foo.c:10:5: error: bad thing\n")
+      (insert "done\n"))
+    (ghostel-compile--finalize buf 1 (current-time))
+    (should (eq 1 ghostel-compile--last-exit))                ; exit recorded
+    ;; The error line acquired `compilation-message' somewhere within it,
+    ;; while the pre-existing (pre-scan-marker) line did not.
+    (cl-flet ((region-has-prop-p (begin end prop)
+                (save-excursion
+                  (goto-char begin)
+                  (let ((found nil))
+                    (while (and (not found) (< (point) end))
+                      (if (get-text-property (point) prop)
+                          (setq found t)
+                        (goto-char
+                         (or (next-single-property-change
+                              (point) prop nil end)
+                             end))))
+                    found))))
+      (save-excursion
+        (goto-char (point-min))
+        (let ((err-bol (progn (search-forward "/tmp/foo.c") (line-beginning-position)))
+              (err-eol (line-end-position)))
+          (should (region-has-prop-p err-bol err-eol 'compilation-message))))
+      (save-excursion
+        (goto-char (point-min))
+        (let ((pre-bol (progn (search-forward "pre-existing line")
+                              (line-beginning-position)))
+              (pre-eol (line-end-position)))
+          (should-not (region-has-prop-p pre-bol pre-eol 'compilation-message)))))
+    (should (eq buf next-error-last-buffer))))                ; next-error target set
+
+(ert-deftest ghostel-test-compile-finalize-inserts-header-and-footer ()
+  "Finalize inserts plain-text header/footer matching `M-x compile' format."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t)
+          (ghostel-compile-finished-major-mode nil))
+      (insert "output line\n")
+      (setq ghostel-compile--command "make -j4 test"
+            ghostel-compile--start-time (time-subtract (current-time) 2)
+            ghostel-compile--running 'armed
+            ghostel-compile--scan-marker (copy-marker (point-min)))
+      (ghostel-compile--finalize buf 0 (current-time))
+      (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+        (should (string-match-p "\\`-\\*- mode: ghostel-compile -\\*-" text))
+        (should (string-match-p "Compilation started at" text))
+        (should (string-match-p "make -j4 test" text))
+        (should (string-match-p "output line" text))
+        (should (string-match-p "Compilation finished at" text))
+        (should (string-match-p "duration " text))))))
+
+(ert-deftest ghostel-test-compile-on-start-snaps-scan-marker ()
+  "OSC 133 C must snap `ghostel-compile--scan-marker' to the current
+`point-max'.  `ghostel-compile' sends `\\f' to refresh the prompt and
+then writes the command to the shell — the shell's response (fresh
+prompt re-echo, possibly A/B markers) arrives asynchronously through
+the process filter AFTER `ghostel-compile' returns.  If we captured
+the marker synchronously in `ghostel-compile' it would sit above
+that noise; snapping on C puts it exactly at the command-output
+boundary."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (setq ghostel-compile--running 'pending
+            ghostel-compile--scan-marker nil)
+      ;; Simulate the async echo of the refreshed prompt arriving
+      ;; after `ghostel-compile' already returned but BEFORE C.
+      (insert "$ ")
+      (let ((snap-point (point)))
+        (ghostel-compile--on-start buf)
+        (should (eq 'armed ghostel-compile--running))
+        (should (markerp ghostel-compile--scan-marker))
+        (should (= snap-point
+                   (marker-position ghostel-compile--scan-marker)))))))
+
+(ert-deftest ghostel-test-compile-clear-buffer-isolates-stale-errors ()
+  "With `ghostel-compile-clear-buffer' t, stale error-shaped lines
+that linger in the buffer above the fresh scan-marker must not leak
+into the final error count.  This exercises the realistic flow:
+pre-existing content + \\f echo → C snaps scan-marker → command
+output → D → finalize — only the command's own errors count."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t)
+          (ghostel-compile-finished-major-mode nil))
+      ;; Two leftover error-shaped lines from previous interactive
+      ;; commands that would otherwise be double-counted.
+      (insert "/tmp/old1.c:99:1: error: STALE-ONE\n"
+              "/tmp/old2.c:42:1: error: STALE-TWO\n")
+      ;; Mid-flight state as set by `ghostel-compile'.
+      (setq ghostel-compile--command "make"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--directory default-directory
+            ghostel-compile--last-exit nil
+            ghostel-compile--running 'pending
+            ghostel-compile--scan-marker nil)
+      ;; C arrives: scan-marker snaps here, past the stale content.
+      (ghostel-compile--on-start buf)
+      (should (markerp ghostel-compile--scan-marker))
+      ;; One real error in the run's output.
+      (insert "/tmp/new.c:1:1: error: real\n")
+      (ghostel-compile--finalize buf 1 (current-time))
+      ;; Stale lines are still in the buffer but not in the error count.
+      (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+        (should (string-match-p "STALE-ONE" text))
+        (should (string-match-p "STALE-TWO" text)))
+      ;; Three error-shaped lines in the buffer, but only the one
+      ;; below the scan marker should count.
+      (should (= 1 compilation-num-errors-found)))))
+
+(ert-deftest ghostel-test-compile-finalize-anchors-header-at-scan-marker ()
+  "When pre-existing output is kept (`--clear-buffer nil'), the header
+must be inserted at the start of THIS run's output, not at point-min,
+so it stays attached to the region described.  Also: parsing must
+not pick up errors above the scan marker (would inflate
+`compilation-num-errors-found' with stale matches)."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t)
+          (ghostel-compile-finished-major-mode nil))
+      ;; Pre-existing output that contains an error-shaped line —
+      ;; this is from a previous run that was kept around.
+      (insert "/tmp/old.c:99:1: error: STALE\n")
+      ;; Now start a fresh run from here.
+      (setq ghostel-compile--command "make"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--running 'armed
+            ghostel-compile--scan-marker (copy-marker (point-max)))
+      (insert "/tmp/new.c:1:1: error: real\n")
+      (ghostel-compile--finalize buf 1 (current-time))
+      (let ((text (buffer-substring-no-properties (point-min) (point-max))))
+        ;; Stale line is still present (we didn't clear).
+        (should (string-match-p "STALE" text))
+        ;; Header is anchored ABOVE the new run, BELOW the stale line.
+        (let ((stale-pos (string-match-p "STALE" text))
+              (header-pos (string-match-p "Compilation started at" text)))
+          (should (< stale-pos header-pos))))
+      ;; Only the current run's error is counted, not the stale one.
+      (should (= 1 compilation-num-errors-found)))))
+
+(ert-deftest ghostel-test-compile-finalize-footer-on-failure ()
+  "Non-zero exit produces an \"exited abnormally\" footer in buffer text."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t)
+          (ghostel-compile-finished-major-mode nil))
+      (insert "boom\n")
+      (setq ghostel-compile--command "false"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--running 'armed
+            ghostel-compile--scan-marker (copy-marker (point-min)))
+      (ghostel-compile--finalize buf 2 (current-time))
+      (should (string-match-p
+               "exited abnormally with code 2"
+               (buffer-substring-no-properties (point-min) (point-max)))))))
+
+(ert-deftest ghostel-test-compile-finalize-hides-prompts ()
+  "ghostel-compile--finalize marks ghostel-prompt regions AND the
+echoed command on the same line invisible — users don't want to
+see `$ echo hi' right below the header's already-shown
+`echo hi'."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t)
+          (ghostel-compile-finished-major-mode nil))
+      (setq ghostel-compile--command "echo hi"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--running 'armed
+            ghostel-compile--scan-marker (copy-marker (point-min)))
+      ;; Prompt + echoed command on the same line (only the `$ ' part
+      ;; carries the `ghostel-prompt' property; the command itself is
+      ;; past the OSC 133 B marker).
+      (let ((prompt-start (point)))
+        (insert "$ ")
+        (put-text-property prompt-start (point) 'ghostel-prompt t))
+      (insert "echo hi\n")
+      (insert "hi\n")
+      ;; Trailing prompt (no echoed command follows).
+      (let ((prompt2-start (point)))
+        (insert "$ ")
+        (put-text-property prompt2-start (point) 'ghostel-prompt t))
+      (ghostel-compile--finalize buf 0 (current-time))
+      ;; Prompt markers and the echoed command line should all be invisible.
+      (save-excursion
+        (goto-char (point-min))
+        (re-search-forward "\\$ " nil t)
+        (should (get-text-property (match-beginning 0) 'invisible))
+        ;; The echoed command on the same line must also be hidden.
+        (re-search-forward "echo hi" nil t)
+        (should (get-text-property (match-beginning 0) 'invisible)))
+      ;; The actual output line must still be visible.
+      (save-excursion
+        (goto-char (point-min))
+        (re-search-forward "^hi" nil t)
+        (should-not (get-text-property (match-beginning 0) 'invisible))))))
+
+(ert-deftest ghostel-test-compile-finalize-hides-echoed-command-without-prompt-property ()
+  "Regression: when the native renderer puts `ghostel-prompt' only
+on the prompt glyph itself and NOT on the echoed command that
+follows on the same row, `--hide-prompts' must still hide the
+whole line by matching the line against
+`ghostel-compile--command'."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t)
+          (ghostel-compile-finished-major-mode nil))
+      (setq ghostel-compile--command "make -j4 test"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--running 'armed
+            ghostel-compile--scan-marker (copy-marker (point-min)))
+      ;; Simulate the exact visual from the user report: a prompt +
+      ;; echoed command on one line, but NO `ghostel-prompt' property
+      ;; anywhere on the line.
+      (insert "~/.emacs.d/lib/ghostel λ make -j4 test\n")
+      (insert "output\n")
+      (ghostel-compile--finalize buf 0 (current-time))
+      (save-excursion
+        (goto-char (point-min))
+        ;; The echoed prompt + command line must be hidden.
+        (re-search-forward "~/\\.emacs\\.d/lib/ghostel" nil t)
+        (should (get-text-property (match-beginning 0) 'invisible)))
+      (save-excursion
+        (goto-char (point-min))
+        ;; The real output line must NOT be hidden.
+        (re-search-forward "^output$" nil t)
+        (should-not (get-text-property (match-beginning 0) 'invisible))))))
+
+(ert-deftest ghostel-test-compile-finalize-hide-prompts-nil ()
+  "When `ghostel-compile-hide-prompts' is nil, prompts stay visible."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t)
+          (ghostel-compile-finished-major-mode nil)
+          (ghostel-compile-hide-prompts nil))
+      (setq ghostel-compile--command "echo hi"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--running 'armed
+            ghostel-compile--scan-marker (copy-marker (point-min)))
+      (let ((prompt-start (point)))
+        (insert "$ ")
+        (put-text-property prompt-start (point) 'ghostel-prompt t))
+      (insert "echo hi\nhi\n")
+      (ghostel-compile--finalize buf 0 (current-time))
+      ;; The prompt's `$ ' must NOT have `invisible' set.
+      (goto-char (point-min))
+      (re-search-forward "\\$ " nil t)
+      (should-not (get-text-property (match-beginning 0) 'invisible)))))
+
+(ert-deftest ghostel-test-command-finish-hook-runs-synchronously ()
+  "Regression: `ghostel-command-finish-functions' must fire synchronously
+inside `ghostel--osc133-marker', not be deferred via timers.  Downstream
+consumers (notably `ghostel-compile') depend on it."
+  (let ((ran nil))
+    (let ((ghostel-command-finish-functions
+           (list (lambda (_b _e) (setq ran t)))))
+      (ghostel--osc133-marker "D" "0")
+      (should ran))))                                          ; in-stack call
+
+(ert-deftest ghostel-test-command-start-hook-runs-synchronously ()
+  "Regression: `ghostel-command-start-functions' must fire synchronously."
+  (let ((ran nil))
+    (let ((ghostel-command-start-functions
+           (list (lambda (_b) (setq ran t)))))
+      (ghostel--osc133-marker "C" nil)
+      (should ran))))                                          ; in-stack call
+
+(ert-deftest ghostel-test-compile-finalize-colors-errors ()
+  "After finalize, error lines carry `compilation-line-number' / error faces."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (setq ghostel-compile--command "make"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--running 'armed
+            ghostel-compile--scan-marker (copy-marker (point-max)))
+      (insert "/tmp/x.c:42:5: error: bad\n"))
+    (ghostel-compile--finalize buf 1 (current-time))
+    (goto-char (point-min))
+    (search-forward "/tmp/x.c")
+    (let ((props (text-properties-at (1- (point)))))
+      (should (or (memq 'compilation-error props)
+                  (memq 'compilation-error
+                        (ensure-list
+                         (plist-get props 'font-lock-face)))
+                  (plist-member props 'compilation-message))))
+    (goto-char (point-min))
+    (search-forward ":42")
+    (let ((line-face (get-text-property (1- (point)) 'font-lock-face)))
+      (should (or (eq line-face 'compilation-line-number)
+                  (memq 'compilation-line-number
+                        (ensure-list line-face)))))))
+
+(ert-deftest ghostel-test-compile-spurious-d-without-c-is-ignored ()
+  "Regression: a D marker without a preceding C must not finalize.
+
+Some shells (notably zsh's clear-screen widget after we send `\\f'
+in `ghostel-clear-scrollback') redraw the prompt and re-fire precmd,
+which emits OSC 133 D with the *previous* command's exit (typically
+0).  Without C-gating we'd report `:exit [0]' even though the user's
+real command exited non-zero."
+  (let ((scheduled nil))
+    (cl-letf (((symbol-function 'run-at-time)
+               (lambda (_when _repeat fn &rest args)
+                 (push (cons fn args) scheduled)
+                 :timer-stub)))
+      (ghostel-test--with-compile-buffer buf
+        (setq ghostel-compile--command "make"
+              ghostel-compile--start-time (current-time)
+              ghostel-compile--running 'pending          ; just sent the cmd
+              ghostel-compile--scan-marker (copy-marker (point-max)))
+        ;; Spurious D from prompt redraw arrives BEFORE any C.
+        (ghostel-compile--on-finish buf 0)
+        (should-not scheduled)                           ; ignored
+        (should (eq 'pending ghostel-compile--running))  ; still pending
+        ;; Now the real command runs: C arrives, then D;2.
+        (ghostel-compile--on-start buf)
+        (should (eq 'armed ghostel-compile--running))    ; armed by C
+        (ghostel-compile--on-finish buf 2)
+        (should (= 1 (length scheduled)))                ; scheduled once
+        (should (equal 2 (nth 2 (car scheduled))))      ; with the real exit
+        (should (eq 'fired ghostel-compile--running))))))
+
+(ert-deftest ghostel-test-compile-on-finish-only-first-d-counts ()
+  "First D after C wins; subsequent Ds before finalize are ignored."
+  (let ((scheduled nil))
+    (cl-letf (((symbol-function 'run-at-time)
+               (lambda (_when _repeat fn &rest args)
+                 (push (cons fn args) scheduled)
+                 :timer-stub)))
+      (ghostel-test--with-compile-buffer buf
+        (setq ghostel-compile--command "make"
+              ghostel-compile--start-time (current-time)
+              ghostel-compile--running 'armed
+              ghostel-compile--scan-marker (copy-marker (point-max)))
+        (ghostel-compile--on-finish buf 2)                     ; real exit
+        (ghostel-compile--on-finish buf 0)                     ; spurious follow-up
+        (should (= 1 (length scheduled)))                      ; scheduled once
+        ;; entry is (FN BUFFER EXIT END-TIME) — exit at index 2
+        (should (equal 2 (nth 2 (car scheduled))))            ; real exit kept
+        (should (eq 'fired ghostel-compile--running))))))
+
+(ert-deftest ghostel-test-compile-finalize-does-not-double-count-errors ()
+  "Regression: parsing must not count each error twice.
+
+Using `compilation-parse-errors' directly does not advance
+`compilation--parsed', so jit-lock would re-scan and double the
+error count.  `compilation--ensure-parse' is the right entry point."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (insert "/tmp/a.c:1:1: error: oops\n"
+              "/tmp/b.c:2:2: error: oops\n")
+      (setq ghostel-compile--command "make"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--running 'armed
+            ghostel-compile--scan-marker (copy-marker (point-min))))
+    (ghostel-compile--finalize buf 1 (current-time))
+    (should (= 2 compilation-num-errors-found))))             ; not 4
+
+(ert-deftest ghostel-test-compile-finalize-does-not-kill-buffer ()
+  "Regression: finalize must not let `ghostel--sentinel' kill the buffer.
+
+Previously, teardown called `delete-process' with the ghostel sentinel
+still attached; the sentinel would then invoke `kill-buffer' because
+`ghostel-kill-buffer-on-exit' defaults to t.  The visible symptom is a
+compile buffer that flashes open and disappears."
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf (generate-new-buffer " *ghostel-test-compile-live*"))
+         (inhibit-message t)
+         proc)
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (ghostel-compile-mode 1)
+          (setq proc (start-process "gh-compile-dummy" buf
+                                    "/bin/sh" "-c" "sleep 5"))
+          (set-process-query-on-exit-flag proc nil)
+          (set-process-sentinel proc #'ghostel--sentinel)
+          (setq-local ghostel--process proc
+                      ghostel-compile--command "sleep 5"
+                      ghostel-compile--start-time (current-time)
+                      ghostel-compile--running 'armed
+                      ghostel-compile--scan-marker (copy-marker (point-max)))
+          ;; Finalize with a real process attached: must NOT kill the
+          ;; buffer AND must NOT insert the default sentinel's
+          ;; "Process NAME killed: N" line into it.
+          (ghostel-compile--finalize buf 0 (current-time))
+          (should (buffer-live-p buf))                         ; buffer survived
+          (should-not (process-live-p proc))                   ; process was stopped
+          (should-not (string-match-p
+                       "Process .*killed"
+                       (buffer-substring-no-properties
+                        (point-min) (point-max)))))            ; no noise text
+      (when (process-live-p proc) (delete-process proc))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-compile-view-mode-n-p-navigate-without-opening ()
+  "`n'/`p' walk errors in the buffer without opening source files.
+The user wants `n'/`p' to behave like `M-n'/`M-p' in `compilation-mode' —
+move point through compile messages without auto-opening files in
+another window.  RET/`compile-goto-error' is for opening."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (insert "/tmp/aa.c:1:1: error: first\n"
+              "blah\n"
+              "/tmp/bb.c:2:2: error: second\n")
+      (setq ghostel-compile--command "make"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--running 'armed
+            ghostel-compile--scan-marker (copy-marker (point-min))))
+    (ghostel-compile--finalize buf 1 (current-time))
+    ;; n/p should map to the navigation-only commands (no file open).
+    (should (eq (lookup-key (current-local-map) "n")
+                #'compilation-next-error))
+    (should (eq (lookup-key (current-local-map) "p")
+                #'compilation-previous-error))
+    ;; Walking n twice must visit BOTH error lines, never opening files.
+    (let ((opened nil))
+      (cl-letf (((symbol-function 'compilation-find-file)
+                 (lambda (&rest _) (setq opened t)
+                   (current-buffer))))
+        (goto-char (point-min))
+        (compilation-next-error 1)
+        (let ((p1 (point)))
+          (should (save-excursion
+                    (beginning-of-line)
+                    (looking-at "/tmp/aa\\.c")))
+          (compilation-next-error 1)
+          (should (/= p1 (point)))                            ; point moved
+          (should (save-excursion
+                    (beginning-of-line)
+                    (looking-at "/tmp/bb\\.c"))))
+        (should-not opened)))))                              ; no file opened
+
+(ert-deftest ghostel-test-compile-finalize-leaves-point-at-end ()
+  "Regression: finalize must put point at `point-max' — past the
+footer — so the \"Compilation finished at ..., duration ...\" line
+is visible when the window recenters to the bottom.  Point at the
+start of the footer (or at the end of output before the footer)
+leaves the footer scrolled below the window."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (insert "line A\nline B\nline C\n")
+      (goto-char (point-max))
+      (setq ghostel-compile--command "true"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--running 'armed
+            ghostel-compile--scan-marker (copy-marker (point-min))))
+    (ghostel-compile--finalize buf 0 (current-time))
+    (should (= (point) (point-max)))                           ; past footer
+    ;; And the footer text really is the last thing in the buffer.
+    (should (string-match-p
+             "Compilation finished at.*duration"
+             (buffer-substring-no-properties
+              (max (point-min) (- (point-max) 200))
+              (point-max))))))
+
+(ert-deftest ghostel-test-compile-bash-integration-saves-real-status ()
+  "The bash PROMPT_COMMAND wrapper must capture \\='$?\\=' before any
+bare assignment.  Bare assignments such as `__ghostel_in_prompt_command=1'
+reset $? to 0 in bash, so capturing $? must be the very first thing
+inside the wrapper.  Otherwise OSC 133 D always reports exit 0."
+  (skip-unless (file-executable-p "/bin/bash"))
+  (let* ((script (expand-file-name "etc/ghostel.bash"
+                                   (file-name-directory
+                                    (locate-library "ghostel"))))
+         (cmd (format "source %s; \
+__ghostel_prompt_shown=1; \
+( exit 42 ); \
+output=$( __ghostel_wrapped_prompt_command 2>&1 ); \
+case \"$output\" in *$'\\033]133;D;42'*) echo OK ;; *) echo \"FAIL: $output\" ;; esac"
+                      (shell-quote-argument script))))
+    (with-temp-buffer
+      (let ((status (call-process "/bin/bash" nil t nil "-c" cmd)))
+        (should (zerop status))
+        (should (string-match-p "OK" (buffer-string)))))))
+
+(ert-deftest ghostel-test-compile-finalize-switches-major-mode ()
+  "With the default option, finalize switches to `ghostel-compile-view-mode'."
+  (ghostel-test--with-compile-buffer buf
+    (setq ghostel-compile--command "true"
+          ghostel-compile--start-time (current-time)
+          ghostel-compile--running 'armed
+          ghostel-compile--scan-marker (copy-marker (point-max)))
+    (should (derived-mode-p 'ghostel-mode))                    ; starts as ghostel
+    (ghostel-compile--finalize buf 0 (current-time))
+    (should (derived-mode-p 'ghostel-compile-view-mode))        ; switched
+    (should (derived-mode-p 'compilation-mode))                 ; inherits compile
+    (should-not (derived-mode-p 'ghostel-mode))                 ; not ghostel anymore
+    (should buffer-read-only)                                   ; read-only
+    (should (eq next-error-function #'compilation-next-error-function))
+    (should (equal "true" ghostel-compile--command))))          ; state preserved
+
+(ert-deftest ghostel-test-compile-recompile-key-binding ()
+  "`g' in `ghostel-compile-mode' is bound to `ghostel-recompile'."
+  (should (eq (lookup-key ghostel-compile-mode-map (kbd "g"))
+              #'ghostel-recompile)))                           ; direct map binding
+
+(ert-deftest ghostel-test-compile-recompile-overrides-compile-g ()
+  "Our `g' binding overrides `compilation-minor-mode-map's recompile."
+  (ghostel-test--with-compile-buffer buf
+    (should (eq (key-binding (kbd "g")) #'ghostel-recompile)))) ; shadow active
+
+(ert-deftest ghostel-test-compile-format-duration ()
+  "Duration formatting matches `M-x compile's style."
+  (should (equal "0.50 s"  (ghostel-compile--format-duration 0.5)))
+  (should (equal "5.00 s"  (ghostel-compile--format-duration 5)))
+  (should (equal "30.0 s"  (ghostel-compile--format-duration 30)))
+  (should (equal "0:02:05" (ghostel-compile--format-duration 125)))
+  (should (equal "1:01:05" (ghostel-compile--format-duration 3665))))
+
+(ert-deftest ghostel-test-compile-status-message ()
+  "Status message strings match `M-x compile' conventions."
+  (should (equal "finished\n" (ghostel-compile--status-message 0)))
+  (should (equal "exited abnormally with code 2\n"
+                 (ghostel-compile--status-message 2)))
+  (should (equal "finished\n" (ghostel-compile--status-message nil))))
+
+(ert-deftest ghostel-test-compile-mode-line-running ()
+  "`ghostel-compile--set-mode-line-running' sets `:run' with run face."
+  (with-temp-buffer
+    (ghostel-compile--set-mode-line-running)
+    ;; Expect (:propertize ":run" face compilation-mode-line-run) as head.
+    (let ((head (car mode-line-process)))
+      (should (eq :propertize (car head)))
+      (should (equal ":run" (cadr head)))
+      (should (eq 'compilation-mode-line-run
+                  (plist-get (cddr head) 'face))))))
+
+(ert-deftest ghostel-test-compile-mode-line-exit ()
+  "`ghostel-compile--set-mode-line-exit' uses exit/fail face for 0/non-zero."
+  (with-temp-buffer
+    (ghostel-compile--set-mode-line-exit 0)
+    (let* ((first (car mode-line-process)))
+      (should (string-match-p "exit \\[0\\]" first))
+      (should (eq 'compilation-mode-line-exit
+                  (get-text-property 0 'face first))))
+    (ghostel-compile--set-mode-line-exit 1)
+    (let* ((first (car mode-line-process)))
+      (should (string-match-p "exit \\[1\\]" first))
+      (should (eq 'compilation-mode-line-fail
+                  (get-text-property 0 'face first))))))
+
+(ert-deftest ghostel-test-compile-finish-hooks-fire ()
+  "Both `ghostel-compile-finish-functions' and `compilation-finish-functions' run."
+  (ghostel-test--with-compile-buffer buf
+    (let* ((ghostel-compile-finished-major-mode nil)
+           (g-calls nil)
+           (c-calls nil)
+           (ghostel-compile-finish-functions
+            (list (lambda (b m) (push (cons b m) g-calls))))
+           (compilation-finish-functions
+            (list (lambda (b m) (push (cons b m) c-calls)))))
+      (setq ghostel-compile--command "true"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--running 'armed
+            ghostel-compile--scan-marker (copy-marker (point-max)))
+      (ghostel-compile--finalize buf 0 (current-time))
+      (should (equal 1 (length g-calls)))                     ; ghostel hook
+      (should (eq buf (caar g-calls)))
+      (should (equal "finished\n" (cdar g-calls)))
+      (should (equal 1 (length c-calls)))                     ; compile hook
+      (should (equal "finished\n" (cdar c-calls))))))
+
+(ert-deftest ghostel-test-compile-finalize-ignored-when-not-running ()
+  "Finalize is a no-op when `--running' is nil (manual shell activity)."
+  (ghostel-test--with-compile-buffer buf
+    (let ((ghostel-compile-finished-major-mode nil)
+          (ghostel-compile--running nil))
+      ;; Call the hook dispatcher directly — should not schedule finalize.
+      (setq ghostel-compile--command "true"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--scan-marker (copy-marker (point-max)))
+      (ghostel-compile--on-finish buf 0)
+      ;; Finalize should not have run: last-exit stays nil.
+      (should-not ghostel-compile--last-exit))))
+
+(ert-deftest ghostel-test-compile-auto-jump-to-first-error ()
+  "With `compilation-auto-jump-to-first-error' set, jump after parsing."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t)
+          (ghostel-compile-finished-major-mode nil)
+          (compilation-auto-jump-to-first-error t)
+          (jumped nil))
+      (cl-letf (((symbol-function 'first-error)
+                 (lambda (&rest _) (setq jumped t))))
+        (setq ghostel-compile--command "make"
+              ghostel-compile--start-time (current-time)
+              ghostel-compile--running 'armed
+              ghostel-compile--scan-marker (copy-marker (point-max)))
+        (insert "/tmp/x.c:1:1: error: boom\n")
+        (ghostel-compile--finalize buf 1 (current-time))
+        (should jumped)))))                                    ; first-error called
+
+(ert-deftest ghostel-test-compile-clears-buffer-before-run ()
+  "`ghostel-compile' clears the buffer before sending the command."
+  (ghostel-test--with-compile-buffer buf
+    (let ((cleared nil)
+          (sent nil)
+          (ghostel-compile-buffer-name (buffer-name buf))
+          (ghostel-compile-clear-buffer t))
+      (cl-letf (((symbol-function 'ghostel-clear-scrollback)
+                 (lambda () (setq cleared t)))
+                ((symbol-function 'ghostel--flush-output)
+                 (lambda (data) (setq sent data)))
+                ((symbol-function 'ghostel-compile--get-or-create-buffer)
+                 (lambda () buf))
+                ((symbol-function 'pop-to-buffer)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'save-some-buffers)
+                 (lambda (&rest _) nil)))
+        (ghostel-compile "make test")
+        (should cleared)                                      ; clear was called
+        (should (equal "make test\n" sent))))))               ; then command sent
+
+(ert-deftest ghostel-test-compile-clear-disabled ()
+  "`ghostel-compile-clear-buffer' nil skips the clear."
+  (ghostel-test--with-compile-buffer buf
+    (let ((cleared nil)
+          (ghostel-compile-buffer-name (buffer-name buf))
+          (ghostel-compile-clear-buffer nil))
+      (cl-letf (((symbol-function 'ghostel-clear-scrollback)
+                 (lambda () (setq cleared t)))
+                ((symbol-function 'ghostel--flush-output)
+                 (lambda (_) nil))
+                ((symbol-function 'ghostel-compile--get-or-create-buffer)
+                 (lambda () buf))
+                ((symbol-function 'pop-to-buffer)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'save-some-buffers)
+                 (lambda (&rest _) nil)))
+        (ghostel-compile "make test")
+        (should-not cleared)))))                              ; clear skipped
+
+(ert-deftest ghostel-test-compile-recompile-uses-original-directory ()
+  "`ghostel-recompile' must run in the original `default-directory'.
+
+The user's report: run `ghostel-compile' in /A, switch to a buffer
+in /B, switch back, press `g'.  Without preserving the directory,
+the new compile inherited /B (or whatever buffer was current after
+the kill-buffer in `--get-or-create-buffer')."
+  (let ((dir-at-call nil)
+        (buf (generate-new-buffer " *ghostel-test-recompile-dir*"))
+        (inhibit-message t))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (ghostel-compile-mode 1)
+          ;; Simulate the post-finalize state of a previous run.
+          (setq ghostel-compile--command "make"
+                ghostel-compile--directory "/some/project/")
+          (cl-letf (((symbol-function 'ghostel-compile)
+                     (lambda (_cmd) (setq dir-at-call default-directory)))
+                    ((symbol-function 'get-buffer)
+                     (lambda (name)
+                       (if (equal name ghostel-compile-buffer-name) buf
+                         (funcall (symbol-function 'get-buffer) name)))))
+            ;; Recompile from a buffer whose default-directory is somewhere else.
+            (let ((default-directory "/elsewhere/"))
+              (ghostel-recompile))
+            (should (equal "/some/project/" dir-at-call))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-compile-finalize-pins-default-directory ()
+  "Finalize must pin `default-directory' to the captured value.
+Even if the shell drifted via OSC 7 or the user customized things,
+the resulting view-mode buffer should report its compile directory
+so `ghostel-recompile' (and other tooling) can rely on it."
+  (ghostel-test--with-compile-buffer buf
+    (setq ghostel-compile--command "make"
+          ghostel-compile--directory "/pinned/dir/"
+          ghostel-compile--start-time (current-time)
+          ghostel-compile--running 'armed
+          ghostel-compile--scan-marker (copy-marker (point-max)))
+    (setq default-directory "/drifted/somewhere/")
+    (ghostel-compile--finalize buf 0 (current-time))
+    (should (equal "/pinned/dir/" default-directory))         ; pinned back
+    (should (equal "/pinned/dir/" ghostel-compile--directory))))
+
+(ert-deftest ghostel-test-compile-recompile-without-history ()
+  "`ghostel-recompile' errors cleanly when nothing has been compiled."
+  (let ((compile-command ""))
+    (when-let* ((buf (get-buffer ghostel-compile-buffer-name)))
+      (kill-buffer buf))
+    (should-error (ghostel-recompile) :type 'user-error)))
+
+(ert-deftest ghostel-test-compile-uses-compile-command ()
+  "`ghostel-compile' persists the run command to `compile-command'."
+  (ghostel-test--with-compile-buffer buf
+    (let ((compile-command "make old")
+          (ghostel-compile-buffer-name (buffer-name buf))
+          (ghostel-compile-clear-buffer nil))
+      (cl-letf (((symbol-function 'ghostel--flush-output)
+                 (lambda (_) nil))
+                ((symbol-function 'ghostel-compile--get-or-create-buffer)
+                 (lambda () buf))
+                ((symbol-function 'pop-to-buffer)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'save-some-buffers)
+                 (lambda (&rest _) nil)))
+        (ghostel-compile "make new")
+        (should (equal "make new" compile-command))))))       ; persisted
+
+(ert-deftest ghostel-test-compile-interactive-uses-compile-history ()
+  "`ghostel-compile's prompt uses `compile-history' as the history list."
+  (ghostel-test--with-compile-buffer buf
+    (let ((captured nil)
+          (compile-history '("old-cmd"))
+          (compile-command "make default")
+          (compilation-read-command t)
+          (ghostel-compile-buffer-name (buffer-name buf)))
+      (cl-letf (((symbol-function 'read-shell-command)
+                 (lambda (_prompt _default hist-sym &rest _)
+                   (setq captured hist-sym)
+                   "chosen-cmd"))
+                ((symbol-function 'ghostel--flush-output)
+                 (lambda (_) nil))
+                ((symbol-function 'ghostel-compile--get-or-create-buffer)
+                 (lambda () buf))
+                ((symbol-function 'pop-to-buffer)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'save-some-buffers)
+                 (lambda (&rest _) nil)))
+        (call-interactively #'ghostel-compile)
+        ;; History symbol should be (or directly reference) `compile-history'.
+        (should (or (eq captured 'compile-history)
+                    (and (consp captured)
+                         (eq (car captured) 'compile-history))))))))
+
+(ert-deftest ghostel-test-compile-respects-compilation-read-command ()
+  "When `compilation-read-command' is nil, use `compile-command' silently."
+  (ghostel-test--with-compile-buffer buf
+    (let ((prompted nil)
+          (compile-command "make -C /tmp silent")
+          (compilation-read-command nil)
+          (ghostel-compile-buffer-name (buffer-name buf)))
+      (cl-letf (((symbol-function 'read-shell-command)
+                 (lambda (&rest _) (setq prompted t) "never"))
+                ((symbol-function 'ghostel--flush-output)
+                 (lambda (_) nil))
+                ((symbol-function 'ghostel-compile--get-or-create-buffer)
+                 (lambda () buf))
+                ((symbol-function 'pop-to-buffer)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'save-some-buffers)
+                 (lambda (&rest _) nil)))
+        (call-interactively #'ghostel-compile)
+        (should-not prompted)                                  ; no prompt
+        (should (equal ghostel-compile--command              ; command used as-is
+                       "make -C /tmp silent"))))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: prompt navigation
@@ -3128,7 +4055,52 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-sigwinch-reaches-shell-basic
     ghostel-test-sigwinch-reaches-shell-ghostel-style
     ghostel-test-sigwinch-reaches-child-process
-    ghostel-test-sigwinch-via-ghostel-resize-handler)
+    ghostel-test-sigwinch-via-ghostel-resize-handler
+    ghostel-test-command-finish-hook
+    ghostel-test-command-finish-hook-error-caught
+    ghostel-test-command-finish-hook-error-isolated
+    ghostel-test-compile-mode-requires-ghostel-buffer
+    ghostel-test-compile-mode-sets-up-finish-hook
+    ghostel-test-compile-mode-disable-is-reversible
+    ghostel-test-compile-mode-respects-prior-compilation-minor
+    ghostel-test-compile-mode-disable-cancels-pending
+    ghostel-test-compile-finalize-hide-prompts-nil
+    ghostel-test-command-finish-hook-runs-synchronously
+    ghostel-test-command-start-hook-runs-synchronously
+    ghostel-test-compile-finalize-scans-errors
+    ghostel-test-compile-finalize-inserts-header-and-footer
+    ghostel-test-compile-on-start-snaps-scan-marker
+    ghostel-test-compile-clear-buffer-isolates-stale-errors
+    ghostel-test-compile-finalize-anchors-header-at-scan-marker
+    ghostel-test-compile-finalize-footer-on-failure
+    ghostel-test-compile-finalize-hides-prompts
+    ghostel-test-compile-finalize-hides-echoed-command-without-prompt-property
+    ghostel-test-compile-finalize-colors-errors
+    ghostel-test-compile-spurious-d-without-c-is-ignored
+    ghostel-test-compile-on-finish-only-first-d-counts
+    ghostel-test-compile-finalize-does-not-double-count-errors
+    ghostel-test-compile-finalize-does-not-kill-buffer
+    ghostel-test-compile-view-mode-n-p-navigate-without-opening
+    ghostel-test-compile-finalize-leaves-point-at-end
+    ghostel-test-compile-bash-integration-saves-real-status
+    ghostel-test-compile-finalize-pins-default-directory
+    ghostel-test-compile-recompile-uses-original-directory
+    ghostel-test-compile-finalize-switches-major-mode
+    ghostel-test-compile-recompile-key-binding
+    ghostel-test-compile-recompile-overrides-compile-g
+    ghostel-test-compile-format-duration
+    ghostel-test-compile-status-message
+    ghostel-test-compile-mode-line-running
+    ghostel-test-compile-mode-line-exit
+    ghostel-test-compile-finish-hooks-fire
+    ghostel-test-compile-finalize-ignored-when-not-running
+    ghostel-test-compile-auto-jump-to-first-error
+    ghostel-test-compile-clears-buffer-before-run
+    ghostel-test-compile-clear-disabled
+    ghostel-test-compile-recompile-without-history
+    ghostel-test-compile-uses-compile-command
+    ghostel-test-compile-interactive-uses-compile-history
+    ghostel-test-compile-respects-compilation-read-command)
   "Tests that require only Elisp (no native module).")
 
 (defun ghostel-test-run-elisp ()


### PR DESCRIPTION
## Summary

- **Expose `ghostel-command-finish-functions` hook** — fires with `(buffer exit-status)` when the shell reports an OSC 133 `D;<exit>` marker. Gives downstream integrations a clean way to react to command boundaries and exit codes without polling the terminal.
- **Add `ghostel-compile` / `ghostel-recompile`** — run a shell command in a ghostel terminal buffer and populate `next-error` from the output, the same way `M-x compile` does. Uses the new hook to trigger an error scan at command completion. Unlike `M-x compile`, programs that probe `isatty(3)` (progress bars, curses tools, colourful output) work naturally because they get a real TTY.

Minor `ghostel-compile-mode` is also provided so any ghostel buffer can be turned into a `next-error` source without going through `ghostel-compile`.

## Test plan

- [x] New pure-elisp tests: hook firing, error-catching, mode enable/disable, error scan region scoping, recompile without history
- [x] New native test: OSC 133 D bytes through the VT parser fire the hook end-to-end
- [x] `make test` (76 elisp tests)
- [x] `make test-native` (49 native tests)
- [x] `make test-evil` (30 evil tests)
- [x] `make lint` (byte-compile + package-lint + checkdoc)