### PR TITLE
Add Windows ConPTY support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,13 @@ jobs:
           version: 0.15.2
 
       - name: Run pure-Zig unit tests
-        run: zig build test
+        shell: bash
+        run: |
+          target_args=()
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            target_args=(-Dtarget=x86_64-windows-gnu)
+          fi
+          zig build test "${target_args[@]}"
 
   test:
     runs-on: ubuntu-latest
@@ -287,6 +293,7 @@ jobs:
   test-native-windows:
     needs: build-native
     runs-on: windows-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -310,7 +317,8 @@ jobs:
         run: |
           touch ghostel-module.dll
           git clone --depth 1 https://github.com/emacs-compat/compat.git /tmp/compat
-          make -j$(getconf _NPROCESSORS_ONLN) \
+          make \
+            EMACS="timeout 60s emacs" \
             EMACSFLAGS="-L /tmp/compat" \
             test-native
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,10 @@ jobs:
             platform: x86_64-windows
             suffix: .dll
             target: x86_64-windows-gnu
+          - os: windows-latest
+            platform: aarch64-windows
+            suffix: .dll
+            target: aarch64-windows-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,10 @@ jobs:
             platform: x86_64-freebsd
             suffix: .so
             target: x86_64-freebsd
+          - os: windows-latest
+            platform: x86_64-windows
+            suffix: .dll
+            target: x86_64-windows-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -178,6 +182,7 @@ jobs:
           cache-key: ${{ matrix.platform }}-zig-0.15.2
 
       - name: Build native module
+        shell: bash
         run: |
           if [ -n "${{ matrix.target }}" ]; then
             zig build --prefix . -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast -Dcpu=baseline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,13 @@ jobs:
         run: make package-lint checkdoc docquotes
 
   test-zig:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -185,13 +191,24 @@ jobs:
           version: 0.15.2
           cache-key: ${{ matrix.platform }}-zig-0.15.2
 
+      - name: Download ConPTY runtime
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/Microsoft.Windows.Console.ConPTY/1.24.260512001 -OutFile conpty.zip
+          Expand-Archive -LiteralPath conpty.zip -DestinationPath conpty-package -Force
+
       - name: Build native module
         shell: bash
         run: |
+          conpty_args=()
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            conpty_args=(-Dwindows-conpty-package-dir=conpty-package)
+          fi
           if [ -n "${{ matrix.target }}" ]; then
-            zig build --prefix . -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast -Dcpu=baseline
+            zig build --prefix . -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast -Dcpu=baseline "${conpty_args[@]}"
           else
-            zig build --prefix . -Doptimize=ReleaseFast -Dcpu=baseline
+            zig build --prefix . -Doptimize=ReleaseFast -Dcpu=baseline "${conpty_args[@]}"
           fi
 
       - name: Upload module artifact
@@ -201,6 +218,9 @@ jobs:
           path: |
             ghostel-module${{ matrix.suffix }}
             ghostel-module.version
+            conpty.dll
+            x64/OpenConsole.exe
+            arm64/OpenConsole.exe
 
   test-native:
     needs: build-native
@@ -227,6 +247,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
       - uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ github.token }}
@@ -257,6 +280,36 @@ jobs:
 
       - name: Run native module tests
         run: |
+          make -j$(getconf _NPROCESSORS_ONLN) \
+            EMACSFLAGS="-L /tmp/compat" \
+            test-native
+
+  test-native-windows:
+    needs: build-native
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            git
+            make
+            mingw-w64-ucrt-x86_64-emacs
+            mingw-w64-ucrt-x86_64-python
+
+      - name: Download native module
+        uses: actions/download-artifact@v4
+        with:
+          name: ghostel-module-x86_64-windows
+
+      - name: Run Windows native module tests
+        shell: msys2 {0}
+        run: |
+          touch ghostel-module.dll
+          git clone --depth 1 https://github.com/emacs-compat/compat.git /tmp/compat
           make -j$(getconf _NPROCESSORS_ONLN) \
             EMACSFLAGS="-L /tmp/compat" \
             test-native

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,13 +54,24 @@ jobs:
           version: 0.15.2
           cache-key: ${{ matrix.platform }}-zig-0.15.2
 
+      - name: Download ConPTY runtime
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/Microsoft.Windows.Console.ConPTY/1.24.260512001 -OutFile conpty.zip
+          Expand-Archive -LiteralPath conpty.zip -DestinationPath conpty-package -Force
+
       - name: Build native module
         shell: bash
         run: |
+          conpty_args=()
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            conpty_args=(-Dwindows-conpty-package-dir=conpty-package)
+          fi
           if [ -n "${{ matrix.target }}" ]; then
-            zig build --prefix . -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast -Dcpu=baseline
+            zig build --prefix . -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast -Dcpu=baseline "${conpty_args[@]}"
           else
-            zig build --prefix . -Doptimize=ReleaseFast -Dcpu=baseline
+            zig build --prefix . -Doptimize=ReleaseFast -Dcpu=baseline "${conpty_args[@]}"
           fi
 
       - name: Strip non-exported symbols (macOS)
@@ -72,12 +83,24 @@ jobs:
         run: |
           mv ghostel-module${{ matrix.suffix }} \
              ghostel-module-${{ matrix.platform }}${{ matrix.suffix }}
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            mv conpty.dll ghostel-conpty-${{ matrix.platform }}.dll
+            for host in x86 x64 arm64; do
+              if [ -f "$host/OpenConsole.exe" ]; then
+                mv "$host/OpenConsole.exe" \
+                   "ghostel-openconsole-${{ matrix.platform }}-$host.exe"
+              fi
+            done
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ghostel-module-${{ matrix.platform }}
-          path: ghostel-module-${{ matrix.platform }}${{ matrix.suffix }}
+          path: |
+            ghostel-module-${{ matrix.platform }}${{ matrix.suffix }}
+            ghostel-conpty-${{ matrix.platform }}.dll
+            ghostel-openconsole-${{ matrix.platform }}-*.exe
 
   release:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,14 @@ jobs:
             platform: x86_64-freebsd
             suffix: .so
             target: x86_64-freebsd
+          - os: windows-latest
+            platform: x86_64-windows
+            suffix: .dll
+            target: x86_64-windows-gnu
+          - os: windows-latest
+            platform: aarch64-windows
+            suffix: .dll
+            target: aarch64-windows-gnu
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -47,6 +55,7 @@ jobs:
           cache-key: ${{ matrix.platform }}-zig-0.15.2
 
       - name: Build native module
+        shell: bash
         run: |
           if [ -n "${{ matrix.target }}" ]; then
             zig build --prefix . -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast -Dcpu=baseline
@@ -59,6 +68,7 @@ jobs:
         run: strip -x ghostel-module${{ matrix.suffix }}
 
       - name: Rename artifact for release
+        shell: bash
         run: |
           mv ghostel-module${{ matrix.suffix }} \
              ghostel-module-${{ matrix.platform }}${{ matrix.suffix }}

