### PR TITLE
Add ghostel-eshell-visual-command-mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ XDG_CACHE_HOME ?= $(HOME)/.cache
 MELPAZOID_DIR  ?= $(XDG_CACHE_HOME)/melpazoid
 EVIL_DIR       ?= $(XDG_CACHE_HOME)/evil
 
-ELC := ghostel.elc ghostel-debug.elc ghostel-compile.elc
+ELC := ghostel.elc ghostel-debug.elc ghostel-compile.elc ghostel-eshell.elc
 
 .PHONY: all build test test-native test-all test-evil lint melpazoid byte-compile bench bench-quick clean
 
@@ -53,7 +53,7 @@ checkdoc:
 		              (checkdoc-proper-noun-list nil) \
 		              (checkdoc-verb-check-experimental-flag nil) \
 		              (ok t)) \
-		  (dolist (f '(\"ghostel.el\" \"ghostel-debug.el\" \"ghostel-compile.el\" \"evil-ghostel.el\")) \
+		  (dolist (f '(\"ghostel.el\" \"ghostel-debug.el\" \"ghostel-compile.el\" \"ghostel-eshell.el\" \"evil-ghostel.el\")) \
 		    (ignore-errors (kill-buffer \"*Warnings*\")) \
 		    (let ((inhibit-message t)) \
 		      (checkdoc-file f)) \

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ process, keymap, and buffer.
 - [Configuration](#configuration)
 - [Commands](#commands)
   - [Compilation mode](#compilation-mode)
+  - [Eshell integration](#eshell-integration)
 - [Running Tests](#running-tests)
 - [Performance](#performance)
 - [Ghostel vs vterm](#ghostel-vs-vterm)
@@ -536,14 +537,14 @@ was invoked from, regardless of which buffer you're in when you press
 
 Ghostel-specific customisation:
 
-| Option                                | Effect                                                                                                          |
-|---------------------------------------|-----------------------------------------------------------------------------------------------------------------|
-| `ghostel-compile-buffer-name`         | Buffer name (default `*ghostel-compile*`)                                                                        |
+| Option                                | Effect                                                                                                             |
+|---------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| `ghostel-compile-buffer-name`         | Buffer name (default `*ghostel-compile*`)                                                                          |
 | `ghostel-compile-finished-major-mode` | Major mode to switch to after each run (default `ghostel-compile-view-mode`; set to nil to stay in `ghostel-mode`) |
-| `ghostel-compile-hide-prompts`        | Hide surrounding shell prompts (default `t`)                                                                     |
-| `ghostel-compile-clear-buffer`        | Clear the buffer before each run (default `t`)                                                                   |
-| `ghostel-compile-finish-functions`    | Ghostel-specific finish hook (runs alongside `compilation-finish-functions`)                                     |
-| `ghostel-compile-debug`               | Log every OSC 133 C/D event to `*Messages*` (default `nil`)                                                      |
+| `ghostel-compile-hide-prompts`        | Hide surrounding shell prompts (default `t`)                                                                       |
+| `ghostel-compile-clear-buffer`        | Clear the buffer before each run (default `t`)                                                                     |
+| `ghostel-compile-finish-functions`    | Ghostel-specific finish hook (runs alongside `compilation-finish-functions`)                                       |
+| `ghostel-compile-debug`               | Log every OSC 133 C/D event to `*Messages*` (default `nil`)                                                        |
 
 Completion is detected via the OSC 133 `D;<exit>` semantic prompt
 marker, so shell integration (`ghostel-shell-integration`, enabled by
@@ -561,6 +562,49 @@ command in *any* ghostel buffer:
 
 Errors raised by individual hook functions are caught and logged so
 one bad consumer can't break the rest.
+
+### Eshell integration
+
+`ghostel-eshell-visual-command-mode` makes eshell run "visual" commands
+— programs in `eshell-visual-commands`, `eshell-visual-subcommands`,
+and `eshell-visual-options` (vim, htop, less, top, `git log`'s pager,
+…) — inside a dedicated ghostel buffer instead of the default
+`term-mode` fallback, so they get a real terminal emulator.
+
+```elisp
+(require 'ghostel-eshell)
+(add-hook 'eshell-load-hook #'ghostel-eshell-visual-command-mode)
+```
+
+When the program exits, the buffer stays on `[Process exited]` so
+you can read any remaining output (window point snaps to the end so
+it's visible without scrolling).  Press `q` to dismiss the dead
+buffer.  Set `eshell-destroy-buffer-when-process-dies` to `t` to
+kill the buffer automatically on exit instead.
+
+To run an ad-hoc command in a ghostel buffer without editing
+`eshell-visual-commands`, use the `ghostel` eshell built-in:
+
+```
+~ $ ghostel nethack
+```
+
+Add a shorter alias if you like:
+
+```elisp
+(defalias 'eshell/v 'eshell/ghostel)    ;; then:  ~ $ v nethack
+```
+
+Customisation:
+
+| Option                       | Effect                                                                                                                    |
+|------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `ghostel-eshell-track-title` | When non-nil, let programs rename the visual-command buffer via OSC title escapes.  Default `nil` (keeps `*vim*` stable). |
+
+The public primitive behind the mode is `ghostel-exec BUFFER PROGRAM
+&optional ARGS`, which launches an arbitrary program in a ghostel
+buffer with no shell integration applied.  Useful for building your
+own integrations.
 
 ## Running Tests
 

--- a/ghostel-eshell.el
+++ b/ghostel-eshell.el
@@ -1,0 +1,125 @@
+;;; ghostel-eshell.el --- Eshell integration for ghostel -*- lexical-binding: t; -*-
+
+;; Author: Daniel Kraus <daniel@kraus.my>
+;; Keywords: processes, tools, convenience
+;; Package-Requires: ((emacs "28.1"))
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; Run Eshell "visual" commands (programs in `eshell-visual-commands',
+;; `eshell-visual-subcommands', and `eshell-visual-options' — e.g. vim,
+;; htop, less, top) inside a dedicated ghostel buffer.  Eshell's default
+;; implementation uses `term-mode' via `eshell-exec-visual'; this mode
+;; overrides that to dispatch through `ghostel-exec' so full-screen
+;; TUIs get a real terminal emulator.
+;;
+;; Enable with:
+;;
+;;   (add-hook 'eshell-load-hook #'ghostel-eshell-visual-command-mode)
+;;
+;; Running ad-hoc commands in a ghostel buffer without adding them to
+;; `eshell-visual-commands' is also supported via the `ghostel' eshell
+;; built-in:
+;;
+;;   ~ $ ghostel nethack
+;;
+;; Add a shorter alias in your init.el if you like:
+;;
+;;   (defalias 'eshell/v 'eshell/ghostel)    ;; then:  ~ $ v nethack
+
+;;; Code:
+
+(require 'ghostel)
+
+(defvar eshell-interpreter-alist)
+(defvar eshell-destroy-buffer-when-process-dies)
+
+(declare-function eshell-find-interpreter "esh-ext"
+                  (file args &optional no-examine-p))
+(declare-function eshell-stringify-list "esh-util" (args))
+(declare-function eshell-exec-visual "em-term" (&rest args))
+
+(defcustom ghostel-eshell-track-title nil
+  "Whether to let visual-command buffers rename themselves via OSC titles.
+When nil (the default), the visual-command buffer keeps its initial
+name (e.g. \"*vim*\") for the duration of the program.  When non-nil,
+the terminal program may rename the buffer via OSC 0/2 title escapes
+the same way a regular ghostel terminal does."
+  :type 'boolean
+  :group 'ghostel)
+
+(defun ghostel-eshell--visual-exit (buffer _event)
+  "Post-exit cleanup for a visual-command BUFFER.
+Deferred via `run-at-time' so ghostel's sentinel has appended its
+\"[Process exited]\" marker first.  No-op if the buffer was killed
+\(i.e. `ghostel-kill-buffer-on-exit' was non-nil).  Otherwise snaps
+point and all windows showing BUFFER to `point-max' and binds `q'
+to dismiss the buffer."
+  (run-at-time
+   0 nil
+   (lambda ()
+     (when (buffer-live-p buffer)
+       (with-current-buffer buffer
+         (goto-char (point-max))
+         (local-set-key (kbd "q") #'kill-current-buffer)
+         (dolist (win (get-buffer-window-list buffer nil t))
+           (set-window-point win (point-max))))))))
+
+(defun ghostel-eshell--exec-visual (&rest args)
+  "Replacement for `eshell-exec-visual' that dispatches to ghostel.
+ARGS are the program name followed by its arguments, as passed by
+eshell."
+  (require 'esh-ext)
+  (require 'esh-util)
+  (save-current-buffer
+    (let* ((eshell-interpreter-alist nil)
+           (interp (eshell-find-interpreter (car args) (cdr args)))
+           (program (car interp))
+           (prog-args (flatten-tree
+                       (eshell-stringify-list
+                        (append (cdr interp) (cdr args)))))
+           (buf (generate-new-buffer
+                 (concat "*" (file-name-nondirectory program) "*"))))
+      (switch-to-buffer buf)
+      (ghostel-exec buf program prog-args)
+      (with-current-buffer buf
+        (setq-local ghostel-kill-buffer-on-exit
+                    (bound-and-true-p eshell-destroy-buffer-when-process-dies))
+        (unless ghostel-eshell-track-title
+          (setq-local ghostel-enable-title-tracking nil))
+        (add-hook 'ghostel-exit-functions
+                  #'ghostel-eshell--visual-exit nil t))
+      nil)))
+
+;;;###autoload
+(defun eshell/ghostel (&rest args)
+  "Run ARGS as a visual command in a dedicated ghostel buffer.
+This is an eshell built-in; type `ghostel PROGRAM ...' at the
+eshell prompt to launch any program in a ghostel terminal buffer
+without adding it to `eshell-visual-commands'.  Dispatches through
+`eshell-exec-visual', so when `ghostel-eshell-visual-command-mode'
+is enabled the program runs under ghostel; otherwise it falls
+back to eshell's default `term-mode' visual handling."
+  (apply #'eshell-exec-visual args))
+
+;;;###autoload
+(define-minor-mode ghostel-eshell-visual-command-mode
+  "Run Eshell visual commands (vim, htop, less, ...) in ghostel buffers.
+When enabled, `eshell-exec-visual' is overridden to launch the
+program in a dedicated ghostel terminal buffer.  When the program
+exits, the buffer stays on `[Process exited]' so any remaining
+output is visible; press `q' to dismiss it.  Set
+`eshell-destroy-buffer-when-process-dies' to non-nil to kill the
+buffer automatically on exit instead."
+  :global t
+  :group 'ghostel
+  (if ghostel-eshell-visual-command-mode
+      (advice-add 'eshell-exec-visual :override
+                  #'ghostel-eshell--exec-visual)
+    (advice-remove 'eshell-exec-visual
+                   #'ghostel-eshell--exec-visual)))
+
+(provide 'ghostel-eshell)
+
+;;; ghostel-eshell.el ends here

--- a/ghostel.el
+++ b/ghostel.el
@@ -2260,6 +2260,73 @@ Returns nil on failure."
               (error-message-string err))
      nil)))
 
+(defun ghostel--spawn-pty (program program-args height width stty-flags
+                                   extra-env &optional remote-p)
+  "Spawn PROGRAM with PROGRAM-ARGS as a PTY-backed process in the current buffer.
+
+Wraps PROGRAM in `/bin/sh -c' so that `stty' can configure the PTY
+\(with STTY-FLAGS plus rows=HEIGHT columns=WIDTH) and the screen is
+cleared before PROGRAM is exec'd.  EXTRA-ENV is prepended to
+`process-environment'.  Non-nil REMOTE-P spawns the process via the
+TRAMP file handler (for remote shells).
+
+Installs `ghostel--filter' and `ghostel--sentinel', sets binary I/O,
+matches the PTY window size, and stores the process in
+`ghostel--process'.  Returns the process."
+  ;; Wrap the program in /bin/sh -c so we can configure the PTY
+  ;; before the program reads its terminal attributes:
+  ;;  - erase '^?': Emacs PTYs leave VERASE undefined, but
+  ;;    shells like fish check VERASE at startup to decide
+  ;;    whether \x7f means backspace.
+  ;;  - iutf8: kernel-level UTF-8 awareness so backspace
+  ;;    correctly erases multi-byte characters.
+  ;;  - -ixon: disable XON/XOFF flow control so C-q and C-s
+  ;;    pass through to the application instead of being
+  ;;    swallowed by the PTY line discipline.
+  ;;  - echo (bash-only): readline buffers its own echo, so
+  ;;    we need PTY-level echo early in startup.  Old bash
+  ;;    versions (notably macOS /bin/bash 3.2) may initialize
+  ;;    readline before ENV-sourced integration runs.
+  ;; The clear-screen hides the stty output.  exec replaces
+  ;; the wrapper so only the target program remains.
+  (let* ((shell-command
+          (list "/bin/sh" "-c"
+                (concat "stty " stty-flags
+                        (format " rows %d columns %d" height width)
+                        " 2>/dev/null; "
+                        "printf '\\033[H\\033[2J'; exec "
+                        (shell-quote-argument program)
+                        (and program-args
+                             (concat " "
+                                     (mapconcat #'shell-quote-argument
+                                                program-args " "))))))
+         (process-environment
+          (append
+           (list
+            "INSIDE_EMACS=ghostel"
+            "TERM=xterm-256color"
+            "COLORTERM=truecolor")
+           extra-env
+           process-environment))
+         (proc (make-process
+                :name "ghostel"
+                :buffer (current-buffer)
+                :command shell-command
+                :connection-type 'pty
+                :file-handler remote-p
+                :filter #'ghostel--filter
+                :sentinel #'ghostel--sentinel)))
+    (setq ghostel--process proc)
+    ;; Raw binary I/O — no encoding/decoding by Emacs
+    (set-process-coding-system proc 'binary 'binary)
+    ;; Set the PTY's actual window size (ioctl TIOCSWINSZ) so that
+    ;; the program's line editor (readline/ZLE) can render properly.
+    (set-process-window-size proc height width)
+    (set-process-query-on-exit-flag proc nil)
+    (process-put proc 'adjust-window-size-function
+                 #'ghostel--window-adjust-process-window-size)
+    proc))
+
 (defun ghostel--start-process ()
   "Start the shell process with a PTY.
 When `default-directory' is a remote TRAMP path, spawn the shell
@@ -2328,22 +2395,6 @@ on the remote host."
                            (format "XDG_DATA_DIRS=%s:%s" integ-dir xdg)
                            (format "GHOSTEL_SHELL_INTEGRATION_XDG_DIR=%s"
                                    integ-dir))))))))))
-         ;; Wrap the shell in /bin/sh -c so we can configure the PTY
-         ;; before the shell reads its terminal attributes:
-         ;;  - erase '^?': Emacs PTYs leave VERASE undefined, but
-         ;;    shells like fish check VERASE at startup to decide
-         ;;    whether \x7f means backspace.
-         ;;  - iutf8: kernel-level UTF-8 awareness so backspace
-         ;;    correctly erases multi-byte characters.
-         ;;  - -ixon: disable XON/XOFF flow control so C-q and C-s
-         ;;    pass through to the application instead of being
-         ;;    swallowed by the PTY line discipline.
-         ;;  - echo: bash-only — readline buffers its own echo, so
-         ;;    we need PTY-level echo early in startup.  Old bash
-         ;;    versions (notably macOS /bin/bash 3.2) may initialize
-         ;;    readline before ENV-sourced integration runs.
-         ;; The clear-screen hides the stty output.  exec replaces
-         ;; the wrapper so only the shell process remains.
          (shell-args (cond
                       (remote-integration
                        (plist-get remote-integration :args))
@@ -2356,48 +2407,16 @@ on the remote host."
                       ((eq shell-type 'bash)
                        "erase '^?' iutf8 -ixon echo")
                       (t "erase '^?' iutf8 -ixon")))
-         (shell-command
-          (list "/bin/sh" "-c"
-                (concat "stty " stty-flags
-                        (format " rows %d columns %d" height width)
-                        " 2>/dev/null; "
-                        "printf '\\033[H\\033[2J'; exec "
-                        (shell-quote-argument shell)
-                        (and shell-args
-                             (concat " "
-                                     (mapconcat #'shell-quote-argument
-                                                shell-args " "))))))
-         (process-environment
-          (append
-           (list
-            "INSIDE_EMACS=ghostel"
-            "TERM=xterm-256color"
-            "COLORTERM=truecolor")
-           (unless remote-p
-             (list (format "EMACS_GHOSTEL_PATH=%s" ghostel-dir)))
-           integration-env
-           process-environment))
-         (proc (make-process
-                :name "ghostel"
-                :buffer (current-buffer)
-                :command shell-command
-                :connection-type 'pty
-                :file-handler remote-p
-                :filter #'ghostel--filter
-                :sentinel #'ghostel--sentinel)))
+         (extra-env (append
+                     (unless remote-p
+                       (list (format "EMACS_GHOSTEL_PATH=%s" ghostel-dir)))
+                     integration-env))
+         (proc (ghostel--spawn-pty shell shell-args height width
+                                   stty-flags extra-env remote-p)))
     (when remote-integration
       (ghostel--cleanup-temp-paths
        (plist-get remote-integration :temp-files)
        (plist-get remote-integration :temp-dirs)))
-    (setq ghostel--process proc)
-    ;; Raw binary I/O — no encoding/decoding by Emacs
-    (set-process-coding-system proc 'binary 'binary)
-    ;; Set the PTY's actual window size (ioctl TIOCSWINSZ) so that
-    ;; the shell's line editor (readline/ZLE) can render properly.
-    (set-process-window-size proc height width)
-    (set-process-query-on-exit-flag proc nil)
-    (process-put proc 'adjust-window-size-function
-                 #'ghostel--window-adjust-process-window-size)
     proc))
 
 
@@ -2719,6 +2738,17 @@ prevent redraw flicker."
 
 ;;; Entry point
 
+(defun ghostel--load-module ()
+  "Load the ghostel native module if it is not already loaded."
+  (unless (fboundp 'ghostel--new)
+    (let ((dir (file-name-directory (locate-library "ghostel"))))
+      (ghostel--ensure-module dir)
+      (let ((mod (expand-file-name
+                  (concat "ghostel-module" module-file-suffix) dir)))
+        (if (file-exists-p mod)
+            (module-load mod)
+          (user-error "Ghostel native module not available"))))))
+
 ;;;###autoload
 (defun ghostel (&optional arg)
   "Start a new Ghostel terminal.  If the buffer already exists, switch to it.
@@ -2727,14 +2757,7 @@ With a numeric prefix ARG, switch to the buffer with that number or
 create it if it doesn't exist yet.
 The name of the buffer is determined by the value of `ghostel-buffer-name'."
   (interactive "P")
-  (unless (fboundp 'ghostel--new)
-    (let ((dir (file-name-directory (locate-library "ghostel"))))
-      (ghostel--ensure-module dir)
-      (let ((mod (expand-file-name
-                  (concat "ghostel-module" module-file-suffix) dir)))
-        (if (file-exists-p mod)
-            (module-load mod)
-          (user-error "Ghostel native module not available")))))
+  (ghostel--load-module)
   (let ((buffer (cond ((numberp arg)
                        (get-buffer-create (format "%s<%d>"
                                                   ghostel-buffer-name
@@ -2755,6 +2778,38 @@ The name of the buffer is determined by the value of `ghostel-buffer-name'."
         (setq ghostel--term-rows height)
         (ghostel--apply-palette ghostel--term))
       (ghostel--start-process))))
+
+(defun ghostel-exec (buffer program &optional args)
+  "Run PROGRAM with ARGS as a ghostel terminal in BUFFER.
+
+BUFFER is switched into `ghostel-mode' (if not already) and a new
+terminal is created sized to the window displaying BUFFER, falling
+back to the selected window if BUFFER is not displayed.  No shell
+integration is applied — PROGRAM is exec'd directly via
+`ghostel--spawn-pty'.  PROGRAM is shell-quoted before it is passed
+to `/bin/sh -c', so shell metacharacters are not interpreted; pass
+extra tokens via ARGS, a list of strings.  Returns the process.
+
+Signals `user-error' if BUFFER already has a live ghostel process."
+  (ghostel--load-module)
+  (when (and (buffer-local-value 'ghostel--process buffer)
+             (process-live-p (buffer-local-value 'ghostel--process buffer)))
+    (user-error "Buffer %s already has a running ghostel process"
+                (buffer-name buffer)))
+  (let ((window (or (get-buffer-window buffer t) (selected-window))))
+    (with-current-buffer buffer
+      (unless (derived-mode-p 'ghostel-mode)
+        (ghostel-mode))
+      (setq ghostel--managed-buffer-name (buffer-name))
+      (let* ((height (max 1 (window-body-height window)))
+             (width (max 1 (window-max-chars-per-line window)))
+             (remote-p (file-remote-p default-directory)))
+        (setq ghostel--term
+              (ghostel--new height width ghostel-max-scrollback))
+        (setq ghostel--term-rows height)
+        (ghostel--apply-palette ghostel--term)
+        (ghostel--spawn-pty program args height width
+                            "erase '^?' iutf8 -ixon echo" nil remote-p)))))
 
 ;;;###autoload
 (defun ghostel-project (&optional arg)

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -13,6 +13,7 @@
 (require 'ert)
 (require 'ghostel)
 (require 'ghostel-compile)
+(require 'ghostel-eshell)
 
 (declare-function ghostel--cleanup-temp-paths "ghostel")
 
@@ -5194,6 +5195,93 @@ while :; do sleep 0.1; done'\n")
         (kill-buffer buf)))))
 
 
+;; -----------------------------------------------------------------------
+;; Test: ghostel-exec public API
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-exec-errors-on-live-process ()
+  "`ghostel-exec' signals `user-error' if BUFFER has a live process."
+  (let ((buf (generate-new-buffer " *ghostel-exec-test*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer buf
+            (setq ghostel--process 'fake-process))
+          (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                    ((symbol-function 'process-live-p)
+                     (lambda (p) (eq p 'fake-process))))
+            (should-error (ghostel-exec buf "ls" nil) :type 'user-error)))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-exec-calls-spawn-pty-with-expected-args ()
+  "`ghostel-exec' forwards PROGRAM, ARGS, size, stty flags, and remote-p."
+  (let ((buf (generate-new-buffer " *ghostel-exec-test*"))
+        captured)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                  ((symbol-function 'ghostel--new)
+                   (lambda (&rest _) 'fake-term))
+                  ((symbol-function 'ghostel--apply-palette) #'ignore)
+                  ((symbol-function 'ghostel--spawn-pty)
+                   (lambda (&rest args) (setq captured args) 'fake-proc)))
+          (ghostel-exec buf "less" '("/etc/hosts"))
+          ;; Signature: program args height width stty-flags extra-env remote-p
+          (should (equal (nth 0 captured) "less"))
+          (should (equal (nth 1 captured) '("/etc/hosts")))
+          (should (numberp (nth 2 captured)))
+          (should (numberp (nth 3 captured)))
+          (should (equal (nth 4 captured) "erase '^?' iutf8 -ixon echo"))
+          (should (null (nth 5 captured)))
+          ;; Local default-directory — no TRAMP — so remote-p must be nil.
+          (should (null (nth 6 captured))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-exec-threads-remote-p-from-tramp-dir ()
+  "`ghostel-exec' derives remote-p from BUFFER's `default-directory'."
+  (let ((buf (generate-new-buffer " *ghostel-exec-test*"))
+        captured)
+    (unwind-protect
+        (progn
+          (with-current-buffer buf
+            (setq-local default-directory "/ssh:somehost:/home/user/"))
+          (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                    ((symbol-function 'ghostel--new)
+                     (lambda (&rest _) 'fake-term))
+                    ((symbol-function 'ghostel--apply-palette) #'ignore)
+                    ((symbol-function 'ghostel--spawn-pty)
+                     (lambda (&rest args) (setq captured args) 'fake-proc)))
+            (ghostel-exec buf "ls" nil)
+            (should (nth 6 captured))))
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
+;; Test: ghostel-eshell integration
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-eshell-visual-command-mode-toggles-advice ()
+  "Enabling/disabling the mode adds/removes the `eshell-exec-visual' advice."
+  (let ((was-on ghostel-eshell-visual-command-mode))
+    (unwind-protect
+        (progn
+          (ghostel-eshell-visual-command-mode -1)
+          (should-not (advice-member-p #'ghostel-eshell--exec-visual
+                                       'eshell-exec-visual))
+          (ghostel-eshell-visual-command-mode 1)
+          (should (advice-member-p #'ghostel-eshell--exec-visual
+                                   'eshell-exec-visual))
+          (ghostel-eshell-visual-command-mode -1)
+          (should-not (advice-member-p #'ghostel-eshell--exec-visual
+                                       'eshell-exec-visual)))
+      (ghostel-eshell-visual-command-mode (if was-on 1 -1)))))
+
+(ert-deftest ghostel-test-eshell/ghostel-dispatches-to-exec-visual ()
+  "`eshell/ghostel' forwards its arguments to `eshell-exec-visual'."
+  (let (captured)
+    (cl-letf (((symbol-function 'eshell-exec-visual)
+               (lambda (&rest args) (setq captured args))))
+      (eshell/ghostel "vim" "file.txt")
+      (should (equal captured '("vim" "file.txt"))))))
+
+
 (defconst ghostel-test--elisp-tests
   '(ghostel-test-raw-key-sequences
     ghostel-test-modifier-number
@@ -5315,7 +5403,12 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-compile-uses-compile-command
     ghostel-test-compile-interactive-uses-compile-history
     ghostel-test-compile-respects-compilation-read-command
-    ghostel-test-viewport-start-skips-trailing-newline)
+    ghostel-test-viewport-start-skips-trailing-newline
+    ghostel-test-exec-errors-on-live-process
+    ghostel-test-exec-calls-spawn-pty-with-expected-args
+    ghostel-test-exec-threads-remote-p-from-tramp-dir
+    ghostel-test-eshell-visual-command-mode-toggles-advice
+    ghostel-test-eshell/ghostel-dispatches-to-exec-visual)
   "Tests that require only Elisp (no native module).")
 
 (defun ghostel-test-run-elisp ()


### PR DESCRIPTION
## Summary
- New global minor mode `ghostel-eshell-visual-command-mode` that advises `eshell-exec-visual`, so TUI programs launched from eshell (vim, htop, less, top, `git log`'s pager, ...) run in a dedicated ghostel buffer instead of the default `term-mode` fallback. Modelled after eat's `eat-eshell-visual-command-mode`.
- Factors the generic PTY-wrapping logic (`/bin/sh -c 'stty ...; exec PROGRAM'` + `make-process` + filter/sentinel/resize hookup) out of `ghostel--start-process` into a new helper `ghostel--spawn-pty`. Existing shell-launch behaviour is unchanged.
- Exposes `ghostel-exec BUFFER PROGRAM &optional ARGS` as the public primitive for running an arbitrary program in a ghostel buffer (no shell-integration env is applied — the program is exec'd directly).

Enable with:
```elisp
(add-hook 'eshell-load-hook #'ghostel-eshell-visual-command-mode)
```

When the visual command exits, the window returns to the originating eshell buffer. `eshell-destroy-buffer-when-process-dies` is honoured.

Not in scope: inline terminal emulation for non-visual eshell commands (the equivalent of `eat-eshell-mode`). That would require region-scoped rendering in the Zig layer, which currently rewrites the full buffer on every redraw.

## Test plan
- [x] `make -j4 all` — build, 66 elisp tests, 121 native tests, byte-compile, checkdoc, package-lint all pass
- [x] Manual: `M-x eshell` → `M-x ghostel-eshell-visual-command-mode` → `vim /tmp/x`, `:q` → window returns to eshell
- [x] Manual: `htop` (alt-screen + mouse), `less /etc/passwd`, `man ls` via pager
- [x] Manual: window resize while `vim` runs delivers SIGWINCH correctly
- [x] Manual: toggling the mode off removes the advice and restores ansi-term fallback