--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,28 @@ elisp-string-list = $(foreach f,$(1),\"$(f)\")
 # file so the per-test stamp rules depend on its mtime instead of on the
 # phony `build' target — that way the Zig sources, not the act of asking
 # for `build', decide whether tests need to re-run.
-UNAME := $(shell uname)
-ifeq ($(UNAME),Darwin)
+UNAME := $(shell uname 2>/dev/null)
+ifeq ($(OS),Windows_NT)
+  MODULE := ghostel-module.dll
+  # Use MinGW rather than Zig's MSVC-flavoured native Windows target so local
+  # builds match release artifacts and do not require a Windows SDK.  The DLL
+  # architecture must match Emacs, not necessarily the OS (e.g. x64 Emacs under
+  # ARM64 Windows emulation).
+  ifndef ZIG_WINDOWS_TARGET
+    WINDOWS_EMACS_ARCH := $(shell $(EMACS) --batch -Q --eval "(princ (car (split-string system-configuration \"-\")))" 2>/dev/null)
+    WINDOWS_ZIG_ARCH := x86_64
+    ifneq ($(filter arm64 aarch64,$(WINDOWS_EMACS_ARCH)),)
+      WINDOWS_ZIG_ARCH := aarch64
+    endif
+    ZIG_WINDOWS_TARGET := $(WINDOWS_ZIG_ARCH)-windows-gnu
+  endif
+  ZIG_TARGET_FLAG ?= -Dtarget=$(ZIG_WINDOWS_TARGET)
+else ifeq ($(UNAME),Darwin)
   MODULE := ghostel-module.dylib
 else
   MODULE := ghostel-module.so
 endif
-ZIG_BUILD_FLAGS := --prefix . -Doptimize=ReleaseFast -Dcpu=baseline
+ZIG_BUILD_FLAGS := --prefix . -Doptimize=ReleaseFast -Dcpu=baseline $(ZIG_TARGET_FLAG)
 ZIG_SOURCES := $(wildcard src/*.zig src/*.c build.zig build.zig.zon symbols.map) \
                $(wildcard vendor/*.h)
 
@@ -51,7 +66,7 @@ $(MODULE): $(ZIG_SOURCES)
 	zig build $(ZIG_BUILD_FLAGS)
 
 test-zig:
-	zig build test
+	zig build $(ZIG_TARGET_FLAG) test
 
 test-hypothesis: build
 	$(PYTHON) -m unittest test/hypothesis/test_render.py
@@ -84,6 +99,7 @@ TEST_BASES        := $(notdir $(basename $(TEST_FILES)))
 TEST_STAMPS_DIR   := .build/tests
 TEST_ELISP_STAMPS  := $(patsubst %,$(TEST_STAMPS_DIR)/elisp-%.ok,$(TEST_BASES))
 TEST_NATIVE_STAMPS := $(patsubst %,$(TEST_STAMPS_DIR)/native-%.ok,$(TEST_BASES))
+TEST_FIXTURES      := $(wildcard test/fixtures/*.py)
 
 test: $(TEST_ELISP_STAMPS)
 
@@ -98,14 +114,14 @@ $(TEST_STAMPS_DIR)/elisp-%.ok: test/%.el test/ghostel-test-helpers.el $(ELC) | $
 	@printf '  ELISP   %s\n' $*
 	@$(EMACS) --batch $(EMACSFLAGS) -Q -L lisp -L test \
 		-l ert -l test/ghostel-test-helpers.el -l $< \
-		--eval "(ert-run-tests-batch-and-exit '(not (tag native)))"
+		-f ghostel-test-run-elisp
 	@touch $@
 
-$(TEST_STAMPS_DIR)/native-%.ok: test/%.el test/ghostel-test-helpers.el $(ELC) $(MODULE) | $(TEST_STAMPS_DIR)
+$(TEST_STAMPS_DIR)/native-%.ok: test/%.el test/ghostel-test-helpers.el $(TEST_FIXTURES) $(ELC) $(MODULE) | $(TEST_STAMPS_DIR)
 	@printf '  NATIVE  %s\n' $*
 	@$(EMACS) --batch $(EMACSFLAGS) -Q -L lisp -L test \
 		-l ert -l test/ghostel-test-helpers.el -l $< \
-		--eval "(ert-run-tests-batch-and-exit '(tag native))"
+		-f ghostel-test-run-native
 	@touch $@
 
 test-all: test test-zig test-native
@@ -244,7 +260,7 @@ public/index.html: README.org $(DOC_DEPS_STAMP)
 		          (org-export-to-file 'html \"public/index.html\"))"
 
 clean:
-	rm -f ghostel-module.dylib ghostel-module.so ghostel-module.version
+	rm -f ghostel-module.dylib ghostel-module.so ghostel-module.dll ghostel-module.version
 	rm -f $(ELC)
 	rm -rf zig-out .zig-cache .build public
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,14 @@ Check the [documentation](https://dakra.github.io/ghostel/#features) for a full 
 
 ## Quick Start
 
-**Requirements:** Emacs 28.1+ with dynamic module support, on macOS, Linux, or FreeBSD.
+**Requirements:** Emacs 28.1+ with dynamic module support, on macOS, Linux, FreeBSD, or native Windows.
 The native module is a prebuilt binary that **auto-downloads on first use**.
 No toolchain or build step required.
+
+Windows release binaries are built for common native Windows Emacs builds on
+x86_64 and aarch64. Releases include optional ConPTY support files from
+Microsoft's redistributable console runtime, which can improve latency and
+correctness compared with older inbox Windows ConPTY versions.
 
 Install from [MELPA](https://melpa.org/#/ghostel):
 

--- a/README.org
+++ b/README.org
@@ -143,7 +143,7 @@ mark.
 #+cindex: requirements
 
 - Emacs 28.1+ with dynamic module support
-- macOS, Linux, or FreeBSD
+- macOS, Linux, FreeBSD, or native Windows
 
 The native module is *automatically downloaded* on first use.  Pre-built
 binaries are available for:
@@ -153,6 +153,8 @@ binaries are available for:
 - =x86_64-linux=
 - =aarch64-linux=
 - =x86_64-freebsd=
+- =x86_64-windows=
+- =aarch64-windows=
 
 If you prefer to build from source or need a different platform, you will also
 need [[https://ziglang.org/][Zig]] 0.15.2 - see [[#building-from-source][Building from source]].
@@ -221,6 +223,38 @@ your package manager rebuilds or reinstalls the tree while Emacs has the module
 loaded, point =ghostel-module-directory= at a stable location outside the
 package tree (for example =~/.config/emacs/ghostel/=).
 
+** Platform notes
+:properties:
+:custom_id: platform-notes
+:end:
+
+*** Windows
+:properties:
+:custom_id: windows-platform-notes
+:end:
+
+Ghostel supports native Windows Emacs builds with dynamic module support.  The
+pre-built release modules target the common =x86_64= and =aarch64= native Emacs
+architectures; the module DLL must match the architecture of Emacs, not merely
+the architecture of Windows itself.  Unusual custom Emacs builds, including
+static-CRT builds, are best-effort.
+
+Local terminals use Windows ConPTY.  Ghostel first looks for support files from
+Microsoft's redistributable console runtime next to the native module
+(=conpty.dll= and the matching =OpenConsole.exe= helpers).  When present, those
+files provide newer ConPTY behavior than older inbox Windows versions and can
+improve both interactivity and terminal-protocol correctness.  If they are not
+installed, Ghostel falls back to the inbox Windows ConPTY API.
+
+Downloading a pre-built Ghostel module also downloads the matching support files
+from the same Ghostel release.  When compiling the module locally, Ghostel tries
+to install the latest available support files; failure to install them is
+non-fatal because the inbox ConPTY fallback remains available.
+
+TRAMP remote terminals from Windows are limited to POSIX remotes.  They use
+TRAMP/ssh rather than local ConPTY, so the PTY lives on the remote host.  Dynamic
+window resizing for Windows-to-TRAMP terminals is not currently supported.
+
 * Building from source
 :properties:
 :custom_id: building-from-source
@@ -255,6 +289,9 @@ zig build --prefix . -Doptimize=ReleaseFast
 The module and =ghostel-module.version= sidecar are installed under Zig's
 install prefix.  Use =--prefix .= when building into a checkout that Ghostel
 should load directly, or pass another prefix matching =ghostel-module-directory=.
+On Windows, local builds normally use Zig's MinGW target (for example
+=-Dtarget=x86_64-windows-gnu=) so they match common native Emacs builds and do
+not require a Windows SDK.
 
 When installed from MELPA, =M-x ghostel-module-compile= builds the native module
 from source using =zig build --prefix <ghostel-module-directory>=; the Zig package
@@ -948,6 +985,7 @@ ghostel= spawns a shell on the remote host via TRAMP's process machinery.  The
 ;; Default configuration
 (setq ghostel-tramp-shells
       '(("ssh" login-shell)          ; auto-detect via getent
+        ("sshx" login-shell)
         ("scp" login-shell)
         ("docker" "/bin/sh")))       ; fixed shell for containers
 #+end_src
@@ -978,6 +1016,15 @@ existing TRAMP prefix (method, user, multi-hop) when available.  When no prefix
 exists, the method defaults to =tramp-default-method=; set
 =ghostel-tramp-default-method= to override it for ghostel specifically (e.g.
 ="scp"=, or ="rpc"= with [[https://github.com/ArthurHeymans/emacs-tramp-rpc][emacs-tramp-rpc]]).
+
+Remote terminals are supported for POSIX remotes reached through SSH-style TRAMP
+methods.  Windows remotes are not supported by this path: Ghostel's remote
+wrapper uses POSIX shell and tty facilities.
+
+Dynamic remote resize support depends on the local platform and TRAMP method.
+POSIX local Emacs builds can rely on the SSH client to propagate window-size
+changes to the remote PTY.  Windows-to-TRAMP remote terminals can run, but
+dynamic resize is currently unsupported.
 
 ** Remote shell integration
 :properties:
@@ -1894,7 +1941,7 @@ while ghostel and vterm trade a compile step for a C/Zig engine.
 | Shell integration auto-inject | ✅      | manual   | manual   |
 | Prompt navigation             | ✅      | ✅       | ✅       |
 | Elisp eval from shell         | ✅      | ✅       | ❌       |
-| TRAMP remote terminals        | ✅      | ✅       | ✅       |
+| TRAMP remote terminals        | POSIX   | ✅       | ✅       |
 | Eshell integration            | ✅      | ❌       | ✅       |
 | Bookmark support              | ✅      | ✅       | ❌       |
 |-------------------------------+---------+----------+----------|
@@ -1913,9 +1960,11 @@ while ghostel and vterm trade a compile step for a C/Zig engine.
 =manual= means supported but requiring manual setup (sourcing a script);
 =partial= means a subset (eat answers OSC 10/11 but not OSC 4 palette queries, and
 renders curly but not double/dotted/dashed underlines; vterm's input modes cover
-only its default and a copy mode).  Scrollback units differ by design - ghostel
-and eat bound it by bytes, vterm by lines.  Throughput is the plain-ASCII figure
-from [[#performance][Performance]] (Emacs 32.0.50, Apple M4 Max).
+only its default and a copy mode).  =POSIX= means TRAMP terminals target POSIX
+remotes; Windows-to-TRAMP remote terminals currently do not support dynamic
+resize.  Scrollback units differ by design - ghostel and eat bound it by bytes,
+vterm by lines.  Throughput is the plain-ASCII figure from [[#performance][Performance]]
+(Emacs 32.0.50, Apple M4 Max).
 
 ** Key differences
 

--- a/build.zig
+++ b/build.zig
@@ -71,6 +71,12 @@ pub fn build(b: *std.Build) void {
     const copy_version_step = b.addInstallFile(version_file, "ghostel-module.version");
     b.getInstallStep().dependOn(&copy_version_step.step);
 
+    if (target_os == .windows) {
+        if (b.option([]const u8, "windows-conpty-package-dir", "Unpacked Microsoft.Windows.Console.ConPTY NuGet package directory")) |dir| {
+            installWindowsConptyRuntime(b, target.result.cpu.arch, dir);
+        }
+    }
+
     // ----------------------------------------------------------------
     // `zig build test` — pure-Zig unit tests.
     //
@@ -161,4 +167,41 @@ fn moduleOutputName(target_os: std.Target.Os.Tag) []const u8 {
         .windows => "ghostel-module.dll",
         else => "ghostel-module.so",
     };
+}
+
+fn installWindowsConptyRuntime(b: *std.Build, arch: std.Target.Cpu.Arch, package_dir: []const u8) void {
+    const runtime_arch = windowsConptyRuntimeArch(arch) orelse return;
+    const conpty_path = b.pathJoin(&.{ package_dir, "runtimes", b.fmt("win-{s}", .{runtime_arch}), "native", "conpty.dll" });
+    const copy_conpty = b.addInstallFile(.{ .cwd_relative = conpty_path }, "conpty.dll");
+    b.getInstallStep().dependOn(&copy_conpty.step);
+
+    switch (arch) {
+        .x86 => {
+            installWindowsOpenConsole(b, package_dir, "x86");
+            installWindowsOpenConsole(b, package_dir, "x64");
+            installWindowsOpenConsole(b, package_dir, "arm64");
+        },
+        .x86_64 => {
+            installWindowsOpenConsole(b, package_dir, "x64");
+            installWindowsOpenConsole(b, package_dir, "arm64");
+        },
+        .aarch64 => installWindowsOpenConsole(b, package_dir, "arm64"),
+        else => {},
+    }
+}
+
+fn windowsConptyRuntimeArch(arch: std.Target.Cpu.Arch) ?[]const u8 {
+    return switch (arch) {
+        .x86 => "x86",
+        .x86_64 => "x64",
+        .aarch64 => "arm64",
+        else => null,
+    };
+}
+
+fn installWindowsOpenConsole(b: *std.Build, package_dir: []const u8, host_arch: []const u8) void {
+    const source = b.pathJoin(&.{ package_dir, "build", "native", "runtimes", host_arch, "OpenConsole.exe" });
+    const dest = b.fmt("{s}/OpenConsole.exe", .{host_arch});
+    const copy = b.addInstallFile(.{ .cwd_relative = source }, dest);
+    b.getInstallStep().dependOn(&copy.step);
 }

--- a/build.zig
+++ b/build.zig
@@ -53,6 +53,9 @@ pub fn build(b: *std.Build) void {
             lib.setVersionScript(b.path("symbols.map"));
         }
     }
+    if (target_os == .windows) {
+        lib.linkSystemLibrary("kernel32");
+    }
 
     const copy_step = b.addInstallFile(
         lib.getEmittedBin(),
@@ -155,6 +158,7 @@ fn dirHasEmacsModuleHeader(allocator: std.mem.Allocator, dir: []const u8) bool {
 fn moduleOutputName(target_os: std.Target.Os.Tag) []const u8 {
     return switch (target_os) {
         .macos => "ghostel-module.dylib",
+        .windows => "ghostel-module.dll",
         else => "ghostel-module.so",
     };
 }

--- a/lisp/ghostel-module-install.el
+++ b/lisp/ghostel-module-install.el
@@ -95,22 +95,59 @@ Returns nil if the platform is not recognized."
     (when tag
       (format "ghostel-module-%s%s" tag module-file-suffix))))
 
+(defun ghostel--release-asset-url (asset-name &optional version)
+  "Return the GitHub release download URL for ASSET-NAME.
+When VERSION is nil, use the latest release download URL."
+  (if version
+      (format "%s/download/v%s/%s"
+              ghostel-github-release-url version asset-name)
+    (format "%s/latest/download/%s"
+            ghostel-github-release-url asset-name)))
+
 (defun ghostel--module-download-url (&optional version)
   "Return the download URL for the current platform's pre-built module.
 When VERSION is nil, use the latest release download URL."
-  (let ((asset-name (ghostel--module-asset-name)))
-    (when asset-name
-      (if version
-          (format "%s/download/v%s/%s"
-                  ghostel-github-release-url version asset-name)
-        (format "%s/latest/download/%s"
-                ghostel-github-release-url asset-name)))))
+  (when-let* ((asset-name (ghostel--module-asset-name)))
+    (ghostel--release-asset-url asset-name version)))
+
+(defun ghostel--windows-support-assets ()
+  "Return side-by-side ConPTY release asset mappings for Windows, or nil.
+Each mapping is an (ASSET-NAME . RELATIVE-DESTINATION) pair."
+  (when (eq system-type 'windows-nt)
+    (when-let* ((tag (ghostel--module-platform-tag))
+                (arch (car (split-string tag "-"))))
+      (let ((hosts (pcase arch
+                     ("x86" '("x86" "x64" "arm64"))
+                     ("x86_64" '("x64" "arm64"))
+                     ("aarch64" '("arm64")))))
+        (when hosts
+          (cons (cons (format "ghostel-conpty-%s.dll" tag) "conpty.dll")
+                (mapcar (lambda (host)
+                          (cons (format "ghostel-openconsole-%s-%s.exe" tag host)
+                                (format "%s/OpenConsole.exe" host)))
+                        hosts)))))))
+
+(defun ghostel--install-support-assets (dir &optional version)
+  "Install Windows support release assets into DIR.
+VERSION nil means the latest release.  Warn but continue on failure,
+since Ghostel can use the system ConPTY."
+  (dolist (asset (ghostel--windows-support-assets))
+    (let* ((asset-name (car asset))
+           (url (ghostel--release-asset-url asset-name version))
+           (dest (expand-file-name (cdr asset) dir)))
+      (unless (string-prefix-p "https://" url)
+        (error "Refusing non-HTTPS download URL: %s" url))
+      (make-directory (file-name-directory dest) t)
+      (message "ghostel: downloading support asset from %s..." url)
+      (unless (ghostel--download-file url dest)
+        (message "ghostel: warning: failed to download support asset %s"
+                 asset-name)))))
 
 (defun ghostel--release-version-from-url (url)
   "Return the release version embedded in URL, or nil.
 GitHub's `/releases/latest/download/<asset>' redirect resolves to
 `/releases/download/v<X.Y.Z>/<asset>'; extract the X.Y.Z segment."
-  (when (and url
+  (when (and (stringp url)
              (string-match "/releases/download/v\\([0-9]+\\.[0-9]+\\.[0-9]+\\)/"
                            url))
     (match-string 1 url)))
@@ -144,9 +181,12 @@ Returns non-nil on success."
               ;; parse the URL the server redirected us to.  If parsing
               ;; fails we fall back to the minimum so the sidecar still
               ;; reflects a safe lower bound.
-              (let ((resolved (or requested-version
-                                  (ghostel--release-version-from-url final-url)
-                                  ghostel--minimum-module-version)))
+              (let* ((downloaded-version (ghostel--release-version-from-url final-url))
+                     (resolved (or requested-version
+                                   downloaded-version
+                                   ghostel--minimum-module-version)))
+                (ghostel--install-support-assets
+                 dir (or requested-version downloaded-version))
                 (ghostel--write-module-sidecar-version dir resolved))
               (message "ghostel: native module downloaded successfully")
               t))))
@@ -183,6 +223,7 @@ on success the produced module and its sidecar are moved into DEST-DIR."
                        built final
                        (expand-file-name "ghostel-module.version" build-dir)
                        (expand-file-name "ghostel-module.version" dest-dir))
+                      (ghostel--install-support-assets dest-dir)
                       (message "ghostel: native module compiled successfully"))))))
           (when (and build-dir (file-directory-p build-dir))
             (ignore-errors (delete-directory build-dir t))))
@@ -412,6 +453,7 @@ Leaving the prompt empty downloads the latest release."
                           (progn
                             (ghostel--install-module-pair
                              built final built-sidecar final-sidecar)
+                            (ghostel--install-support-assets dest-dir)
                             (message "ghostel: module installed at %s" final))
                         (error
                          (display-warning

--- a/lisp/ghostel-module-install.el
+++ b/lisp/ghostel-module-install.el
@@ -84,6 +84,7 @@ Returns nil if the platform is not recognized."
          (os (cond
               ((eq system-type 'darwin) "macos")
               ((eq system-type 'gnu/linux) "linux")
+              ((eq system-type 'windows-nt) "windows")
               (t nil))))
     (when os
       (format "%s-%s" arch os))))

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4378,6 +4378,7 @@ writes a final exit status before closing it."
                 :noquery t))
          (pid (ghostel--spawn-native-process ghostel--term command pipe)))
     (setq ghostel--pid pid)
+    (process-put pipe 'ghostel--native-pid pid)
 
     (set-process-sentinel pipe
                           (lambda (process event)
@@ -4385,10 +4386,21 @@ writes a final exit status before closing it."
                             ;; If Emacs deletes it before normal exit, make sure
                             ;; the child is not left running.  After normal exit
                             ;; the reaper has already waited, so this is a no-op.
-                            (signal-process pid 9)
+                            (signal-process
+                             (process-get process 'ghostel--native-pid) 9)
                             (ghostel--sentinel process event)))
     (add-hook 'kill-buffer-hook #'ghostel--kill-native-process-hook nil t)
     pipe))
+
+(defun ghostel--kill-native-processes-on-exit ()
+  "Force native children to exit before Emacs disables process sentinels."
+  (dolist (process (process-list))
+    (let ((pid (and (process-live-p process)
+                    (process-get process 'ghostel--native-pid))))
+      (when pid
+        (ignore-errors (signal-process pid 9))))))
+
+(add-hook 'kill-emacs-hook #'ghostel--kill-native-processes-on-exit)
 
 (defun ghostel--kill-native-process-hook ()
   "Detach the native event pipe and request child termination.

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -228,6 +228,7 @@ README for the full design and per-call escape hatch."
 
 (defcustom ghostel-tramp-shells
   '(("ssh" login-shell)
+    ("sshx" login-shell)
     ("scp" login-shell)
     ("docker" "/bin/sh"))
   "Shell to use for remote TRAMP connections, per method.
@@ -3120,22 +3121,19 @@ default."
   "Return non-nil if the foreground program looks like it's reading a password.
 Two arms:
 
-  - libghostty heuristic (`ghostel--pty-password-input-p'): the current
+  - Zig heuristic (`ghostel--pty-password-input-p'): the current
     PTY is in canonical mode with echo off.  Catches local sudo, ssh's
     own password prompt, gpg, etc.
 
   - cursor-row regex (`ghostel-password-prompt-regex', defaulting to
-    `comint-password-prompt-regexp').  Used only when the libghostty
-    heuristic returns nil AND `ghostel--remote-shell-p' indicates a
-    remote shell - the case where the local pty is in raw mode for ssh
-    forwarding and the remote pty's canonical+!echo isn't visible locally.
+    `comint-password-prompt-regexp').  Used when `ghostel--remote-shell-p'
+    indicates a remote shell, where the remote pty's canonical+!echo state
+    isn't visible through a local pty probe.
 
 Returns nil on miss, or a symbol naming the arm on hit (`zig' or`regex')."
-  (cond
-   ((ghostel--pty-password-input-p ghostel--term) 'zig)
-   ((and (ghostel--remote-shell-p)
-         (ghostel--password-regex-matches-cursor-row-p))
-    'regex)))
+  (if (ghostel--remote-shell-p)
+      (when (ghostel--password-regex-matches-cursor-row-p) 'regex)
+    (when (ghostel--pty-password-input-p ghostel--term) 'zig)))
 
 (defun ghostel--password-regex-matches-cursor-row-p ()
   "Return non-nil if the cursor row looks like a password prompt.

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4311,13 +4311,15 @@ Local PROGRAM is resolved to an absolute path before backend dispatch.
 Local buffers use the native PTY path when `ghostel-use-native-pty'
 is non-nil; remote (REMOTE-P) buffers always go through Emacs so
 TRAMP can manage the remote shell."
-  (let ((program (if remote-p
-                     program
-                   (ghostel--resolve-local-executable program))))
-    (setq ghostel--process
-          (if (and ghostel-use-native-pty (not remote-p))
-              (ghostel--spawn-via-native (cons program program-args))
-            (ghostel--spawn-via-emacs program program-args remote-p)))))
+  (let* ((program (if remote-p
+                      program
+                    (ghostel--resolve-local-executable program)))
+         (process (if (and ghostel-use-native-pty (not remote-p))
+                      (ghostel--spawn-via-native (cons program program-args))
+                    (ghostel--spawn-via-emacs program program-args remote-p))))
+    (when (processp process)
+      (process-put process 'adjust-window-size-function #'ignore))
+    (setq ghostel--process process)))
 
 (defun ghostel--spawn-via-emacs (program program-args &optional remote-p)
   "Spawn PROGRAM with PROGRAM-ARGS through Emacs process machinery.

--- a/src/ConPtyProcess.zig
+++ b/src/ConPtyProcess.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
+const backend_types = @import("backend_types.zig");
+
 const c = @cImport({
     @cInclude("windows.h");
 });
@@ -13,23 +15,27 @@ const ResizePseudoConsoleFn = *const fn (HPCON, c.COORD) callconv(.winapi) c.HRE
 const ClosePseudoConsoleFn = *const fn (HPCON) callconv(.winapi) void;
 
 const PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE: usize = 0x00020016;
+const PIPE_REJECT_REMOTE_CLIENTS: c.DWORD = 0x00000008;
+const GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT: c.DWORD = 0x00000002;
+const GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS: c.DWORD = 0x00000004;
 const READ_BUFFER_SIZE = 64 * 1024;
+const WRITE_CHUNK_SIZE = 4096;
 
+const OverlappedPipeEnd = enum { read, write };
+
+alloc: Allocator,
 hpc: HPCON = null,
 pty_input: c.HANDLE = c.INVALID_HANDLE_VALUE,
 pty_output: c.HANDLE = c.INVALID_HANDLE_VALUE,
-command_event: c.HANDLE = c.INVALID_HANDLE_VALUE,
+interrupt_event: c.HANDLE = c.INVALID_HANDLE_VALUE,
 output_read_event: c.HANDLE = c.INVALID_HANDLE_VALUE,
+input_write_event: c.HANDLE = c.INVALID_HANDLE_VALUE,
 shell_process: c.HANDLE = c.INVALID_HANDLE_VALUE,
-running: std.atomic.Value(bool) = .init(true),
 pid: i64 = -1,
 
 var create_pseudo_console: ?CreatePseudoConsoleFn = null;
 var resize_pseudo_console: ?ResizePseudoConsoleFn = null;
 var close_pseudo_console: ?ClosePseudoConsoleFn = null;
-var pipe_name_counter = std.atomic.Value(u32).init(1);
-
-pub const ProcessParams = @import("ProcessParams.zig");
 
 pub const EventWriter = struct {
     pub const Fd = c_int;
@@ -85,6 +91,8 @@ pub const EventWriter = struct {
     fn notifyCrtProviderForImport(dll_name: []const u8, symbol_name: []const u8) ?NotifyCrtProvider {
         if (!std.mem.eql(u8, symbol_name, "_dup")) return null;
 
+        // Emacs' `open_channel' returns a CRT fd owned by Emacs, so event
+        // writes must go through the same mainstream CRT family Emacs imports.
         if (std.ascii.eqlIgnoreCase(dll_name, "msvcrt.dll")) return .msvcrt;
         if (std.ascii.eqlIgnoreCase(dll_name, "ucrtbase.dll")) return .ucrt;
         // Newer Emacs builds may link the UCRT through api-ms-win-crt
@@ -172,17 +180,23 @@ pub const EventWriter = struct {
     }
 };
 
-pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: ProcessParams) !Self {
+pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: backend_types.ProcessParams) !Self {
     try initApi();
 
-    var self: Self = .{};
-    self.command_event = c.CreateEventW(null, c.TRUE, c.FALSE, null);
-    if (self.command_event == null) return error.CreateEventFailed;
-    errdefer self.closeConPtyHandles();
+    var self: Self = .{ .alloc = alloc };
+
+    self.interrupt_event = c.CreateEventW(null, c.TRUE, c.FALSE, null);
+    if (self.interrupt_event == null) return error.CreateEventFailed;
+    errdefer closeConPtyHandles(&self);
+
     self.output_read_event = c.CreateEventW(null, c.TRUE, c.FALSE, null);
     if (self.output_read_event == null) return error.CreateEventFailed;
-    try self.createConPty(initial_rows, initial_cols);
-    try self.spawnChild(alloc, params);
+
+    self.input_write_event = c.CreateEventW(null, c.TRUE, c.FALSE, null);
+    if (self.input_write_event == null) return error.CreateEventFailed;
+
+    try createConPty(&self, initial_rows, initial_cols);
+    try spawnChild(&self, params);
 
     return self;
 }
@@ -191,210 +205,191 @@ pub fn pidValue(self: *const Self) i64 {
     return self.pid;
 }
 
-pub fn drain(
-    self: *Self,
-    stream: anytype,
-) !bool {
-    var buf: [READ_BUFFER_SIZE]u8 = undefined;
+pub fn drain(self: *Self, stream: anytype) !bool {
+    const interrupt_handles = [_]c.HANDLE{
+        self.shell_process,
+        self.interrupt_event,
+    };
 
-    while (self.running.load(.acquire)) {
-        switch (try self.readOutput(stream, buf[0..])) {
-            .output, .command => return false,
-            .eof => {
-                self.stopRunning();
-                return true;
-            },
-        }
-    }
-
-    return true;
+    return try self.readOutput(stream, &interrupt_handles) == .ok;
 }
 
-const ReadOutputResult = enum {
-    output,
-    eof,
-    command,
-};
+pub fn finishDrain(self: *Self, stream: anytype) !void {
+    self.clearInterruptEvent();
+    const close_thread = startPseudoConsoleClose(self) orelse return;
+    defer close_thread.join();
+
+    while (try self.readOutput(stream, &.{}) == .ok) {}
+}
 
 fn readOutput(
     self: *Self,
     stream: anytype,
-    buf: []u8,
-) !ReadOutputResult {
-    if (self.pty_output == c.INVALID_HANDLE_VALUE) return .eof;
-    if (self.output_read_event == c.INVALID_HANDLE_VALUE) return error.ReadFailed;
+    interrupt_handles: []const c.HANDLE,
+) !union(enum) { ok, finished } {
+    if (self.pty_output == c.INVALID_HANDLE_VALUE) return .finished;
+    if (self.output_read_event == c.INVALID_HANDLE_VALUE) return error.IoFailed;
 
     _ = c.ResetEvent(self.output_read_event);
 
     var overlapped = std.mem.zeroes(c.OVERLAPPED);
     overlapped.hEvent = self.output_read_event;
 
+    var buf: [READ_BUFFER_SIZE]u8 = undefined;
     var bytes_read: c.DWORD = 0;
     if (c.ReadFile(
         self.pty_output,
-        buf.ptr,
+        &buf,
         @intCast(buf.len),
         &bytes_read,
         &overlapped,
     ) != 0) {
-        return self.finishRead(stream, buf, bytes_read);
+        stream.nextSlice(buf[0..bytes_read]);
+        return .ok;
     }
 
     switch (c.GetLastError()) {
         c.ERROR_IO_PENDING => {},
-        c.ERROR_OPERATION_ABORTED => return .command,
-        c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => return .eof,
-        else => return error.ReadFailed,
+        c.ERROR_OPERATION_ABORTED, c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => {
+            return .finished;
+        },
+        else => return error.IoFailed,
     }
+    errdefer _ = completeOverlapped(self.pty_output, &overlapped, true) catch {};
 
-    var include_process = true;
-    while (true) {
-        switch (try self.waitForReadOrCommand(include_process)) {
-            .read => return self.finishOverlappedRead(stream, buf, &overlapped),
-            .command => {
-                self.clearCommandEvent();
-                return self.cancelPendingRead(stream, buf, &overlapped);
-            },
-            .process => {
-                self.closePseudoConsole();
-                include_process = false;
-            },
-        }
-    }
-}
-
-fn finishRead(self: *Self, stream: anytype, buf: []u8, bytes_read: c.DWORD) ReadOutputResult {
-    _ = self;
-    if (bytes_read == 0) return .eof;
-    stream.nextSlice(buf[0..@as(usize, @intCast(bytes_read))]);
-    return .output;
-}
-
-fn finishOverlappedRead(
-    self: *Self,
-    stream: anytype,
-    buf: []u8,
-    overlapped: *c.OVERLAPPED,
-) !ReadOutputResult {
-    var bytes_read: c.DWORD = 0;
-    if (c.GetOverlappedResult(
+    const wait_result = try self.waitForRead(interrupt_handles);
+    const complete_result = try completeOverlapped(
         self.pty_output,
-        overlapped,
-        &bytes_read,
-        c.FALSE,
-    ) == 0) {
-        const err = c.GetLastError();
-        switch (err) {
-            c.ERROR_OPERATION_ABORTED => return .command,
-            c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => return .eof,
-            else => return error.ReadFailed,
-        }
-    }
+        &overlapped,
+        wait_result == .interrupted,
+    );
+    if (complete_result == .bytes) stream.nextSlice(buf[0..complete_result.bytes]);
 
-    return self.finishRead(stream, buf, bytes_read);
+    if (wait_result == .interrupted or complete_result != .bytes) return .finished;
+    return .ok;
 }
 
-fn cancelPendingRead(
-    self: *Self,
-    stream: anytype,
-    buf: []u8,
+fn completeOverlapped(
+    handle: c.HANDLE,
     overlapped: *c.OVERLAPPED,
-) !ReadOutputResult {
-    if (c.CancelIoEx(self.pty_output, overlapped) == 0) {
-        const err = c.GetLastError();
-        switch (err) {
-            c.ERROR_NOT_FOUND => {},
-            c.ERROR_INVALID_HANDLE => return .eof,
-            else => return error.ReadFailed,
-        }
+    cancel: bool,
+) !union(enum) { bytes: usize, aborted, closed } {
+    if (cancel and c.CancelIoEx(handle, overlapped) == 0 and
+        c.GetLastError() == c.ERROR_INVALID_HANDLE)
+    {
+        return .closed;
     }
 
-    var bytes_read: c.DWORD = 0;
+    var bytes_transferred: c.DWORD = 0;
     if (c.GetOverlappedResult(
-        self.pty_output,
+        handle,
         overlapped,
-        &bytes_read,
+        &bytes_transferred,
         c.TRUE,
     ) == 0) {
         const err = c.GetLastError();
         switch (err) {
-            c.ERROR_OPERATION_ABORTED => return .command,
-            c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => return .eof,
-            else => return error.ReadFailed,
+            c.ERROR_OPERATION_ABORTED => return .aborted,
+            c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => return .closed,
+            else => return error.IoFailed,
         }
     }
 
-    return self.finishRead(stream, buf, bytes_read);
+    return .{ .bytes = @intCast(bytes_transferred) };
 }
 
-const WaitResult = enum {
-    read,
-    process,
-    command,
-};
-
-fn waitForReadOrCommand(self: *Self, include_process: bool) !WaitResult {
+fn waitForRead(
+    self: *Self,
+    interrupt_handles: []const c.HANDLE,
+) !union(enum) { ready, interrupted } {
     var handles: [3]c.HANDLE = undefined;
     var count: c.DWORD = 0;
     const read_index = count;
     handles[count] = self.output_read_event;
     count += 1;
 
-    var process_index: ?c.DWORD = null;
-    var command_index: c.DWORD = undefined;
-
-    if (include_process and self.shell_process != c.INVALID_HANDLE_VALUE) {
-        process_index = count;
-        handles[count] = self.shell_process;
+    for (interrupt_handles) |handle| {
+        if (handle == c.INVALID_HANDLE_VALUE) continue;
+        handles[count] = handle;
         count += 1;
     }
-
-    command_index = count;
-    handles[count] = self.command_event;
-    count += 1;
 
     const result = c.WaitForMultipleObjects(count, &handles, c.FALSE, c.INFINITE);
     if (result < c.WAIT_OBJECT_0 or result >= c.WAIT_OBJECT_0 + count) return error.WaitFailed;
 
     const index = result - c.WAIT_OBJECT_0;
-    if (index == read_index) return .read;
-    if (process_index != null and index == process_index.?) return .process;
-    if (index == command_index) return .command;
-    return error.WaitFailed;
+    return if (index == read_index) .ready else .interrupted;
 }
 
-pub fn write(self: *Self, data: []const u8) !void {
-    if (data.len == 0) return;
-    if (self.pty_input == c.INVALID_HANDLE_VALUE) return error.WriteFailed;
+pub fn write(
+    self: *Self,
+    data: []const u8,
+    cancellation: ?backend_types.CancellationToken,
+) !backend_types.WriteResult {
+    if (data.len == 0) return .{ .written = 0 };
+    if (self.pty_input == c.INVALID_HANDLE_VALUE) return error.IoFailed;
+    if (self.input_write_event == c.INVALID_HANDLE_VALUE) return error.IoFailed;
+    if (self.interrupt_event == c.INVALID_HANDLE_VALUE) return error.IoFailed;
 
-    var offset: usize = 0;
-    while (offset < data.len) {
-        var wrote: c.DWORD = 0;
-        const chunk_len: c.DWORD = @intCast(@min(data.len - offset, std.math.maxInt(c.DWORD)));
-        if (c.WriteFile(self.pty_input, data[offset..].ptr, chunk_len, &wrote, null) == 0) {
-            return error.WriteFailed;
+    _ = c.ResetEvent(self.input_write_event);
+
+    var overlapped = std.mem.zeroes(c.OVERLAPPED);
+    overlapped.hEvent = self.input_write_event;
+
+    var bytes_written: c.DWORD = 0;
+    const chunk_len: c.DWORD = @intCast(@min(data.len, WRITE_CHUNK_SIZE));
+    if (c.WriteFile(
+        self.pty_input,
+        data.ptr,
+        chunk_len,
+        &bytes_written,
+        &overlapped,
+    ) != 0) {
+        if (bytes_written == 0) return error.IoFailed;
+        return .{ .written = @intCast(bytes_written) };
+    }
+
+    switch (c.GetLastError()) {
+        c.ERROR_IO_PENDING => {},
+        c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => return error.ProcessExited,
+        else => return error.IoFailed,
+    }
+    errdefer _ = completeOverlapped(self.pty_input, &overlapped, true) catch {};
+
+    const handles = [_]c.HANDLE{
+        self.input_write_event,
+        self.interrupt_event,
+    };
+    const timeout = if (cancellation) |token| token.poll_interval_ms else c.INFINITE;
+    while (true) {
+        const wait_result = c.WaitForMultipleObjects(
+            handles.len,
+            &handles,
+            c.FALSE,
+            timeout,
+        );
+        if (wait_result == c.WAIT_TIMEOUT) {
+            try cancellation.?.check();
+            continue;
         }
-        if (wrote == 0) return error.WriteFailed;
-        offset += wrote;
-    }
-}
 
-pub fn requestStop(self: *Self, read_thread: std.Thread) void {
-    self.stopRunning();
-    if (self.command_event != c.INVALID_HANDLE_VALUE) {
-        _ = c.SetEvent(self.command_event);
-    }
+        const interrupted = wait_result == c.WAIT_OBJECT_0 + 1;
+        if (!interrupted and wait_result != c.WAIT_OBJECT_0) return error.IoFailed;
 
-    if (self.pty_input != c.INVALID_HANDLE_VALUE) {
-        _ = c.CloseHandle(self.pty_input);
-        self.pty_input = c.INVALID_HANDLE_VALUE;
+        const complete_result = try completeOverlapped(
+            self.pty_input,
+            &overlapped,
+            interrupted,
+        );
+        return switch (complete_result) {
+            .bytes => |n| if (n > 0) .{ .written = n } else error.IoFailed,
+            .aborted => if (interrupted) .interrupted else error.IoFailed,
+            else => error.IoFailed,
+        };
     }
-
-    _ = c.CancelSynchronousIo(read_thread.getHandle());
 }
 
 pub fn resize(self: *Self, cols: u16, rows: u16) !void {
-    if (!self.running.load(.acquire)) return error.PtyResizeFailed;
     const hpc = self.hpc orelse return error.PtyResizeFailed;
     const size = c.COORD{
         .X = @intCast(cols),
@@ -403,12 +398,16 @@ pub fn resize(self: *Self, cols: u16, rows: u16) !void {
     if (resize_pseudo_console.?(hpc, size) < 0) return error.PtyResizeFailed;
 }
 
+pub fn requestStop(self: *Self, _: std.Thread) void {
+    if (self.interrupt_event == c.INVALID_HANDLE_VALUE) return;
+    _ = c.SetEvent(self.interrupt_event);
+}
+
 pub fn replicaName(_: *Self) []const u8 {
     return "";
 }
 
 pub fn deinitAndWait(self: *Self) u8 {
-    self.stopRunning();
     self.closeConPtyHandles();
 
     var exit_code: c.DWORD = 0;
@@ -425,10 +424,72 @@ pub fn deinitAndWait(self: *Self) u8 {
 fn initApi() !void {
     if (create_pseudo_console != null) return;
 
+    // Prefer the redistributable Microsoft.Windows.Console.ConPTY runtime when
+    // it is shipped next to ghostel-module.dll. Its side-by-side OpenConsole
+    // path avoids the stock conhost response-to-input latency seen through
+    // kernel32!CreatePseudoConsole. Fall back to kernel32 so local/debug builds
+    // and unsupported layouts keep working with the public OS API.
+    if (loadSideBySideConpty()) |conpty| {
+        if (resolveApi(conpty, "ConptyCreatePseudoConsole", "ConptyResizePseudoConsole", "ConptyClosePseudoConsole")) {
+            return;
+        }
+    }
+
+    try resolveKernel32Api();
+}
+
+fn resolveKernel32Api() !void {
     const kernel32 = c.GetModuleHandleA("kernel32.dll") orelse return error.MissingConPty;
-    create_pseudo_console = @ptrCast(c.GetProcAddress(kernel32, "CreatePseudoConsole") orelse return error.MissingConPty);
-    resize_pseudo_console = @ptrCast(c.GetProcAddress(kernel32, "ResizePseudoConsole") orelse return error.MissingConPty);
-    close_pseudo_console = @ptrCast(c.GetProcAddress(kernel32, "ClosePseudoConsole") orelse return error.MissingConPty);
+    if (!resolveApi(kernel32, "CreatePseudoConsole", "ResizePseudoConsole", "ClosePseudoConsole")) {
+        return error.MissingConPty;
+    }
+}
+
+fn resolveApi(module: c.HMODULE, create_name: [*:0]const u8, resize_name: [*:0]const u8, close_name: [*:0]const u8) bool {
+    const create_proc = c.GetProcAddress(module, create_name) orelse return false;
+    const resize_proc = c.GetProcAddress(module, resize_name) orelse return false;
+    const close_proc = c.GetProcAddress(module, close_name) orelse return false;
+    create_pseudo_console = @ptrCast(create_proc);
+    resize_pseudo_console = @ptrCast(resize_proc);
+    close_pseudo_console = @ptrCast(close_proc);
+    return true;
+}
+
+fn loadSideBySideConpty() ?c.HMODULE {
+    var module_dir_buf: [32768]u8 = undefined;
+    const module_dir = currentModuleDir(&module_dir_buf) orelse return null;
+    var conpty_path_buf: [32768]u8 = undefined;
+    const conpty_path = std.fmt.bufPrintZ(
+        &conpty_path_buf,
+        "{s}\\conpty.dll",
+        .{module_dir},
+    ) catch return null;
+
+    var conpty_path_w_buf: [32768]u16 = undefined;
+    const conpty_path_w_len = std.unicode.utf8ToUtf16Le(
+        &conpty_path_w_buf,
+        conpty_path,
+    ) catch return null;
+    conpty_path_w_buf[conpty_path_w_len] = 0;
+    const conpty_path_w = conpty_path_w_buf[0..conpty_path_w_len :0];
+    return c.LoadLibraryW(conpty_path_w.ptr);
+}
+
+fn currentModuleDir(module_path_buf: *[32768]u8) ?[]const u8 {
+    var self_module: c.HMODULE = null;
+    const flags = GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
+    if (c.GetModuleHandleExW(flags, @ptrCast(&create_pseudo_console), &self_module) == 0) return null;
+
+    var module_path_w: [32768]u16 = undefined;
+    const len = c.GetModuleFileNameW(self_module, &module_path_w, module_path_w.len);
+    if (len == 0 or len >= module_path_w.len) return null;
+
+    const module_path_len = std.unicode.utf16LeToUtf8(
+        module_path_buf,
+        module_path_w[0..@intCast(len)],
+    ) catch return null;
+    const module_path = module_path_buf[0..module_path_len];
+    return std.fs.path.dirname(module_path);
 }
 
 fn createConPty(self: *Self, rows: u16, cols: u16) !void {
@@ -444,20 +505,15 @@ fn createConPty(self: *Self, rows: u16, cols: u16) !void {
         if (out_write != c.INVALID_HANDLE_VALUE) _ = c.CloseHandle(out_write);
     }
 
-    var sa = std.mem.zeroes(c.SECURITY_ATTRIBUTES);
-    sa.nLength = @sizeOf(c.SECURITY_ATTRIBUTES);
-    sa.bInheritHandle = c.TRUE;
-
-    if (c.CreatePipe(&in_read, &in_write, &sa, 0) == 0) return error.CreatePipeFailed;
-    try createOverlappedPipe(&out_read, &out_write);
+    try createOverlappedPipe(&in_read, &in_write, .write);
+    try createOverlappedPipe(&out_read, &out_write, .read);
 
     const size = c.COORD{
         .X = @intCast(cols),
         .Y = @intCast(rows),
     };
-    if (create_pseudo_console.?(size, in_read, out_write, 0, &self.hpc) < 0) {
-        return error.CreatePseudoConsoleFailed;
-    }
+    const create_result = create_pseudo_console.?(size, in_read, out_write, 0, &self.hpc);
+    if (create_result < 0) return error.CreatePseudoConsoleFailed;
 
     self.pty_input = in_write;
     self.pty_output = out_read;
@@ -469,52 +525,73 @@ fn createConPty(self: *Self, rows: u16, cols: u16) !void {
     out_write = c.INVALID_HANDLE_VALUE;
 }
 
+fn closeHandle(handle: *c.HANDLE) void {
+    if (handle.* != c.INVALID_HANDLE_VALUE) {
+        _ = c.CloseHandle(handle.*);
+        handle.* = c.INVALID_HANDLE_VALUE;
+    }
+}
+
 fn closeConPtyHandles(self: *Self) void {
-    if (self.pty_input != c.INVALID_HANDLE_VALUE) {
-        _ = c.CloseHandle(self.pty_input);
-        self.pty_input = c.INVALID_HANDLE_VALUE;
-    }
-    if (self.pty_output != c.INVALID_HANDLE_VALUE) {
-        _ = c.CloseHandle(self.pty_output);
-        self.pty_output = c.INVALID_HANDLE_VALUE;
-    }
+    closeHandle(&self.pty_input);
+    closeHandle(&self.pty_output);
+    self.closePseudoConsole();
+    closeHandle(&self.interrupt_event);
+    closeHandle(&self.output_read_event);
+    closeHandle(&self.input_write_event);
+}
+
+fn closePseudoConsole(self: *Self) void {
     if (self.hpc != null) {
         // ClosePseudoConsole owns the documented ConPTY teardown path.
         close_pseudo_console.?(self.hpc);
         self.hpc = null;
     }
-    if (self.command_event != c.INVALID_HANDLE_VALUE) {
-        _ = c.CloseHandle(self.command_event);
-        self.command_event = c.INVALID_HANDLE_VALUE;
-    }
-    if (self.output_read_event != c.INVALID_HANDLE_VALUE) {
-        _ = c.CloseHandle(self.output_read_event);
-        self.output_read_event = c.INVALID_HANDLE_VALUE;
-    }
 }
 
-fn closePseudoConsole(self: *Self) void {
-    if (self.hpc != null) {
-        close_pseudo_console.?(self.hpc);
-        self.hpc = null;
-    }
+fn startPseudoConsoleClose(self: *Self) ?std.Thread {
+    const hpc = self.hpc;
+    if (hpc == null) return null;
+    self.hpc = null;
+
+    // Child exit only tells us when to initiate teardown; EOF on the output
+    // pipe tells us when ConPTY has flushed its final output. Older Windows can
+    // block inside ClosePseudoConsole until that drain completes, so the reader
+    // thread must hand the handle to a helper, keep reading to EOF, and then
+    // join the helper.
+    return std.Thread.spawn(
+        .{ .stack_size = 128 * 1024 },
+        closePseudoConsoleHandle,
+        .{hpc},
+    ) catch |err| {
+        std.log.scoped(.ConPtyProcess).err(
+            "Failed to spawn ConPTY closer thread; leaking pseudoconsole handle to avoid reader deadlock: {any}",
+            .{err},
+        );
+        return null;
+    };
 }
 
-fn clearCommandEvent(self: *Self) void {
-    if (self.command_event == c.INVALID_HANDLE_VALUE) return;
-    _ = c.ResetEvent(self.command_event);
+fn closePseudoConsoleHandle(hpc: HPCON) void {
+    close_pseudo_console.?(hpc);
 }
 
-fn createOverlappedPipe(read_handle: *c.HANDLE, write_handle: *c.HANDLE) !void {
-    var pipe_path_buf: [128]u8 = undefined;
-    var pipe_path_buf_w: [128]u16 = undefined;
+fn clearInterruptEvent(self: *Self) void {
+    if (self.interrupt_event == c.INVALID_HANDLE_VALUE) return;
+    _ = c.ResetEvent(self.interrupt_event);
+}
+
+fn createOverlappedPipe(
+    read_handle: *c.HANDLE,
+    write_handle: *c.HANDLE,
+    overlapped_end: OverlappedPipeEnd,
+) !void {
+    var pipe_path_buf: [160]u8 = undefined;
+    var pipe_path_buf_w: [160]u16 = undefined;
     const pipe_path = std.fmt.bufPrintZ(
         &pipe_path_buf,
-        "\\\\.\\pipe\\ghostel-conpty-{d}-{d}",
-        .{
-            c.GetCurrentProcessId(),
-            pipe_name_counter.fetchAdd(1, .monotonic),
-        },
+        "\\\\.\\pipe\\ghostel-conpty-{d}-{x}",
+        .{ c.GetCurrentProcessId(), std.crypto.random.int(u64) },
     ) catch unreachable;
 
     const pipe_path_w_len = std.unicode.utf8ToUtf16Le(
@@ -524,19 +601,22 @@ fn createOverlappedPipe(read_handle: *c.HANDLE, write_handle: *c.HANDLE) !void {
     pipe_path_buf_w[pipe_path_w_len] = 0;
     const pipe_path_w = pipe_path_buf_w[0..pipe_path_w_len :0];
 
-    var sa = std.mem.zeroes(c.SECURITY_ATTRIBUTES);
-    sa.nLength = @sizeOf(c.SECURITY_ATTRIBUTES);
-    sa.bInheritHandle = c.TRUE;
+    var read_flags: c.DWORD = @intCast(c.PIPE_ACCESS_INBOUND);
+    read_flags |= @intCast(c.FILE_FLAG_FIRST_PIPE_INSTANCE);
+    if (overlapped_end == .read) read_flags |= @intCast(c.FILE_FLAG_OVERLAPPED);
+
+    var write_flags: c.DWORD = @intCast(c.FILE_ATTRIBUTE_NORMAL);
+    if (overlapped_end == .write) write_flags |= @intCast(c.FILE_FLAG_OVERLAPPED);
 
     read_handle.* = c.CreateNamedPipeW(
         pipe_path_w.ptr,
-        c.PIPE_ACCESS_INBOUND | c.FILE_FLAG_OVERLAPPED | c.FILE_FLAG_FIRST_PIPE_INSTANCE,
-        c.PIPE_TYPE_BYTE,
+        read_flags,
+        c.PIPE_TYPE_BYTE | PIPE_REJECT_REMOTE_CLIENTS,
         1,
         4096,
         4096,
         0,
-        &sa,
+        null,
     );
     if (read_handle.* == c.INVALID_HANDLE_VALUE) return error.CreatePipeFailed;
     errdefer {
@@ -548,16 +628,16 @@ fn createOverlappedPipe(read_handle: *c.HANDLE, write_handle: *c.HANDLE) !void {
         pipe_path_w.ptr,
         c.GENERIC_WRITE,
         0,
-        &sa,
+        null,
         c.OPEN_EXISTING,
-        c.FILE_ATTRIBUTE_NORMAL,
+        write_flags,
         null,
     );
     if (write_handle.* == c.INVALID_HANDLE_VALUE) return error.CreatePipeFailed;
 }
 
-fn spawnChild(self: *Self, alloc: Allocator, params: ProcessParams) !void {
-    var arena_allocator = std.heap.ArenaAllocator.init(alloc);
+fn spawnChild(self: *Self, params: backend_types.ProcessParams) !void {
+    var arena_allocator = std.heap.ArenaAllocator.init(self.alloc);
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
 
@@ -570,11 +650,19 @@ fn spawnChild(self: *Self, alloc: Allocator, params: ProcessParams) !void {
 
     var attr_list_size: usize = 0;
     _ = c.InitializeProcThreadAttributeList(null, 1, 0, &attr_list_size);
-    const attr_list_buf = try arena.alloc(u8, attr_list_size);
+    const attr_list_word_count = try std.math.divCeil(usize, attr_list_size, @sizeOf(usize));
+    const attr_list_buf = try arena.alloc(usize, attr_list_word_count);
 
     var si = std.mem.zeroes(c.STARTUPINFOEXW);
     si.StartupInfo.cb = @sizeOf(c.STARTUPINFOEXW);
-    si.lpAttributeList = @ptrCast(@alignCast(attr_list_buf.ptr));
+    // Prevent console children from inheriting Emacs' redirected stdio when
+    // Emacs itself is running under SSH or another pipe-backed parent.  This
+    // intentionally follows the ConPTY workaround recommended by Microsoft
+    // Terminal maintainers: set STARTF_USESTDHANDLES with null hStd* handles
+    // so Windows does not copy the parent's redirected handles into the child.
+    // The child's console association comes from PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE.
+    si.StartupInfo.dwFlags = c.STARTF_USESTDHANDLES;
+    si.lpAttributeList = @ptrCast(attr_list_buf.ptr);
     if (c.InitializeProcThreadAttributeList(si.lpAttributeList, 1, 0, &attr_list_size) == 0) {
         return error.InitializeProcThreadAttributeListFailed;
     }
@@ -623,27 +711,19 @@ fn argvToCommandLineWindows(
 
     if (argv.len != 0) {
         const arg0 = argv[0];
-
-        var needs_quotes = arg0.len == 0;
         for (arg0) |ch| {
-            if (ch <= ' ') {
-                needs_quotes = true;
-            } else if (ch == '"') {
-                return error.InvalidArg0;
-            }
+            if (ch == '"') return error.InvalidArg0;
         }
-        if (needs_quotes) {
-            try buf.append('"');
-            try buf.appendSlice(arg0);
-            try buf.append('"');
-        } else {
-            try buf.appendSlice(arg0);
+        try buf.append('"');
+        for (arg0) |ch| {
+            try buf.append(if (ch == '/') '\\' else ch);
         }
+        try buf.append('"');
 
         for (argv[1..]) |arg| {
             try buf.append(' ');
 
-            needs_quotes = for (arg) |ch| {
+            const needs_quotes = for (arg) |ch| {
                 if (ch <= ' ' or ch == '"') {
                     break true;
                 }
@@ -719,10 +799,6 @@ fn appendWtf8AsWtf16(builder: *std.ArrayList(u16), arena: Allocator, value: []co
     std.debug.assert(written == len);
 }
 
-fn stopRunning(self: *Self) void {
-    self.running.store(false, .release);
-}
-
 test "notify CRT provider follows the CRT that owns Emacs dup" {
     try std.testing.expectEqual(
         EventWriter.NotifyCrtProvider.msvcrt,
@@ -747,6 +823,22 @@ test "notify CRT provider ignores non-dup CRT imports" {
         @as(?EventWriter.NotifyCrtProvider, null),
         EventWriter.notifyCrtProviderForImport("kernel32.dll", "_dup"),
     );
+}
+
+test "argvToCommandLineWindows quotes argv0" {
+    const argv = [_][:0]const u8{
+        "c:/Windows/System32/cmd.exe",
+        "/d",
+        "/c",
+        "echo hi",
+    };
+    const command_line = try argvToCommandLineWindows(std.testing.allocator, &argv);
+    defer std.testing.allocator.free(command_line);
+
+    const expected = std.unicode.utf8ToUtf16LeStringLiteral(
+        "\"c:\\Windows\\System32\\cmd.exe\" /d /c \"echo hi\"",
+    );
+    try std.testing.expectEqualSlices(u16, expected, command_line);
 }
 
 test "buildEnvironmentBlock writes nul-separated UTF-16 entries" {

--- a/src/ConPtyProcess.zig
+++ b/src/ConPtyProcess.zig
@@ -15,21 +15,14 @@ const ClosePseudoConsoleFn = *const fn (HPCON) callconv(.winapi) void;
 const PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE: usize = 0x00020016;
 const READ_BUFFER_SIZE = 64 * 1024;
 
-// Kept separate from Self because NativeProcess hands this backend by value to
-// a detached reaper thread.
-const State = struct {
-    alloc: Allocator,
-    hpc: HPCON = null,
-    pty_input: c.HANDLE = c.INVALID_HANDLE_VALUE,
-    pty_output: c.HANDLE = c.INVALID_HANDLE_VALUE,
-    command_event: c.HANDLE = c.INVALID_HANDLE_VALUE,
-    output_read_event: c.HANDLE = c.INVALID_HANDLE_VALUE,
-    shell_process: c.HANDLE = c.INVALID_HANDLE_VALUE,
-    running: std.atomic.Value(bool) = .init(true),
-    pid: i64 = -1,
-};
-
-state: *State,
+hpc: HPCON = null,
+pty_input: c.HANDLE = c.INVALID_HANDLE_VALUE,
+pty_output: c.HANDLE = c.INVALID_HANDLE_VALUE,
+command_event: c.HANDLE = c.INVALID_HANDLE_VALUE,
+output_read_event: c.HANDLE = c.INVALID_HANDLE_VALUE,
+shell_process: c.HANDLE = c.INVALID_HANDLE_VALUE,
+running: std.atomic.Value(bool) = .init(true),
+pid: i64 = -1,
 
 var create_pseudo_console: ?CreatePseudoConsoleFn = null;
 var resize_pseudo_console: ?ResizePseudoConsoleFn = null;
@@ -182,33 +175,33 @@ pub const EventWriter = struct {
 pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: ProcessParams) !Self {
     try initApi();
 
-    const state = try alloc.create(State);
-    errdefer alloc.destroy(state);
-    state.* = .{ .alloc = alloc };
+    var self: Self = .{};
+    self.command_event = c.CreateEventW(null, c.TRUE, c.FALSE, null);
+    if (self.command_event == null) return error.CreateEventFailed;
+    errdefer self.closeConPtyHandles();
+    self.output_read_event = c.CreateEventW(null, c.TRUE, c.FALSE, null);
+    if (self.output_read_event == null) return error.CreateEventFailed;
+    try self.createConPty(initial_rows, initial_cols);
+    try self.spawnChild(alloc, params);
 
-    state.command_event = c.CreateEventW(null, c.TRUE, c.FALSE, null);
-    if (state.command_event == null) return error.CreateEventFailed;
-    errdefer closeConPtyHandles(state);
-    state.output_read_event = c.CreateEventW(null, c.TRUE, c.FALSE, null);
-    if (state.output_read_event == null) return error.CreateEventFailed;
-    try createConPty(state, initial_rows, initial_cols);
-    try spawnChild(state, params);
-
-    return .{ .state = state };
+    return self;
 }
 
 pub fn pidValue(self: *const Self) i64 {
-    return self.state.pid;
+    return self.pid;
 }
 
-pub fn drain(self: *Self, stream: anytype) !bool {
+pub fn drain(
+    self: *Self,
+    stream: anytype,
+) !bool {
     var buf: [READ_BUFFER_SIZE]u8 = undefined;
 
-    while (self.state.running.load(.acquire)) {
+    while (self.running.load(.acquire)) {
         switch (try self.readOutput(stream, buf[0..])) {
             .output, .command => return false,
             .eof => {
-                stopRunning(self.state);
+                self.stopRunning();
                 return true;
             },
         }
@@ -223,25 +216,28 @@ const ReadOutputResult = enum {
     command,
 };
 
-fn readOutput(self: *Self, stream: anytype, buf: []u8) !ReadOutputResult {
-    const state = self.state;
-    if (state.pty_output == c.INVALID_HANDLE_VALUE) return .eof;
-    if (state.output_read_event == c.INVALID_HANDLE_VALUE) return error.ReadFailed;
+fn readOutput(
+    self: *Self,
+    stream: anytype,
+    buf: []u8,
+) !ReadOutputResult {
+    if (self.pty_output == c.INVALID_HANDLE_VALUE) return .eof;
+    if (self.output_read_event == c.INVALID_HANDLE_VALUE) return error.ReadFailed;
 
-    _ = c.ResetEvent(state.output_read_event);
+    _ = c.ResetEvent(self.output_read_event);
 
     var overlapped = std.mem.zeroes(c.OVERLAPPED);
-    overlapped.hEvent = state.output_read_event;
+    overlapped.hEvent = self.output_read_event;
 
     var bytes_read: c.DWORD = 0;
     if (c.ReadFile(
-        state.pty_output,
+        self.pty_output,
         buf.ptr,
         @intCast(buf.len),
         &bytes_read,
         &overlapped,
     ) != 0) {
-        return finishRead(stream, buf, bytes_read);
+        return self.finishRead(stream, buf, bytes_read);
     }
 
     switch (c.GetLastError()) {
@@ -253,35 +249,36 @@ fn readOutput(self: *Self, stream: anytype, buf: []u8) !ReadOutputResult {
 
     var include_process = true;
     while (true) {
-        switch (try waitForReadOrCommand(state, include_process)) {
-            .read => return finishOverlappedRead(state, stream, buf, &overlapped),
+        switch (try self.waitForReadOrCommand(include_process)) {
+            .read => return self.finishOverlappedRead(stream, buf, &overlapped),
             .command => {
-                clearCommandEvent(state);
-                return cancelPendingRead(state, stream, buf, &overlapped);
+                self.clearCommandEvent();
+                return self.cancelPendingRead(stream, buf, &overlapped);
             },
             .process => {
-                closePseudoConsole(state);
+                self.closePseudoConsole();
                 include_process = false;
             },
         }
     }
 }
 
-fn finishRead(stream: anytype, buf: []u8, bytes_read: c.DWORD) ReadOutputResult {
+fn finishRead(self: *Self, stream: anytype, buf: []u8, bytes_read: c.DWORD) ReadOutputResult {
+    _ = self;
     if (bytes_read == 0) return .eof;
     stream.nextSlice(buf[0..@as(usize, @intCast(bytes_read))]);
     return .output;
 }
 
 fn finishOverlappedRead(
-    state: *State,
+    self: *Self,
     stream: anytype,
     buf: []u8,
     overlapped: *c.OVERLAPPED,
 ) !ReadOutputResult {
     var bytes_read: c.DWORD = 0;
     if (c.GetOverlappedResult(
-        state.pty_output,
+        self.pty_output,
         overlapped,
         &bytes_read,
         c.FALSE,
@@ -294,16 +291,16 @@ fn finishOverlappedRead(
         }
     }
 
-    return finishRead(stream, buf, bytes_read);
+    return self.finishRead(stream, buf, bytes_read);
 }
 
 fn cancelPendingRead(
-    state: *State,
+    self: *Self,
     stream: anytype,
     buf: []u8,
     overlapped: *c.OVERLAPPED,
 ) !ReadOutputResult {
-    if (c.CancelIoEx(state.pty_output, overlapped) == 0) {
+    if (c.CancelIoEx(self.pty_output, overlapped) == 0) {
         const err = c.GetLastError();
         switch (err) {
             c.ERROR_NOT_FOUND => {},
@@ -314,7 +311,7 @@ fn cancelPendingRead(
 
     var bytes_read: c.DWORD = 0;
     if (c.GetOverlappedResult(
-        state.pty_output,
+        self.pty_output,
         overlapped,
         &bytes_read,
         c.TRUE,
@@ -327,7 +324,7 @@ fn cancelPendingRead(
         }
     }
 
-    return finishRead(stream, buf, bytes_read);
+    return self.finishRead(stream, buf, bytes_read);
 }
 
 const WaitResult = enum {
@@ -336,24 +333,24 @@ const WaitResult = enum {
     command,
 };
 
-fn waitForReadOrCommand(state: *State, include_process: bool) !WaitResult {
+fn waitForReadOrCommand(self: *Self, include_process: bool) !WaitResult {
     var handles: [3]c.HANDLE = undefined;
     var count: c.DWORD = 0;
     const read_index = count;
-    handles[count] = state.output_read_event;
+    handles[count] = self.output_read_event;
     count += 1;
 
     var process_index: ?c.DWORD = null;
     var command_index: c.DWORD = undefined;
 
-    if (include_process and state.shell_process != c.INVALID_HANDLE_VALUE) {
+    if (include_process and self.shell_process != c.INVALID_HANDLE_VALUE) {
         process_index = count;
-        handles[count] = state.shell_process;
+        handles[count] = self.shell_process;
         count += 1;
     }
 
     command_index = count;
-    handles[count] = state.command_event;
+    handles[count] = self.command_event;
     count += 1;
 
     const result = c.WaitForMultipleObjects(count, &handles, c.FALSE, c.INFINITE);
@@ -368,13 +365,13 @@ fn waitForReadOrCommand(state: *State, include_process: bool) !WaitResult {
 
 pub fn write(self: *Self, data: []const u8) !void {
     if (data.len == 0) return;
-    if (self.state.pty_input == c.INVALID_HANDLE_VALUE) return error.WriteFailed;
+    if (self.pty_input == c.INVALID_HANDLE_VALUE) return error.WriteFailed;
 
     var offset: usize = 0;
     while (offset < data.len) {
         var wrote: c.DWORD = 0;
         const chunk_len: c.DWORD = @intCast(@min(data.len - offset, std.math.maxInt(c.DWORD)));
-        if (c.WriteFile(self.state.pty_input, data[offset..].ptr, chunk_len, &wrote, null) == 0) {
+        if (c.WriteFile(self.pty_input, data[offset..].ptr, chunk_len, &wrote, null) == 0) {
             return error.WriteFailed;
         }
         if (wrote == 0) return error.WriteFailed;
@@ -382,9 +379,23 @@ pub fn write(self: *Self, data: []const u8) !void {
     }
 }
 
+pub fn requestStop(self: *Self, read_thread: std.Thread) void {
+    self.stopRunning();
+    if (self.command_event != c.INVALID_HANDLE_VALUE) {
+        _ = c.SetEvent(self.command_event);
+    }
+
+    if (self.pty_input != c.INVALID_HANDLE_VALUE) {
+        _ = c.CloseHandle(self.pty_input);
+        self.pty_input = c.INVALID_HANDLE_VALUE;
+    }
+
+    _ = c.CancelSynchronousIo(read_thread.getHandle());
+}
+
 pub fn resize(self: *Self, cols: u16, rows: u16) !void {
-    if (!self.state.running.load(.acquire)) return error.PtyResizeFailed;
-    const hpc = self.state.hpc orelse return error.PtyResizeFailed;
+    if (!self.running.load(.acquire)) return error.PtyResizeFailed;
+    const hpc = self.hpc orelse return error.PtyResizeFailed;
     const size = c.COORD{
         .X = @intCast(cols),
         .Y = @intCast(rows),
@@ -392,36 +403,22 @@ pub fn resize(self: *Self, cols: u16, rows: u16) !void {
     if (resize_pseudo_console.?(hpc, size) < 0) return error.PtyResizeFailed;
 }
 
-pub fn requestStop(self: *Self, read_thread: std.Thread) void {
-    stopRunning(self.state);
-    wake(self.state);
-
-    if (self.state.pty_input != c.INVALID_HANDLE_VALUE) {
-        _ = c.CloseHandle(self.state.pty_input);
-        self.state.pty_input = c.INVALID_HANDLE_VALUE;
-    }
-
-    _ = c.CancelSynchronousIo(read_thread.getHandle());
-}
-
 pub fn replicaName(_: *Self) []const u8 {
     return "";
 }
 
 pub fn deinitAndWait(self: *Self) u8 {
-    const state = self.state;
-    stopRunning(state);
-    closeConPtyHandles(state);
+    self.stopRunning();
+    self.closeConPtyHandles();
 
     var exit_code: c.DWORD = 0;
-    if (state.shell_process != c.INVALID_HANDLE_VALUE) {
-        _ = c.WaitForSingleObject(state.shell_process, c.INFINITE);
-        _ = c.GetExitCodeProcess(state.shell_process, &exit_code);
-        _ = c.CloseHandle(state.shell_process);
+    if (self.shell_process != c.INVALID_HANDLE_VALUE) {
+        _ = c.WaitForSingleObject(self.shell_process, c.INFINITE);
+        _ = c.GetExitCodeProcess(self.shell_process, &exit_code);
+        _ = c.CloseHandle(self.shell_process);
+        self.shell_process = c.INVALID_HANDLE_VALUE;
     }
 
-    const alloc = state.alloc;
-    alloc.destroy(state);
     return @truncate(exit_code);
 }
 
@@ -434,13 +431,13 @@ fn initApi() !void {
     close_pseudo_console = @ptrCast(c.GetProcAddress(kernel32, "ClosePseudoConsole") orelse return error.MissingConPty);
 }
 
-fn createConPty(state: *State, rows: u16, cols: u16) !void {
+fn createConPty(self: *Self, rows: u16, cols: u16) !void {
     var in_read: c.HANDLE = c.INVALID_HANDLE_VALUE;
     var in_write: c.HANDLE = c.INVALID_HANDLE_VALUE;
     var out_read: c.HANDLE = c.INVALID_HANDLE_VALUE;
     var out_write: c.HANDLE = c.INVALID_HANDLE_VALUE;
     errdefer {
-        closeConPtyHandles(state);
+        self.closeConPtyHandles();
         if (in_read != c.INVALID_HANDLE_VALUE) _ = c.CloseHandle(in_read);
         if (in_write != c.INVALID_HANDLE_VALUE) _ = c.CloseHandle(in_write);
         if (out_read != c.INVALID_HANDLE_VALUE) _ = c.CloseHandle(out_read);
@@ -458,12 +455,12 @@ fn createConPty(state: *State, rows: u16, cols: u16) !void {
         .X = @intCast(cols),
         .Y = @intCast(rows),
     };
-    if (create_pseudo_console.?(size, in_read, out_write, 0, &state.hpc) < 0) {
+    if (create_pseudo_console.?(size, in_read, out_write, 0, &self.hpc) < 0) {
         return error.CreatePseudoConsoleFailed;
     }
 
-    state.pty_input = in_write;
-    state.pty_output = out_read;
+    self.pty_input = in_write;
+    self.pty_output = out_read;
     _ = c.CloseHandle(in_read);
     _ = c.CloseHandle(out_write);
     in_write = c.INVALID_HANDLE_VALUE;
@@ -472,41 +469,40 @@ fn createConPty(state: *State, rows: u16, cols: u16) !void {
     out_write = c.INVALID_HANDLE_VALUE;
 }
 
-fn closeConPtyHandles(state: *State) void {
-    if (state.pty_input != c.INVALID_HANDLE_VALUE) {
-        _ = c.CloseHandle(state.pty_input);
-        state.pty_input = c.INVALID_HANDLE_VALUE;
+fn closeConPtyHandles(self: *Self) void {
+    if (self.pty_input != c.INVALID_HANDLE_VALUE) {
+        _ = c.CloseHandle(self.pty_input);
+        self.pty_input = c.INVALID_HANDLE_VALUE;
     }
-    if (state.pty_output != c.INVALID_HANDLE_VALUE) {
-        _ = c.CloseHandle(state.pty_output);
-        state.pty_output = c.INVALID_HANDLE_VALUE;
+    if (self.pty_output != c.INVALID_HANDLE_VALUE) {
+        _ = c.CloseHandle(self.pty_output);
+        self.pty_output = c.INVALID_HANDLE_VALUE;
     }
-    closePseudoConsole(state);
-    if (state.command_event != c.INVALID_HANDLE_VALUE) {
-        _ = c.CloseHandle(state.command_event);
-        state.command_event = c.INVALID_HANDLE_VALUE;
+    if (self.hpc != null) {
+        // ClosePseudoConsole owns the documented ConPTY teardown path.
+        close_pseudo_console.?(self.hpc);
+        self.hpc = null;
     }
-    if (state.output_read_event != c.INVALID_HANDLE_VALUE) {
-        _ = c.CloseHandle(state.output_read_event);
-        state.output_read_event = c.INVALID_HANDLE_VALUE;
+    if (self.command_event != c.INVALID_HANDLE_VALUE) {
+        _ = c.CloseHandle(self.command_event);
+        self.command_event = c.INVALID_HANDLE_VALUE;
+    }
+    if (self.output_read_event != c.INVALID_HANDLE_VALUE) {
+        _ = c.CloseHandle(self.output_read_event);
+        self.output_read_event = c.INVALID_HANDLE_VALUE;
     }
 }
 
-fn closePseudoConsole(state: *State) void {
-    if (state.hpc == null) return;
-    // ClosePseudoConsole owns the documented ConPTY teardown path.
-    close_pseudo_console.?(state.hpc);
-    state.hpc = null;
+fn closePseudoConsole(self: *Self) void {
+    if (self.hpc != null) {
+        close_pseudo_console.?(self.hpc);
+        self.hpc = null;
+    }
 }
 
-fn wake(state: *State) void {
-    if (state.command_event == c.INVALID_HANDLE_VALUE) return;
-    _ = c.SetEvent(state.command_event);
-}
-
-fn clearCommandEvent(state: *State) void {
-    if (state.command_event == c.INVALID_HANDLE_VALUE) return;
-    _ = c.ResetEvent(state.command_event);
+fn clearCommandEvent(self: *Self) void {
+    if (self.command_event == c.INVALID_HANDLE_VALUE) return;
+    _ = c.ResetEvent(self.command_event);
 }
 
 fn createOverlappedPipe(read_handle: *c.HANDLE, write_handle: *c.HANDLE) !void {
@@ -560,8 +556,8 @@ fn createOverlappedPipe(read_handle: *c.HANDLE, write_handle: *c.HANDLE) !void {
     if (write_handle.* == c.INVALID_HANDLE_VALUE) return error.CreatePipeFailed;
 }
 
-fn spawnChild(state: *State, params: ProcessParams) !void {
-    var arena_allocator = std.heap.ArenaAllocator.init(state.alloc);
+fn spawnChild(self: *Self, alloc: Allocator, params: ProcessParams) !void {
+    var arena_allocator = std.heap.ArenaAllocator.init(alloc);
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
 
@@ -588,7 +584,7 @@ fn spawnChild(state: *State, params: ProcessParams) !void {
         si.lpAttributeList,
         0,
         PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
-        state.hpc,
+        self.hpc,
         @sizeOf(HPCON),
         null,
         null,
@@ -613,8 +609,8 @@ fn spawnChild(state: *State, params: ProcessParams) !void {
         return error.CreateProcessFailed;
     }
 
-    state.shell_process = pi.hProcess;
-    state.pid = @intCast(pi.dwProcessId);
+    self.shell_process = pi.hProcess;
+    self.pid = @intCast(pi.dwProcessId);
     _ = c.CloseHandle(pi.hThread);
 }
 
@@ -723,8 +719,8 @@ fn appendWtf8AsWtf16(builder: *std.ArrayList(u16), arena: Allocator, value: []co
     std.debug.assert(written == len);
 }
 
-fn stopRunning(state: *State) void {
-    state.running.store(false, .release);
+fn stopRunning(self: *Self) void {
+    self.running.store(false, .release);
 }
 
 test "notify CRT provider follows the CRT that owns Emacs dup" {

--- a/src/ConPtyProcess.zig
+++ b/src/ConPtyProcess.zig
@@ -22,6 +22,8 @@ const State = struct {
     hpc: HPCON = null,
     pty_input: c.HANDLE = c.INVALID_HANDLE_VALUE,
     pty_output: c.HANDLE = c.INVALID_HANDLE_VALUE,
+    command_event: c.HANDLE = c.INVALID_HANDLE_VALUE,
+    output_read_event: c.HANDLE = c.INVALID_HANDLE_VALUE,
     shell_process: c.HANDLE = c.INVALID_HANDLE_VALUE,
     running: std.atomic.Value(bool) = .init(true),
     pid: i64 = -1,
@@ -32,6 +34,7 @@ state: *State,
 var create_pseudo_console: ?CreatePseudoConsoleFn = null;
 var resize_pseudo_console: ?ResizePseudoConsoleFn = null;
 var close_pseudo_console: ?ClosePseudoConsoleFn = null;
+var pipe_name_counter = std.atomic.Value(u32).init(1);
 
 pub const ProcessParams = @import("ProcessParams.zig");
 
@@ -183,8 +186,12 @@ pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: Proc
     errdefer alloc.destroy(state);
     state.* = .{ .alloc = alloc };
 
-    try createConPty(state, initial_rows, initial_cols);
+    state.command_event = c.CreateEventW(null, c.TRUE, c.FALSE, null);
+    if (state.command_event == null) return error.CreateEventFailed;
     errdefer closeConPtyHandles(state);
+    state.output_read_event = c.CreateEventW(null, c.TRUE, c.FALSE, null);
+    if (state.output_read_event == null) return error.CreateEventFailed;
+    try createConPty(state, initial_rows, initial_cols);
     try spawnChild(state, params);
 
     return .{ .state = state };
@@ -195,64 +202,168 @@ pub fn pidValue(self: *const Self) i64 {
 }
 
 pub fn drain(self: *Self, stream: anytype) !bool {
-    var drained = false;
     var buf: [READ_BUFFER_SIZE]u8 = undefined;
 
     while (self.state.running.load(.acquire)) {
-        const available = try peekOutputAvailable(self.state);
-        if (available == 0) {
-            if (drained) return true;
-            if (shellProcessExited(self.state)) {
+        switch (try self.readOutput(stream, buf[0..])) {
+            .output, .command => return false,
+            .eof => {
                 stopRunning(self.state);
-                return drained;
-            }
-            // The ConPTY output pipe is polled with PeekNamedPipe; wait briefly
-            // on the child process handle to avoid a hot spin while still
-            // noticing process exit promptly.
-            _ = c.WaitForSingleObject(self.state.shell_process, 10);
-            continue;
+                return true;
+            },
         }
-
-        var bytes_read: c.DWORD = 0;
-        const read_len: c.DWORD = @intCast(@min(buf.len, available));
-        if (c.ReadFile(self.state.pty_output, buf[0..].ptr, read_len, &bytes_read, null) == 0) {
-            const err = c.GetLastError();
-            switch (err) {
-                c.ERROR_OPERATION_ABORTED, c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => {
-                    stopRunning(self.state);
-                    return drained;
-                },
-                else => return error.ReadFailed,
-            }
-        }
-        if (bytes_read == 0) {
-            stopRunning(self.state);
-            return drained;
-        }
-        stream.nextSlice(buf[0..@as(usize, @intCast(bytes_read))]);
-        drained = true;
     }
 
-    return drained;
+    return true;
 }
 
-fn peekOutputAvailable(state: *State) !c.DWORD {
-    if (state.pty_output == c.INVALID_HANDLE_VALUE) return 0;
+const ReadOutputResult = enum {
+    output,
+    eof,
+    command,
+};
 
-    var available: c.DWORD = 0;
-    if (c.PeekNamedPipe(state.pty_output, null, 0, null, &available, null) == 0) {
+fn readOutput(self: *Self, stream: anytype, buf: []u8) !ReadOutputResult {
+    const state = self.state;
+    if (state.pty_output == c.INVALID_HANDLE_VALUE) return .eof;
+    if (state.output_read_event == c.INVALID_HANDLE_VALUE) return error.ReadFailed;
+
+    _ = c.ResetEvent(state.output_read_event);
+
+    var overlapped = std.mem.zeroes(c.OVERLAPPED);
+    overlapped.hEvent = state.output_read_event;
+
+    var bytes_read: c.DWORD = 0;
+    if (c.ReadFile(
+        state.pty_output,
+        buf.ptr,
+        @intCast(buf.len),
+        &bytes_read,
+        &overlapped,
+    ) != 0) {
+        return finishRead(stream, buf, bytes_read);
+    }
+
+    switch (c.GetLastError()) {
+        c.ERROR_IO_PENDING => {},
+        c.ERROR_OPERATION_ABORTED => return .command,
+        c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => return .eof,
+        else => return error.ReadFailed,
+    }
+
+    var include_process = true;
+    while (true) {
+        switch (try waitForReadOrCommand(state, include_process)) {
+            .read => return finishOverlappedRead(state, stream, buf, &overlapped),
+            .command => {
+                clearCommandEvent(state);
+                return cancelPendingRead(state, stream, buf, &overlapped);
+            },
+            .process => {
+                closePseudoConsole(state);
+                include_process = false;
+            },
+        }
+    }
+}
+
+fn finishRead(stream: anytype, buf: []u8, bytes_read: c.DWORD) ReadOutputResult {
+    if (bytes_read == 0) return .eof;
+    stream.nextSlice(buf[0..@as(usize, @intCast(bytes_read))]);
+    return .output;
+}
+
+fn finishOverlappedRead(
+    state: *State,
+    stream: anytype,
+    buf: []u8,
+    overlapped: *c.OVERLAPPED,
+) !ReadOutputResult {
+    var bytes_read: c.DWORD = 0;
+    if (c.GetOverlappedResult(
+        state.pty_output,
+        overlapped,
+        &bytes_read,
+        c.FALSE,
+    ) == 0) {
         const err = c.GetLastError();
         switch (err) {
-            c.ERROR_OPERATION_ABORTED, c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => return 0,
+            c.ERROR_OPERATION_ABORTED => return .command,
+            c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => return .eof,
             else => return error.ReadFailed,
         }
     }
-    return available;
+
+    return finishRead(stream, buf, bytes_read);
 }
 
-fn shellProcessExited(state: *State) bool {
-    if (state.shell_process == c.INVALID_HANDLE_VALUE) return true;
-    return c.WaitForSingleObject(state.shell_process, 0) == c.WAIT_OBJECT_0;
+fn cancelPendingRead(
+    state: *State,
+    stream: anytype,
+    buf: []u8,
+    overlapped: *c.OVERLAPPED,
+) !ReadOutputResult {
+    if (c.CancelIoEx(state.pty_output, overlapped) == 0) {
+        const err = c.GetLastError();
+        switch (err) {
+            c.ERROR_NOT_FOUND => {},
+            c.ERROR_INVALID_HANDLE => return .eof,
+            else => return error.ReadFailed,
+        }
+    }
+
+    var bytes_read: c.DWORD = 0;
+    if (c.GetOverlappedResult(
+        state.pty_output,
+        overlapped,
+        &bytes_read,
+        c.TRUE,
+    ) == 0) {
+        const err = c.GetLastError();
+        switch (err) {
+            c.ERROR_OPERATION_ABORTED => return .command,
+            c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => return .eof,
+            else => return error.ReadFailed,
+        }
+    }
+
+    return finishRead(stream, buf, bytes_read);
+}
+
+const WaitResult = enum {
+    read,
+    process,
+    command,
+};
+
+fn waitForReadOrCommand(state: *State, include_process: bool) !WaitResult {
+    var handles: [3]c.HANDLE = undefined;
+    var count: c.DWORD = 0;
+    const read_index = count;
+    handles[count] = state.output_read_event;
+    count += 1;
+
+    var process_index: ?c.DWORD = null;
+    var command_index: c.DWORD = undefined;
+
+    if (include_process and state.shell_process != c.INVALID_HANDLE_VALUE) {
+        process_index = count;
+        handles[count] = state.shell_process;
+        count += 1;
+    }
+
+    command_index = count;
+    handles[count] = state.command_event;
+    count += 1;
+
+    const result = c.WaitForMultipleObjects(count, &handles, c.FALSE, c.INFINITE);
+    if (result < c.WAIT_OBJECT_0 or result >= c.WAIT_OBJECT_0 + count) return error.WaitFailed;
+
+    const index = result - c.WAIT_OBJECT_0;
+    if (index == read_index) return .read;
+    if (process_index != null and index == process_index.?) return .process;
+    if (index == command_index) return .command;
+    return error.WaitFailed;
 }
 
 pub fn write(self: *Self, data: []const u8) !void {
@@ -283,6 +394,7 @@ pub fn resize(self: *Self, cols: u16, rows: u16) !void {
 
 pub fn requestStop(self: *Self, read_thread: std.Thread) void {
     stopRunning(self.state);
+    wake(self.state);
 
     if (self.state.pty_input != c.INVALID_HANDLE_VALUE) {
         _ = c.CloseHandle(self.state.pty_input);
@@ -340,7 +452,7 @@ fn createConPty(state: *State, rows: u16, cols: u16) !void {
     sa.bInheritHandle = c.TRUE;
 
     if (c.CreatePipe(&in_read, &in_write, &sa, 0) == 0) return error.CreatePipeFailed;
-    if (c.CreatePipe(&out_read, &out_write, &sa, 0) == 0) return error.CreatePipeFailed;
+    try createOverlappedPipe(&out_read, &out_write);
 
     const size = c.COORD{
         .X = @intCast(cols),
@@ -369,11 +481,83 @@ fn closeConPtyHandles(state: *State) void {
         _ = c.CloseHandle(state.pty_output);
         state.pty_output = c.INVALID_HANDLE_VALUE;
     }
-    if (state.hpc != null) {
-        // ClosePseudoConsole owns the documented ConPTY teardown path.
-        close_pseudo_console.?(state.hpc);
-        state.hpc = null;
+    closePseudoConsole(state);
+    if (state.command_event != c.INVALID_HANDLE_VALUE) {
+        _ = c.CloseHandle(state.command_event);
+        state.command_event = c.INVALID_HANDLE_VALUE;
     }
+    if (state.output_read_event != c.INVALID_HANDLE_VALUE) {
+        _ = c.CloseHandle(state.output_read_event);
+        state.output_read_event = c.INVALID_HANDLE_VALUE;
+    }
+}
+
+fn closePseudoConsole(state: *State) void {
+    if (state.hpc == null) return;
+    // ClosePseudoConsole owns the documented ConPTY teardown path.
+    close_pseudo_console.?(state.hpc);
+    state.hpc = null;
+}
+
+fn wake(state: *State) void {
+    if (state.command_event == c.INVALID_HANDLE_VALUE) return;
+    _ = c.SetEvent(state.command_event);
+}
+
+fn clearCommandEvent(state: *State) void {
+    if (state.command_event == c.INVALID_HANDLE_VALUE) return;
+    _ = c.ResetEvent(state.command_event);
+}
+
+fn createOverlappedPipe(read_handle: *c.HANDLE, write_handle: *c.HANDLE) !void {
+    var pipe_path_buf: [128]u8 = undefined;
+    var pipe_path_buf_w: [128]u16 = undefined;
+    const pipe_path = std.fmt.bufPrintZ(
+        &pipe_path_buf,
+        "\\\\.\\pipe\\ghostel-conpty-{d}-{d}",
+        .{
+            c.GetCurrentProcessId(),
+            pipe_name_counter.fetchAdd(1, .monotonic),
+        },
+    ) catch unreachable;
+
+    const pipe_path_w_len = std.unicode.utf8ToUtf16Le(
+        &pipe_path_buf_w,
+        pipe_path,
+    ) catch unreachable;
+    pipe_path_buf_w[pipe_path_w_len] = 0;
+    const pipe_path_w = pipe_path_buf_w[0..pipe_path_w_len :0];
+
+    var sa = std.mem.zeroes(c.SECURITY_ATTRIBUTES);
+    sa.nLength = @sizeOf(c.SECURITY_ATTRIBUTES);
+    sa.bInheritHandle = c.TRUE;
+
+    read_handle.* = c.CreateNamedPipeW(
+        pipe_path_w.ptr,
+        c.PIPE_ACCESS_INBOUND | c.FILE_FLAG_OVERLAPPED | c.FILE_FLAG_FIRST_PIPE_INSTANCE,
+        c.PIPE_TYPE_BYTE,
+        1,
+        4096,
+        4096,
+        0,
+        &sa,
+    );
+    if (read_handle.* == c.INVALID_HANDLE_VALUE) return error.CreatePipeFailed;
+    errdefer {
+        _ = c.CloseHandle(read_handle.*);
+        read_handle.* = c.INVALID_HANDLE_VALUE;
+    }
+
+    write_handle.* = c.CreateFileW(
+        pipe_path_w.ptr,
+        c.GENERIC_WRITE,
+        0,
+        &sa,
+        c.OPEN_EXISTING,
+        c.FILE_ATTRIBUTE_NORMAL,
+        null,
+    );
+    if (write_handle.* == c.INVALID_HANDLE_VALUE) return error.CreatePipeFailed;
 }
 
 fn spawnChild(state: *State, params: ProcessParams) !void {

--- a/src/ConPtyProcess.zig
+++ b/src/ConPtyProcess.zig
@@ -407,7 +407,7 @@ pub fn replicaName(_: *Self) []const u8 {
     return "";
 }
 
-pub fn deinitAndWait(self: *Self) u8 {
+pub fn deinitAndWait(self: *Self) u32 {
     self.closeConPtyHandles();
 
     var exit_code: c.DWORD = 0;
@@ -418,7 +418,7 @@ pub fn deinitAndWait(self: *Self) u8 {
         self.shell_process = c.INVALID_HANDLE_VALUE;
     }
 
-    return @truncate(exit_code);
+    return exit_code;
 }
 
 fn initApi() !void {

--- a/src/ConPtyProcess.zig
+++ b/src/ConPtyProcess.zig
@@ -1,0 +1,589 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const c = @cImport({
+    @cInclude("windows.h");
+});
+
+const Self = @This();
+
+const HPCON = ?*anyopaque;
+const CreatePseudoConsoleFn = *const fn (c.COORD, c.HANDLE, c.HANDLE, u32, *HPCON) callconv(.winapi) c.HRESULT;
+const ResizePseudoConsoleFn = *const fn (HPCON, c.COORD) callconv(.winapi) c.HRESULT;
+const ClosePseudoConsoleFn = *const fn (HPCON) callconv(.winapi) void;
+
+const PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE: usize = 0x00020016;
+const READ_BUFFER_SIZE = 64 * 1024;
+
+// Kept separate from Self because NativeProcess hands this backend by value to
+// a detached reaper thread.
+const State = struct {
+    alloc: Allocator,
+    hpc: HPCON = null,
+    pty_input: c.HANDLE = c.INVALID_HANDLE_VALUE,
+    pty_output: c.HANDLE = c.INVALID_HANDLE_VALUE,
+    shell_process: c.HANDLE = c.INVALID_HANDLE_VALUE,
+    running: std.atomic.Value(bool) = .init(true),
+    forced_stop: std.atomic.Value(bool) = .init(false),
+    pid: i64 = -1,
+};
+
+state: *State,
+
+var create_pseudo_console: ?CreatePseudoConsoleFn = null;
+var resize_pseudo_console: ?ResizePseudoConsoleFn = null;
+var close_pseudo_console: ?ClosePseudoConsoleFn = null;
+
+pub const ProcessParams = struct {
+    file: [:0]const u8,
+    args: [][:0]const u8,
+    env: *const std.process.EnvMap,
+    cwd: ?[]const u8 = null,
+};
+
+pub const EventWriter = struct {
+    pub const Fd = c_int;
+
+    const NotifyCrtProvider = enum {
+        msvcrt,
+        ucrt,
+    };
+
+    const NotifyCrtWriteFn = *const fn (c_int, ?*const anyopaque, c_uint) callconv(.c) c_int;
+    const NotifyCrtCloseFn = *const fn (c_int) callconv(.c) c_int;
+    const NotifyCrt = struct {
+        write: NotifyCrtWriteFn,
+        close: NotifyCrtCloseFn,
+    };
+
+    fd: Fd,
+    notify_crt: NotifyCrt,
+
+    var cached_notify_crt: ?NotifyCrt = null;
+
+    pub fn init(fd: Fd) !EventWriter {
+        return .{
+            .fd = fd,
+            .notify_crt = try resolveNotifyCrt(),
+        };
+    }
+
+    pub fn write(self: *EventWriter, data: []const u8) !void {
+        var written: usize = 0;
+        while (written < data.len) {
+            const chunk_len: c_uint = @intCast(@min(data.len - written, std.math.maxInt(c_uint)));
+            const n = self.notify_crt.write(
+                self.fd,
+                @ptrCast(data[written..].ptr),
+                chunk_len,
+            );
+            if (n <= 0) return error.EventWriteFailed;
+            written += @intCast(n);
+        }
+    }
+
+    pub fn close(self: *EventWriter) void {
+        if (self.fd < 0) return;
+        _ = self.notify_crt.close(self.fd);
+        self.fd = -1;
+    }
+
+    pub fn onThreadEnter(_: *EventWriter) void {}
+
+    pub fn onThreadExit() void {}
+
+    fn notifyCrtProviderForImport(dll_name: []const u8, symbol_name: []const u8) ?NotifyCrtProvider {
+        if (!std.mem.eql(u8, symbol_name, "_dup")) return null;
+
+        if (std.ascii.eqlIgnoreCase(dll_name, "msvcrt.dll")) return .msvcrt;
+        if (std.ascii.eqlIgnoreCase(dll_name, "ucrtbase.dll")) return .ucrt;
+        // Newer Emacs builds may link the UCRT through api-ms-win-crt
+        // forwarding DLLs rather than importing ucrtbase.dll directly.
+        if (std.ascii.startsWithIgnoreCase(dll_name, "api-ms-win-crt-")) return .ucrt;
+        return null;
+    }
+
+    fn ptrFromRva(comptime T: type, base: usize, rva: c.DWORD) *const T {
+        return @ptrFromInt(base + @as(usize, @intCast(rva)));
+    }
+
+    fn cStringFromRva(base: usize, rva: c.DWORD) []const u8 {
+        const ptr: [*:0]const u8 = @ptrFromInt(base + @as(usize, @intCast(rva)));
+        return std.mem.span(ptr);
+    }
+
+    fn importDescriptorHasSymbol(base: usize, descriptor: *const c.IMAGE_IMPORT_DESCRIPTOR, symbol_name: []const u8) bool {
+        const thunk_rva = if (descriptor.unnamed_0.OriginalFirstThunk != 0)
+            descriptor.unnamed_0.OriginalFirstThunk
+        else
+            descriptor.FirstThunk;
+        if (thunk_rva == 0) return false;
+
+        const thunks: [*]const c.IMAGE_THUNK_DATA = @ptrFromInt(base + @as(usize, @intCast(thunk_rva)));
+        var i: usize = 0;
+        while (thunks[i].u1.AddressOfData != 0) : (i += 1) {
+            const address = thunks[i].u1.AddressOfData;
+            const ordinal_flag = @as(@TypeOf(address), 1) << (@bitSizeOf(@TypeOf(address)) - 1);
+            if ((address & ordinal_flag) != 0) continue;
+
+            const import_by_name = ptrFromRva(c.IMAGE_IMPORT_BY_NAME, base, @intCast(address));
+            const name_addr = @intFromPtr(import_by_name) + @offsetOf(c.IMAGE_IMPORT_BY_NAME, "Name");
+            const import_name: [*:0]const u8 = @ptrFromInt(name_addr);
+            if (std.mem.eql(u8, std.mem.span(import_name), symbol_name)) return true;
+        }
+        return false;
+    }
+
+    fn findNotifyCrtProviderInImage(module: c.HMODULE) ?NotifyCrtProvider {
+        const base = @intFromPtr(module);
+        const dos = ptrFromRva(c.IMAGE_DOS_HEADER, base, 0);
+        if (dos.e_magic != c.IMAGE_DOS_SIGNATURE or dos.e_lfanew < 0) return null;
+
+        const nt: *const c.IMAGE_NT_HEADERS = @ptrFromInt(base + @as(usize, @intCast(dos.e_lfanew)));
+        if (nt.Signature != c.IMAGE_NT_SIGNATURE) return null;
+
+        const import_index: usize = @intCast(c.IMAGE_DIRECTORY_ENTRY_IMPORT);
+        if (nt.OptionalHeader.NumberOfRvaAndSizes <= import_index) return null;
+        const import_directory = nt.OptionalHeader.DataDirectory[import_index];
+        if (import_directory.VirtualAddress == 0) return null;
+
+        const descriptors: [*]const c.IMAGE_IMPORT_DESCRIPTOR = @ptrFromInt(base + @as(usize, @intCast(import_directory.VirtualAddress)));
+        var i: usize = 0;
+        while (descriptors[i].Name != 0) : (i += 1) {
+            const dll_name = cStringFromRva(base, descriptors[i].Name);
+            if (importDescriptorHasSymbol(base, &descriptors[i], "_dup")) {
+                if (notifyCrtProviderForImport(dll_name, "_dup")) |provider| return provider;
+            }
+        }
+        return null;
+    }
+
+    fn detectNotifyCrtProvider() !NotifyCrtProvider {
+        const module = c.GetModuleHandleW(null) orelse return error.NotifyCrtUnavailable;
+        return findNotifyCrtProviderInImage(module) orelse error.NotifyCrtUnavailable;
+    }
+
+    fn resolveNotifyCrt() !NotifyCrt {
+        if (cached_notify_crt) |crt| return crt;
+
+        const provider = try detectNotifyCrtProvider();
+        const dll_name = switch (provider) {
+            .msvcrt => std.unicode.utf8ToUtf16LeStringLiteral("msvcrt.dll"),
+            .ucrt => std.unicode.utf8ToUtf16LeStringLiteral("ucrtbase.dll"),
+        };
+        const module = c.GetModuleHandleW(dll_name) orelse return error.NotifyCrtUnavailable;
+        const write_proc = c.GetProcAddress(module, "_write") orelse return error.NotifyCrtUnavailable;
+        const close_proc = c.GetProcAddress(module, "_close") orelse return error.NotifyCrtUnavailable;
+        cached_notify_crt = .{
+            .write = @ptrCast(write_proc),
+            .close = @ptrCast(close_proc),
+        };
+        return cached_notify_crt.?;
+    }
+};
+
+pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: ProcessParams) !Self {
+    try initApi();
+
+    const state = try alloc.create(State);
+    errdefer alloc.destroy(state);
+    state.* = .{ .alloc = alloc };
+
+    try createConPty(state, initial_rows, initial_cols);
+    errdefer closeConPtyHandles(state);
+    try spawnChild(state, params);
+
+    return .{ .state = state };
+}
+
+pub fn pidValue(self: *const Self) i64 {
+    return self.state.pid;
+}
+
+pub fn drain(self: *Self, stream: anytype) !bool {
+    var drained = false;
+    var buf: [READ_BUFFER_SIZE]u8 = undefined;
+
+    while (self.state.running.load(.acquire)) {
+        const available = try peekOutputAvailable(self.state);
+        if (available == 0) {
+            if (drained) return true;
+            if (shellProcessExited(self.state)) {
+                stopRunning(self.state);
+                return drained;
+            }
+            // The ConPTY output pipe is polled with PeekNamedPipe; wait briefly
+            // on the child process handle to avoid a hot spin while still
+            // noticing process exit promptly.
+            _ = c.WaitForSingleObject(self.state.shell_process, 10);
+            continue;
+        }
+
+        var bytes_read: c.DWORD = 0;
+        const read_len: c.DWORD = @intCast(@min(buf.len, available));
+        if (c.ReadFile(self.state.pty_output, buf[0..].ptr, read_len, &bytes_read, null) == 0) {
+            const err = c.GetLastError();
+            switch (err) {
+                c.ERROR_OPERATION_ABORTED, c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => {
+                    stopRunning(self.state);
+                    return drained;
+                },
+                else => return error.ReadFailed,
+            }
+        }
+        if (bytes_read == 0) {
+            stopRunning(self.state);
+            return drained;
+        }
+        stream.nextSlice(buf[0..@as(usize, @intCast(bytes_read))]);
+        drained = true;
+    }
+
+    return drained;
+}
+
+fn peekOutputAvailable(state: *State) !c.DWORD {
+    if (state.pty_output == c.INVALID_HANDLE_VALUE) return 0;
+
+    var available: c.DWORD = 0;
+    if (c.PeekNamedPipe(state.pty_output, null, 0, null, &available, null) == 0) {
+        const err = c.GetLastError();
+        switch (err) {
+            c.ERROR_OPERATION_ABORTED, c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => return 0,
+            else => return error.ReadFailed,
+        }
+    }
+    return available;
+}
+
+fn shellProcessExited(state: *State) bool {
+    if (state.shell_process == c.INVALID_HANDLE_VALUE) return true;
+    return c.WaitForSingleObject(state.shell_process, 0) == c.WAIT_OBJECT_0;
+}
+
+pub fn write(self: *Self, data: []const u8) !void {
+    if (data.len == 0) return;
+    if (self.state.pty_input == c.INVALID_HANDLE_VALUE) return error.WriteFailed;
+
+    var offset: usize = 0;
+    while (offset < data.len) {
+        var wrote: c.DWORD = 0;
+        const chunk_len: c.DWORD = @intCast(@min(data.len - offset, std.math.maxInt(c.DWORD)));
+        if (c.WriteFile(self.state.pty_input, data[offset..].ptr, chunk_len, &wrote, null) == 0) {
+            return error.WriteFailed;
+        }
+        if (wrote == 0) return error.WriteFailed;
+        offset += wrote;
+    }
+}
+
+pub fn resize(self: *Self, cols: u16, rows: u16) !void {
+    if (!self.state.running.load(.acquire)) return error.PtyResizeFailed;
+    const hpc = self.state.hpc orelse return error.PtyResizeFailed;
+    const size = c.COORD{
+        .X = @intCast(cols),
+        .Y = @intCast(rows),
+    };
+    if (resize_pseudo_console.?(hpc, size) < 0) return error.PtyResizeFailed;
+}
+
+pub fn requestStop(self: *Self, read_thread: std.Thread) void {
+    self.state.forced_stop.store(true, .release);
+    stopRunning(self.state);
+
+    if (self.state.pty_input != c.INVALID_HANDLE_VALUE) {
+        _ = c.CloseHandle(self.state.pty_input);
+        self.state.pty_input = c.INVALID_HANDLE_VALUE;
+    }
+
+    _ = c.CancelSynchronousIo(read_thread.getHandle());
+}
+
+pub fn replicaName(_: *Self) []const u8 {
+    return "";
+}
+
+pub fn deinitAndWait(self: *Self) u8 {
+    const state = self.state;
+    stopRunning(state);
+
+    if (state.forced_stop.load(.acquire)) {
+        closeConPtyHandles(state);
+    }
+
+    var exit_code: c.DWORD = 0;
+    if (state.shell_process != c.INVALID_HANDLE_VALUE) {
+        _ = c.WaitForSingleObject(state.shell_process, c.INFINITE);
+        _ = c.GetExitCodeProcess(state.shell_process, &exit_code);
+        _ = c.CloseHandle(state.shell_process);
+    }
+
+    closeConPtyHandles(state);
+
+    const alloc = state.alloc;
+    alloc.destroy(state);
+    return @truncate(exit_code);
+}
+
+fn initApi() !void {
+    if (create_pseudo_console != null) return;
+
+    const kernel32 = c.GetModuleHandleA("kernel32.dll") orelse return error.MissingConPty;
+    create_pseudo_console = @ptrCast(c.GetProcAddress(kernel32, "CreatePseudoConsole") orelse return error.MissingConPty);
+    resize_pseudo_console = @ptrCast(c.GetProcAddress(kernel32, "ResizePseudoConsole") orelse return error.MissingConPty);
+    close_pseudo_console = @ptrCast(c.GetProcAddress(kernel32, "ClosePseudoConsole") orelse return error.MissingConPty);
+}
+
+fn createConPty(state: *State, rows: u16, cols: u16) !void {
+    var in_read: c.HANDLE = c.INVALID_HANDLE_VALUE;
+    var in_write: c.HANDLE = c.INVALID_HANDLE_VALUE;
+    var out_read: c.HANDLE = c.INVALID_HANDLE_VALUE;
+    var out_write: c.HANDLE = c.INVALID_HANDLE_VALUE;
+    errdefer {
+        closeConPtyHandles(state);
+        if (in_read != c.INVALID_HANDLE_VALUE) _ = c.CloseHandle(in_read);
+        if (in_write != c.INVALID_HANDLE_VALUE) _ = c.CloseHandle(in_write);
+        if (out_read != c.INVALID_HANDLE_VALUE) _ = c.CloseHandle(out_read);
+        if (out_write != c.INVALID_HANDLE_VALUE) _ = c.CloseHandle(out_write);
+    }
+
+    var sa = std.mem.zeroes(c.SECURITY_ATTRIBUTES);
+    sa.nLength = @sizeOf(c.SECURITY_ATTRIBUTES);
+    sa.bInheritHandle = c.TRUE;
+
+    if (c.CreatePipe(&in_read, &in_write, &sa, 0) == 0) return error.CreatePipeFailed;
+    if (c.CreatePipe(&out_read, &out_write, &sa, 0) == 0) return error.CreatePipeFailed;
+
+    const size = c.COORD{
+        .X = @intCast(cols),
+        .Y = @intCast(rows),
+    };
+    if (create_pseudo_console.?(size, in_read, out_write, 0, &state.hpc) < 0) {
+        return error.CreatePseudoConsoleFailed;
+    }
+
+    state.pty_input = in_write;
+    state.pty_output = out_read;
+    _ = c.CloseHandle(in_read);
+    _ = c.CloseHandle(out_write);
+    in_write = c.INVALID_HANDLE_VALUE;
+    out_read = c.INVALID_HANDLE_VALUE;
+    in_read = c.INVALID_HANDLE_VALUE;
+    out_write = c.INVALID_HANDLE_VALUE;
+}
+
+fn closeConPtyHandles(state: *State) void {
+    if (state.pty_input != c.INVALID_HANDLE_VALUE) {
+        _ = c.CloseHandle(state.pty_input);
+        state.pty_input = c.INVALID_HANDLE_VALUE;
+    }
+    if (state.pty_output != c.INVALID_HANDLE_VALUE) {
+        _ = c.CloseHandle(state.pty_output);
+        state.pty_output = c.INVALID_HANDLE_VALUE;
+    }
+    if (state.hpc != null) {
+        // ClosePseudoConsole owns the documented ConPTY teardown path.
+        close_pseudo_console.?(state.hpc);
+        state.hpc = null;
+    }
+}
+
+fn spawnChild(state: *State, params: ProcessParams) !void {
+    var arena_allocator = std.heap.ArenaAllocator.init(state.alloc);
+    defer arena_allocator.deinit();
+    const arena = arena_allocator.allocator();
+
+    const command_line = try argvToCommandLineWindows(arena, params.args);
+    const cwd = if (params.cwd) |cwd_path|
+        try std.unicode.wtf8ToWtf16LeAllocZ(arena, cwd_path)
+    else
+        null;
+    const env_block = try buildEnvironmentBlock(arena, params.env);
+
+    var attr_list_size: usize = 0;
+    _ = c.InitializeProcThreadAttributeList(null, 1, 0, &attr_list_size);
+    const attr_list_buf = try arena.alloc(u8, attr_list_size);
+
+    var si = std.mem.zeroes(c.STARTUPINFOEXW);
+    si.StartupInfo.cb = @sizeOf(c.STARTUPINFOEXW);
+    si.lpAttributeList = @ptrCast(@alignCast(attr_list_buf.ptr));
+    if (c.InitializeProcThreadAttributeList(si.lpAttributeList, 1, 0, &attr_list_size) == 0) {
+        return error.InitializeProcThreadAttributeListFailed;
+    }
+    defer c.DeleteProcThreadAttributeList(si.lpAttributeList);
+
+    if (c.UpdateProcThreadAttribute(
+        si.lpAttributeList,
+        0,
+        PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+        state.hpc,
+        @sizeOf(HPCON),
+        null,
+        null,
+    ) == 0) {
+        return error.UpdateProcThreadAttributeFailed;
+    }
+
+    var pi = std.mem.zeroes(c.PROCESS_INFORMATION);
+    const flags = c.EXTENDED_STARTUPINFO_PRESENT | c.CREATE_UNICODE_ENVIRONMENT;
+    if (c.CreateProcessW(
+        null,
+        command_line.ptr,
+        null,
+        null,
+        c.FALSE,
+        flags,
+        @ptrCast(env_block.ptr),
+        if (cwd) |cwd_w| cwd_w.ptr else null,
+        &si.StartupInfo,
+        &pi,
+    ) == 0) {
+        return error.CreateProcessFailed;
+    }
+
+    state.shell_process = pi.hProcess;
+    state.pid = @intCast(pi.dwProcessId);
+    _ = c.CloseHandle(pi.hThread);
+}
+
+fn argvToCommandLineWindows(
+    allocator: Allocator,
+    argv: []const [:0]const u8,
+) ![:0]u16 {
+    var buf = std.array_list.Managed(u8).init(allocator);
+    defer buf.deinit();
+
+    if (argv.len != 0) {
+        const arg0 = argv[0];
+
+        var needs_quotes = arg0.len == 0;
+        for (arg0) |ch| {
+            if (ch <= ' ') {
+                needs_quotes = true;
+            } else if (ch == '"') {
+                return error.InvalidArg0;
+            }
+        }
+        if (needs_quotes) {
+            try buf.append('"');
+            try buf.appendSlice(arg0);
+            try buf.append('"');
+        } else {
+            try buf.appendSlice(arg0);
+        }
+
+        for (argv[1..]) |arg| {
+            try buf.append(' ');
+
+            needs_quotes = for (arg) |ch| {
+                if (ch <= ' ' or ch == '"') {
+                    break true;
+                }
+            } else arg.len == 0;
+            if (!needs_quotes) {
+                try buf.appendSlice(arg);
+                continue;
+            }
+
+            try buf.append('"');
+            var backslash_count: usize = 0;
+            for (arg) |byte| {
+                switch (byte) {
+                    '\\' => {
+                        backslash_count += 1;
+                    },
+                    '"' => {
+                        try buf.appendNTimes('\\', backslash_count * 2 + 1);
+                        try buf.append('"');
+                        backslash_count = 0;
+                    },
+                    else => {
+                        try buf.appendNTimes('\\', backslash_count);
+                        try buf.append(byte);
+                        backslash_count = 0;
+                    },
+                }
+            }
+            try buf.appendNTimes('\\', backslash_count * 2);
+            try buf.append('"');
+        }
+    }
+
+    return try std.unicode.wtf8ToWtf16LeAllocZ(allocator, buf.items);
+}
+
+fn buildEnvironmentBlock(arena: Allocator, env_map: *const std.process.EnvMap) ![]u16 {
+    var builder = std.ArrayList(u16).empty;
+    errdefer builder.deinit(arena);
+
+    var it = env_map.iterator();
+    while (it.next()) |pair| {
+        try appendWtf8AsWtf16(&builder, arena, pair.key_ptr.*);
+        try builder.append(arena, '=');
+        try appendWtf8AsWtf16(&builder, arena, pair.value_ptr.*);
+        try builder.append(arena, 0);
+    }
+    try builder.append(arena, 0);
+    return try builder.toOwnedSlice(arena);
+}
+
+fn appendWtf8AsWtf16(builder: *std.ArrayList(u16), arena: Allocator, value: []const u8) !void {
+    const len = try std.unicode.calcWtf16LeLen(value);
+    const dest = try builder.addManyAsSlice(arena, len);
+    const written = try std.unicode.wtf8ToWtf16Le(dest, value);
+    std.debug.assert(written == len);
+}
+
+fn stopRunning(state: *State) void {
+    state.running.store(false, .release);
+}
+
+test "notify CRT provider follows the CRT that owns Emacs dup" {
+    try std.testing.expectEqual(
+        EventWriter.NotifyCrtProvider.msvcrt,
+        EventWriter.notifyCrtProviderForImport("msvcrt.dll", "_dup").?,
+    );
+    try std.testing.expectEqual(
+        EventWriter.NotifyCrtProvider.ucrt,
+        EventWriter.notifyCrtProviderForImport("api-ms-win-crt-stdio-l1-1-0.dll", "_dup").?,
+    );
+    try std.testing.expectEqual(
+        EventWriter.NotifyCrtProvider.ucrt,
+        EventWriter.notifyCrtProviderForImport("ucrtbase.dll", "_dup").?,
+    );
+}
+
+test "notify CRT provider ignores non-dup CRT imports" {
+    try std.testing.expectEqual(
+        @as(?EventWriter.NotifyCrtProvider, null),
+        EventWriter.notifyCrtProviderForImport("msvcrt.dll", "_write"),
+    );
+    try std.testing.expectEqual(
+        @as(?EventWriter.NotifyCrtProvider, null),
+        EventWriter.notifyCrtProviderForImport("kernel32.dll", "_dup"),
+    );
+}
+
+test "buildEnvironmentBlock writes nul-separated UTF-16 entries" {
+    var env = std.process.EnvMap.init(std.testing.allocator);
+    defer env.deinit();
+    try env.put("FOO", "bar");
+
+    const block = try buildEnvironmentBlock(std.testing.allocator, &env);
+    defer std.testing.allocator.free(block);
+
+    try std.testing.expectEqualSlices(u16, &[_]u16{
+        'F', 'O', 'O', '=', 'b', 'a', 'r', 0,
+        0,
+    }, block);
+}
+
+test "EnvMap keeps environment names unique on Windows" {
+    var env = std.process.EnvMap.init(std.testing.allocator);
+    defer env.deinit();
+    try env.put("Path", "first");
+    try env.put("PATH", "second");
+
+    try std.testing.expectEqual(@as(std.process.EnvMap.Size, 1), env.count());
+    try std.testing.expectEqualStrings("second", env.get("path").?);
+}

--- a/src/ConPtyProcess.zig
+++ b/src/ConPtyProcess.zig
@@ -24,7 +24,6 @@ const State = struct {
     pty_output: c.HANDLE = c.INVALID_HANDLE_VALUE,
     shell_process: c.HANDLE = c.INVALID_HANDLE_VALUE,
     running: std.atomic.Value(bool) = .init(true),
-    forced_stop: std.atomic.Value(bool) = .init(false),
     pid: i64 = -1,
 };
 
@@ -34,12 +33,7 @@ var create_pseudo_console: ?CreatePseudoConsoleFn = null;
 var resize_pseudo_console: ?ResizePseudoConsoleFn = null;
 var close_pseudo_console: ?ClosePseudoConsoleFn = null;
 
-pub const ProcessParams = struct {
-    file: [:0]const u8,
-    args: [][:0]const u8,
-    env: *const std.process.EnvMap,
-    cwd: ?[]const u8 = null,
-};
+pub const ProcessParams = @import("ProcessParams.zig");
 
 pub const EventWriter = struct {
     pub const Fd = c_int;
@@ -57,22 +51,22 @@ pub const EventWriter = struct {
     };
 
     fd: Fd,
-    notify_crt: NotifyCrt,
 
-    var cached_notify_crt: ?NotifyCrt = null;
+    var notify_crt: ?NotifyCrt = null;
 
     pub fn init(fd: Fd) !EventWriter {
+        _ = try resolveNotifyCrt();
         return .{
             .fd = fd,
-            .notify_crt = try resolveNotifyCrt(),
         };
     }
 
     pub fn write(self: *EventWriter, data: []const u8) !void {
+        const crt = notify_crt.?;
         var written: usize = 0;
         while (written < data.len) {
             const chunk_len: c_uint = @intCast(@min(data.len - written, std.math.maxInt(c_uint)));
-            const n = self.notify_crt.write(
+            const n = crt.write(
                 self.fd,
                 @ptrCast(data[written..].ptr),
                 chunk_len,
@@ -84,7 +78,7 @@ pub const EventWriter = struct {
 
     pub fn close(self: *EventWriter) void {
         if (self.fd < 0) return;
-        _ = self.notify_crt.close(self.fd);
+        _ = notify_crt.?.close(self.fd);
         self.fd = -1;
     }
 
@@ -164,7 +158,7 @@ pub const EventWriter = struct {
     }
 
     fn resolveNotifyCrt() !NotifyCrt {
-        if (cached_notify_crt) |crt| return crt;
+        if (notify_crt) |crt| return crt;
 
         const provider = try detectNotifyCrtProvider();
         const dll_name = switch (provider) {
@@ -174,11 +168,11 @@ pub const EventWriter = struct {
         const module = c.GetModuleHandleW(dll_name) orelse return error.NotifyCrtUnavailable;
         const write_proc = c.GetProcAddress(module, "_write") orelse return error.NotifyCrtUnavailable;
         const close_proc = c.GetProcAddress(module, "_close") orelse return error.NotifyCrtUnavailable;
-        cached_notify_crt = .{
+        notify_crt = .{
             .write = @ptrCast(write_proc),
             .close = @ptrCast(close_proc),
         };
-        return cached_notify_crt.?;
+        return notify_crt.?;
     }
 };
 
@@ -288,7 +282,6 @@ pub fn resize(self: *Self, cols: u16, rows: u16) !void {
 }
 
 pub fn requestStop(self: *Self, read_thread: std.Thread) void {
-    self.state.forced_stop.store(true, .release);
     stopRunning(self.state);
 
     if (self.state.pty_input != c.INVALID_HANDLE_VALUE) {
@@ -306,10 +299,7 @@ pub fn replicaName(_: *Self) []const u8 {
 pub fn deinitAndWait(self: *Self) u8 {
     const state = self.state;
     stopRunning(state);
-
-    if (state.forced_stop.load(.acquire)) {
-        closeConPtyHandles(state);
-    }
+    closeConPtyHandles(state);
 
     var exit_code: c.DWORD = 0;
     if (state.shell_process != c.INVALID_HANDLE_VALUE) {
@@ -317,8 +307,6 @@ pub fn deinitAndWait(self: *Self) u8 {
         _ = c.GetExitCodeProcess(state.shell_process, &exit_code);
         _ = c.CloseHandle(state.shell_process);
     }
-
-    closeConPtyHandles(state);
 
     const alloc = state.alloc;
     alloc.destroy(state);
@@ -512,15 +500,32 @@ fn argvToCommandLineWindows(
     return try std.unicode.wtf8ToWtf16LeAllocZ(allocator, buf.items);
 }
 
+const EnvEntry = struct {
+    key: []const u8,
+    value: []const u8,
+};
+
+fn envEntryLessThan(_: void, lhs: EnvEntry, rhs: EnvEntry) bool {
+    return std.ascii.lessThanIgnoreCase(lhs.key, rhs.key);
+}
+
 fn buildEnvironmentBlock(arena: Allocator, env_map: *const std.process.EnvMap) ![]u16 {
     var builder = std.ArrayList(u16).empty;
     errdefer builder.deinit(arena);
 
+    const entries = try arena.alloc(EnvEntry, @intCast(env_map.count()));
+    defer arena.free(entries);
     var it = env_map.iterator();
-    while (it.next()) |pair| {
-        try appendWtf8AsWtf16(&builder, arena, pair.key_ptr.*);
+    var i: usize = 0;
+    while (it.next()) |pair| : (i += 1) {
+        entries[i] = .{ .key = pair.key_ptr.*, .value = pair.value_ptr.* };
+    }
+    std.mem.sort(EnvEntry, entries, {}, envEntryLessThan);
+
+    for (entries) |entry| {
+        try appendWtf8AsWtf16(&builder, arena, entry.key);
         try builder.append(arena, '=');
-        try appendWtf8AsWtf16(&builder, arena, pair.value_ptr.*);
+        try appendWtf8AsWtf16(&builder, arena, entry.value);
         try builder.append(arena, 0);
     }
     try builder.append(arena, 0);
@@ -575,6 +580,23 @@ test "buildEnvironmentBlock writes nul-separated UTF-16 entries" {
     try std.testing.expectEqualSlices(u16, &[_]u16{
         'F', 'O', 'O', '=', 'b', 'a', 'r', 0,
         0,
+    }, block);
+}
+
+test "buildEnvironmentBlock sorts entries by environment name" {
+    var env = std.process.EnvMap.init(std.testing.allocator);
+    defer env.deinit();
+    try env.put("ZED", "last");
+    try env.put("ALPHA", "first");
+    try env.put("Path", "middle");
+
+    const block = try buildEnvironmentBlock(std.testing.allocator, &env);
+    defer std.testing.allocator.free(block);
+
+    try std.testing.expectEqualSlices(u16, &[_]u16{
+        'A', 'L', 'P', 'H', 'A', '=', 'f', 'i', 'r', 's', 't', 0,
+        'P', 'a', 't', 'h', '=', 'm', 'i', 'd', 'd', 'l', 'e', 0,
+        'Z', 'E', 'D', '=', 'l', 'a', 's', 't', 0,   0,
     }, block);
 }
 

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -145,9 +145,19 @@ pub fn vtWrite(self: *Self, data: []const u8) void {
 pub fn ptyWrite(self: *Self, data: []const u8) !void {
     if (!self.isProcessLive()) return;
 
+    const env = emacs.current_env orelse return error.MissingEmacsEnv;
     if (self.process) |proc| {
-        try proc.ptyWrite(data);
-    } else if (emacs.current_env) |env| {
+        try proc.ptyWrite(env, data);
+    } else {
+        _ = env.f(
+            "process-send-string",
+            .{ env.symbolValue("ghostel--process"), data },
+        );
+    }
+}
+
+pub fn ptyWriteFromTerminal(_: *Self, data: []const u8) void {
+    if (emacs.current_env) |env| {
         _ = env.f(
             "process-send-string",
             .{ env.symbolValue("ghostel--process"), data },
@@ -316,6 +326,7 @@ pub fn isPasswordMode(self: *Self) !bool {
             "process-tty-name",
             .{env.symbolValue("ghostel--process")},
         );
+        if (env.isNil(tty_name_val)) return false;
         const tty_name = try env.extractStringAlloc(
             self.alloc,
             tty_name_val,

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -285,7 +285,7 @@ pub fn spawnNativeProcess(
         event_fd,
     );
     self.process = process;
-    return process.backend.pidValue();
+    return process.pidValue();
 }
 
 pub fn killNativeProcess(self: *Self) void {

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -11,8 +11,12 @@ const GhostelHandler = @import("handler.zig").GhostelHandler;
 const Renderer = @import("Renderer.zig");
 const input = @import("input.zig");
 const kitty_graphics = @import("kitty_graphics.zig");
-const PtyProcess = @import("PtyProcess.zig");
+const utils = @import("utils.zig");
+const parseHexColor = utils.parseHexColor;
 const NativeProcess = @import("NativeProcess.zig");
+const ChannelFd = NativeProcess.ChannelFd;
+const ProcessParams = NativeProcess.ProcessParams;
+const ProcessPid = i64;
 const pty_utils = @import("pty_utils.zig");
 
 const Self = @This();
@@ -84,7 +88,7 @@ pub fn redraw(self: *Self, force_full: bool) !void {
 
     if (self.isProcessLive() and !std.meta.eql(pre_size, post_size)) {
         if (self.process) |proc| {
-            try proc.process.pty.resize(post_size[0], post_size[1]);
+            try proc.process.resize(post_size[0], post_size[1]);
         } else {
             _ = env.f(
                 "set-process-window-size",
@@ -142,7 +146,7 @@ pub fn ptyWrite(self: *Self, data: []const u8) !void {
     if (!self.isProcessLive()) return;
 
     if (self.process) |proc| {
-        try proc.process.pty.write(data);
+        try proc.ptyWrite(data);
     } else if (emacs.current_env) |env| {
         _ = env.f(
             "process-send-string",
@@ -251,6 +255,9 @@ pub fn resize(self: *Self, cols: u16, rows: u16, cell_w: u16, cell_h: u16) !void
     self.lockTerm();
     try self.renderer.resize(cols, rows, cell_w, cell_h);
     self.unlockTerm();
+    if (self.process) |process| {
+        try process.resizePty(cols, rows);
+    }
 }
 
 pub fn lockTerm(self: *Self) void {
@@ -266,22 +273,22 @@ pub fn spawnNativeProcess(
     command: [][:0]const u8,
     env: *const std.process.EnvMap,
     cwd: [:0]const u8,
-    event_pipe: std.posix.fd_t,
-) !std.posix.pid_t {
+    event_fd: ChannelFd,
+) !ProcessPid {
     if (command.len == 0) return error.InvalidCommand;
 
-    var pty_process = try PtyProcess.init(
+    const process = try self.alloc.create(NativeProcess);
+    errdefer self.alloc.destroy(process);
+    try process.init(
         self.alloc,
         self.terminal.cols,
         self.terminal.rows,
-        .{ .file = command[0], .args = command, .env = env, .cwd = cwd },
+        ProcessParams{ .file = command[0], .args = command, .env = env, .cwd = cwd },
+        &self.terminal,
+        event_fd,
     );
-    errdefer _ = pty_process.deinitAndWait();
-    const process = try self.alloc.create(NativeProcess);
-    errdefer self.alloc.destroy(process);
-    try process.init(self.alloc, pty_process, &self.terminal, event_pipe);
     self.process = process;
-    return process.process.pid;
+    return process.process.pidValue();
 }
 
 pub fn killNativeProcess(self: *Self) void {
@@ -293,8 +300,8 @@ pub fn killNativeProcess(self: *Self) void {
 }
 
 pub fn isProcessLive(self: *Self) bool {
-    if (self.process != null) {
-        return true;
+    if (self.process) |process| {
+        return process.isBackendAlive();
     } else if (emacs.current_env) |env| {
         return env.isNotNil(env.f("process-live-p", .{env.symbolValue("ghostel--process")}));
     }

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -88,7 +88,7 @@ pub fn redraw(self: *Self, force_full: bool) !void {
 
     if (self.isProcessLive() and !std.meta.eql(pre_size, post_size)) {
         if (self.process) |proc| {
-            try proc.process.resize(post_size[0], post_size[1]);
+            try proc.resizePty(post_size[0], post_size[1]);
         } else {
             _ = env.f(
                 "set-process-window-size",
@@ -253,11 +253,8 @@ pub fn encodePaste(self: *Self, data: []u8) !bool {
 /// get promoted to scrollback due to vertical shrinking of the viewport.
 pub fn resize(self: *Self, cols: u16, rows: u16, cell_w: u16, cell_h: u16) !void {
     self.lockTerm();
+    defer self.unlockTerm();
     try self.renderer.resize(cols, rows, cell_w, cell_h);
-    self.unlockTerm();
-    if (self.process) |process| {
-        try process.resizePty(cols, rows);
-    }
 }
 
 pub fn lockTerm(self: *Self) void {
@@ -288,7 +285,7 @@ pub fn spawnNativeProcess(
         event_fd,
     );
     self.process = process;
-    return process.process.pidValue();
+    return process.backend.pidValue();
 }
 
 pub fn killNativeProcess(self: *Self) void {

--- a/src/NativeProcess.zig
+++ b/src/NativeProcess.zig
@@ -19,9 +19,12 @@ const log = std.log.scoped(.NativeProcessHandler);
 pub const ChannelFd = EventWriter.Fd;
 pub const ProcessParams = Backend.ProcessParams;
 
-backend: Backend,
-backend_alive: std.atomic.Value(bool) = .init(false),
+backend_mutex: std.Thread.Mutex = .{},
+backend: ?Backend,
 event_writer: EventWriter,
+alloc: Allocator,
+pid: i64,
+replica_name: []u8,
 // Buffer event notifications so large terminal updates can be reported with
 // few writes to Emacs.
 event_buf: FixedArrayList(u8, 16 * 1024) = .{},
@@ -35,10 +38,12 @@ thread: std.Thread,
 
 const LockedStream = struct {
     process: *Self,
+    drained: bool = false,
 
     pub fn nextSlice(self: *LockedStream, data: []const u8) void {
         self.process.term_mutex.lock();
         defer self.process.term_mutex.unlock();
+        self.drained = true;
         self.process.stream.nextSlice(data);
     }
 };
@@ -61,10 +66,15 @@ pub fn init(
     var stream: @TypeOf(self.stream) = .initAlloc(alloc, .init(self, term));
     errdefer stream.deinit();
 
+    const replica_name = try alloc.dupe(u8, backend.replicaName());
+    errdefer alloc.free(replica_name);
+
     self.* = .{
         .backend = backend,
-        .backend_alive = .init(true),
         .event_writer = event_writer,
+        .alloc = alloc,
+        .pid = backend.pidValue(),
+        .replica_name = replica_name,
         .term = term,
         .stream = stream,
         .thread = undefined,
@@ -81,21 +91,25 @@ pub fn unlockTerm(self: *Self) void {
 }
 
 pub fn ptyWrite(self: *Self, data: []const u8) !void {
-    if (!self.isBackendAlive()) return error.ProcessExited;
-    return self.backend.write(data);
+    self.backend_mutex.lock();
+    defer self.backend_mutex.unlock();
+
+    if (self.backend) |*backend| return backend.write(data);
+    return error.ProcessExited;
 }
 
 pub fn resizePty(self: *Self, cols: u16, rows: u16) !void {
-    if (!self.isBackendAlive()) return;
-    try self.backend.resize(cols, rows);
+    self.backend_mutex.lock();
+    defer self.backend_mutex.unlock();
+
+    if (self.backend) |*backend| try backend.resize(cols, rows);
 }
 
 pub fn isBackendAlive(self: *Self) bool {
-    return self.backend_alive.load(.acquire);
-}
+    self.backend_mutex.lock();
+    defer self.backend_mutex.unlock();
 
-fn takeBackendAlive(self: *Self) bool {
-    return self.backend_alive.swap(false, .acq_rel);
+    return self.backend != null;
 }
 
 pub fn effect(self: *Self, comptime func: []const u8, args: anytype) void {
@@ -105,7 +119,11 @@ pub fn effect(self: *Self, comptime func: []const u8, args: anytype) void {
 }
 
 pub fn replicaName(self: *Self) []const u8 {
-    return self.backend.replicaName();
+    return self.replica_name;
+}
+
+pub fn pidValue(self: *Self) i64 {
+    return self.pid;
 }
 
 fn effectFallible(self: *Self, comptime func: []const u8, args: anytype) !void {
@@ -155,7 +173,14 @@ fn run(self: *Self) void {
     self.loop() catch |err| {
         log.warn("ghostel: error in read loop: {any}", .{err});
     };
-    _ = self.takeBackendAlive();
+    const backend = blk: {
+        self.backend_mutex.lock();
+        defer self.backend_mutex.unlock();
+
+        const backend = self.backend orelse return;
+        self.backend = null;
+        break :blk backend;
+    };
 
     // The reader thread must not waitpid here: it may be joined from Emacs
     // during buffer teardown, and blocking that path would freeze Emacs.  Hand
@@ -165,7 +190,7 @@ fn run(self: *Self) void {
     const reaper_thread = std.Thread.spawn(
         .{ .stack_size = 1024 * 1024 },
         reapChild,
-        .{ self.backend, self.event_writer },
+        .{ backend, self.event_writer },
     ) catch |err| {
         log.err("Failed to spawn reaper thread: {any}", .{err});
         return;
@@ -181,9 +206,9 @@ fn loopOnce(self: *Self) !bool {
     if (@atomicLoad(bool, &self.quit, .monotonic)) return false;
 
     var stream = LockedStream{ .process = self };
-    const drained = try self.backend.drain(&stream);
-    try self.notifyVtUpdate();
-    return drained;
+    const eof = try self.backend.?.drain(&stream);
+    if (stream.drained) try self.notifyVtUpdate();
+    return !eof;
 }
 
 fn notifyVtUpdate(self: *Self) !void {
@@ -230,10 +255,13 @@ fn reapChild(process: Backend, event_writer: EventWriter) void {
 
 pub fn deinit(self: *Self) void {
     @atomicStore(bool, &self.quit, true, .monotonic);
-    if (self.takeBackendAlive()) {
-        self.backend.requestStop(self.thread);
+    self.backend_mutex.lock();
+    if (self.backend) |*backend| {
+        backend.requestStop(self.thread);
     }
+    self.backend_mutex.unlock();
     self.thread.join();
 
     self.stream.deinit();
+    self.alloc.free(self.replica_name);
 }

--- a/src/NativeProcess.zig
+++ b/src/NativeProcess.zig
@@ -257,8 +257,11 @@ fn run(self: *Self) void {
         reapChild,
         .{ backend, self.event_writer },
     ) catch |err| {
-        log.err("Failed to spawn reaper thread; reaping synchronously: {any}", .{err});
-        reapChild(backend, self.event_writer);
+        log.err(
+            "ghostel: Failed to spawn reaper thread; leaking native backend: {any}",
+            .{err},
+        );
+        finishEventChannel(self.event_writer, 255);
         return;
     };
     reaper_thread.detach();
@@ -319,17 +322,19 @@ fn flushEvents(self: *Self) !void {
 
 fn reapChild(backend: Backend, event_writer: EventWriter) void {
     var be = backend;
+    finishEventChannel(event_writer, be.deinitAndWait());
+}
+
+fn finishEventChannel(event_writer: EventWriter, exit_code: u8) void {
     var writer = event_writer;
-    const exit_code = be.deinitAndWait();
 
     // A bare number is not a terminal callback; the Elisp event filter treats
     // it as the child's exit status and deletes the pipe process to run its
-    // sentinel. Closing the fd after the write releases Emacs' pipe once the
-    // native child is truly gone.
+    // sentinel. Closing the fd after the write releases Emacs' pipe.
     var exit_code_buf: [3]u8 = undefined;
     const str = std.fmt.bufPrint(&exit_code_buf, "{}", .{exit_code}) catch unreachable;
     writer.write(str) catch |err| {
-        log.warn("Failed to write native child exit event: {any}", .{err});
+        log.warn("ghostel: Failed to write native child exit event: {any}", .{err});
     };
     writer.close();
 }

--- a/src/NativeProcess.zig
+++ b/src/NativeProcess.zig
@@ -4,6 +4,8 @@ const Allocator = std.mem.Allocator;
 
 const gt = @import("ghostty-vt");
 
+const backend_types = @import("backend_types.zig");
+const emacs = @import("emacs.zig");
 const GhostelHandler = @import("handler.zig").GhostelHandler;
 const FixedArrayList = @import("fixed_array_list.zig").FixedArrayList;
 
@@ -16,10 +18,13 @@ const EventWriter = Backend.EventWriter;
 const Self = @This();
 
 const log = std.log.scoped(.NativeProcessHandler);
-pub const ChannelFd = EventWriter.Fd;
-pub const ProcessParams = Backend.ProcessParams;
+const CANCELLATION_POLL_INTERVAL_MS = 20;
 
-backend_mutex: std.Thread.Mutex = .{},
+pub const ChannelFd = EventWriter.Fd;
+pub const ProcessParams = backend_types.ProcessParams;
+
+backend_handoff_mutex: std.Thread.Mutex = .{},
+write_mutex: std.Thread.Mutex = .{},
 backend: ?Backend,
 event_writer: EventWriter,
 alloc: Allocator,
@@ -38,12 +43,10 @@ thread: std.Thread,
 
 const LockedStream = struct {
     process: *Self,
-    drained: bool = false,
 
     pub fn nextSlice(self: *LockedStream, data: []const u8) void {
         self.process.term_mutex.lock();
         defer self.process.term_mutex.unlock();
-        self.drained = true;
         self.process.stream.nextSlice(data);
     }
 };
@@ -90,31 +93,91 @@ pub fn unlockTerm(self: *Self) void {
     self.term_mutex.unlock();
 }
 
-pub fn ptyWrite(self: *Self, data: []const u8) !void {
-    self.backend_mutex.lock();
-    defer self.backend_mutex.unlock();
+pub fn ptyWrite(self: *Self, env: emacs.Env, data: []const u8) !void {
+    while (!self.write_mutex.tryLock()) {
+        try env.checkQuit();
+        std.Thread.sleep(CANCELLATION_POLL_INTERVAL_MS * std.time.ns_per_ms);
+    }
+    defer self.write_mutex.unlock();
 
-    if (self.backend) |*backend| return backend.write(data);
-    return error.ProcessExited;
+    var cancellation_env = env;
+    const cancellation = backend_types.CancellationToken{
+        .context = &cancellation_env,
+        .check_fn = checkEmacsQuit,
+        .poll_interval_ms = CANCELLATION_POLL_INTERVAL_MS,
+    };
+
+    var offset: usize = 0;
+    while (offset < data.len) {
+        switch (try self.ptyWriteBackend(data[offset..], cancellation)) {
+            .written => |n| {
+                offset += n;
+                try env.checkQuit();
+            },
+            .interrupted => return error.ProcessExited,
+        }
+    }
+}
+
+pub fn ptyWriteFromTerminal(self: *Self, data: []const u8) void {
+    // This callback runs on the reader thread, which cannot retire the backend
+    // until the callback returns. Avoid the handoff mutex so shutdown can signal
+    // a blocked write through the backend's existing interrupt mechanism.
+    const backend = if (self.backend) |*backend| backend else return;
+
+    self.write_mutex.lock();
+    defer self.write_mutex.unlock();
+
+    var offset: usize = 0;
+    while (offset < data.len) {
+        if (@atomicLoad(bool, &self.quit, .monotonic)) return;
+        const write_result = backend.write(data[offset..], null) catch |err| {
+            log.err("ghostel: Failed to write to PTY from terminal: {any}", .{err});
+            return;
+        };
+        switch (write_result) {
+            .written => |n| offset += n,
+            .interrupted => return,
+        }
+    }
+}
+
+fn ptyWriteBackend(
+    self: *Self,
+    data: []const u8,
+    cancellation: ?backend_types.CancellationToken,
+) !backend_types.WriteResult {
+    self.backend_handoff_mutex.lock();
+    defer self.backend_handoff_mutex.unlock();
+
+    return if (self.backend) |*backend|
+        backend.write(data, cancellation)
+    else
+        error.ProcessExited;
+}
+
+fn checkEmacsQuit(context: *const anyopaque) !void {
+    const env: *const emacs.Env = @ptrCast(@alignCast(context));
+    try env.checkQuit();
 }
 
 pub fn resizePty(self: *Self, cols: u16, rows: u16) !void {
-    self.backend_mutex.lock();
-    defer self.backend_mutex.unlock();
+    self.backend_handoff_mutex.lock();
+    defer self.backend_handoff_mutex.unlock();
 
     if (self.backend) |*backend| try backend.resize(cols, rows);
 }
 
 pub fn isBackendAlive(self: *Self) bool {
-    self.backend_mutex.lock();
-    defer self.backend_mutex.unlock();
+    self.backend_handoff_mutex.lock();
+    defer self.backend_handoff_mutex.unlock();
 
     return self.backend != null;
 }
 
 pub fn effect(self: *Self, comptime func: []const u8, args: anytype) void {
     self.effectFallible(func, args) catch |err| {
-        log.err("Failed to write to event pipe: {s}", .{@errorName(err)});
+        log.err("ghostel: Failed to write to event pipe: {s}", .{@errorName(err)});
     };
 }
 
@@ -173,13 +236,15 @@ fn run(self: *Self) void {
     self.loop() catch |err| {
         log.warn("ghostel: error in read loop: {any}", .{err});
     };
-    const backend = blk: {
-        self.backend_mutex.lock();
-        defer self.backend_mutex.unlock();
 
-        const backend = self.backend orelse return;
-        self.backend = null;
-        break :blk backend;
+    var backend = self.retireBackend() orelse return;
+
+    var final_stream = LockedStream{ .process = self };
+    backend.finishDrain(&final_stream) catch |err| {
+        log.warn("ghostel: error finishing read loop: {any}", .{err});
+    };
+    self.notifyVtUpdate() catch |err| {
+        log.warn("ghostel: error notifying final terminal update: {any}", .{err});
     };
 
     // The reader thread must not waitpid here: it may be joined from Emacs
@@ -192,7 +257,8 @@ fn run(self: *Self) void {
         reapChild,
         .{ backend, self.event_writer },
     ) catch |err| {
-        log.err("Failed to spawn reaper thread: {any}", .{err});
+        log.err("Failed to spawn reaper thread; reaping synchronously: {any}", .{err});
+        reapChild(backend, self.event_writer);
         return;
     };
     reaper_thread.detach();
@@ -205,10 +271,25 @@ fn loop(self: *Self) !void {
 fn loopOnce(self: *Self) !bool {
     if (@atomicLoad(bool, &self.quit, .monotonic)) return false;
 
-    var stream = LockedStream{ .process = self };
-    const eof = try self.backend.?.drain(&stream);
-    if (stream.drained) try self.notifyVtUpdate();
-    return !eof;
+    // The reader thread exclusively owns backend retirement, so self.backend is
+    // stable here without the handoff mutex.
+    if (self.backend) |*backend| {
+        var stream = LockedStream{ .process = self };
+        const keep_going = try backend.drain(&stream);
+        try self.notifyVtUpdate();
+        return keep_going;
+    }
+
+    return false;
+}
+
+fn retireBackend(self: *Self) ?Backend {
+    self.backend_handoff_mutex.lock();
+    defer self.backend_handoff_mutex.unlock();
+
+    const backend = self.backend orelse return null;
+    self.backend = null;
+    return backend;
 }
 
 fn notifyVtUpdate(self: *Self) !void {
@@ -237,9 +318,9 @@ fn flushEvents(self: *Self) !void {
 }
 
 fn reapChild(backend: Backend, event_writer: EventWriter) void {
-    var proc = backend;
+    var be = backend;
     var writer = event_writer;
-    const exit_code = proc.deinitAndWait();
+    const exit_code = be.deinitAndWait();
 
     // A bare number is not a terminal callback; the Elisp event filter treats
     // it as the child's exit status and deletes the pipe process to run its
@@ -255,11 +336,13 @@ fn reapChild(backend: Backend, event_writer: EventWriter) void {
 
 pub fn deinit(self: *Self) void {
     @atomicStore(bool, &self.quit, true, .monotonic);
-    self.backend_mutex.lock();
-    if (self.backend) |*backend| {
-        backend.requestStop(self.thread);
+
+    {
+        self.backend_handoff_mutex.lock();
+        defer self.backend_handoff_mutex.unlock();
+        if (self.backend) |*backend| backend.requestStop(self.thread);
     }
-    self.backend_mutex.unlock();
+
     self.thread.join();
 
     self.stream.deinit();

--- a/src/NativeProcess.zig
+++ b/src/NativeProcess.zig
@@ -236,8 +236,8 @@ fn flushEvents(self: *Self) !void {
     self.event_buf.resize(0);
 }
 
-fn reapChild(process: Backend, event_writer: EventWriter) void {
-    var proc = process;
+fn reapChild(backend: Backend, event_writer: EventWriter) void {
+    var proc = backend;
     var writer = event_writer;
     const exit_code = proc.deinitAndWait();
 

--- a/src/NativeProcess.zig
+++ b/src/NativeProcess.zig
@@ -325,13 +325,13 @@ fn reapChild(backend: Backend, event_writer: EventWriter) void {
     finishEventChannel(event_writer, be.deinitAndWait());
 }
 
-fn finishEventChannel(event_writer: EventWriter, exit_code: u8) void {
+fn finishEventChannel(event_writer: EventWriter, exit_code: u32) void {
     var writer = event_writer;
 
     // A bare number is not a terminal callback; the Elisp event filter treats
     // it as the child's exit status and deletes the pipe process to run its
     // sentinel. Closing the fd after the write releases Emacs' pipe.
-    var exit_code_buf: [3]u8 = undefined;
+    var exit_code_buf: [10]u8 = undefined;
     const str = std.fmt.bufPrint(&exit_code_buf, "{}", .{exit_code}) catch unreachable;
     writer.write(str) catch |err| {
         log.warn("ghostel: Failed to write native child exit event: {any}", .{err});

--- a/src/NativeProcess.zig
+++ b/src/NativeProcess.zig
@@ -1,24 +1,27 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
-const posix = std.posix;
-
-const c = @cImport({
-    @cInclude("signal.h");
-    @cInclude("fcntl.h");
-});
 
 const gt = @import("ghostty-vt");
 
-const PtyProcess = @import("PtyProcess.zig");
 const GhostelHandler = @import("handler.zig").GhostelHandler;
 const FixedArrayList = @import("fixed_array_list.zig").FixedArrayList;
+
+const Backend = switch (builtin.os.tag) {
+    .windows => @import("ConPtyProcess.zig"),
+    else => @import("PosixPtyProcess.zig"),
+};
+const EventWriter = Backend.EventWriter;
 
 const Self = @This();
 
 const log = std.log.scoped(.NativeProcessHandler);
+pub const ChannelFd = EventWriter.Fd;
+pub const ProcessParams = Backend.ProcessParams;
 
-process: PtyProcess,
-event_pipe: posix.fd_t = -1,
+process: Backend,
+backend_alive: std.atomic.Value(bool) = .init(false),
+event_writer: EventWriter,
 // Buffer event notifications so large terminal updates can be reported with
 // few writes to Emacs.
 event_buf: FixedArrayList(u8, 16 * 1024) = .{},
@@ -27,34 +30,46 @@ term_mutex: std.Thread.Mutex.Recursive = .init,
 term: *gt.Terminal,
 stream: gt.Stream(GhostelHandler(*Self)),
 
-wake_pipe: [2]posix.fd_t = .{ -1, -1 },
 quit: bool = false,
 thread: std.Thread,
+
+const LockedStream = struct {
+    process: *Self,
+
+    pub fn nextSlice(self: *LockedStream, data: []const u8) void {
+        self.process.term_mutex.lock();
+        defer self.process.term_mutex.unlock();
+        self.process.stream.nextSlice(data);
+    }
+};
 
 pub fn init(
     self: *Self,
     alloc: Allocator,
-    process: PtyProcess,
+    initial_cols: u16,
+    initial_rows: u16,
+    params: ProcessParams,
     term: *gt.Terminal,
-    event_pipe: posix.fd_t,
+    event_fd: ChannelFd,
 ) !void {
-    const pipe = try posix.pipe();
-    errdefer {
-        posix.close(pipe[0]);
-        posix.close(pipe[1]);
-    }
+    var process = try Backend.init(alloc, initial_cols, initial_rows, params);
+    errdefer _ = process.deinitAndWait();
+
+    var event_writer = try EventWriter.init(event_fd);
+    errdefer event_writer.close();
 
     var stream: @TypeOf(self.stream) = .initAlloc(alloc, .init(self, term));
     errdefer stream.deinit();
 
     self.* = .{
         .process = process,
-        .event_pipe = event_pipe,
+        .backend_alive = .init(true),
+        .event_writer = event_writer,
         .term = term,
         .stream = stream,
-        .wake_pipe = pipe,
-        .thread = try std.Thread.spawn(.{}, Self.run, .{self}),
+        .thread = undefined,
     };
+    self.thread = try std.Thread.spawn(.{}, Self.run, .{self});
 }
 
 pub fn lockTerm(self: *Self) void {
@@ -66,7 +81,21 @@ pub fn unlockTerm(self: *Self) void {
 }
 
 pub fn ptyWrite(self: *Self, data: []const u8) !void {
-    return self.process.pty.write(data);
+    if (!self.isBackendAlive()) return error.ProcessExited;
+    return self.process.write(data);
+}
+
+pub fn resizePty(self: *Self, cols: u16, rows: u16) !void {
+    if (!self.isBackendAlive()) return;
+    try self.process.resize(cols, rows);
+}
+
+pub fn isBackendAlive(self: *Self) bool {
+    return self.backend_alive.load(.acquire);
+}
+
+fn takeBackendAlive(self: *Self) bool {
+    return self.backend_alive.swap(false, .acq_rel);
 }
 
 pub fn effect(self: *Self, comptime func: []const u8, args: anytype) void {
@@ -76,7 +105,7 @@ pub fn effect(self: *Self, comptime func: []const u8, args: anytype) void {
 }
 
 pub fn replicaName(self: *Self) []const u8 {
-    return self.process.pty.replicaName();
+    return self.process.replicaName();
 }
 
 fn effectFallible(self: *Self, comptime func: []const u8, args: anytype) !void {
@@ -120,22 +149,23 @@ fn writeEventLispString(self: *Self, str: []const u8) !void {
 }
 
 fn run(self: *Self) void {
-    self.blockSigpipe();
-    defer drainSigpipe();
+    self.event_writer.onThreadEnter();
+    defer EventWriter.onThreadExit();
 
     self.loop() catch |err| {
         log.warn("ghostel: error in read loop: {any}", .{err});
     };
+    _ = self.takeBackendAlive();
 
     // The reader thread must not waitpid here: it may be joined from Emacs
     // during buffer teardown, and blocking that path would freeze Emacs.  Hand
-    // the child and event pipe to a detached reaper instead.  The pipe stays
+    // the child and event writer to a detached reaper instead. The channel stays
     // open until the reaper observes child exit, mirroring Emacs process
     // lifetime semantics for the Lisp-side pipe process.
     const reaper_thread = std.Thread.spawn(
         .{ .stack_size = 1024 * 1024 },
         reapChild,
-        .{ self.process, self.event_pipe },
+        .{ self.process, self.event_writer },
     ) catch |err| {
         log.err("Failed to spawn reaper thread: {any}", .{err});
         return;
@@ -144,57 +174,16 @@ fn run(self: *Self) void {
 }
 
 fn loop(self: *Self) !void {
-    const fd = self.process.pty.primary_fd;
-    const flags = try posix.fcntl(fd, posix.F.GETFL, 0);
-    _ = try posix.fcntl(
-        fd,
-        posix.F.SETFL,
-        flags | @as(u32, @bitCast(posix.O{ .NONBLOCK = true })),
-    );
-
     while (try self.loopOnce()) {}
 }
 
 fn loopOnce(self: *Self) !bool {
-    var pollfds = [_]posix.pollfd{
-        .{
-            .fd = self.process.pty.primary_fd,
-            .events = posix.POLL.IN,
-            .revents = undefined,
-        },
-        .{
-            .fd = self.wake_pipe[0],
-            .events = posix.POLL.IN,
-            .revents = undefined,
-        },
-    };
+    if (@atomicLoad(bool, &self.quit, .monotonic)) return false;
 
-    var buf: [1024]u8 = undefined;
-    _ = try posix.poll(&pollfds, -1);
-
-    self.term_mutex.lock();
-    defer self.term_mutex.unlock();
-    while (true) {
-        if (@atomicLoad(bool, &self.quit, .monotonic)) return false;
-
-        const len = posix.read(self.process.pty.primary_fd, &buf) catch |err| switch (err) {
-            error.WouldBlock => break,
-            error.NotOpenForReading, error.InputOutput => break,
-            else => return err,
-        };
-
-        if (len == 0) break;
-
-        self.stream.nextSlice(buf[0..len]);
-    }
-
+    var stream = LockedStream{ .process = self };
+    const drained = try self.process.drain(&stream);
     try self.notifyVtUpdate();
-
-    if (pollfds[0].revents & posix.POLL.HUP != 0) {
-        return false;
-    }
-
-    return true;
+    return drained;
 }
 
 fn notifyVtUpdate(self: *Self) !void {
@@ -218,65 +207,33 @@ fn writeEvent(self: *Self, data: []const u8) !void {
 }
 
 fn flushEvents(self: *Self) !void {
-    var written: usize = 0;
-    while (written < self.event_buf.len) {
-        written += try posix.write(
-            self.event_pipe,
-            self.event_buf.items()[written..self.event_buf.len],
-        );
-    }
+    try self.event_writer.write(self.event_buf.items());
     self.event_buf.resize(0);
 }
 
-fn blockSigpipe(self: *Self) void {
-    // On macOS and platforms that have it, set F_SETNOSIGPIPE
-    if (@hasDecl(posix.F, "SETNOSIGPIPE")) {
-        _ = posix.fcntl(self.event_pipe, posix.F.SETNOSIGPIPE, 1) catch |err| {
-            log.warn("Unable to set SETNOSIGPIPE: {any}", .{err});
-        };
-    }
-    // Linux doesn't have F_SETNOSIGPIPE so mask the SIGPIPE
-    // and drain it at the end.
-    var set: c.sigset_t = undefined;
-    _ = c.sigemptyset(&set);
-    _ = c.sigaddset(&set, posix.SIG.PIPE);
-    _ = posix.errno(c.pthread_sigmask(c.SIG_BLOCK, &set, null));
-}
-
-fn drainSigpipe() void {
-    // On Linux, clear any SIGPIPE that is pending. This doesn't work on macOS
-    // but on macOS we have F_SETNOSIGPIPE instead and the code below is noop.
-    var pending: c.sigset_t = undefined;
-    _ = c.sigpending(&pending);
-    if (c.sigismember(&pending, posix.SIG.PIPE) != 0) {
-        var wait_sigs: c.sigset_t = undefined;
-        _ = c.sigemptyset(&wait_sigs);
-        _ = c.sigaddset(&wait_sigs, posix.SIG.PIPE);
-        var sig: c_int = undefined;
-        _ = c.sigwait(&wait_sigs, &sig);
-    }
-}
-
-fn reapChild(process: PtyProcess, event_pipe: posix.fd_t) void {
+fn reapChild(process: Backend, event_writer: EventWriter) void {
     var proc = process;
+    var writer = event_writer;
     const exit_code = proc.deinitAndWait();
 
     // A bare number is not a terminal callback; the Elisp event filter treats
     // it as the child's exit status and deletes the pipe process to run its
-    // sentinel.  Closing the fd after the write releases Emacs' pipe once the
+    // sentinel. Closing the fd after the write releases Emacs' pipe once the
     // native child is truly gone.
     var exit_code_buf: [3]u8 = undefined;
     const str = std.fmt.bufPrint(&exit_code_buf, "{}", .{exit_code}) catch unreachable;
-    _ = posix.write(event_pipe, str) catch {};
-    posix.close(event_pipe);
+    writer.write(str) catch |err| {
+        log.warn("Failed to write native child exit event: {any}", .{err});
+    };
+    writer.close();
 }
 
 pub fn deinit(self: *Self) void {
     @atomicStore(bool, &self.quit, true, .monotonic);
-    _ = posix.write(self.wake_pipe[1], "X") catch {};
+    if (self.takeBackendAlive()) {
+        self.process.requestStop(self.thread);
+    }
     self.thread.join();
-    posix.close(self.wake_pipe[0]);
-    posix.close(self.wake_pipe[1]);
 
     self.stream.deinit();
 }

--- a/src/NativeProcess.zig
+++ b/src/NativeProcess.zig
@@ -19,7 +19,7 @@ const log = std.log.scoped(.NativeProcessHandler);
 pub const ChannelFd = EventWriter.Fd;
 pub const ProcessParams = Backend.ProcessParams;
 
-process: Backend,
+backend: Backend,
 backend_alive: std.atomic.Value(bool) = .init(false),
 event_writer: EventWriter,
 // Buffer event notifications so large terminal updates can be reported with
@@ -52,8 +52,8 @@ pub fn init(
     term: *gt.Terminal,
     event_fd: ChannelFd,
 ) !void {
-    var process = try Backend.init(alloc, initial_cols, initial_rows, params);
-    errdefer _ = process.deinitAndWait();
+    var backend = try Backend.init(alloc, initial_cols, initial_rows, params);
+    errdefer _ = backend.deinitAndWait();
 
     var event_writer = try EventWriter.init(event_fd);
     errdefer event_writer.close();
@@ -62,7 +62,7 @@ pub fn init(
     errdefer stream.deinit();
 
     self.* = .{
-        .process = process,
+        .backend = backend,
         .backend_alive = .init(true),
         .event_writer = event_writer,
         .term = term,
@@ -82,12 +82,12 @@ pub fn unlockTerm(self: *Self) void {
 
 pub fn ptyWrite(self: *Self, data: []const u8) !void {
     if (!self.isBackendAlive()) return error.ProcessExited;
-    return self.process.write(data);
+    return self.backend.write(data);
 }
 
 pub fn resizePty(self: *Self, cols: u16, rows: u16) !void {
     if (!self.isBackendAlive()) return;
-    try self.process.resize(cols, rows);
+    try self.backend.resize(cols, rows);
 }
 
 pub fn isBackendAlive(self: *Self) bool {
@@ -105,7 +105,7 @@ pub fn effect(self: *Self, comptime func: []const u8, args: anytype) void {
 }
 
 pub fn replicaName(self: *Self) []const u8 {
-    return self.process.replicaName();
+    return self.backend.replicaName();
 }
 
 fn effectFallible(self: *Self, comptime func: []const u8, args: anytype) !void {
@@ -165,7 +165,7 @@ fn run(self: *Self) void {
     const reaper_thread = std.Thread.spawn(
         .{ .stack_size = 1024 * 1024 },
         reapChild,
-        .{ self.process, self.event_writer },
+        .{ self.backend, self.event_writer },
     ) catch |err| {
         log.err("Failed to spawn reaper thread: {any}", .{err});
         return;
@@ -181,7 +181,7 @@ fn loopOnce(self: *Self) !bool {
     if (@atomicLoad(bool, &self.quit, .monotonic)) return false;
 
     var stream = LockedStream{ .process = self };
-    const drained = try self.process.drain(&stream);
+    const drained = try self.backend.drain(&stream);
     try self.notifyVtUpdate();
     return drained;
 }
@@ -231,7 +231,7 @@ fn reapChild(process: Backend, event_writer: EventWriter) void {
 pub fn deinit(self: *Self) void {
     @atomicStore(bool, &self.quit, true, .monotonic);
     if (self.takeBackendAlive()) {
-        self.process.requestStop(self.thread);
+        self.backend.requestStop(self.thread);
     }
     self.thread.join();
 

--- a/src/PosixPtyProcess.zig
+++ b/src/PosixPtyProcess.zig
@@ -212,6 +212,7 @@ pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: back
     if (params.cwd) |cwd| posix.chdir(cwd) catch |err| {
         _ = posix.write(posix.STDERR_FILENO, "Failed to change working directory: ") catch 0;
         _ = posix.write(posix.STDERR_FILENO, @errorName(err)) catch 0;
+        std.c._exit(1);
     };
 
     const err = posix.execvpeZ(params.file, args, env);

--- a/src/PosixPtyProcess.zig
+++ b/src/PosixPtyProcess.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const posix = std.posix;
 
+const backend_types = @import("backend_types.zig");
+
 const c = @cImport({
     @cDefine("_GNU_SOURCE", {});
     @cInclude("stdlib.h");
@@ -13,6 +15,7 @@ const c = @cImport({
 });
 
 const Self = @This();
+const WRITE_CHUNK_SIZE = 4096;
 
 const Pty = struct {
     primary_fd: c_int = -1,
@@ -80,30 +83,6 @@ const Pty = struct {
         }
     }
 
-    pub fn write(self: *@This(), data: []const u8) !void {
-        var offset: usize = 0;
-        while (offset < data.len) {
-            offset += posix.write(self.primary_fd, data[offset..data.len]) catch |err| switch (err) {
-                // If the master fd is non-blocking, a write that would fill the
-                // replica's input buffer fails with WouldBlock; wait for the
-                // replica to drain rather than dropping the tail of a large
-                // write (e.g. a big paste to a child that reads slowly). Under
-                // a blocking fd this branch never fires and the loop is an
-                // ordinary blocking write, so write() works in either mode.
-                error.WouldBlock => {
-                    var pollfds = [_]posix.pollfd{.{
-                        .fd = self.primary_fd,
-                        .events = posix.POLL.OUT,
-                        .revents = undefined,
-                    }};
-                    _ = try posix.poll(&pollfds, -1);
-                    continue;
-                },
-                else => return err,
-            };
-        }
-    }
-
     pub fn closePrimary(self: *@This()) void {
         if (self.primary_fd != -1) {
             posix.close(self.primary_fd);
@@ -139,8 +118,6 @@ const Pty = struct {
 pty: Pty,
 pid: posix.pid_t = -1,
 wake_pipe: [2]posix.fd_t = .{ -1, -1 },
-
-pub const ProcessParams = @import("ProcessParams.zig");
 
 pub const EventWriter = struct {
     pub const Fd = posix.fd_t;
@@ -192,7 +169,7 @@ pub const EventWriter = struct {
     }
 };
 
-pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: ProcessParams) !Self {
+pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: backend_types.ProcessParams) !Self {
     var self = Self{ .pty = try .init() };
     errdefer self.pty.deinit();
     try self.pty.resize(initial_cols, initial_rows);
@@ -252,8 +229,46 @@ pub fn resize(self: *Self, cols: u16, rows: u16) !void {
     try self.pty.resize(cols, rows);
 }
 
-pub fn write(self: *Self, data: []const u8) !void {
-    try self.pty.write(data);
+pub fn write(
+    self: *Self,
+    data: []const u8,
+    cancellation: ?backend_types.CancellationToken,
+) !backend_types.WriteResult {
+    if (data.len == 0) return .{ .written = 0 };
+
+    const chunk = data[0..@min(data.len, WRITE_CHUNK_SIZE)];
+    while (true) {
+        const written = posix.write(self.pty.primary_fd, chunk) catch |err| switch (err) {
+            error.WouldBlock => {
+                var pollfds = [_]posix.pollfd{
+                    .{
+                        .fd = self.pty.primary_fd,
+                        .events = posix.POLL.OUT,
+                        .revents = undefined,
+                    },
+                    .{
+                        .fd = self.wake_pipe[0],
+                        .events = posix.POLL.IN,
+                        .revents = undefined,
+                    },
+                };
+                const timeout: i32 = if (cancellation) |token|
+                    @intCast(@min(token.poll_interval_ms, @as(u32, @intCast(std.math.maxInt(i32)))))
+                else
+                    -1;
+                const ready = try posix.poll(&pollfds, timeout);
+                if (ready == 0) {
+                    try cancellation.?.check();
+                    continue;
+                }
+                if (pollfds[1].revents != 0) return .interrupted;
+                continue;
+            },
+            else => return err,
+        };
+        if (written == 0) return error.IoFailed;
+        return .{ .written = written };
+    }
 }
 
 pub fn drain(self: *Self, stream: anytype) !bool {
@@ -274,15 +289,19 @@ pub fn drain(self: *Self, stream: anytype) !bool {
     _ = try posix.poll(&pollfds, -1);
     if (pollfds[1].revents != 0) return false;
 
-    const len = posix.read(self.pty.primary_fd, buf[0..]) catch |err| switch (err) {
-        error.WouldBlock => return false,
-        error.NotOpenForReading, error.InputOutput => return true,
-        else => return err,
-    };
-    if (len == 0) return true;
-    stream.nextSlice(buf[0..len]);
-    return false;
+    const eof = pollfds[0].revents & posix.POLL.HUP != 0;
+    while (true) {
+        const len = posix.read(self.pty.primary_fd, buf[0..]) catch |err| switch (err) {
+            error.WouldBlock => return !eof,
+            error.NotOpenForReading, error.InputOutput => return false,
+            else => return err,
+        };
+        if (len == 0) return !eof;
+        stream.nextSlice(buf[0..len]);
+    }
 }
+
+pub fn finishDrain(_: *Self, _: anytype) !void {}
 
 pub fn requestStop(self: *Self, _: std.Thread) void {
     if (self.wake_pipe[1] != -1) {
@@ -295,6 +314,7 @@ pub fn replicaName(self: *Self) []const u8 {
 }
 
 pub fn deinitAndWait(self: *Self) u8 {
+    std.debug.assert(self.pid > 0);
     self.pty.deinit();
     posix.close(self.wake_pipe[0]);
     posix.close(self.wake_pipe[1]);

--- a/src/PosixPtyProcess.zig
+++ b/src/PosixPtyProcess.zig
@@ -319,5 +319,8 @@ pub fn deinitAndWait(self: *Self) u8 {
     posix.close(self.wake_pipe[0]);
     posix.close(self.wake_pipe[1]);
     const result = posix.waitpid(self.pid, 0);
-    return @intCast(c.WEXITSTATUS(@as(c_int, @bitCast(result.status))));
+    const status: c_int = @bitCast(result.status);
+    if (c.WIFEXITED(status)) return @intCast(c.WEXITSTATUS(status));
+    if (c.WIFSIGNALED(status)) return @intCast(128 + c.WTERMSIG(status));
+    return 255;
 }

--- a/src/PosixPtyProcess.zig
+++ b/src/PosixPtyProcess.zig
@@ -257,7 +257,7 @@ pub fn write(self: *Self, data: []const u8) !void {
 }
 
 pub fn drain(self: *Self, stream: anytype) !bool {
-    var buf: [64 * 1024]u8 = undefined;
+    var buf: [4096]u8 = undefined;
 
     var pollfds = [_]posix.pollfd{
         .{
@@ -274,17 +274,14 @@ pub fn drain(self: *Self, stream: anytype) !bool {
     _ = try posix.poll(&pollfds, -1);
     if (pollfds[1].revents != 0) return false;
 
-    var drained = false;
-    while (true) {
-        const len = posix.read(self.pty.primary_fd, buf[0..]) catch |err| switch (err) {
-            error.WouldBlock => return drained,
-            error.NotOpenForReading, error.InputOutput => return drained,
-            else => return err,
-        };
-        if (len == 0) return drained;
-        stream.nextSlice(buf[0..len]);
-        drained = true;
-    }
+    const len = posix.read(self.pty.primary_fd, buf[0..]) catch |err| switch (err) {
+        error.WouldBlock => return false,
+        error.NotOpenForReading, error.InputOutput => return true,
+        else => return err,
+    };
+    if (len == 0) return true;
+    stream.nextSlice(buf[0..len]);
+    return false;
 }
 
 pub fn requestStop(self: *Self, _: std.Thread) void {

--- a/src/PosixPtyProcess.zig
+++ b/src/PosixPtyProcess.zig
@@ -140,12 +140,7 @@ pty: Pty,
 pid: posix.pid_t = -1,
 wake_pipe: [2]posix.fd_t = .{ -1, -1 },
 
-pub const ProcessParams = struct {
-    file: [:0]const u8,
-    args: [][:0]const u8,
-    env: *const std.process.EnvMap,
-    cwd: ?[]const u8 = null,
-};
+pub const ProcessParams = @import("ProcessParams.zig");
 
 pub const EventWriter = struct {
     pub const Fd = posix.fd_t;
@@ -210,22 +205,23 @@ pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: Proc
     const args = try arena.allocSentinel(?[*:0]const u8, params.args.len, null);
     for (params.args, 0..) |arg, i| args[i] = arg;
 
+    self.wake_pipe = try posix.pipe2(.{ .CLOEXEC = true });
+    errdefer {
+        posix.close(self.wake_pipe[0]);
+        posix.close(self.wake_pipe[1]);
+    }
+    const flags = try posix.fcntl(self.pty.primary_fd, posix.F.GETFL, 0);
+    _ = try posix.fcntl(
+        self.pty.primary_fd,
+        posix.F.SETFL,
+        flags | @as(u32, @bitCast(posix.O{ .NONBLOCK = true })),
+    );
+
     const pid = try posix.fork();
     if (pid != 0) {
         // This is the parent, child started successfully.
         self.pty.closeReplica();
         self.pid = pid;
-        self.wake_pipe = try posix.pipe2(.{ .CLOEXEC = true });
-        errdefer {
-            posix.close(self.wake_pipe[0]);
-            posix.close(self.wake_pipe[1]);
-        }
-        const flags = try posix.fcntl(self.pty.primary_fd, posix.F.GETFL, 0);
-        _ = try posix.fcntl(
-            self.pty.primary_fd,
-            posix.F.SETFL,
-            flags | @as(u32, @bitCast(posix.O{ .NONBLOCK = true })),
-        );
         return self;
     }
 
@@ -261,40 +257,33 @@ pub fn write(self: *Self, data: []const u8) !void {
 }
 
 pub fn drain(self: *Self, stream: anytype) !bool {
-    var drained = false;
     var buf: [64 * 1024]u8 = undefined;
 
-    while (true) {
-        var pollfds = [_]posix.pollfd{
-            .{
-                .fd = self.pty.primary_fd,
-                .events = posix.POLL.IN,
-                .revents = undefined,
-            },
-            .{
-                .fd = self.wake_pipe[0],
-                .events = posix.POLL.IN,
-                .revents = undefined,
-            },
-        };
-        _ = try posix.poll(&pollfds, -1);
+    var pollfds = [_]posix.pollfd{
+        .{
+            .fd = self.pty.primary_fd,
+            .events = posix.POLL.IN,
+            .revents = undefined,
+        },
+        .{
+            .fd = self.wake_pipe[0],
+            .events = posix.POLL.IN,
+            .revents = undefined,
+        },
+    };
+    _ = try posix.poll(&pollfds, -1);
+    if (pollfds[1].revents != 0) return false;
 
-        if (pollfds[1].revents != 0) return drained;
-        break;
-    }
-
+    var drained = false;
     while (true) {
         const len = posix.read(self.pty.primary_fd, buf[0..]) catch |err| switch (err) {
             error.WouldBlock => return drained,
             error.NotOpenForReading, error.InputOutput => return drained,
             else => return err,
         };
-        if (len != 0) {
-            stream.nextSlice(buf[0..len]);
-            drained = true;
-            continue;
-        }
         if (len == 0) return drained;
+        stream.nextSlice(buf[0..len]);
+        drained = true;
     }
 }
 

--- a/src/PosixPtyProcess.zig
+++ b/src/PosixPtyProcess.zig
@@ -314,7 +314,7 @@ pub fn replicaName(self: *Self) []const u8 {
     return self.pty.replicaName();
 }
 
-pub fn deinitAndWait(self: *Self) u8 {
+pub fn deinitAndWait(self: *Self) u32 {
     std.debug.assert(self.pid > 0);
     self.pty.deinit();
     posix.close(self.wake_pipe[0]);

--- a/src/PosixPtyProcess.zig
+++ b/src/PosixPtyProcess.zig
@@ -6,6 +6,7 @@ const c = @cImport({
     @cDefine("_GNU_SOURCE", {});
     @cInclude("stdlib.h");
     @cInclude("fcntl.h");
+    @cInclude("signal.h");
     @cInclude("sys/ioctl.h");
     @cInclude("sys/wait.h");
     @cInclude("termios.h");
@@ -50,9 +51,9 @@ const Pty = struct {
         );
         errdefer posix.close(self.replica_fd);
 
-        // Configure the line discipline on the replica.  On macOS/BSD the
-        // master (ptm) fd rejects termios ioctls with ENOTTY — only the
-        // replica carries the terminal attributes — so this must run on
+        // Configure the line discipline on the replica. On macOS/BSD the
+        // master (ptm) fd rejects termios ioctls with ENOTTY; only the
+        // replica carries the terminal attributes, so this must run on
         // `replica_fd', not `primary_fd'.
         var attrs: c.termios = undefined;
         if (c.tcgetattr(self.replica_fd, &attrs) != 0) {
@@ -62,7 +63,7 @@ const Pty = struct {
         attrs.c_iflag |= c.IUTF8;
         // Disable XON/XOFF flow control so C-q (DC1) and C-s (DC3) pass
         // through to the application instead of being swallowed by the
-        // line discipline.  Ghostel's send-next-key escape hatch and the
+        // line discipline. Ghostel's send-next-key escape hatch and the
         // direct C-q binding rely on these bytes reaching the child.
         attrs.c_iflag &= ~@as(@TypeOf(attrs.c_iflag), c.IXON);
         if (c.tcsetattr(self.replica_fd, c.TCSANOW, &attrs) != 0) {
@@ -86,7 +87,7 @@ const Pty = struct {
                 // If the master fd is non-blocking, a write that would fill the
                 // replica's input buffer fails with WouldBlock; wait for the
                 // replica to drain rather than dropping the tail of a large
-                // write (e.g. a big paste to a child that reads slowly).  Under
+                // write (e.g. a big paste to a child that reads slowly). Under
                 // a blocking fd this branch never fires and the loop is an
                 // ordinary blocking write, so write() works in either mode.
                 error.WouldBlock => {
@@ -137,16 +138,68 @@ const Pty = struct {
 
 pty: Pty,
 pid: posix.pid_t = -1,
+wake_pipe: [2]posix.fd_t = .{ -1, -1 },
 
-const ProcessParams = struct {
+pub const ProcessParams = struct {
     file: [:0]const u8,
     args: [][:0]const u8,
     env: *const std.process.EnvMap,
     cwd: ?[]const u8 = null,
 };
 
+pub const EventWriter = struct {
+    pub const Fd = posix.fd_t;
+
+    fd: Fd,
+
+    pub fn init(fd: Fd) !EventWriter {
+        return .{ .fd = fd };
+    }
+
+    pub fn write(self: *EventWriter, data: []const u8) !void {
+        var written: usize = 0;
+        while (written < data.len) {
+            const n = try posix.write(self.fd, data[written..data.len]);
+            if (n == 0) return error.EventWriteFailed;
+            written += n;
+        }
+    }
+
+    pub fn close(self: *EventWriter) void {
+        if (self.fd == -1) return;
+        posix.close(self.fd);
+        self.fd = -1;
+    }
+
+    pub fn onThreadEnter(self: *EventWriter) void {
+        if (@hasDecl(posix.F, "SETNOSIGPIPE")) {
+            _ = posix.fcntl(self.fd, posix.F.SETNOSIGPIPE, 1) catch |err| {
+                std.log.scoped(.NativeProcessHandler).warn("Unable to set SETNOSIGPIPE: {any}", .{err});
+            };
+        }
+
+        var set: c.sigset_t = undefined;
+        _ = c.sigemptyset(&set);
+        _ = c.sigaddset(&set, posix.SIG.PIPE);
+        _ = posix.errno(c.pthread_sigmask(c.SIG_BLOCK, &set, null));
+    }
+
+    pub fn onThreadExit() void {
+        var pending: c.sigset_t = undefined;
+        _ = c.sigpending(&pending);
+        if (c.sigismember(&pending, posix.SIG.PIPE) != 0) {
+            var wait_sigs: c.sigset_t = undefined;
+            _ = c.sigemptyset(&wait_sigs);
+            _ = c.sigaddset(&wait_sigs, posix.SIG.PIPE);
+            var sig: c_int = undefined;
+            _ = c.sigwait(&wait_sigs, &sig);
+        }
+    }
+};
+
 pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: ProcessParams) !Self {
     var self = Self{ .pty = try .init() };
+    errdefer self.pty.deinit();
     try self.pty.resize(initial_cols, initial_rows);
 
     var arena_allocator = std.heap.ArenaAllocator.init(alloc);
@@ -159,34 +212,106 @@ pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: Proc
 
     const pid = try posix.fork();
     if (pid != 0) {
-        // This is the parent, child started successfully
+        // This is the parent, child started successfully.
         self.pty.closeReplica();
         self.pid = pid;
+        self.wake_pipe = try posix.pipe2(.{ .CLOEXEC = true });
+        errdefer {
+            posix.close(self.wake_pipe[0]);
+            posix.close(self.wake_pipe[1]);
+        }
+        const flags = try posix.fcntl(self.pty.primary_fd, posix.F.GETFL, 0);
+        _ = try posix.fcntl(
+            self.pty.primary_fd,
+            posix.F.SETFL,
+            flags | @as(u32, @bitCast(posix.O{ .NONBLOCK = true })),
+        );
         return self;
     }
 
-    // This is the child
+    // This is the child.
     self.pty.setupReplica() catch |err| {
-        _ = posix.write(posix.STDERR_FILENO, "Failed to set up PTY replica: ") catch {};
-        _ = posix.write(posix.STDERR_FILENO, @errorName(err)) catch {};
+        _ = posix.write(posix.STDERR_FILENO, "Failed to set up PTY replica: ") catch 0;
+        _ = posix.write(posix.STDERR_FILENO, @errorName(err)) catch 0;
         std.c._exit(1);
     };
 
     if (params.cwd) |cwd| posix.chdir(cwd) catch |err| {
-        _ = posix.write(posix.STDERR_FILENO, "Failed to change working directory: ") catch {};
-        _ = posix.write(posix.STDERR_FILENO, @errorName(err)) catch {};
+        _ = posix.write(posix.STDERR_FILENO, "Failed to change working directory: ") catch 0;
+        _ = posix.write(posix.STDERR_FILENO, @errorName(err)) catch 0;
     };
 
     const err = posix.execvpeZ(params.file, args, env);
-    // The above never returns on success, if we're here it means we failed
-    _ = posix.write(posix.STDERR_FILENO, "Failed to start subprocess: ") catch {};
-    _ = posix.write(posix.STDERR_FILENO, @errorName(err)) catch {};
+    // The above never returns on success, if we're here it means we failed.
+    _ = posix.write(posix.STDERR_FILENO, "Failed to start subprocess: ") catch 0;
+    _ = posix.write(posix.STDERR_FILENO, @errorName(err)) catch 0;
     std.c._exit(1);
+}
+
+pub fn pidValue(self: *const Self) i64 {
+    return @intCast(self.pid);
+}
+
+pub fn resize(self: *Self, cols: u16, rows: u16) !void {
+    try self.pty.resize(cols, rows);
+}
+
+pub fn write(self: *Self, data: []const u8) !void {
+    try self.pty.write(data);
+}
+
+pub fn drain(self: *Self, stream: anytype) !bool {
+    var drained = false;
+    var buf: [64 * 1024]u8 = undefined;
+
+    while (true) {
+        var pollfds = [_]posix.pollfd{
+            .{
+                .fd = self.pty.primary_fd,
+                .events = posix.POLL.IN,
+                .revents = undefined,
+            },
+            .{
+                .fd = self.wake_pipe[0],
+                .events = posix.POLL.IN,
+                .revents = undefined,
+            },
+        };
+        _ = try posix.poll(&pollfds, -1);
+
+        if (pollfds[1].revents != 0) return drained;
+        break;
+    }
+
+    while (true) {
+        const len = posix.read(self.pty.primary_fd, buf[0..]) catch |err| switch (err) {
+            error.WouldBlock => return drained,
+            error.NotOpenForReading, error.InputOutput => return drained,
+            else => return err,
+        };
+        if (len != 0) {
+            stream.nextSlice(buf[0..len]);
+            drained = true;
+            continue;
+        }
+        if (len == 0) return drained;
+    }
+}
+
+pub fn requestStop(self: *Self, _: std.Thread) void {
+    if (self.wake_pipe[1] != -1) {
+        _ = posix.write(self.wake_pipe[1], "X") catch 0;
+    }
+}
+
+pub fn replicaName(self: *Self) []const u8 {
+    return self.pty.replicaName();
 }
 
 pub fn deinitAndWait(self: *Self) u8 {
     self.pty.deinit();
-    if (self.pid == -1) return 0;
+    posix.close(self.wake_pipe[0]);
+    posix.close(self.wake_pipe[1]);
     const result = posix.waitpid(self.pid, 0);
     return @intCast(c.WEXITSTATUS(@as(c_int, @bitCast(result.status))));
 }

--- a/src/ProcessParams.zig
+++ b/src/ProcessParams.zig
@@ -1,6 +1,0 @@
-const std = @import("std");
-
-file: [:0]const u8,
-args: [][:0]const u8,
-env: *const std.process.EnvMap,
-cwd: ?[]const u8 = null,

--- a/src/ProcessParams.zig
+++ b/src/ProcessParams.zig
@@ -1,0 +1,6 @@
+const std = @import("std");
+
+file: [:0]const u8,
+args: [][:0]const u8,
+env: *const std.process.EnvMap,
+cwd: ?[]const u8 = null,

--- a/src/backend_types.zig
+++ b/src/backend_types.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+
+pub const ProcessParams = struct {
+    file: [:0]const u8,
+    args: [][:0]const u8,
+    env: *const std.process.EnvMap,
+    cwd: ?[]const u8 = null,
+};
+
+pub const CancellationToken = struct {
+    context: *const anyopaque,
+    check_fn: *const fn (*const anyopaque) anyerror!void,
+    poll_interval_ms: u32,
+
+    pub fn check(self: CancellationToken) !void {
+        try self.check_fn(self.context);
+    }
+};
+
+pub const WriteResult = union(enum) {
+    written: usize,
+    interrupted,
+};
+
+test "CancellationToken delegates cancellation checks" {
+    const Context = struct {
+        checked: bool = false,
+
+        fn check(raw: *const anyopaque) !void {
+            const context: *@This() = @ptrCast(@alignCast(@constCast(raw)));
+            context.checked = true;
+        }
+    };
+
+    var context = Context{};
+    const token = CancellationToken{
+        .context = &context,
+        .check_fn = Context.check,
+        .poll_interval_ms = 20,
+    };
+    try token.check();
+    try std.testing.expect(context.checked);
+}

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -280,6 +280,18 @@ pub const Env = struct {
         self.raw.non_local_exit_signal.?(self.raw, symbol, data);
     }
 
+    pub fn checkQuit(self: Env) !void {
+        if (self.raw.should_quit) |shouldQuit| {
+            if (shouldQuit(self.raw)) return error.EmacsQuit;
+        }
+        if (self.raw.process_input) |processInput| {
+            if (processInput(self.raw) == c.emacs_process_input_quit) return error.EmacsQuit;
+        }
+        if (self.raw.should_quit) |shouldQuit| {
+            if (shouldQuit(self.raw)) return error.EmacsQuit;
+        }
+    }
+
     pub fn makeFunction(
         self: Env,
         min_arity: i32,
@@ -313,8 +325,16 @@ pub const Env = struct {
                 current_env = env;
                 defer current_env = prev_env;
                 return entry.impl.call(env, nargs, args) catch |e| {
-                    env.logStackTrace(@errorReturnTrace());
-                    env.signalError("error in %s: %s", .{ entry.name, @errorName(e) });
+                    // Widen narrow per-function error sets so the shared wrapper can
+                    // handle EmacsQuit even for functions that don't return it.
+                    const err: anyerror = e;
+                    switch (err) {
+                        error.EmacsQuit => env.nonLocalExitSignal(sym.quit, env.nil()),
+                        else => {
+                            env.logStackTrace(@errorReturnTrace());
+                            env.signalError("error in %s: %s", .{ entry.name, @errorName(err) });
+                        },
+                    }
                     return env.nil();
                 };
             }
@@ -518,6 +538,7 @@ const interned_symbols = [_][:0]const u8{
     "put-text-property",
     "puthash",
     "query-font",
+    "quit",
     "reverse",
     "run-at-time",
     "selected-window",

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -335,7 +335,7 @@ pub const Env = struct {
         return func(self.raw, str.ptr, @intCast(str.len));
     }
 
-    pub fn openChannel(self: Env, pipe: Value) std.posix.fd_t {
+    pub fn openChannel(self: Env, pipe: Value) c_int {
         return self.raw.open_channel.?(self.raw, pipe);
     }
 

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -62,7 +62,7 @@ pub fn GhostelHandler(Context: type) type {
         fn writePtyCallback(handler: *gt.TerminalStream.Handler, data: [:0]const u8) void {
             const self: *Self = @fieldParentPtr("inner", handler);
             if (data.len == 0) return;
-            self.context.ptyWrite(data) catch {};
+            self.context.ptyWriteFromTerminal(data);
         }
 
         /// Called when the terminal receives BEL.

--- a/src/pty_utils.zig
+++ b/src/pty_utils.zig
@@ -6,6 +6,7 @@
 /// signal.  The check is purely a read of the slave's termios; it does
 /// not change the device's state and is safe to run frequently.
 const std = @import("std");
+const builtin = @import("builtin");
 
 /// Returns true if the tty at PATH is in canonical mode with echo
 /// disabled — the heuristic libghostty uses to decide that the
@@ -22,6 +23,8 @@ const std = @import("std");
 /// sufficient — we never write to the slave; reducing the mode means
 /// a stray write through this fd can't garble the child's input.
 pub fn isPasswordMode(path: []const u8) bool {
+    if (builtin.os.tag == .windows) return false;
+
     const fd = std.posix.open(path, .{
         .ACCMODE = .RDONLY,
         .NOCTTY = true,

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1,6 +1,13 @@
+const builtin = @import("builtin");
+
 test {
     _ = @import("ppm.zig");
     _ = @import("png.zig");
     _ = @import("GlyphMetricsCache.zig");
     _ = @import("fixed_array_list.zig");
+    if (builtin.os.tag == .windows) {
+        _ = @import("ConPtyProcess.zig");
+    } else {
+        _ = @import("PosixPtyProcess.zig");
+    }
 }

--- a/test/fixtures/pty_setup.py
+++ b/test/fixtures/pty_setup.py
@@ -1,0 +1,42 @@
+"""Portable terminal setup for PTY integration-test children."""
+
+import os
+import sys
+
+
+def set_raw_stdio():
+    """Put standard input in raw/no-echo mode and use binary I/O."""
+    if os.name == "nt":
+        import ctypes
+        import msvcrt
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        get_console_mode = kernel32.GetConsoleMode
+        get_console_mode.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+        get_console_mode.restype = wintypes.BOOL
+        set_console_mode = kernel32.SetConsoleMode
+        set_console_mode.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+        set_console_mode.restype = wintypes.BOOL
+
+        stdin_fd = sys.stdin.fileno()
+        stdin_handle = msvcrt.get_osfhandle(stdin_fd)
+        mode = wintypes.DWORD()
+        if not get_console_mode(stdin_handle, ctypes.byref(mode)):
+            raise ctypes.WinError(ctypes.get_last_error())
+
+        enable_processed_input = 0x0001
+        enable_line_input = 0x0002
+        enable_echo_input = 0x0004
+        raw_mode = mode.value & ~(
+            enable_processed_input | enable_line_input | enable_echo_input
+        )
+        if not set_console_mode(stdin_handle, raw_mode):
+            raise ctypes.WinError(ctypes.get_last_error())
+
+        msvcrt.setmode(stdin_fd, os.O_BINARY)
+        msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
+    else:
+        import tty
+
+        tty.setraw(sys.stdin.fileno())

--- a/test/ghostel-buffers-test.el
+++ b/test/ghostel-buffers-test.el
@@ -166,11 +166,14 @@ Each BINDING is (VAR NAME [DIR [IDENTITY]])."
 
 (ert-deftest ghostel-test-project-buffers-default-directory ()
   "Scope `default-directory' matches buffers under the project root."
-  (let ((root "/tmp/myproj/"))
+  (let* ((root (make-temp-file "ghostel-myproj" t))
+         (root (file-name-as-directory root))
+         (outside-root (file-name-as-directory
+                        (make-temp-file "ghostel-other" t))))
     (ghostel-buffers-test--with-bufs
-        ((inside "*ghostel-in*" "/tmp/myproj/src/")
-         (outside "*ghostel-out*" "/tmp/other/")
-         (also-in "*ghostel-also*" "/tmp/myproj/"))
+        ((inside "*ghostel-in*" (expand-file-name "src/" root))
+         (outside "*ghostel-out*" outside-root)
+         (also-in "*ghostel-also*" root))
       (cl-letf (((symbol-function 'project-current)
                  (ghostel-buffers-test--proj-stub root))
                 ((symbol-function 'project-root) (lambda (p) (cdr p)))
@@ -185,11 +188,14 @@ Each BINDING is (VAR NAME [DIR [IDENTITY]])."
 
 (ert-deftest ghostel-test-project-buffers-identity ()
   "Scope `identity' matches buffers whose identity is the project-prefixed name."
-  (let ((root "/tmp/myproj/")
-        (ghostel-buffer-name "*ghostel*"))
+  (let* ((root (make-temp-file "ghostel-myproj" t))
+         (root (file-name-as-directory root))
+         (outside-root (file-name-as-directory
+                        (make-temp-file "ghostel-other" t)))
+         (ghostel-buffer-name "*ghostel*"))
     (ghostel-buffers-test--with-bufs
-        ((tagged "*ghostel-tagged*" "/tmp/other/" "*myproj-ghostel*")
-         (untagged "*ghostel-untag*" "/tmp/myproj/" nil))
+        ((tagged "*ghostel-tagged*" outside-root "*myproj-ghostel*")
+         (untagged "*ghostel-untag*" root nil))
       (cl-letf (((symbol-function 'project-current)
                  (ghostel-buffers-test--proj-stub root))
                 ((symbol-function 'project-root) (lambda (p) (cdr p)))
@@ -203,13 +209,16 @@ Each BINDING is (VAR NAME [DIR [IDENTITY]])."
 
 (ert-deftest ghostel-test-project-buffers-both ()
   "Scope `both' unions `default-directory' and identity matches; no duplicates."
-  (let ((root "/tmp/myproj/")
-        (ghostel-buffer-name "*ghostel*"))
+  (let* ((root (make-temp-file "ghostel-myproj" t))
+         (root (file-name-as-directory root))
+         (outside-root (file-name-as-directory
+                        (make-temp-file "ghostel-other" t)))
+         (ghostel-buffer-name "*ghostel*"))
     (ghostel-buffers-test--with-bufs
-        ((by-dir "*ghostel-d*" "/tmp/myproj/" nil)
-         (by-id "*ghostel-i*" "/tmp/other/" "*myproj-ghostel*")
-         (both "*ghostel-b*" "/tmp/myproj/sub/" "*myproj-ghostel*")
-         (neither "*ghostel-n*" "/tmp/other/" nil))
+        ((by-dir "*ghostel-d*" root nil)
+         (by-id "*ghostel-i*" outside-root "*myproj-ghostel*")
+         (both "*ghostel-b*" (expand-file-name "sub/" root) "*myproj-ghostel*")
+         (neither "*ghostel-n*" outside-root nil))
       (cl-letf (((symbol-function 'project-current)
                  (ghostel-buffers-test--proj-stub root))
                 ((symbol-function 'project-root) (lambda (p) (cdr p)))

--- a/test/ghostel-compile-test.el
+++ b/test/ghostel-compile-test.el
@@ -1011,14 +1011,14 @@ custom MODE / NAME-FUNCTION / HIGHLIGHT-REGEXP survive a revert."
                #'ignore)
               ((symbol-function 'ghostel-compile--spawn)
                (lambda (_cmd buf _h _w)
-                 (let ((p (start-process "ghostel-test-args" buf
-                                         "sleep" "100")))
+                 (let ((p (ghostel-test--dummy-process
+                           "ghostel-test-args" buf)))
                    (set-process-sentinel p #'ignore)
-                   (set-process-query-on-exit-flag p nil)
                    (with-current-buffer buf (setq ghostel--process p))
                    p))))
       (unwind-protect
-          (let ((buf (ghostel-compile--start "make" buf-name "/tmp/" nil nil)))
+          (let ((buf (ghostel-compile--start
+                      "make" buf-name (ghostel-test--temp-directory) nil nil)))
             (with-current-buffer buf
               ;; Default tuple records nil in MODE (read-only run).
               (should (equal '("make" nil nil nil) compilation-arguments))
@@ -1046,16 +1046,15 @@ custom MODE / NAME-FUNCTION / HIGHLIGHT-REGEXP survive a revert."
                #'ignore)
               ((symbol-function 'ghostel-compile--spawn)
                (lambda (_cmd buf _h _w)
-                 (let ((p (start-process "ghostel-test-args2" buf
-                                         "sleep" "100")))
+                 (let ((p (ghostel-test--dummy-process "ghostel-test-args2" buf)))
                    (set-process-sentinel p #'ignore)
-                   (set-process-query-on-exit-flag p nil)
                    (with-current-buffer buf (setq ghostel--process p))
                    p))))
       (unwind-protect
           (let* ((tuple '("make" my-mode my-namer "rgxp"))
-                 (buf (ghostel-compile--start "make" buf-name "/tmp/"
-                                              nil nil tuple)))
+                 (buf (ghostel-compile--start
+                       "make" buf-name (ghostel-test--temp-directory)
+                       nil nil tuple)))
             (with-current-buffer buf
               (should (equal tuple compilation-arguments))
               (let ((p ghostel--process))
@@ -1409,10 +1408,9 @@ the same dimensions so PTY and VT always agree."
                     (lambda (_cmd buf h w)
                       (push 'spawn call-order)
                       (push (list h w) spawn-calls)
-                      (let ((p (start-process "ghostel-test-size-fake"
-                                              buf "sleep" "100")))
+                      (let ((p (ghostel-test--dummy-process
+                                "ghostel-test-size-fake" buf)))
                         (set-process-sentinel p #'ignore)
-                        (set-process-query-on-exit-flag p nil)
                         (with-current-buffer buf
                           (setq ghostel--process p))
                         p))))
@@ -1470,10 +1468,9 @@ dimensions when no output window exists."
                    (ghostel--cursor-pos (cons 0 0))
                    ((symbol-function 'ghostel-compile--spawn)
                     (lambda (_cmd buf _h _w)
-                      (let ((p (start-process "ghostel-test-nowin-fake"
-                                              buf "sleep" "100")))
+                      (let ((p (ghostel-test--dummy-process
+                                "ghostel-test-nowin-fake" buf)))
                         (set-process-sentinel p #'ignore)
-                        (set-process-query-on-exit-flag p nil)
                         (with-current-buffer buf
                           (setq ghostel--process p))
                         p))))
@@ -1580,13 +1577,15 @@ It must also raise `read-process-output-max'.  Same reason as
 `ghostel--spawn-pty' (issue #85)."
   :tags '(native)
   (let ((captured-adaptive 'unset)
-        (captured-max nil)
-        (orig-make-process (symbol-function #'make-process)))
+        (captured-max nil))
     (cl-letf (((symbol-function #'make-process)
                (lambda (&rest plist)
                  (setq captured-adaptive process-adaptive-read-buffering
                        captured-max read-process-output-max)
-                 (apply orig-make-process plist))))
+                 (make-pipe-process
+                  :name "ghostel-compile-test-spawn"
+                  :buffer (plist-get plist :buffer)
+                  :noquery t))))
       (with-temp-buffer
         (let ((proc (ghostel-compile--spawn "true" (current-buffer) 24 80)))
           (unwind-protect
@@ -1604,14 +1603,14 @@ so this path needs its own coverage — without it, users setting
 compile jobs.  Also pins the position: `compilation-environment'
 entries must precede `ghostel-environment', and both must precede
 ghostel's own `INSIDE_EMACS=...,compile' marker."
-  (let ((captured-env nil)
-        (orig-make-process (symbol-function #'make-process)))
+  (let ((captured-env nil))
     (cl-letf (((symbol-function #'make-process)
                (lambda (&rest plist)
                  (setq captured-env process-environment)
-                 (apply orig-make-process plist))))
+                 (ghostel-test--dummy-process
+                  "ghostel-compile-test-env" (plist-get plist :buffer)))))
       (with-temp-buffer
-        (let* ((default-directory "/tmp/")
+        (let* ((default-directory (ghostel-test--temp-directory))
                (compilation-environment '("COMPENV=first"))
                (ghostel-environment '("CC=clang"))
                (proc (ghostel-compile--spawn "true" (current-buffer) 24 80)))

--- a/test/ghostel-debug-test.el
+++ b/test/ghostel-debug-test.el
@@ -447,13 +447,14 @@ so no actual shell is spawned."
         (display-buffer-overriding-action '(display-buffer-no-window))
         (inhibit-message t)
         (ghostel-use-native-pty nil)
-        (orig-make-process (symbol-function #'make-process)))
+        (orig-make-process (symbol-function #'make-process))
+        (executed-command (ghostel-test--shell-command "")))
     (cl-letf (((symbol-function #'make-process)
                (lambda (&rest plist)
                  ;; Return a dummy process object so the advice still
                  ;; records :command from (process-command proc).
                  (apply orig-make-process
-                        (plist-put plist :command '("true"))))))
+                        (plist-put plist :command executed-command)))))
       (let* ((buf (generate-new-buffer " *ghostel-test-debug-ghostel*"))
              ;; Stub `ghostel' to call `ghostel--spawn-pty' synchronously
              ;; in `buf' — mimics the path through `ghostel--start-process'
@@ -502,8 +503,8 @@ so no actual shell is spawned."
                     (should (equal "/bin/sh" (car cmd)))
                     (should (equal "-c" (cadr cmd))))
                   ;; :executed-command is what process-command returns,
-                  ;; which is the test-substituted '("true").
-                  (should (equal '("true")
+                  ;; which is the test-substituted portable no-op command.
+                  (should (equal executed-command
                                  (plist-get cap :executed-command)))))
             (when (buffer-live-p buf)
               (let ((p (buffer-local-value 'ghostel--process buf)))

--- a/test/ghostel-environment-test.el
+++ b/test/ghostel-environment-test.el
@@ -16,13 +16,13 @@ out — otherwise outbound `ssh' (or any consumer of those vars) would
 falsely conclude that ghostty is the controlling terminal."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
-           (ghostel-shell '("/bin/sh" "-c" "env; printf GHOSTEL_ENV_DONE"))
+    (let* ((process-environment (ghostel-test--base-process-environment))
+           (ghostel-shell (ghostel-test--env-done-command))
            (ghostel-shell-integration nil)
            (ghostel-macos-login-shell nil)
            (ghostel-kill-buffer-on-exit nil)
            (ghostel-term "xterm-256color")
-           (default-directory "/tmp/")
+           (default-directory (ghostel-test--temp-directory))
            (text (ghostel-test--start-process-and-wait-for-text
                   "GHOSTEL_ENV_DONE" 25 80 5)))
       (should (ghostel-test--terminal-text-line-p "TERM=xterm-256color" text))
@@ -43,12 +43,12 @@ when that's non-nil, off otherwise.  Setting it to t forces on,
 setting it to nil forces off."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
-           (ghostel-shell '("/bin/sh" "-c" "env; printf GHOSTEL_ENV_DONE"))
+    (let* ((process-environment (ghostel-test--base-process-environment))
+           (ghostel-shell (ghostel-test--env-done-command))
            (ghostel-shell-integration nil)
            (ghostel-macos-login-shell nil)
            (ghostel-kill-buffer-on-exit nil)
-           (default-directory "/tmp/"))
+           (default-directory (ghostel-test--temp-directory)))
       ;; auto + tramp-shell-integration nil → not exported.
       (let* ((ghostel-ssh-install-terminfo 'auto)
              (ghostel-tramp-shell-integration nil)
@@ -113,13 +113,13 @@ internal `TERM=xterm-ghostty' so a `process-environment' lookup (which
 returns the first match) resolves to the user's value."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
-           (ghostel-shell '("/bin/sh" "-c" "env; printf GHOSTEL_ENV_DONE"))
+    (let* ((process-environment (ghostel-test--base-process-environment))
+           (ghostel-shell (ghostel-test--env-done-command))
            (ghostel-shell-integration nil)
            (ghostel-macos-login-shell nil)
            (ghostel-kill-buffer-on-exit nil)
            (ghostel-environment '("TERM=dumb" "MY_VAR=42"))
-           (default-directory "/tmp/")
+           (default-directory (ghostel-test--temp-directory))
            (text (ghostel-test--start-process-and-wait-for-text
                   "GHOSTEL_ENV_DONE" 25 80 5)))
       (should (ghostel-test--terminal-text-line-p "MY_VAR=42" text))

--- a/test/ghostel-exec-test.el
+++ b/test/ghostel-exec-test.el
@@ -127,32 +127,31 @@ is nil, SIGHUP is ignored."
   (when (ghostel-test-exec--pid-live-p pid)
     (ignore-errors (signal-process pid 'KILL))))
 
-(ert-deftest ghostel-test-exec-cat-roundtrip ()
+(ert-deftest ghostel-test-exec-pty-roundtrip ()
   "Bytes written to a `ghostel-exec' PTY reach the child."
   :tags '(native)
-  (skip-unless (file-executable-p "/bin/cat"))
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-exec-buffer (buf proc "/bin/cat")
-      (ghostel--write-pty ghostel--term "GHOSTEL_CAT_OK\r")
-      (ghostel-test--wait-for-text "GHOSTEL_CAT_OK" proc 5))))
+    (ghostel-test--with-raw-echo-buffer (buf proc)
+      (ghostel--write-pty ghostel--term "GHOSTEL_ECHO_OK")
+      (ghostel-test--wait-for-text "GHOSTEL_ECHO_OK" proc 5))))
 
 (ert-deftest ghostel-test-exec-keeps-final-output-after-exit ()
   "Final `ghostel-exec' output remains readable after process exit."
   :tags '(native)
-  (skip-unless (file-executable-p "/bin/sh"))
-  (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-exec-buffer
-        (buf proc "/bin/sh" '("-c" "printf GHOSTEL_FINAL_OUTPUT"))
-      (ghostel-test--wait-for-text "GHOSTEL_FINAL_OUTPUT" nil 5)
-      (ghostel-test--wait-until
-       (lambda () (not (process-live-p proc))) nil 5)
-      (should (buffer-live-p buf))
-      (should (string-match-p "GHOSTEL_FINAL_OUTPUT"
-                              (ghostel-test--terminal-text))))))
+  (pcase-let ((`(,program . ,args)
+               (ghostel-test--shell-command "echo GHOSTEL_FINAL_OUTPUT")))
+    (ghostel-test--with-pty-matrix backend
+      (ghostel-test--with-exec-buffer (buf proc program args)
+        (ghostel-test--wait-for-text "GHOSTEL_FINAL_OUTPUT" nil 5)
+        (ghostel-test--wait-until
+         (lambda () (not (process-live-p proc))) nil 5)
+        (should (buffer-live-p buf))
+        (should (string-match-p "GHOSTEL_FINAL_OUTPUT"
+                                (ghostel-test--terminal-text)))))))
 
 (ert-deftest ghostel-test-exec-kill-buffer-sends-sighup ()
   "Killing a `ghostel-exec' buffer sends SIGHUP to the child."
-  :tags '(native)
+  :tags '(native posix)
   (skip-unless (file-executable-p "/bin/sh"))
   (ghostel-test--with-pty-matrix backend
     (let* ((dir (make-temp-file (expand-file-name "ghostel-life-" default-directory) t))
@@ -181,7 +180,7 @@ is nil, SIGHUP is ignored."
 
 (ert-deftest ghostel-test-exec-kill-buffer-leaves-sighup-ignoring-child-live ()
   "A child that ignores SIGHUP keeps the lifecycle process alive after buffer kill."
-  :tags '(native)
+  :tags '(native posix)
   (skip-unless (file-executable-p "/bin/sh"))
   (ghostel-test--with-pty-matrix backend
     (let* ((dir (make-temp-file (expand-file-name "ghostel-life-" default-directory) t))
@@ -215,7 +214,7 @@ is nil, SIGHUP is ignored."
 
 (ert-deftest ghostel-test-exec-child-kill-runs-exit-lifecycle ()
   "Killing the child process runs the normal Ghostel exit lifecycle."
-  :tags '(native)
+  :tags '(native posix)
   (skip-unless (file-executable-p "/bin/sh"))
   (ghostel-test--with-pty-matrix backend
     (let* ((dir (make-temp-file (expand-file-name "ghostel-life-" default-directory) t))
@@ -247,7 +246,7 @@ is nil, SIGHUP is ignored."
 
 (ert-deftest ghostel-test-exec-delete-process-kills-sighup-ignoring-child ()
   "Deleting the lifecycle process kills the child even when it ignores SIGHUP."
-  :tags '(native)
+  :tags '(native posix)
   (skip-unless (file-executable-p "/bin/sh"))
   (ghostel-test--with-pty-matrix backend
     (let* ((dir (make-temp-file (expand-file-name "ghostel-life-" default-directory) t))

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -135,7 +135,7 @@ SETUP, when non-nil, is called before sending the key."
 
 (ert-deftest ghostel-test-encode-key-kitty-backspace ()
   "Test that backspace is correctly encoded when kitty keyboard mode is active."
-  :tags '(native)
+  :tags '(native posix)
   (ghostel-test--with-pty-matrix backend
     ;; Activate kitty keyboard protocol (flags=5: disambiguate +
     ;; report-alternates) on the terminal model, then encode backspace —
@@ -147,7 +147,7 @@ SETUP, when non-nil, is called before sending the key."
 
 (ert-deftest ghostel-test-encode-key-legacy-backspace ()
   "Test that backspace is correctly encoded in legacy mode (no kitty)."
-  :tags '(native)
+  :tags '(native posix)
   (ghostel-test--with-pty-matrix backend
     (should (equal "7f" (ghostel-test--send-key-and-read-hex "backspace" "" 1)))))
 
@@ -258,7 +258,7 @@ SETUP, when non-nil, is called before sending the paste."
 
 (ert-deftest ghostel-test-encode-paste-bracketed ()
   "Bracketed-paste mode wraps pasted data via libghostty's paste encoder."
-  :tags '(native)
+  :tags '(native posix)
   (ghostel-test--with-pty-matrix backend
     (let ((expected (ghostel-test--hex-encode-string "\e[200~hello\e[201~")))
       (should (equal expected
@@ -268,7 +268,7 @@ SETUP, when non-nil, is called before sending the paste."
 
 (ert-deftest ghostel-test-encode-paste-unbracketed-newline ()
   "Without bracketed-paste mode, libghostty normalizes paste newlines to CR."
-  :tags '(native)
+  :tags '(native posix)
   (ghostel-test--with-pty-matrix backend
     (let ((expected (ghostel-test--hex-encode-string "hello\rworld")))
       (should (equal expected
@@ -276,7 +276,7 @@ SETUP, when non-nil, is called before sending the paste."
 
 (ert-deftest ghostel-test-encode-paste-strips-unsafe-bytes ()
   "Libghostty replaces unsafe paste control bytes with spaces."
-  :tags '(native)
+  :tags '(native posix)
   (ghostel-test--with-pty-matrix backend
     (let ((expected (ghostel-test--hex-encode-string "a b")))
       (should (equal expected
@@ -525,7 +525,7 @@ Only keys that the ghostty encoder maps to a terminal byte are forwarded."
   "Control-Meta letter chords encode to ESC + control byte in legacy mode.
 Regression test for issue #239: these byte sequences match readline
 `.inputrc' rules of the form \"\\e\\<C-letter>\"."
-  :tags '(native)
+  :tags '(native posix)
   (ghostel-test--with-pty-matrix backend
     (pcase-dolist (`(,name ,expected) '(("f" "1b06") ("v" "1b16")))
       (should (equal expected
@@ -536,7 +536,7 @@ Regression test for issue #239: these byte sequences match readline
 C-] is the headline case (-> 0x1d); C-/ -> 0x1f.  Control-Meta prepends
 ESC, matching the bytes eat sends.  (Only the punctuation the ghostty
 encoder recognizes is forwarded; see `ghostel--define-terminal-keys'.)"
-  :tags '(native)
+  :tags '(native posix)
   (ghostel-test--with-pty-matrix backend
     (pcase-dolist (`(,name ,mods ,count ,expected)
                    '(("]" "ctrl" 1 "1d")

--- a/test/ghostel-links-test.el
+++ b/test/ghostel-links-test.el
@@ -260,15 +260,17 @@ E.g. `compilation-mode' error loci in `ghostel-compile-view-mode'."
       (ghostel--detect-urls))
     (should (equal "https://example.com/path"              ; url strips trailing dot
                    (get-text-property 5 'help-echo))))
-  ;; File:line detection with absolute path
-  (let ((test-file (locate-library "ghostel")))
+  ;; File:line detection with an existing relative path.
+  (let* ((test-file (locate-library "ghostel"))
+         (display-file (concat "./" (file-name-nondirectory test-file))))
     (with-temp-buffer
-      (insert (format "Error at %s:42 bad\n" test-file))
-      (let ((ghostel-enable-url-detection t))
-        (ghostel--detect-urls))
-      (let ((he (get-text-property 10 'help-echo)))
-        (should (and he (string-prefix-p "fileref:" he)))  ; file:line help-echo set
-        (should (and he (string-suffix-p ":42" he)))))     ; file:line contains line number
+      (let ((default-directory (file-name-directory test-file)))
+        (insert (format "Error at %s:42 bad\n" display-file))
+        (let ((ghostel-enable-url-detection t))
+          (ghostel--detect-urls))
+        (let ((he (get-text-property 10 'help-echo)))
+          (should (and he (string-prefix-p "fileref:" he))) ; file:line help-echo set
+          (should (and he (string-suffix-p ":42" he))))))   ; file:line contains line number
     ;; File:line for non-existent file produces no link
     (with-temp-buffer
       (insert "Error at /no/such/file.el:10 bad\n")
@@ -277,11 +279,12 @@ E.g. `compilation-mode' error loci in `ghostel-compile-view-mode'."
       (should (null (get-text-property 10 'help-echo))))   ; nonexistent file: no help-echo
     ;; File detection disabled
     (with-temp-buffer
-      (insert (format "Error at %s:42 bad\n" test-file))
-      (let ((ghostel-enable-url-detection t)
-            (ghostel-enable-file-detection nil))
-        (ghostel--detect-urls))
-      (should (null (get-text-property 10 'help-echo))))   ; file detection disabled
+      (let ((default-directory (file-name-directory test-file)))
+        (insert (format "Error at %s:42 bad\n" display-file))
+        (let ((ghostel-enable-url-detection t)
+              (ghostel-enable-file-detection nil))
+          (ghostel--detect-urls))
+        (should (null (get-text-property 10 'help-echo))))) ; file detection disabled
     ;; ghostel--open-link dispatches fileref:
     (let ((opened nil))
       (cl-letf (((symbol-function 'find-file-other-window)
@@ -423,27 +426,28 @@ E.g. `compilation-mode' error loci in `ghostel-compile-view-mode'."
 - Other lines (historical typed commands, output): linkified, so users
   can follow paths in past commands and program output."
   :tags '(native)
-  (let ((test-file (locate-library "ghostel")))
+  (let* ((test-file (locate-library "ghostel"))
+         (display-file (concat "./" (file-name-nondirectory test-file))))
     ;; History line → both file ref and URL linkified.  Active line
     ;; (cursor's line) → both skipped, regardless of whether the cells
     ;; carry `ghostel-input' or not.
     (with-temp-buffer
       (let ((default-directory (file-name-directory test-file)))
-        (insert (format "$ ls %s https://hist.example\n" test-file)) ; line 1: history
-        (insert (format "$ cat %s https://live.example" test-file))  ; line 2: active
+        (insert (format "$ ls %s https://hist.example\n" display-file)) ; line 1: history
+        (insert (format "$ cat %s https://live.example" display-file))  ; line 2: active
         (put-text-property (point-min) (point-max) 'ghostel-input t)
         (goto-char (point-max))                                       ; cursor on line 2
         (let ((ghostel-enable-url-detection t)
               (ghostel-enable-file-detection t))
           (ghostel--detect-urls))
         (goto-char (point-min))
-        (search-forward test-file nil t)
+        (search-forward display-file nil t)
         (let ((he (get-text-property (match-beginning 0) 'help-echo)))
           (should (and he (string-prefix-p "fileref:" he)))) ; history file → linked
         (search-forward "https://hist.example")
         (should (equal "https://hist.example"
                        (get-text-property (match-beginning 0) 'help-echo))) ; history URL → linked
-        (search-forward test-file nil t)
+        (search-forward display-file nil t)
         (should (null (get-text-property (match-beginning 0) 'help-echo))) ; active file → skipped
         (search-forward "https://live.example")
         (should (null (get-text-property (match-beginning 0) 'help-echo))))) ; active URL → skipped
@@ -484,9 +488,9 @@ E.g. `compilation-mode' error loci in `ghostel-compile-view-mode'."
     ;; cwd display; output below is plain text and stays linkifiable.
     (with-temp-buffer
       (let ((default-directory (file-name-directory test-file)))
-        (insert (format "%s λ ls\n" test-file))           ; line 1: prompt prefix
-        (insert (format "%s\n" test-file))                ; line 2: output
-        (insert (format "%s λ " test-file))               ; line 3: live prompt
+        (insert (format "%s λ ls\n" display-file))        ; line 1: prompt prefix
+        (insert (format "%s\n" display-file))             ; line 2: output
+        (insert (format "%s λ " display-file))            ; line 3: live prompt
         ;; Prompt rows carry `ghostel-prompt' on the prefix; output does not.
         (save-excursion
           (goto-char (point-min))
@@ -499,11 +503,11 @@ E.g. `compilation-mode' error loci in `ghostel-compile-view-mode'."
               (ghostel-enable-file-detection t))
           (ghostel--detect-urls))
         (goto-char (point-min))
-        (search-forward test-file nil t)                  ; line 1: prompt prefix
+        (search-forward display-file nil t)               ; line 1: prompt prefix
         (should (null (get-text-property (match-beginning 0) 'help-echo)))
-        (search-forward test-file nil t)                  ; line 2: output
+        (search-forward display-file nil t)               ; line 2: output
         (should (get-text-property (match-beginning 0) 'help-echo))
-        (search-forward test-file nil t)                  ; line 3: live prompt prefix
+        (search-forward display-file nil t)               ; line 3: live prompt prefix
         (should (null (get-text-property (match-beginning 0) 'help-echo)))))))
 
 (ert-deftest ghostel-test-delayed-redraw-defers-plain-link-detection ()

--- a/test/ghostel-module-test.el
+++ b/test/ghostel-module-test.el
@@ -24,6 +24,32 @@
       (should (equal "https://example.invalid/releases/latest/download/ghostel-module-x86_64-linux.so"
                      (ghostel--module-download-url nil))))))
 
+(ert-deftest ghostel-test-install-support-assets-downloads-windows-assets ()
+  "Support asset installation downloads the Windows asset mapping."
+  (let* ((ghostel-github-release-url "https://example.invalid/releases")
+         (dir (make-temp-file "ghostel-support-" t))
+         (downloads nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--windows-support-assets)
+                   (lambda ()
+                     '(("support-a.dll" . "support-a.dll")
+                       ("support-b.exe" . "x64/support-b.exe"))))
+                  ((symbol-function 'ghostel--download-file)
+                   (lambda (url dest)
+                     (push (list url dest) downloads)
+                     url))
+                  ((symbol-function 'message) (lambda (&rest _))))
+          (ghostel--install-support-assets dir "0.9.0")
+          (should (equal
+                   (list
+                    (list "https://example.invalid/releases/download/v0.9.0/support-b.exe"
+                          (expand-file-name "x64/support-b.exe" dir))
+                    (list "https://example.invalid/releases/download/v0.9.0/support-a.dll"
+                          (expand-file-name "support-a.dll" dir)))
+                   downloads)))
+      (when (file-exists-p dir)
+        (delete-directory dir t)))))
+
 (ert-deftest ghostel-test-download-module-defaults-to-minimum-version ()
   "Automatic downloads pin to the minimum supported native module version."
   (let* ((ghostel--minimum-module-version "0.7.1")

--- a/test/ghostel-module-test.el
+++ b/test/ghostel-module-test.el
@@ -65,6 +65,8 @@
                    (lambda (_url dest)
                      (setq download-dest dest)
                      t))
+                  ((symbol-function 'ghostel--install-support-assets)
+                   (lambda (&rest _)))
                   ((symbol-function 'message)
                    (lambda (&rest _))))
           (should (ghostel--download-module dir))
@@ -73,6 +75,29 @@
                                     (concat "ghostel-module" module-file-suffix)
                                     dir))
                          (downcase download-dest))))
+      (when (file-exists-p dir)
+        (delete-directory dir t)))))
+
+(ert-deftest ghostel-test-download-module-installs-support-assets-from-resolved-release ()
+  "Latest module downloads install support assets from the same resolved release."
+  (let* ((ghostel--minimum-module-version "0.7.1")
+         (support-args nil)
+         (dir (make-temp-file "ghostel-dl-latest-" t)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--module-download-url)
+                   (lambda (&optional version)
+                     (should (null version))
+                     "https://example.invalid/releases/latest/download/ghostel-module-x86_64-linux.so"))
+                  ((symbol-function 'ghostel--download-file)
+                   (lambda (_url _dest)
+                     "https://example.invalid/releases/download/v0.9.0/ghostel-module-x86_64-linux.so"))
+                  ((symbol-function 'ghostel--install-support-assets)
+                   (lambda (support-dir version)
+                     (setq support-args (list support-dir version))))
+                  ((symbol-function 'message) (lambda (&rest _))))
+          (should (ghostel--download-module dir nil t))
+          (should (equal (list dir "0.9.0") support-args))
+          (should (equal "0.9.0" (ghostel--read-module-sidecar-version dir))))
       (when (file-exists-p dir)
         (delete-directory dir t)))))
 
@@ -299,7 +324,7 @@ file mmap'd keeps a valid mapping (issue #247)."
         (messages nil)
         (warnings nil)
         (process-invocation nil))
-    (let ((native-comp-enable-subr-trampolines nil))
+    (let ((native-comp-enable-subr-trampolines t))
       (cl-letf (((symbol-function 'ghostel--resource-root)
                  (lambda () "C:/ghostel/"))
                 ((symbol-function 'ghostel--make-module-build-dir)
@@ -314,12 +339,15 @@ file mmap'd keeps a valid mapping (issue #247)."
                  (lambda (&rest _)))
                 ((symbol-function 'make-directory)
                  (lambda (&rest _)))
+                ((symbol-function 'ghostel--install-support-assets)
+                 (lambda (&rest _)))
                 ((symbol-function 'message)
                  (lambda (fmt &rest args)
                    (push (apply #'format fmt args) messages)))
                 ((symbol-function 'display-warning)
-                 (lambda (&rest args)
-                   (push args warnings)))
+                 (lambda (type &rest args)
+                   (when (eq type 'ghostel)
+                     (push args warnings))))
                 ((symbol-function 'process-file)
                  (lambda (program infile buffer display &rest args)
                    (setq process-invocation
@@ -343,8 +371,9 @@ module beside a stale sidecar (issue #256 follow-up B1)."
   (let ((rename-args nil)
         (made-dirs nil)
         (deleted nil)
+        (support-installs nil)
         (warnings nil))
-    (let ((native-comp-enable-subr-trampolines nil))
+    (let ((native-comp-enable-subr-trampolines t))
       (cl-letf (((symbol-function 'ghostel--resource-root)
                  (lambda () "/src/ghostel/"))
                 ((symbol-function 'ghostel--make-module-build-dir)
@@ -360,13 +389,19 @@ module beside a stale sidecar (issue #256 follow-up B1)."
                 ((symbol-function 'rename-file)
                  (lambda (from to &optional _ok)
                    (push (list from to) rename-args)))
+                ((symbol-function 'ghostel--install-support-assets)
+                 (lambda (dir &optional version)
+                   (push (list dir version) support-installs)))
                 ((symbol-function 'message) (lambda (&rest _)))
                 ((symbol-function 'display-warning)
-                 (lambda (&rest args) (push args warnings)))
+                 (lambda (type &rest args)
+                   (when (eq type 'ghostel)
+                     (push args warnings))))
                 ((symbol-function 'process-file)
                  (lambda (&rest _) 0)))
         (ghostel--compile-module "/custom/dir/")
         (should-not warnings)
+        (should (equal '(("/custom/dir/" nil)) support-installs))
         (should (equal 1 (length deleted)))
         (should (equal (downcase (expand-file-name
                                   "ghostel-module.version"
@@ -391,12 +426,15 @@ module beside a stale sidecar (issue #256 follow-up B1)."
                                     "ghostel-module.version"
                                     "/custom/dir/"))
                          (downcase (nth 1 sidecar-args)))))
-        (should (member "/custom/dir/" made-dirs))))))
+        (should (member (downcase (expand-file-name "/custom/dir/"))
+                        (mapcar (lambda (dir)
+                                  (downcase (expand-file-name dir)))
+                                made-dirs)))))))
 
 (ert-deftest ghostel-test-compile-module-warns-when-build-missing ()
   "When the build returns success but no module file appears, warn."
   (let ((warnings nil))
-    (let ((native-comp-enable-subr-trampolines nil))
+    (let ((native-comp-enable-subr-trampolines t))
       (cl-letf (((symbol-function 'ghostel--resource-root)
                  (lambda () "/src/ghostel/"))
                 ((symbol-function 'ghostel--make-module-build-dir)
@@ -407,7 +445,9 @@ module beside a stale sidecar (issue #256 follow-up B1)."
                  (lambda (_) nil))
                 ((symbol-function 'message) (lambda (&rest _)))
                 ((symbol-function 'display-warning)
-                 (lambda (&rest args) (push args warnings)))
+                 (lambda (type &rest args)
+                   (when (eq type 'ghostel)
+                     (push args warnings))))
                 ((symbol-function 'process-file)
                  (lambda (&rest _) 0)))
         (ghostel--compile-module "/src/ghostel/")
@@ -433,8 +473,9 @@ module beside a stale sidecar (issue #256 follow-up B1)."
                          (list command mode name-function default-directory))
                    (current-buffer))))
         (ghostel-module-compile)
-        (should (equal (concat "zig build --prefix /src/ghostel/.ghostel-build/ "
-                               "-Doptimize=ReleaseFast -Dcpu=baseline")
+        (should (equal (format "zig build --prefix %s -Doptimize=ReleaseFast -Dcpu=baseline"
+                               (shell-quote-argument
+                                (expand-file-name "/src/ghostel/.ghostel-build/")))
                        (nth 0 compile-invocation)))
         (should (eq #'ghostel-module-compilation-mode (nth 1 compile-invocation)))
         (should (eq #'ghostel--module-compilation-buffer-name
@@ -468,8 +509,9 @@ sidecar and then renames the module and sidecar into place."
                          (list command mode name-function default-directory))
                    (current-buffer))))
         (ghostel-module-compile)
-        (should (equal (concat "zig build --prefix /custom/dir/.ghostel-build/ "
-                               "-Doptimize=ReleaseFast -Dcpu=baseline")
+        (should (equal (format "zig build --prefix %s -Doptimize=ReleaseFast -Dcpu=baseline"
+                               (shell-quote-argument
+                                (expand-file-name "/custom/dir/.ghostel-build/")))
                        (nth 0 compile-invocation)))
         (should (eq #'ghostel-module-compilation-mode (nth 1 compile-invocation)))
         (should (eq #'ghostel--module-compilation-buffer-name
@@ -480,6 +522,37 @@ sidecar and then renames the module and sidecar into place."
                              "/custom/dir/")
                        finish-args))))))
 
+(ert-deftest ghostel-test-module-compile-finish-installs-support-assets ()
+  "Interactive compile finish installs latest support assets after the module."
+  (let* ((root (make-temp-file "ghostel-module-finish" t))
+         (build-dir (file-name-as-directory (expand-file-name "build" root)))
+         (dest-dir (file-name-as-directory (expand-file-name "module" root)))
+         (module-name (concat "ghostel-module" module-file-suffix))
+         (support-installs nil)
+         (buf (generate-new-buffer " *ghostel-module-finish*")))
+    (unwind-protect
+        (progn
+          (make-directory build-dir t)
+          (with-temp-file (expand-file-name module-name build-dir)
+            (insert "module"))
+          (with-temp-file (expand-file-name "ghostel-module.version" build-dir)
+            (insert "0.99.0\n"))
+          (with-current-buffer buf
+            (setq-local ghostel--module-compile-build-dir build-dir
+                        ghostel--module-compile-dest-dir dest-dir))
+          (cl-letf (((symbol-function 'ghostel--install-support-assets)
+                     (lambda (dir &optional version)
+                       (push (list dir version) support-installs)))
+                    ((symbol-function 'message) (lambda (&rest _))))
+            (ghostel--install-built-module-after-compilation buf "finished\n"))
+          (should (file-exists-p (expand-file-name module-name dest-dir)))
+          (should (equal "0.99.0" (ghostel--read-module-sidecar-version dest-dir)))
+          (should (equal (list (list dest-dir nil)) support-installs)))
+      (when (buffer-live-p buf)
+        (kill-buffer buf))
+      (when (file-exists-p root)
+        (delete-directory root t)))))
+
 (ert-deftest ghostel-test-module-compile-recompile-installs-built-module ()
   "`ghostel-module-compile' installs artifacts again after `recompile'."
   (let* ((root (make-temp-file "ghostel-module-recompile" t))
@@ -489,19 +562,34 @@ sidecar and then renames the module and sidecar into place."
          (final (expand-file-name module-name dest-dir))
          (final-sidecar (expand-file-name "ghostel-module.version" dest-dir))
          (compile-buffer-name " *ghostel-module-recompile*")
+         (script (expand-file-name "write-module.el" root))
+         (emacs (expand-file-name invocation-name invocation-directory))
          (compilation-ask-about-save nil)
          (ghostel-module-directory dest-dir)
          (ghostel-module-compile-command
-          (format "sh -c %s sh %%s"
-                  (shell-quote-argument
-                   (format (concat "n=$(($(cat %s 2>/dev/null || echo 0)+1)); "
-                                   "printf \"$n\" > %s; "
-                                   "mkdir -p \"$1\"; "
-                                   "printf \"module-$n\" > \"$1/%s\"; "
-                                   "printf \"$n\" > \"$1/ghostel-module.version\"")
-                           (shell-quote-argument counter)
-                           (shell-quote-argument counter)
-                           module-name)))))
+          (format "%s --batch -Q --script %s %%s"
+                  (shell-quote-argument emacs)
+                  (shell-quote-argument script))))
+    (with-temp-file script
+      (prin1
+       `(let* ((build-dir (file-name-as-directory
+                           (car command-line-args-left)))
+               (counter ,counter)
+               (module-name ,module-name)
+               (n (if (file-exists-p counter)
+                      (with-temp-buffer
+                        (insert-file-contents counter)
+                        (string-to-number (buffer-string)))
+                    0)))
+          (setq n (1+ n))
+          (make-directory build-dir t)
+          (with-temp-file counter (princ n (current-buffer)))
+          (with-temp-file (expand-file-name module-name build-dir)
+            (princ (format "module-%d" n) (current-buffer)))
+          (with-temp-file (expand-file-name "ghostel-module.version" build-dir)
+            (princ n (current-buffer))))
+       (current-buffer))
+      (terpri (current-buffer)))
     (cl-labels ((read-file (file)
                   (and (file-exists-p file)
                        (with-temp-buffer
@@ -514,7 +602,9 @@ sidecar and then renames the module and sidecar into place."
       (cl-letf (((symbol-function 'ghostel--resource-root)
                  (lambda () root))
                 ((symbol-function 'ghostel--module-compilation-buffer-name)
-                 (lambda (_mode-name) compile-buffer-name)))
+                 (lambda (_mode-name) compile-buffer-name))
+                ((symbol-function 'ghostel--windows-support-assets)
+                 #'ignore))
         (unwind-protect
             (let ((inhibit-message t))
               (ghostel-module-compile)
@@ -922,7 +1012,14 @@ both the .so/.dylib and ghostel-module.version next to it."
   ;; aarch64 unchanged
   (let ((system-configuration "aarch64-unknown-linux-gnu")
         (system-type 'gnu/linux))
-    (should (equal (ghostel--module-platform-tag) "aarch64-linux"))))
+    (should (equal (ghostel--module-platform-tag) "aarch64-linux")))
+  ;; Windows release tags use the same normalized arch names.
+  (let ((system-configuration "amd64-w64-mingw32")
+        (system-type 'windows-nt))
+    (should (equal (ghostel--module-platform-tag) "x86_64-windows")))
+  (let ((system-configuration "arm64-w64-mingw32")
+        (system-type 'windows-nt))
+    (should (equal (ghostel--module-platform-tag) "aarch64-windows"))))
 
 (provide 'ghostel-module-test)
 ;;; ghostel-module-test.el ends here

--- a/test/ghostel-mouse-paste-test.el
+++ b/test/ghostel-mouse-paste-test.el
@@ -19,8 +19,8 @@ Returns the buffer."
       (ghostel-mode)
       (setq ghostel--term (vector 'fake-term))
       (setq ghostel--process
-            (start-process (concat "ghostel-test-focus-" name)
-                           nil "cat"))
+            (ghostel-test--dummy-process
+             (concat "ghostel-test-focus-" name) nil))
       (set-process-query-on-exit-flag ghostel--process nil))
     buf))
 
@@ -1693,7 +1693,7 @@ Emacs's regular `yank' so paste lands in the input region."
          (kill-ring-yank-pointer kill-ring)
          (ghostel--yank-index 0)
          (last-command 'ghostel-yank)
-         (ghostel--process (start-process "true" nil "true")))
+         (ghostel--process 'fake-process))
     (cl-letf (((symbol-function 'ghostel--paste-text)
                (lambda (text) (push text pasted)))
               ((symbol-function 'process-live-p) (lambda (_) t))
@@ -1846,6 +1846,7 @@ The paste is still forwarded to the terminal (matching `ghostel-yank')."
         (exit-called nil)
         (kill-ring '("payload"))
         (kill-ring-yank-pointer nil)
+        (interprogram-paste-function nil)
         (ghostel--input-mode 'copy)
         (ghostel-readonly-fast-exit t))
     (cl-letf (((symbol-function 'ghostel--paste-text)
@@ -1862,6 +1863,7 @@ The paste is still forwarded to the terminal (matching `ghostel-yank')."
         (exit-called nil)
         (kill-ring '("payload"))
         (kill-ring-yank-pointer nil)
+        (interprogram-paste-function nil)
         (ghostel--input-mode 'emacs)
         (ghostel-readonly-fast-exit t))
     (cl-letf (((symbol-function 'ghostel--paste-text)
@@ -1878,6 +1880,7 @@ The paste is still forwarded to the terminal (matching `ghostel-yank')."
         (exit-called nil)
         (kill-ring '("payload"))
         (kill-ring-yank-pointer nil)
+        (interprogram-paste-function nil)
         (ghostel--input-mode 'copy)
         (ghostel-readonly-fast-exit nil))
     (cl-letf (((symbol-function 'ghostel--paste-text)

--- a/test/ghostel-native-process-test.el
+++ b/test/ghostel-native-process-test.el
@@ -64,6 +64,26 @@ function and should call it under any dynamic bindings needed by the test."
         (when (process-live-p pipe)
           (delete-process pipe))))))
 
+(ert-deftest ghostel-test-native-process-exit-hook-kills-children ()
+  "Emacs exit signals every live native child with SIGKILL."
+  (let (signals)
+    (cl-letf (((symbol-function 'process-list)
+               (lambda () '(pipe-a unrelated pipe-b dead-pipe)))
+              ((symbol-function 'process-live-p)
+               (lambda (process) (not (eq process 'dead-pipe))))
+              ((symbol-function 'process-get)
+               (lambda (process property)
+                 (and (eq property 'ghostel--native-pid)
+                      (pcase process
+                        ('pipe-a 101)
+                        ('pipe-b 202)
+                        ('dead-pipe 303)))))
+              ((symbol-function 'signal-process)
+               (lambda (pid signal)
+                 (push (list pid signal) signals))))
+      (ghostel--kill-native-processes-on-exit)
+      (should (equal (nreverse signals) '((101 9) (202 9)))))))
+
 (ert-deftest ghostel-test-events-filter-multiple-events-per-chunk ()
   "Native process event filter evaluates multiple events in one chunk."
   (ghostel-test-native-process--with-events-filter

--- a/test/ghostel-native-process-test.el
+++ b/test/ghostel-native-process-test.el
@@ -18,33 +18,6 @@
   "Record ARGS for native process event-filter tests."
   (push args ghostel-test-native-process--events))
 
-(ert-deftest ghostel-test-spawn-process-suppresses-built-in-process-resize ()
-  "`ghostel--spawn-process' leaves resizing to `ghostel--adjust-size'."
-  (let ((pipe nil))
-    (unwind-protect
-        (let ((native-comp-enable-subr-trampolines nil)
-              (comp-enable-subr-trampolines nil))
-          (cl-letf (((symbol-function 'ghostel--resolve-local-executable)
-                     #'identity)
-                    ((symbol-function 'ghostel--spawn-via-native)
-                     (lambda (&rest _)
-                       (setq pipe (make-pipe-process
-                                   :name "ghostel-native-process"
-                                   :buffer (current-buffer)
-                                   :noquery t))))
-                    ((symbol-function 'signal-process)
-                     #'ignore))
-            (with-temp-buffer
-              (let ((ghostel-use-native-pty t))
-                (let ((process (ghostel--spawn-process "sh" nil nil)))
-                  (should (eq pipe process)))
-                (should (process-live-p pipe))
-                (should (eq (process-get pipe 'adjust-window-size-function)
-                            #'ignore))))))
-      (when (and pipe (process-live-p pipe))
-        (set-process-sentinel pipe #'ignore)
-        (delete-process pipe)))))
-
 (defun ghostel-test-native-process--with-events-filter (fn)
   "Call FN in a buffer-local `ghostel--events-filter' unit-test context.
 FN receives a fake pipe process value and a zero-argument function

--- a/test/ghostel-native-process-test.el
+++ b/test/ghostel-native-process-test.el
@@ -36,10 +36,11 @@ returning the number of redraw invalidations requested."
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 
-(defun ghostel-test-native-process--env-output (env-program &optional spawn-wrapper)
-  "Spawn ENV-PROGRAM through the native primitive and return its output.
-SPAWN-WRAPPER, when non-nil, is called with the zero-argument spawn
-function and should call it under any dynamic bindings needed by the test."
+(defun ghostel-test-native-process--env-output (env-command &optional spawn-wrapper)
+  "Spawn ENV-COMMAND through the native primitive and return its output.
+ENV-COMMAND is a command argv list.  SPAWN-WRAPPER, when non-nil, is
+called with the zero-argument spawn function and should call it under
+any dynamic bindings needed by the test."
   (ghostel-test--with-terminal-buffer (buf _term 200 32767 2000000)
     (let ((pipe (make-pipe-process
                  :name "ghostel-native-env-test"
@@ -51,7 +52,7 @@ function and should call it under any dynamic bindings needed by the test."
           (progn
             (let ((spawn (lambda ()
                            (setq pid (ghostel--spawn-native-process
-                                      ghostel--term (list env-program) pipe)))))
+                                      ghostel--term env-command pipe)))))
               (if spawn-wrapper
                   (funcall spawn-wrapper spawn)
                 (funcall spawn)))
@@ -155,12 +156,13 @@ must not leave `ghostel--event-buf' in a poisoned state."
 (ert-deftest ghostel-test-native-process-adds-display-for-graphical-frame ()
   "Native env builder mirrors Emacs' DISPLAY fallback for graphical frames."
   :tags '(native)
-  (let ((env-program (executable-find "env")))
-    (skip-unless env-program)
-    (let* ((process-environment '("DISPLAY_FOO=1" "PATH=/usr/bin:/bin" "HOME=/tmp"))
-           (default-directory "/tmp/")
+  (let ((env-command (ghostel-test--env-command)))
+    (skip-unless (car env-command))
+    (let* ((process-environment (append '("DISPLAY_FOO=1")
+                                        (ghostel-test--base-process-environment)))
+           (default-directory (ghostel-test--temp-directory))
            (text (ghostel-test-native-process--env-output
-                  env-program
+                  env-command
                   (lambda (spawn)
                     (cl-letf (((symbol-function 'display-graphic-p)
                                (lambda (&optional _display) t))
@@ -174,12 +176,12 @@ must not leave `ghostel--event-buf' in a poisoned state."
 (ert-deftest ghostel-test-native-process-does-not-add-display-for-terminal-frame ()
   "Native env builder does not synthesize DISPLAY for non-graphical frames."
   :tags '(native)
-  (let ((env-program (executable-find "env")))
-    (skip-unless env-program)
-    (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
-           (default-directory "/tmp/")
+  (let ((env-command (ghostel-test--env-command)))
+    (skip-unless (car env-command))
+    (let* ((process-environment (ghostel-test--base-process-environment))
+           (default-directory (ghostel-test--temp-directory))
            (text (ghostel-test-native-process--env-output
-                  env-program
+                  env-command
                   (lambda (spawn)
                     (cl-letf (((symbol-function 'display-graphic-p)
                                (lambda (&optional _display) nil))
@@ -192,16 +194,15 @@ must not leave `ghostel--event-buf' in a poisoned state."
 (ert-deftest ghostel-test-native-process-env-first-entry-wins ()
   "Native env builder follows `process-environment' first-entry semantics."
   :tags '(native)
-  (let ((env-program (executable-find "env")))
-    (skip-unless env-program)
-    (let* ((process-environment '("GHOSTEL_ENV_TEST_UNSET"
-                                  "GHOSTEL_ENV_TEST_UNSET=later"
-                                  "GHOSTEL_ENV_TEST_DUP=first"
-                                  "GHOSTEL_ENV_TEST_DUP=later"
-                                  "PATH=/usr/bin:/bin"
-                                  "HOME=/tmp"))
-           (default-directory "/tmp/")
-           (text (ghostel-test-native-process--env-output env-program)))
+  (let ((env-command (ghostel-test--env-command)))
+    (skip-unless (car env-command))
+    (let* ((process-environment (append '("GHOSTEL_ENV_TEST_UNSET"
+                                          "GHOSTEL_ENV_TEST_UNSET=later"
+                                          "GHOSTEL_ENV_TEST_DUP=first"
+                                          "GHOSTEL_ENV_TEST_DUP=later")
+                                        (ghostel-test--base-process-environment)))
+           (default-directory (ghostel-test--temp-directory))
+           (text (ghostel-test-native-process--env-output env-command)))
       (should-not (ghostel-test--terminal-text-line-prefix-p
                    "GHOSTEL_ENV_TEST_UNSET=" text))
       (should (ghostel-test--terminal-text-line-p
@@ -212,12 +213,13 @@ must not leave `ghostel--event-buf' in a poisoned state."
 (ert-deftest ghostel-test-native-process-display-unset-suppresses-fallback ()
   "A bare DISPLAY entry suppresses graphical DISPLAY fallback."
   :tags '(native)
-  (let ((env-program (executable-find "env")))
-    (skip-unless env-program)
-    (let* ((process-environment '("DISPLAY" "PATH=/usr/bin:/bin" "HOME=/tmp"))
-           (default-directory "/tmp/")
+  (let ((env-command (ghostel-test--env-command)))
+    (skip-unless (car env-command))
+    (let* ((process-environment (cons "DISPLAY"
+                                      (ghostel-test--base-process-environment)))
+           (default-directory (ghostel-test--temp-directory))
            (text (ghostel-test-native-process--env-output
-                  env-program
+                  env-command
                   (lambda (spawn)
                     (cl-letf (((symbol-function 'display-graphic-p)
                                (lambda (&optional _display) t))
@@ -237,7 +239,7 @@ must not leave `ghostel--event-buf' in a poisoned state."
                     "quoted \") (setq ghostel-test-native-process--evil 'quote) (\" title"
                     "backslash \\\") (setq ghostel-test-native-process--evil 'backslash) (\" title"
                     "newline\n\")\n(setq ghostel-test-native-process--evil 'newline)\n(\" title")))
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (should ghostel--process)
       (cl-letf (((symbol-function 'ghostel--set-title)
                  (lambda (title) (push title titles))))

--- a/test/ghostel-native-process-test.el
+++ b/test/ghostel-native-process-test.el
@@ -18,6 +18,33 @@
   "Record ARGS for native process event-filter tests."
   (push args ghostel-test-native-process--events))
 
+(ert-deftest ghostel-test-spawn-process-suppresses-built-in-process-resize ()
+  "`ghostel--spawn-process' leaves resizing to `ghostel--adjust-size'."
+  (let ((pipe nil))
+    (unwind-protect
+        (let ((native-comp-enable-subr-trampolines nil)
+              (comp-enable-subr-trampolines nil))
+          (cl-letf (((symbol-function 'ghostel--resolve-local-executable)
+                     #'identity)
+                    ((symbol-function 'ghostel--spawn-via-native)
+                     (lambda (&rest _)
+                       (setq pipe (make-pipe-process
+                                   :name "ghostel-native-process"
+                                   :buffer (current-buffer)
+                                   :noquery t))))
+                    ((symbol-function 'signal-process)
+                     #'ignore))
+            (with-temp-buffer
+              (let ((ghostel-use-native-pty t))
+                (let ((process (ghostel--spawn-process "sh" nil nil)))
+                  (should (eq pipe process)))
+                (should (process-live-p pipe))
+                (should (eq (process-get pipe 'adjust-window-size-function)
+                            #'ignore))))))
+      (when (and pipe (process-live-p pipe))
+        (set-process-sentinel pipe #'ignore)
+        (delete-process pipe)))))
+
 (defun ghostel-test-native-process--with-events-filter (fn)
   "Call FN in a buffer-local `ghostel--events-filter' unit-test context.
 FN receives a fake pipe process value and a zero-argument function

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -13,7 +13,7 @@
   "Test OSC 52 clipboard handling."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       ;; With osc52 disabled, kill ring should not be modified.
       (let ((ghostel-enable-osc52 nil)
             (kill-ring nil))
@@ -49,7 +49,7 @@
   :tags '(native)
   (let ((ghostel-buffer-name-function #'ghostel-buffer-name-by-title))
     (ghostel-test--with-pty-matrix backend
-      (ghostel-test--with-raw-cat-buffer (buf proc)
+      (ghostel-test--with-raw-echo-buffer (buf proc)
         (let* ((title (format "Matrix Title %S" backend))
                (expected (format "*ghostel: %s*" title)))
           (ghostel--write-pty ghostel--term (format "\e]2;%s\e\\" title))
@@ -66,7 +66,7 @@
   :tags '(native)
   (ghostel-test--with-pty-matrix
       backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (let* ((calls nil)
              (ghostel-notification-function
               (lambda (title body) (push (cons title body) calls))))
@@ -105,7 +105,7 @@ mode, prompt start).  Payloads that ghostty-vt rejects fall through
 to the notification path — see `ghostel-test-osc9-invalid-conemu-notifies'."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (let (calls)
         (cl-letf (((symbol-function 'ghostel--handle-notification)
                    (lambda (title body) (push (cons title body) calls)))
@@ -145,7 +145,7 @@ the handler-based dispatch we trust ghostty's parser as the
 authority for OSC 9 disambiguation."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (let (calls)
         (cl-letf (((symbol-function 'ghostel--handle-notification)
                    (lambda (title body) (push (cons title body) calls)))
@@ -171,7 +171,7 @@ ConEmu's CWD-reporting alias uses the same callback as OSC 7, so
 `ghostel--last-directory' records the reported path and no notification fires."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (let (notifs)
         (cl-letf (((symbol-function 'ghostel--handle-notification)
                    (lambda (title body) (push (cons title body) notifs))))
@@ -185,7 +185,7 @@ ConEmu's CWD-reporting alias uses the same callback as OSC 7, so
   "OSC 9;4 progress reports reach `ghostel-progress-function'."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (let* ((calls nil)
              (ghostel-progress-function
               (lambda (state progress) (push (list state progress) calls))))
@@ -235,7 +235,7 @@ ConEmu's CWD-reporting alias uses the same callback as OSC 7, so
   :tags '(native)
   (ghostel-test--with-pty-matrix
       backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (let (calls)
         (cl-letf (((symbol-function 'ghostel--handle-notification)
                    (lambda (title body) (push (cons title body) calls))))
@@ -595,7 +595,7 @@ The parser dispatches the truncated OSC 7 payload and then starts OSC 52
 fresh."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (let ((ghostel-enable-osc52 t)
             (kill-ring nil))
         (ghostel--write-pty ghostel--term "\e]7;PARTIAL\e]52;c;aGVsbG8=\a")
@@ -612,8 +612,7 @@ fresh."
 (ert-deftest ghostel-test-osc-color-query ()
   "Test that OSC 4/10/11/12 and Kitty OSC 21 color queries get responses."
   :tags '(native)
-  (let ((python (executable-find "python3")))
-    (skip-unless python)
+  (let ((python (ghostel-test--python)))
     ;; Each case pairs a payload written to the terminal with a CHECK on the
     ;; reply the terminal writes back to the child (reported as lowercase hex):
     ;;   (PAYLOAD :none)       no reply expected
@@ -674,11 +673,12 @@ fresh."
               "1b5d32313b666f726567726f756e643d7267623a61612f62622f63631b5c"))))
       (cl-labels ((run-probe (payloads)
                     (ghostel-test--with-exec-buffer
-                        (buf proc python
-                             (append (list "-c" ghostel-test--pty-reply-probe-script "0.15")
-                                     (mapcar #'ghostel-test--hex-encode-string payloads)))
-                      (cl-loop for i below (length payloads)
-                               collect (ghostel-test--wait-for-pty-reply i proc 6)))))
+                     (buf proc python
+                          (append (list "-c" ghostel-test--pty-reply-probe-script
+                                        (ghostel-test--fixture-directory) "0.15")
+                                  (mapcar #'ghostel-test--hex-encode-string payloads)))
+                     (cl-loop for i below (length payloads)
+                              collect (ghostel-test--wait-for-pty-reply i proc 6)))))
         (ghostel-test--with-pty-matrix backend
           (let ((replies (run-probe (mapcar #'car cases))))
             (cl-loop for (payload check arg) in cases
@@ -728,7 +728,7 @@ through the filter."
   "OSC 52 kind \='e\=' reaches `ghostel--osc52-eval'."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (let* ((called-with nil)
              (ghostel-eval-cmds
               `(("test-fn" ,(lambda (&rest args) (setq called-with args))))))
@@ -740,7 +740,7 @@ through the filter."
   "OSC 52 dispatches on kind: \='e\=' to eval, others to clipboard."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (let* ((eval-called nil)
              (ghostel-eval-cmds
               `(("k" ,(lambda (&rest _) (setq eval-called t)))))
@@ -764,7 +764,7 @@ elisp callback fires exactly when the terminator arrives in the second
 call.  The OSC 51 scanner this replaces could not handle this case."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (let* ((called-with nil)
              (ghostel-eval-cmds
               `(("test-fn" ,(lambda (&rest args) (setq called-with args))))))
@@ -779,7 +779,7 @@ call.  The OSC 51 scanner this replaces could not handle this case."
   "A single PTY write containing both OSC 52;e and OSC 52;c dispatches both."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (let* ((eval-payloads nil)
              (ghostel-eval-cmds
               `(("k" ,(lambda (&rest args) (push args eval-payloads)))))
@@ -797,7 +797,7 @@ call.  The OSC 51 scanner this replaces could not handle this case."
   "OSC 7 child output updates the buffer-local directory report."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (should (equal nil ghostel--last-directory))
 
       (ghostel--write-pty ghostel--term "\e]7;file:///tmp/testdir\e\\")
@@ -816,7 +816,7 @@ call.  The OSC 51 scanner this replaces could not handle this case."
   "OSC 133 child output dispatches prompt markers."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (let (markers)
         (cl-letf (((symbol-function 'ghostel--osc133-marker)
                    (lambda (type param) (push (cons type param) markers))))
@@ -877,7 +877,7 @@ call.  The OSC 51 scanner this replaces could not handle this case."
   "Deferred VT effects run in the buffer that produced the terminal output."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (let ((other (generate-new-buffer " *ghostel-test-vt-effect-other*"))
             captured)
         (unwind-protect
@@ -919,7 +919,7 @@ call.  The OSC 51 scanner this replaces could not handle this case."
   "OSC 133 D child output fires `ghostel-command-finish-functions'."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
-    (ghostel-test--with-raw-cat-buffer (buf proc)
+    (ghostel-test--with-raw-echo-buffer (buf proc)
       (let* ((calls nil)
              (ghostel-command-finish-functions
               (list (lambda (_buf exit) (push exit calls)))))

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -1705,7 +1705,7 @@ app redraws all rows at new width via the filter pipeline."
           (ghostel-mode)
           (setq ghostel--term (ghostel--new 6 80 100))
           (let* ((ghostel-detect-password-prompts nil)
-                 (proc (start-process "ghostel-test-w" buf "sleep" "60"))
+                 (proc (ghostel-test--dummy-process "ghostel-test-w" buf))
                  (ghostel--process proc)
                  (inhibit-read-only t))
             (set-process-coding-system proc 'binary 'binary)
@@ -1772,7 +1772,7 @@ rendered by `ghostel--redraw-now'.  This is the exact real-world path."
                  (process-environment
                   (append (list "TERM=xterm-256color" "COLUMNS=40" "LINES=10")
                           process-environment))
-                 (proc (start-process "ghostel-test-pipe" buf "sleep" "60")))
+                 (proc (ghostel-test--dummy-process "ghostel-test-pipe" buf)))
             (setq ghostel--process proc)
             (set-process-coding-system proc 'binary 'binary)
             (set-process-window-size proc 10 40)

--- a/test/ghostel-scroll-test.el
+++ b/test/ghostel-scroll-test.el
@@ -289,17 +289,17 @@ regressing to a bare `fboundp' check, which is true on Emacs 28 because
   (let ((orig-config (current-window-configuration)))
     (unwind-protect
         (ghostel-test-scroll--with-buffer (buf term 10 40 200)
-            (ghostel-test-scroll--write-lines term "scroll" 30)
-            (ghostel--redraw term t)
-            (let ((w1 (selected-window)))
+          (ghostel-test-scroll--write-lines term "scroll" 30)
+          (ghostel--redraw term t)
+          (let ((w1 (selected-window)))
             (set-window-start w1 (point-min) t)
             (set-window-point w1 (point-min))
             (let ((start-before (window-start w1))
-                (w2 (split-window w1)))
-            (set-window-buffer w2 buf)
-            (run-hook-with-args 'window-buffer-change-functions w2)
-            (should (= start-before (window-start w1)))
-            (should (= (window-start w2) (ghostel--viewport-start))))))
+                  (w2 (split-window w1)))
+              (set-window-buffer w2 buf)
+              (run-hook-with-args 'window-buffer-change-functions w2)
+              (should (= start-before (window-start w1)))
+              (should (ghostel--window-anchored-p w2)))))
       (set-window-configuration orig-config))))
 
 (ert-deftest ghostel-test-user-rescroll-is-preserved ()
@@ -593,6 +593,7 @@ rows in the viewport — with or without the trailing newline."
   "Paste scrolls the window to the live cursor."
   (let ((kill-ring '("hello"))
         (kill-ring-yank-pointer nil)
+        (interprogram-paste-function nil)
         sent-text)
     (ghostel-test--with-scroll-on-input-window t
       (cl-letf (((symbol-function 'ghostel--encode-paste)
@@ -606,6 +607,7 @@ rows in the viewport — with or without the trailing newline."
   "Yanking in Emacs mode scrolls the window to the live cursor."
   (let ((kill-ring '("hello"))
         (kill-ring-yank-pointer nil)
+        (interprogram-paste-function nil)
         (ghostel-readonly-fast-exit nil)
         sent-text)
     (ghostel-test--with-scroll-on-input-window t

--- a/test/ghostel-shell-test.el
+++ b/test/ghostel-shell-test.el
@@ -11,16 +11,13 @@
 (require 'ghostel-test-helpers)
 
 (defmacro ghostel-test--with-cat-process (var &rest body)
-  "Spawn a long-lived `cat' process bound to VAR, run BODY, then clean up.
+  "Run BODY with a live dummy process bound to VAR.
 The process is killed and the temp buffer destroyed on exit so the
 query-before-killing tests don't leak processes between runs."
   (declare (indent 1))
   `(let* ((buf (generate-new-buffer " *ghostel-test-query-cat*"))
-          (,var (make-process :name "ghostel-test-cat"
-                              :buffer buf
-                              :command '("cat")
-                              :connection-type 'pipe
-                              :noquery nil)))
+          (,var (ghostel-test--dummy-process "ghostel-test-query" buf)))
+     (set-process-query-on-exit-flag ,var nil)
      (unwind-protect (progn ,@body)
        (when (process-live-p ,var)
          (delete-process ,var))
@@ -92,17 +89,17 @@ newest-first list aligns with the buffer-order regions."
 (ert-deftest ghostel-test-da-response ()
   "Test that the terminal responds to DA1 queries."
   :tags '(native)
-  (let ((python (executable-find "python3")))
-    (skip-unless python)
+  (let ((python (ghostel-test--python)))
     (ghostel-test--with-pty-matrix backend
-				   (ghostel-test--with-exec-buffer
-				    (buf proc python
-					 (list "-c"
-					       ghostel-test--pty-reply-probe-script
-					       "0.15"
-					       (ghostel-test--hex-encode-string "\e[c")))
-				    (should (equal "1b5b3f36323b323263"
-						   (ghostel-test--wait-for-pty-reply 0 proc 6)))))))
+								   (ghostel-test--with-exec-buffer
+									(buf proc python
+										 (list "-c"
+											   ghostel-test--pty-reply-probe-script
+											   (ghostel-test--fixture-directory)
+											   "0.15"
+											   (ghostel-test--hex-encode-string "\e[c")))
+									(should (equal "1b5b3f36323b323263"
+												   (ghostel-test--wait-for-pty-reply 0 proc 6)))))))
 
 (ert-deftest ghostel-test-fish-backspace ()
   "Test backspace works with fish shell."
@@ -729,6 +726,25 @@ stubbed nil and `ghostel--remote-shell-p' stubbed t."
                     ((symbol-function 'ghostel--remote-shell-p)
                      (lambda () t)))
             (should-not (ghostel--password-prompt-detected-p))))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-password-detect-remote-skips-pty-probe ()
+  "Remote password detection must not inspect a nonexistent local pty."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-pwd-remote-skip-pty*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term (ghostel--new 5 80 1000))
+          (setq ghostel--term-rows 5)
+          (ghostel--write-vt ghostel--term "Password: ")
+          (let ((inhibit-read-only t))
+            (ghostel--redraw ghostel--term t))
+          (cl-letf (((symbol-function 'ghostel--pty-password-input-p)
+                     (lambda (_term) (error "Local PTY probe should be skipped")))
+                    ((symbol-function 'ghostel--remote-shell-p)
+                     (lambda () t)))
+            (should (eq (ghostel--password-prompt-detected-p) 'regex))))
       (when (buffer-live-p buf) (kill-buffer buf)))))
 
 (ert-deftest ghostel-test-password-detect-skips-regex-on-local ()

--- a/test/ghostel-spawn-test.el
+++ b/test/ghostel-spawn-test.el
@@ -2,7 +2,7 @@
 
 ;;; Commentary:
 
-;; Local shell resolution, login wrapping, PTY process startup, resize signaling,
+;; Local shell resolution, login wrapping, PTY process startup and resizing,
 ;; and pre-spawn hook environment injection.
 
 ;;; Code:
@@ -51,25 +51,6 @@ need to exercise the PTY matrix here."
        ,@body)
      (should ,capture)))
 
-(defconst ghostel-test--pty-winsize-script
-  (string-join
-   '("import os, signal, sys, time"
-     "fd = sys.stdout.fileno()"
-     "def report(tag):"
-     "    sz = os.get_terminal_size(fd)"
-     "    sys.stdout.write('GHOSTEL_WINSIZE_%s:%d,%d\\r\\n' % (tag, sz.lines, sz.columns))"
-     "    sys.stdout.flush()"
-     "signal.signal(signal.SIGWINCH, lambda *_: report('WINCH'))"
-     "report('INIT')"
-     "deadline = time.time() + 10"
-     "while time.time() < deadline:"
-     "    time.sleep(0.05)")
-   "\n")
-  "Python code that reports its PTY window size as the child of a ghostel term.
-Writes `GHOSTEL_WINSIZE_INIT:ROWS,COLS' at startup and
-`GHOSTEL_WINSIZE_WINCH:ROWS,COLS' on every SIGWINCH, so tests can assert
-the dimensions the child actually sees on each PTY backend.")
-
 (defconst ghostel-test--pty-read-dc1-script
   (string-join
    '("import sys"
@@ -93,7 +74,7 @@ this distinguishes a PTY that honors `-ixon' from one that does not.")
 (defun ghostel-test--latest-winsize (tag)
   "Return the most recent (ROWS . COLS) reported for TAG, or nil.
 Scans the terminal text for the last `GHOSTEL_WINSIZE_TAG:R,C' marker
-written by `ghostel-test--pty-winsize-script'."
+written by the portable PTY test helper."
   (let ((text (or (ghostel--copy-all-text ghostel--term) ""))
         (re (format "GHOSTEL_WINSIZE_%s:\\([0-9]+\\),\\([0-9]+\\)" tag))
         (start 0)
@@ -192,6 +173,16 @@ The type-aware default is applied later, at spawn time."
   (let ((default-directory "/ssh:host:/home/u/")
         (ghostel-tramp-shells '(("ssh" "/bin/zsh"))))
     (should (equal '("/bin/zsh") (ghostel--resolve-shell-spec)))))
+
+(ert-deftest ghostel-test-resolve-shell-spec-sshx-uses-login-shell ()
+  "The sshx method uses a remote shell, not the local fallback shell."
+  (cl-letf (((symbol-function 'process-file-shell-command)
+             (lambda (&rest _)
+               (insert "u:x:1000:1000::/home/u:/bin/bash\n")
+               0)))
+    (let ((default-directory "/sshx:host:/home/u/")
+          (ghostel-shell "cmd.exe"))
+      (should (equal '("/bin/bash") (ghostel--resolve-shell-spec))))))
 
 (ert-deftest ghostel-test-start-process-remote-adds-login-interactive ()
   "A recognized remote shell is started login+interactive by default."
@@ -338,7 +329,8 @@ pushed terminfo dir is needed for the whole session besides."
       (should (equal "--norc" (nth 4 args)))
       (should (equal "-c" (nth 5 args)))
       ;; exec -l <quoted-program>; no extra args.
-      (should (equal "exec -l /bin/zsh" (nth 6 args))))))
+      (should (equal (format "exec -l %s" (shell-quote-argument "/bin/zsh"))
+                     (nth 6 args))))))
 
 (ert-deftest ghostel-test-macos-login-wrap-hushlogin ()
   "When ~/.hushlogin exists, -q is prepended."
@@ -358,7 +350,11 @@ pushed terminfo dir is needed for the whole session besides."
             ((symbol-function 'file-exists-p) (lambda (_) nil)))
     (let* ((wrap (ghostel--macos-login-wrap "/bin/bash" '("--login" "--posix")))
            (cmd (nth 6 (cdr wrap))))
-      (should (equal "exec -l /bin/bash --login --posix" cmd)))))
+      (should (equal (concat "exec -l "
+                             (mapconcat #'shell-quote-argument
+                                        '("/bin/bash" "--login" "--posix")
+                                        " "))
+                     cmd)))))
 
 (ert-deftest ghostel-test-start-process-darwin-login-wrap ()
   "On darwin with `ghostel-macos-login-shell', wrap shell via `/usr/bin/login'."
@@ -503,7 +499,7 @@ former defaulted to t and throttled bursty TUI redraws."
 
 (ert-deftest ghostel-test-spawn-emacs-pty-enables-input-echo ()
   "The Emacs PTY path enables input echo before PROGRAM reads."
-  :tags '(native)
+  :tags '(native posix)
   (skip-unless (file-executable-p "/bin/sh"))
   (let ((ghostel-use-native-pty nil)
         (ghostel-kill-buffer-on-exit nil))
@@ -519,50 +515,45 @@ former defaulted to t and throttled bursty TUI redraws."
                                 (ghostel-test--terminal-text)))))))
 
 (ert-deftest ghostel-test-spawn-process-resolves-bare-program-from-exec-path ()
-  "A bare local PROGRAM resolves via variable `exec-path' before backend dispatch.
-This deliberately makes variable `exec-path' and the child PATH disagree: the
-probe program exists only on variable `exec-path', not in `process-environment'."
-  :tags '(native)
-  (let* ((dir (file-name-as-directory (make-temp-file "ghostel-path-" t)))
-         (exec-dir (directory-file-name dir))
-         (program-name "ghostel-path-probe")
-         (program-path (expand-file-name program-name dir)))
-    (unwind-protect
-        (progn
-          (with-temp-file program-path
-            (insert "#!/bin/sh\nprintf 'GHOSTEL_PATH_PROBE:%s\\n' \"$0\"\n"))
-          (set-file-modes program-path #o755)
-          (ghostel-test--with-pty-matrix backend
-            (let* ((child-path (string-join '("/usr/bin" "/bin")
-                                             path-separator))
-                   (process-environment `(,(format "PATH=%s" child-path) "HOME=/tmp"))
-                   (exec-path (list exec-dir "/usr/bin" "/bin"))
-                   (ghostel-kill-buffer-on-exit nil)
-                   (default-directory "/tmp/"))
-              (should-not (member exec-dir
-                                  (split-string (getenv "PATH") path-separator t)))
-              (let ((found (executable-find program-name)))
-                (should found)
-                (should (file-equal-p program-path found)))
-              (ghostel-test--with-terminal-buffer (buf term 24 80 1000)
-                (let ((proc (ghostel--spawn-process program-name nil nil)))
-                  (ghostel-test--wait-for-text "GHOSTEL_PATH_PROBE:" proc 3)
-                  (should (ghostel-test--terminal-text-line-p
-                           (format "GHOSTEL_PATH_PROBE:%s" program-path))))))))
-      (delete-directory dir t))))
+  "A bare local program resolves via variable `exec-path' before backend dispatch."
+  (let* ((program (file-name-nondirectory invocation-name))
+         (expected (expand-file-name invocation-name invocation-directory))
+         (exec-path (list invocation-directory))
+         (process-environment '("PATH="))
+         (ghostel-use-native-pty t)
+         captured)
+    (cl-letf (((symbol-function 'ghostel--spawn-via-native)
+               (lambda (command) (setq captured command))))
+      (ghostel--spawn-process program '("--probe") nil))
+    (should (file-equal-p expected (car captured)))
+    (should (equal '("--probe") (cdr captured)))))
+
+(defconst ghostel-test--pty-winsize-script
+  (string-join
+   '("import os, sys, time"
+     "fd = sys.stdout.fileno()"
+     "def report(tag, size):"
+     "    sys.stdout.write('GHOSTEL_WINSIZE_%s:%d,%d\\r\\n' % (tag, size.lines, size.columns))"
+     "    sys.stdout.flush()"
+     "initial = os.get_terminal_size(fd)"
+     "report('INIT', initial)"
+     "deadline = time.time() + 10"
+     "while time.time() < deadline:"
+     "    current = os.get_terminal_size(fd)"
+     "    if current != initial:"
+     "        report('RESIZE', current)"
+     "        break"
+     "    time.sleep(0.05)")
+   "\n")
+  "Python code that reports initial and changed PTY dimensions.")
 
 (ert-deftest ghostel-test-spawn-initial-winsize-reaches-child ()
-  "The child PTY is sized to the terminal dimensions at spawn.
-On the native path the PTY is opened at the term's rows/cols; on the
-Emacs path `ghostel--spawn-via-emacs' calls `set-process-window-size'.
-Either way the child must read those dimensions, so this drives a real
-child through both backends and asserts the size it sees."
+  "The child PTY is sized to the terminal dimensions at spawn."
   :tags '(native)
-  (let ((python (executable-find "python3")))
-    (skip-unless python)
+  (let ((python (ghostel-test--python)))
     (ghostel-test--with-pty-matrix backend
       (ghostel-test--with-exec-buffer
-          (buf proc python (list "-c" ghostel-test--pty-winsize-script))
+          (buf proc python (list "-u" "-c" ghostel-test--pty-winsize-script))
         ;; ghostel-exec sizes an undisplayed buffer's term to 80x24.
         (let ((got (ghostel-test--wait-until
                     (lambda () (ghostel-test--latest-winsize "INIT")) proc 6)))
@@ -575,7 +566,7 @@ DC1 and DC3; ghostel disables it — natively in C
 \(`PtyProcess'), and via `-ixon' in the Emacs-path `stty' wrapper — so
 the direct key binding and send-next-key can deliver these bytes.
 Driven through both PTY backends."
-  :tags '(native)
+  :tags '(native posix)
   (let ((python (executable-find "python3")))
     (skip-unless python)
     (ghostel-test--with-pty-matrix backend
@@ -596,29 +587,20 @@ Driven through both PTY backends."
           (should (string-match-p "GHOSTEL_GOTBYTE:DC1" report)))))))
 
 (ert-deftest ghostel-test-resize-redraw-delivers-new-winsize-to-child ()
-  "Resize + redraw delivers SIGWINCH carrying the NEW size to the child.
-`ghostel--set-size' stages a pending resize that `ghostel--redraw'
-commits; committing resizes the PTY (native `pty.resize') or calls
-`set-process-window-size' (Emacs), both of which raise SIGWINCH on the
-child's process group.  The child must then read the new dimensions,
-not the old ones — verified on both PTY backends."
+  "Resize + redraw makes the new PTY size visible to the child."
   :tags '(native)
-  (let ((python (executable-find "python3")))
-    (skip-unless python)
+  (let ((python (ghostel-test--python)))
     (ghostel-test--with-pty-matrix backend
       (ghostel-test--with-exec-buffer
-          (buf proc python (list "-c" ghostel-test--pty-winsize-script))
-        ;; Confirm the child is up and reading the initial 80x24.
+          (buf proc python (list "-u" "-c" ghostel-test--pty-winsize-script))
         (should (equal '(24 . 80)
                        (ghostel-test--wait-until
                         (lambda () (ghostel-test--latest-winsize "INIT")) proc 6)))
-        ;; Stage a new size and commit it with a redraw, which fires SIGWINCH.
         (ghostel--set-size-with-cell-dims ghostel--term 30 100)
         (ghostel-test--redraw ghostel--term t)
-        ;; The child's SIGWINCH handler must report the new size, not the old.
         (should (ghostel-test--wait-until
                  (lambda () (equal '(30 . 100)
-                                   (ghostel-test--latest-winsize "WINCH")))
+                                   (ghostel-test--latest-winsize "RESIZE")))
                  proc 6))))))
 
 (ert-deftest ghostel-test-pre-spawn-hook-injects-into-process-environment ()
@@ -636,12 +618,12 @@ intact (with-editor's `with-editor--setup' reads `default-directory')."
   (ghostel-test--with-pty-matrix backend
     (let (captured-buffer
           captured-default-directory)
-      (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
-             (ghostel-shell '("/bin/sh" "-c" "env; printf GHOSTEL_ENV_DONE"))
+      (let* ((process-environment (ghostel-test--base-process-environment))
+             (ghostel-shell (ghostel-test--env-done-command))
              (ghostel-shell-integration nil)
              (ghostel-macos-login-shell nil)
              (ghostel-kill-buffer-on-exit nil)
-             (default-directory "/tmp/")
+             (default-directory (ghostel-test--temp-directory))
              (ghostel-pre-spawn-hook
               (list (lambda ()
                       (setq captured-buffer (current-buffer))
@@ -653,7 +635,7 @@ intact (with-editor's `with-editor--setup' reads `default-directory')."
                        (ghostel-test--wait-for-text "GHOSTEL_ENV_DONE" proc 5)
                        (should (eq captured-buffer test-buffer))
                        (ghostel-test--terminal-text)))))
-        (should (equal captured-default-directory "/tmp/"))
+        (should (equal captured-default-directory default-directory))
         (should (ghostel-test--terminal-text-line-p
                  "GHOSTEL_PRE_SPAWN_TEST=ok" text))))))
 
@@ -661,13 +643,9 @@ intact (with-editor's `with-editor--setup' reads `default-directory')."
   "Child process starts in `default-directory', including abbreviated home paths."
   :tags '(native)
   (let* ((home-dir (file-name-as-directory (expand-file-name "~")))
-         (test-dir (file-name-directory
-                    (or (locate-library "ghostel-spawn-test")
-                        buffer-file-name
-                        default-directory)))
          (tmpdir (file-name-as-directory
                   (make-temp-file (expand-file-name "ghostel-cwd-test-"
-                                                     test-dir)
+                                                    home-dir)
                                   t)))
          (default-directory (abbreviate-file-name tmpdir))
          (expected-cwd (directory-file-name (file-truename tmpdir))))
@@ -676,11 +654,14 @@ intact (with-editor's `with-editor--setup' reads `default-directory')."
           (should (string-prefix-p "~/" default-directory))
           (ghostel-test--with-pty-matrix backend
             (let* ((process-environment
-                    `(,(format "HOME=%s" (directory-file-name home-dir))
-                      "PATH=/usr/bin:/bin"))
+                    (cons (format "HOME=%s" (directory-file-name home-dir))
+                          (ghostel-test--base-process-environment)))
                    (ghostel-shell
-                    '("/bin/sh" "-c"
-                      "printf 'GHOSTEL_CWD:%s\\n' \"$(pwd -P)\"; printf GHOSTEL_CWD_DONE"))
+                    (if (ghostel-test--windows-p)
+                        (ghostel-test--shell-command
+                         "echo GHOSTEL_CWD:%CD:\\=/% & echo GHOSTEL_CWD_DONE")
+                      '("/bin/sh" "-c"
+                        "printf 'GHOSTEL_CWD:%s\\n' \"$(pwd -P)\"; printf GHOSTEL_CWD_DONE")))
                    (ghostel-shell-integration nil)
                    (ghostel-macos-login-shell nil)
                    (ghostel-kill-buffer-on-exit nil)

--- a/test/ghostel-test-helpers.el
+++ b/test/ghostel-test-helpers.el
@@ -5,7 +5,7 @@
 ;; Helpers shared across the per-topic test files (ghostel-*-test.el).
 ;; Also defines the batch runner functions used by the Makefile:
 ;; `ghostel-test-run-elisp' and `ghostel-test-run-native' select via the
-;; `native' ERT tag (set per-test in files that require the Zig module).
+;; `native' and `posix' ERT tags.
 
 ;;; Code:
 
@@ -111,6 +111,49 @@ run; only a genuinely slow startup (or a failing predicate) waits the
 extra time.  Override with the `GHOSTEL_TEST_TIMEOUT_SCALE'
 environment variable (must parse to a positive number).")
 
+(defun ghostel-test--windows-p ()
+  "Return non-nil when the tests are running on native Windows."
+  (eq system-type 'windows-nt))
+
+(defun ghostel-test--posix-p ()
+  "Return non-nil when the tests are running on a POSIX-like system."
+  (not (ghostel-test--windows-p)))
+
+(defun ghostel-test--temp-directory ()
+  "Return a writable local directory for spawned test processes."
+  (file-name-as-directory (expand-file-name temporary-file-directory)))
+
+(defun ghostel-test--shell-command (script)
+  "Return a command list that runs SCRIPT in the platform shell."
+  (if (ghostel-test--windows-p)
+      (list (or (getenv "COMSPEC") "cmd.exe") "/s" "/d" "/c" script)
+    (list "/bin/sh" "-c" script)))
+
+(defun ghostel-test--env-command ()
+  "Return a command list that prints the process environment."
+  (if (ghostel-test--windows-p)
+      (ghostel-test--shell-command "set")
+    (list (executable-find "env"))))
+
+(defun ghostel-test--env-done-command ()
+  "Return a shell command that prints the environment and a done marker."
+  (if (ghostel-test--windows-p)
+      (ghostel-test--shell-command "set & echo GHOSTEL_ENV_DONE")
+    '("/bin/sh" "-c" "env; printf GHOSTEL_ENV_DONE")))
+
+(defun ghostel-test--base-process-environment ()
+  "Return a small process environment suitable for native spawn tests."
+  (if (ghostel-test--windows-p)
+      (delq nil
+            (list (and (getenv "SystemRoot")
+                       (format "SystemRoot=%s" (getenv "SystemRoot")))
+                  (and (getenv "COMSPEC")
+                       (format "COMSPEC=%s" (getenv "COMSPEC")))
+                  (format "PATH=%s" (or (getenv "PATH") ""))
+                  (format "TEMP=%s" (or (getenv "TEMP")
+                                         (ghostel-test--temp-directory)))))
+    '("PATH=/usr/bin:/bin" "HOME=/tmp")))
+
 (defun ghostel-test--wait-for (proc pred &optional timeout)
   "Poll PROC until PRED returns non-nil, or TIMEOUT seconds (default 5).
 Signal an ERT failure if TIMEOUT is reached or PROC exits before PRED
@@ -131,11 +174,16 @@ succeeds.  TIMEOUT is scaled by `ghostel-test--timeout-scale'."
 
 (defmacro ghostel-test--with-pty-matrix (backend &rest body)
   "Run BODY once per local PTY backend.
-BACKEND is bound to `emacs-pty' and `native-pty' in turn.  The
-corresponding `ghostel-use-native-pty' value is let-bound around
-BODY, and failures include the backend name in ERT output."
+BACKEND is bound to `emacs-pty' and `native-pty' in turn on POSIX.
+On Windows, only `native-pty' is exercised because these tests target
+ConPTY and Emacs does not provide the POSIX PTY setup used by the
+`emacs-pty' branch.  The corresponding `ghostel-use-native-pty' value
+is let-bound around BODY, and failures include the backend name in ERT
+output."
   (declare (indent 1))
-  `(dolist (entry '((emacs-pty . nil) (native-pty . t)))
+  `(dolist (entry (if (ghostel-test--windows-p)
+                      '((native-pty . t))
+                    '((emacs-pty . nil) (native-pty . t))))
      (let ((,backend (car entry))
            (ghostel-use-native-pty (cdr entry)))
        (ert-info ((format "backend: %S" ,backend))
@@ -149,12 +197,16 @@ BUFFER defaults to the current buffer."
 
 (defun ghostel-test--cleanup-exec-buffer (buffer)
   "Best-effort cleanup for a ghostel exec BUFFER."
+  ;; Test cleanup is forceful: start child termination before releasing
+  ;; native state.
+  (when (buffer-live-p buffer)
+    (let ((process (buffer-local-value 'ghostel--process buffer)))
+      (when (and process (process-live-p process))
+        (ignore-errors (delete-process process)))))
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (when ghostel--term
         (ignore-errors (ghostel--kill-native-process ghostel--term)))
-      (when (process-live-p ghostel--process)
-        (ignore-errors (delete-process ghostel--process)))
       (when ghostel--redraw-timer
         (cancel-timer ghostel--redraw-timer)
         (setq ghostel--redraw-timer nil))
@@ -162,6 +214,10 @@ BUFFER defaults to the current buffer."
         (cancel-timer ghostel--plain-link-detection-timer)
         (setq ghostel--plain-link-detection-timer nil)))
     (kill-buffer buffer)))
+
+(defun ghostel-test--dummy-process (name buffer)
+  "Return a live pipe process named NAME attached to BUFFER."
+  (make-pipe-process :name name :buffer buffer :noquery t))
 
 (defmacro ghostel-test--with-exec-buffer (spec &rest body)
   "Run BODY in a fresh ghostel buffer running PROGRAM.
@@ -181,32 +237,73 @@ to the lifecycle process returned by `ghostel-exec'; see
              ,@body)
          (ghostel-test--cleanup-exec-buffer ,buffer)))))
 
-(defmacro ghostel-test--with-raw-cat-buffer (spec &rest body)
-  "Run BODY in a fresh ghostel buffer backed by a raw `/bin/cat'.
-SPEC is (BUFFER PROCESS).  The child PTY is switched to raw/no-echo
-before `cat' starts, so bytes written with `ghostel--write-pty' are
-round-tripped to ghostel as terminal output without line-discipline
-rewriting."
+(defvar ghostel-test--python-executable :unknown
+  "Cached Python 3 executable used by integration tests.")
+
+(defun ghostel-test--python ()
+  "Return a Python 3 executable, or skip the current test."
+  (when (eq ghostel-test--python-executable :unknown)
+    (setq ghostel-test--python-executable
+          (cl-find-if
+           (lambda (program)
+             (and program
+                  (eql 0 (call-process
+                          program nil nil nil "-c"
+                          "import sys; raise SystemExit(sys.version_info[0] != 3)"))))
+           (list (executable-find "python3")
+                 (executable-find "python")))))
+  (or ghostel-test--python-executable
+      (ert-skip "Python 3 is unavailable")))
+
+(defun ghostel-test--fixture-directory ()
+  "Return the absolute path of the test fixture directory."
+  (expand-file-name
+   "fixtures"
+   (file-name-directory (locate-library "ghostel-test-helpers"))))
+
+(defconst ghostel-test--raw-echo-script
+  (string-join
+   '("import os, sys"
+     "sys.path.insert(0, sys.argv[1])"
+     "from pty_setup import set_raw_stdio"
+     "set_raw_stdio()"
+     "stdin_fd = sys.stdin.fileno()"
+     "stdout_fd = sys.stdout.fileno()"
+     "def write_all(data):"
+     "    while data:"
+     "        data = data[os.write(stdout_fd, data):]"
+     "write_all(b'GHOSTEL_RAW_ECHO_READY')"
+     "while True:"
+     "    data = os.read(stdin_fd, 4096)"
+     "    if not data:"
+     "        break"
+     "    write_all(data)")
+   "\n")
+  "Python code that copies raw PTY input to output.")
+
+(defmacro ghostel-test--with-raw-echo-buffer (spec &rest body)
+  "Run BODY in a fresh ghostel buffer backed by a raw byte echo process.
+SPEC is (BUFFER PROCESS).  Bytes written with `ghostel--write-pty' are
+returned as terminal output without line-discipline rewriting."
   (declare (indent 1))
   (pcase-let ((`(,buffer ,process) spec))
-    `(progn
-       (skip-unless (and (file-executable-p "/bin/sh")
-                         (file-executable-p "/bin/cat")))
-       (let ((,buffer (generate-new-buffer " *ghostel-test-raw-cat*"))
-             (,process nil)
-             (ghostel-kill-buffer-on-exit nil))
-         (unwind-protect
-             (with-current-buffer ,buffer
-               (let ((ghostel-detect-password-prompts nil))
-                 (setq ,process
-                       (ghostel-exec
-                        ,buffer "/bin/sh"
-                        '("-c" "stty raw -echo; printf GHOSTEL_RAW_CAT_READY; exec /bin/cat"))))
-               (setq-local ghostel-detect-password-prompts nil)
-               (ghostel-test--wait-for-text "GHOSTEL_RAW_CAT_READY"
-                                            ,process 5)
-               ,@body)
-           (ghostel-test--cleanup-exec-buffer ,buffer))))))
+    `(let ((python (ghostel-test--python))
+           (,buffer (generate-new-buffer " *ghostel-test-raw-echo*"))
+           (,process nil)
+           (ghostel-kill-buffer-on-exit nil))
+       (unwind-protect
+           (with-current-buffer ,buffer
+             (let ((ghostel-detect-password-prompts nil))
+               (setq ,process
+                     (ghostel-exec
+                      ,buffer python
+                      (list "-u" "-c" ghostel-test--raw-echo-script
+                            (ghostel-test--fixture-directory)))))
+             (setq-local ghostel-detect-password-prompts nil)
+             (ghostel-test--wait-for-text "GHOSTEL_RAW_ECHO_READY"
+                                          ,process 5)
+             ,@body)
+         (ghostel-test--cleanup-exec-buffer ,buffer)))))
 
 (defun ghostel-test--hex-encode-string (string)
   "Return lowercase hex for STRING's raw bytes."
@@ -216,34 +313,49 @@ rewriting."
 
 (defconst ghostel-test--pty-reply-probe-script
   (string-join
-   '("import os, select, sys, tty, time"
-     "fd = sys.stdin.fileno()"
-     "if os.isatty(fd):"
-     "    tty.setraw(fd)"
-     "timeout = float(sys.argv[1])"
-     "payloads = sys.argv[2:]"
+   '("import os, queue, sys, threading, time"
+     "sys.path.insert(0, sys.argv[1])"
+     "from pty_setup import set_raw_stdio"
+     "set_raw_stdio()"
+     "stdin_fd = sys.stdin.fileno()"
+     "stdout_fd = sys.stdout.fileno()"
+     "timeout = float(sys.argv[2])"
+     "payloads = sys.argv[3:]"
+     "input_queue = queue.Queue()"
+     "def read_input():"
+     "    while True:"
+     "        chunk = os.read(stdin_fd, 4096)"
+     "        input_queue.put(chunk)"
+     "        if not chunk:"
+     "            return"
+     "def write_all(data):"
+     "    while data:"
+     "        data = data[os.write(stdout_fd, data):]"
+     "threading.Thread(target=read_input, daemon=True).start()"
      "for idx, payload_hex in enumerate(payloads):"
-     "    sys.stdout.buffer.write(bytes.fromhex(payload_hex))"
-     "    sys.stdout.buffer.flush()"
-     "    buf = b''"
-     "    deadline = time.time() + timeout"
-     "    while time.time() < deadline:"
-     "        readable, _, _ = select.select([fd], [], [], 0.02)"
-     "        if not readable:"
-     "            continue"
-     "        chunk = os.read(fd, 4096)"
+     "    write_all(bytes.fromhex(payload_hex))"
+     "    buf = bytearray()"
+     "    deadline = time.monotonic() + timeout"
+     "    while True:"
+     "        remaining = deadline - time.monotonic()"
+     "        if remaining <= 0:"
+     "            break"
+     "        try:"
+     "            chunk = input_queue.get(timeout=remaining)"
+     "        except queue.Empty:"
+     "            break"
      "        if not chunk:"
      "            break"
-     "        buf += chunk"
+     "        buf.extend(chunk)"
      "    marker = ('\\r\\nGHOSTEL_PTY_REPLY_%d_HEX:' % idx).encode('ascii')"
-     "    sys.stdout.buffer.write(marker + buf.hex().encode('ascii') + b'\\r\\n')"
-     "    sys.stdout.buffer.flush()")
+     "    write_all(marker + buf.hex().encode('ascii') + b'\\r\\n')")
    "\n")
   "Python code that writes hex payloads and reports PTY replies.
-The first argument is a per-payload read timeout in seconds.  Remaining
-arguments are hex-encoded payloads to write to stdout.  After each write,
-the script prints `GHOSTEL_PTY_REPLY_N_HEX:' followed by any reply bytes
-read from stdin as lowercase hex.")
+The first argument locates the portable PTY setup module, the second is
+a per-payload read timeout in seconds, and the rest are hex-encoded
+payloads to write to stdout.  After each write, the script prints
+`GHOSTEL_PTY_REPLY_N_HEX:' followed by any reply bytes read from stdin
+as lowercase hex.")
 
 (defun ghostel-test--wait-for-pty-reply (index &optional process timeout)
   "Return reply hex for PTY probe reply INDEX.
@@ -361,17 +473,35 @@ runs are unaffected."
 
 (ghostel-test--enable-start-logging)
 
+(defun ghostel-test--elisp-selector ()
+  "Return the ERT selector for pure Elisp tests on the current platform."
+  (if (ghostel-test--windows-p)
+      '(and (not (tag native)) (not (tag posix)))
+    '(not (tag native))))
+
 (defun ghostel-test-run-elisp ()
-  "Run only pure Elisp tests (no native module required)."
-  (ert-run-tests-batch-and-exit '(not (tag native))))
+  "Run only pure Elisp tests for this platform."
+  (ert-run-tests-batch-and-exit (ghostel-test--elisp-selector)))
+
+(defun ghostel-test--native-selector ()
+  "Return the ERT selector for native tests on the current platform."
+  (if (ghostel-test--windows-p)
+      '(and (tag native) (not (tag posix)))
+    '(tag native)))
 
 (defun ghostel-test-run-native ()
-  "Run only tests that require the native module."
-  (ert-run-tests-batch-and-exit '(tag native)))
+  "Run only tests that require the native module for this platform."
+  (ert-run-tests-batch-and-exit (ghostel-test--native-selector)))
+
+(defun ghostel-test--all-selector ()
+  "Return the ERT selector for all tests on the current platform."
+  (if (ghostel-test--windows-p)
+      '(and "^ghostel-test-" (not (tag posix)))
+    "^ghostel-test-"))
 
 (defun ghostel-test-run ()
-  "Run all ghostel tests."
-  (ert-run-tests-batch-and-exit "^ghostel-test-"))
+  "Run all ghostel tests for this platform."
+  (ert-run-tests-batch-and-exit (ghostel-test--all-selector)))
 
 (provide 'ghostel-test-helpers)
 ;;; ghostel-test-helpers.el ends here

--- a/test/ghostel-tramp-test.el
+++ b/test/ghostel-tramp-test.el
@@ -8,6 +8,10 @@
 
 (require 'ghostel-test-helpers)
 
+(defun ghostel-test--remote-assignment-regexp (name value)
+  "Return a regexp matching NAME=VALUE with optional shell quotes."
+  (format "\\b%s=\\\"?%s\\\"?;" name (regexp-quote value)))
+
 (ert-deftest ghostel-test-remote-term-preamble ()
   "`ghostel--remote-term-preamble' embeds an `infocmp' probe.
 The probe runs *on the remote* (inside the per-spawn wrapper), so
@@ -25,11 +29,17 @@ and absent (fall back to `xterm-256color' so echo works)."
   (let* ((ghostel-term "xterm-ghostty")
          (preamble (ghostel--remote-term-preamble)))
     ;; Default value for the case infocmp fails.
-    (should (string-match-p "\\bTERM=xterm-256color;" preamble))
+    (should (string-match-p
+             (ghostel-test--remote-assignment-regexp "TERM" "xterm-256color")
+             preamble))
     ;; Probe and conditional upgrade.
     (should (string-match-p "infocmp xterm-ghostty" preamble))
-    (should (string-match-p "\\bTERM=xterm-ghostty;" preamble))
-    (should (string-match-p "TERM_PROGRAM=ghostty;" preamble))
+    (should (string-match-p
+             (ghostel-test--remote-assignment-regexp "TERM" "xterm-ghostty")
+             preamble))
+    (should (string-match-p
+             (ghostel-test--remote-assignment-regexp "TERM_PROGRAM" "ghostty")
+             preamble))
     (should (string-match-p "TERM_PROGRAM_VERSION=" preamble))
     ;; Co-located bundle gets prepended to TERMINFO_DIRS — so a
     ;; user can `scp` the terminfo dir alongside the shell
@@ -66,12 +76,16 @@ and absent (fall back to `xterm-256color' so echo works)."
     (should-not (string-match-p "infocmp" preamble))
     (should-not (string-match-p "TERM_PROGRAM=ghostty" preamble))
     (should-not (string-match-p "TERMINFO_DIRS" preamble))
-    (should (string-match-p "TERM=xterm-256color" preamble))
+    (should (string-match-p
+             (ghostel-test--remote-assignment-regexp "TERM" "xterm-256color")
+             preamble))
     (should (string-match-p "COLORTERM=truecolor" preamble)))
   (let* ((ghostel-term "screen-256color")
          (preamble (ghostel--remote-term-preamble)))
     (should-not (string-match-p "infocmp" preamble))
-    (should (string-match-p "TERM=screen-256color" preamble))))
+    (should (string-match-p
+             (ghostel-test--remote-assignment-regexp "TERM" "screen-256color")
+             preamble))))
 
 (ert-deftest ghostel-test-spawn-pty-uses-remote-term-preamble ()
   "`ghostel--spawn-pty' embeds the remote preamble in the wrapper script.
@@ -117,7 +131,8 @@ Local spawns must not get the preamble; their TERM still rides in
       (setq captured-env nil
             captured-cmd nil)
       (let ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp")))
-        (ghostel--spawn-pty "/bin/sh" nil nil nil)
+        (pcase-let ((`(,program . ,args) (ghostel-test--shell-command "")))
+          (ghostel--spawn-pty program args nil nil))
         (let ((script (nth 2 captured-cmd)))
           (should-not (string-match-p "infocmp" script))
           (should (member "TERM=xterm-ghostty" captured-env)))))))


### PR DESCRIPTION
- ConPTY pseudoconsole backend for Windows terminal I/O
- Transport abstractions (ghostel--process-send/live-p/set-window-size) that dispatch to ConPTY or PTY depending on the active backend
- Windows-specific process startup skipping the shell wrapper
- ConPTY module build via emacs-util-mods dependency
- Release artifacts packaged as per-platform .tar.xz archives containing ghostel-module + conpty-module (Windows)
- Download/extract flow for .tar.xz release archives
- Windows entries in CI build and test matrix
- 7 new ConPTY tests + extract-module-archive test