### PR TITLE
Perf + cleanup: unified OSC scanner, streaming CRLF, smaller render hot path

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,11 +646,11 @@ Emacs 31.0.50:
 
 | Backend              | Plain ASCII | URL-heavy |
 |----------------------|------------:|----------:|
-| ghostel              |    70 MB/s  |  56 MB/s  |
-| ghostel (no detect)  |    70 MB/s  |  70 MB/s  |
-| vterm                |    34 MB/s  |  27 MB/s  |
-| eat                  |   4.4 MB/s  | 3.5 MB/s  |
-| term                 |   5.6 MB/s  | 4.7 MB/s  |
+| ghostel              |    87 MB/s  |  64 MB/s  |
+| ghostel (no detect)  |    86 MB/s  |  86 MB/s  |
+| vterm                |    35 MB/s  |  27 MB/s  |
+| eat                  |   4.7 MB/s  | 3.5 MB/s  |
+| term                 |   5.7 MB/s  | 4.7 MB/s  |
 
 Ghostel scans terminal output for URLs and file paths, making them clickable.
 The "no detect" row shows throughput with this detection disabled

--- a/ghostel.el
+++ b/ghostel.el
@@ -669,25 +669,47 @@ DIR is the module directory."
       (unless noninteractive
         (ghostel--ensure-module dir)))))
 
-;; Load the native module
-(unless (featurep 'ghostel-module)
-  (let* ((dir (file-name-directory (or load-file-name buffer-file-name)))
-         (mod (expand-file-name
-               (concat "ghostel-module" module-file-suffix) dir)))
-    (unless (or (file-exists-p mod) noninteractive)
-      (ghostel--ensure-module dir))
-    (if (file-exists-p mod)
+(defun ghostel--load-module (&optional prompt-user)
+  "Ensure the ghostel native module is loaded.
+When the module file is missing, trigger `ghostel-module-auto-install'.
+When PROMPT-USER is non-nil (called from an interactive command like
+`ghostel'), failures signal `user-error' so the calling flow aborts.
+Otherwise (load time), failures `display-warning' instead so the user
+can still compile ghostel, read docs, and so on."
+  (unless (featurep 'ghostel-module)
+    (let* ((dir (file-name-directory (or load-file-name
+                                         (locate-library "ghostel")
+                                         buffer-file-name)))
+           (mod (expand-file-name
+                 (concat "ghostel-module" module-file-suffix) dir)))
+      (unless (or (file-exists-p mod) noninteractive)
+        (ghostel--ensure-module dir))
+      (cond
+       ((file-exists-p mod)
         (condition-case err
             (progn
               (module-load mod)
               (ghostel--check-module-version dir))
           (error
-           (display-warning 'ghostel
-                            (format "Failed to load native module: %s\nTry M-x ghostel-module-compile to rebuild"
-                                    (error-message-string err)))))
-      (display-warning 'ghostel
-                       (concat "Native module not found: " mod
-                               "\nRun M-x ghostel-download-module or M-x ghostel-module-compile")))))
+           (if prompt-user
+               (user-error "Failed to load ghostel native module: %s"
+                           (error-message-string err))
+             (display-warning
+              'ghostel
+              (format "Failed to load native module: %s\nTry M-x ghostel-module-compile to rebuild"
+                      (error-message-string err)))))))
+       (prompt-user
+        (user-error "Ghostel native module not found: %s.  Run M-x ghostel-download-module or M-x ghostel-module-compile"
+                    mod))
+       (t
+        (display-warning
+         'ghostel
+         (concat "Native module not found: " mod
+                 "\nRun M-x ghostel-download-module or M-x ghostel-module-compile")))))))
+
+;; Load the native module now so the rest of this file (declare-function,
+;; feature consumers) sees it.  Failure is non-fatal at load time.
+(ghostel--load-module)
 
 
 ;;; Internal variables
@@ -2799,17 +2821,6 @@ prevent redraw flicker."
 
 ;;; Entry point
 
-(defun ghostel--load-module ()
-  "Load the ghostel native module if it is not already loaded."
-  (unless (fboundp 'ghostel--new)
-    (let ((dir (file-name-directory (locate-library "ghostel"))))
-      (ghostel--ensure-module dir)
-      (let ((mod (expand-file-name
-                  (concat "ghostel-module" module-file-suffix) dir)))
-        (if (file-exists-p mod)
-            (module-load mod)
-          (user-error "Ghostel native module not available"))))))
-
 ;;;###autoload
 (defun ghostel (&optional arg)
   "Start a new Ghostel terminal.  If the buffer already exists, switch to it.
@@ -2818,7 +2829,7 @@ With a numeric prefix ARG, switch to the buffer with that number or
 create it if it doesn't exist yet.
 The name of the buffer is determined by the value of `ghostel-buffer-name'."
   (interactive "P")
-  (ghostel--load-module)
+  (ghostel--load-module t)
   (let ((buffer (cond ((numberp arg)
                        (get-buffer-create (format "%s<%d>"
                                                   ghostel-buffer-name
@@ -2852,7 +2863,7 @@ to `/bin/sh -c', so shell metacharacters are not interpreted; pass
 extra tokens via ARGS, a list of strings.  Returns the process.
 
 Signals `user-error' if BUFFER already has a live ghostel process."
-  (ghostel--load-module)
+  (ghostel--load-module t)
   (when (and (buffer-local-value 'ghostel--process buffer)
              (process-live-p (buffer-local-value 'ghostel--process buffer)))
     (user-error "Buffer %s already has a running ghostel process"

--- a/ghostel.el
+++ b/ghostel.el
@@ -675,8 +675,13 @@ When the module file is missing, trigger `ghostel-module-auto-install'.
 When PROMPT-USER is non-nil (called from an interactive command like
 `ghostel'), failures signal `user-error' so the calling flow aborts.
 Otherwise (load time), failures `display-warning' instead so the user
-can still compile ghostel, read docs, and so on."
-  (unless (featurep 'ghostel-module)
+can still compile ghostel, read docs, and so on.
+
+The guard also honours `ghostel--new' being already `fboundp', which
+covers the pure-Elisp test path where `cl-letf' stubs the native
+entry points so tests run without the module present."
+  (unless (or (featurep 'ghostel-module)
+              (fboundp 'ghostel--new))
     (let* ((dir (file-name-directory (or load-file-name
                                          (locate-library "ghostel")
                                          buffer-file-name)))

--- a/src/module.zig
+++ b/src/module.zig
@@ -157,8 +157,14 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
     // and then "\r\n".  libghostty's VT state machine handles arbitrary
     // chunking (that's how the process filter already works), so no
     // scratch buffer, no allocation, no truncation fallback.
+    //
+    // `prev_was_cr` is seeded from `term.last_input_was_cr` so a CRLF
+    // pair split across two writes — chunk A ending with \r, chunk B
+    // starting with \n — is not mis-normalized into \r\r\n.  The final
+    // value is persisted back for the next call. An empty input
+    // round-trips the flag unchanged.
     var seg_start: usize = 0;
-    var prev_was_cr: bool = false;
+    var prev_was_cr: bool = term.last_input_was_cr;
     for (raw, 0..) |ch, i| {
         if (ch == '\n' and !prev_was_cr) {
             if (i > seg_start) term.vtWrite(raw[seg_start..i]);
@@ -172,6 +178,7 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
     if (seg_start < raw.len) {
         term.vtWrite(raw[seg_start..]);
     }
+    term.last_input_was_cr = prev_was_cr;
 
     // Scan for OSC sequences that libghostty-vt discards (7, 51, 52, 133).
     // One pass, dispatched by code in document order.
@@ -191,14 +198,22 @@ const OscEntry = struct {
     /// Payload bytes between the code's trailing `;` and the terminator.
     payload: []const u8,
     /// Terminator bytes (BEL or ESC \) — forwarded back on replies.
-    term: []const u8,
+    terminator: []const u8,
 };
 
 /// Single-pass iterator over well-formed OSC sequences in a byte slice.
 /// Advances past `ESC ]`, parses the decimal code up to `;`, locates the
-/// BEL/ST terminator, and yields `(code, payload, term)`. Partial
-/// sequences at the end of the buffer stop iteration so the caller
-/// doesn't act on half-received data.
+/// BEL/ST terminator, and yields `(code, payload, terminator)`.
+///
+/// An OSC payload is bounded by a real terminator (BEL or ESC \) OR by
+/// the next OSC introducer (ESC ]).  Stopping at a following introducer
+/// handles malformed input where one OSC is missing its terminator
+/// before the next begins — otherwise the partial OSC would cannibalize
+/// the following OSC's bytes (including its terminator) as its own
+/// payload, producing a garbage dispatch AND starving the next OSC.
+/// On partial detection we advance past the current introducer and let
+/// iteration continue, so well-formed OSCs later in the same buffer
+/// still dispatch.
 const OscIterator = struct {
     data: []const u8,
     pos: usize = 0,
@@ -222,24 +237,36 @@ const OscIterator = struct {
             }
             const payload_start = code_end + 1;
 
-            // Terminator search. A partial OSC (no terminator before EOF)
-            // stops iteration entirely: bytes after an unterminated payload
-            // are opaque, so there's no safe way to continue scanning.
+            // Scan for a terminator (BEL or ESC \) or the next OSC
+            // introducer (ESC ]), whichever comes first. An intervening
+            // introducer means the current OSC is partial.
             var end = payload_start;
             var term_len: usize = 0;
             while (end < self.data.len) : (end += 1) {
-                if (self.data[end] == 0x07) {
+                const ch = self.data[end];
+                if (ch == 0x07) {
                     term_len = 1;
                     break;
                 }
-                if (self.data[end] == 0x1b and end + 1 < self.data.len and self.data[end + 1] == '\\') {
-                    term_len = 2;
-                    break;
+                if (ch == 0x1b and end + 1 < self.data.len) {
+                    const next_ch = self.data[end + 1];
+                    if (next_ch == '\\') {
+                        term_len = 2;
+                        break;
+                    }
+                    if (next_ch == ']') {
+                        // Next introducer — current OSC is partial.
+                        break;
+                    }
                 }
             }
             if (term_len == 0) {
-                self.pos = self.data.len;
-                return null;
+                // Partial OSC: skip past the current introducer (which
+                // we already parsed) and resume scanning. If `end` is
+                // still `self.data.len` there were no more introducers,
+                // and the next indexOfPos call will terminate iteration.
+                self.pos = if (end > code_start) end else code_start;
+                continue;
             }
 
             self.pos = end + term_len;
@@ -247,7 +274,7 @@ const OscIterator = struct {
             return .{
                 .code = code,
                 .payload = self.data[payload_start..end],
-                .term = self.data[end .. end + term_len],
+                .terminator = self.data[end .. end + term_len],
             };
         }
         return null;
@@ -255,10 +282,12 @@ const OscIterator = struct {
 };
 
 /// Dispatch OSC 7 / 51 / 52 / 133 from `data` in document order.
-/// These are the sequences that libghostty-vt discards, so ghostel
-/// has to scan for them itself.  All four used to scan the buffer
-/// independently; one unified pass is strictly less work for bulk
-/// output and preserves source-order dispatch.
+/// These are the post-vtWrite sequences that libghostty-vt discards,
+/// so ghostel has to scan for them itself.  All four used to scan the
+/// buffer independently; one unified pass is strictly less work for
+/// bulk output and preserves source-order dispatch.  (OSC 4/10/11
+/// color queries use the same iterator but run before vtWrite — see
+/// `extractOscColorQueries`.)
 ///
 /// Runs AFTER `vtWrite` so libghostty has already seen the bytes —
 /// OSC 7 calls back into libghostty (`setPwd`) and the others call
@@ -388,13 +417,13 @@ fn extractOscColorQueries(env: emacs.Env, term: *Terminal, data: []const u8) voi
                 if (!std.mem.eql(u8, osc.payload, "?")) continue;
                 var fg: gt.ColorRgb = undefined;
                 if (!term.getColorForeground(&fg)) continue;
-                sendDynamicColorReply(env, 10, fg, osc.term);
+                sendDynamicColorReply(env, 10, fg, osc.terminator);
             },
             11 => {
                 if (!std.mem.eql(u8, osc.payload, "?")) continue;
                 var bg: gt.ColorRgb = undefined;
                 if (!term.getColorBackground(&bg)) continue;
-                sendDynamicColorReply(env, 11, bg, osc.term);
+                sendDynamicColorReply(env, 11, bg, osc.terminator);
             },
             4 => {
                 // Payload is a ';'-separated list of `index;value` pairs.
@@ -409,7 +438,7 @@ fn extractOscColorQueries(env: emacs.Env, term: *Terminal, data: []const u8) voi
                         if (!term.getColorPalette(&palette)) break;
                         palette_loaded = true;
                     }
-                    sendPaletteColorReply(env, @intCast(idx), palette[idx], osc.term);
+                    sendPaletteColorReply(env, @intCast(idx), palette[idx], osc.terminator);
                 }
             },
             else => {},

--- a/src/module.zig
+++ b/src/module.zig
@@ -141,9 +141,6 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
         defer vt_log_env = null;
     }
 
-    // Normalize CRLF: Emacs PTYs lack ONLCR, so bare \n arrives
-    // without \r.  Insert \r before every bare \n.
-    // Done here in Zig to avoid Elisp unibyte→multibyte corruption.
     const raw = data.?;
 
     // Respond to OSC 4/10/11 color queries BEFORE feeding libghostty.
@@ -154,44 +151,26 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
     // the program discards our reply as noise.
     extractOscColorQueries(env, term, raw);
 
-    // Count bare \n to determine output size.
-    var extra_cr: usize = 0;
-    for (0..raw.len) |i| {
-        if (raw[i] == '\n' and (i == 0 or raw[i - 1] != '\r')) {
-            extra_cr += 1;
+    // Normalize CRLF by streaming directly into libghostty's parser.
+    // Emacs PTYs lack ONLCR, so bare \n arrives without \r — insert
+    // one before each bare \n by feeding the preceding segment verbatim
+    // and then "\r\n".  libghostty's VT state machine handles arbitrary
+    // chunking (that's how the process filter already works), so no
+    // scratch buffer, no allocation, no truncation fallback.
+    var seg_start: usize = 0;
+    var prev_was_cr: bool = false;
+    for (raw, 0..) |ch, i| {
+        if (ch == '\n' and !prev_was_cr) {
+            if (i > seg_start) term.vtWrite(raw[seg_start..i]);
+            term.vtWrite("\r\n");
+            seg_start = i + 1;
+            prev_was_cr = false;
+        } else {
+            prev_was_cr = (ch == '\r');
         }
     }
-
-    if (extra_cr == 0) {
-        // No normalization needed — feed raw data directly.
-        term.vtWrite(raw);
-    } else {
-        // Need to insert \r before bare \n.
-        const out_len = raw.len + extra_cr;
-        var norm_stack: [131072]u8 = undefined;
-        var norm_heap: ?[]u8 = null;
-        defer if (norm_heap) |nh| std.heap.c_allocator.free(nh);
-
-        const norm_buf: []u8 = if (out_len <= norm_stack.len)
-            &norm_stack
-        else blk: {
-            norm_heap = std.heap.c_allocator.alloc(u8, out_len) catch {
-                // Fall back to stack buffer, truncating if needed.
-                break :blk &norm_stack;
-            };
-            break :blk norm_heap.?;
-        };
-
-        var npos: usize = 0;
-        for (0..raw.len) |i| {
-            if (raw[i] == '\n' and (i == 0 or raw[i - 1] != '\r')) {
-                norm_buf[npos] = '\r';
-                npos += 1;
-            }
-            norm_buf[npos] = raw[i];
-            npos += 1;
-        }
-        term.vtWrite(norm_buf[0..npos]);
+    if (seg_start < raw.len) {
+        term.vtWrite(raw[seg_start..]);
     }
 
     // Scan for OSC sequences that libghostty-vt discards (7, 51, 52, 133).

--- a/src/module.zig
+++ b/src/module.zig
@@ -194,11 +194,9 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
         term.vtWrite(norm_buf[0..npos]);
     }
 
-    // Scan for OSC sequences that libghostty-vt discards.
-    extractAndSetPwd(term, raw);
-    extractOsc51(env, raw);
-    extractOsc52(env, raw);
-    extractOsc133(env, raw);
+    // Scan for OSC sequences that libghostty-vt discards (7, 51, 52, 133).
+    // One pass, dispatched by code in document order.
+    dispatchPostWriteOscs(env, term, raw);
 
     return env.nil();
 }
@@ -207,127 +205,136 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
 // OSC sequence helpers
 // ---------------------------------------------------------------------------
 
-/// Find the end of an OSC sequence payload starting at `start`.
-/// Scans for the terminator: BEL (0x07) or ST (ESC \).
-/// Returns the index of the first terminator byte, or data.len if none found.
-fn findOscTerminator(data: []const u8, start: usize) usize {
-    var pos = start;
-    while (pos < data.len) {
-        if (data[pos] == 0x07) return pos; // BEL
-        if (data[pos] == 0x1b and pos + 1 < data.len and data[pos + 1] == '\\') return pos; // ST
-        pos += 1;
-    }
-    return data.len;
-}
+/// An OSC sequence extracted by `OscIterator`.
+const OscEntry = struct {
+    /// Decimal OSC code (e.g. 4, 7, 10, 11, 51, 52, 133).
+    code: u32,
+    /// Payload bytes between the code's trailing `;` and the terminator.
+    payload: []const u8,
+    /// Terminator bytes (BEL or ESC \) — forwarded back on replies.
+    term: []const u8,
+};
 
-/// Iterator-style scanner that yields successive OSC sequences matching `prefix`.
-/// Each call to `next()` returns the payload slice (after the prefix, before the
-/// terminator), or null when no more matches exist.
-const OscScanner = struct {
+/// Single-pass iterator over well-formed OSC sequences in a byte slice.
+/// Advances past `ESC ]`, parses the decimal code up to `;`, locates the
+/// BEL/ST terminator, and yields `(code, payload, term)`. Partial
+/// sequences at the end of the buffer stop iteration so the caller
+/// doesn't act on half-received data.
+const OscIterator = struct {
     data: []const u8,
-    prefix: []const u8,
     pos: usize = 0,
 
-    const Match = struct {
-        payload: []const u8,
-        end: usize,
-    };
+    fn next(self: *OscIterator) ?OscEntry {
+        while (self.pos < self.data.len) {
+            const intro = std.mem.indexOfPos(u8, self.data, self.pos, "\x1b]") orelse {
+                self.pos = self.data.len;
+                return null;
+            };
+            const code_start = intro + 2;
 
-    fn next(self: *OscScanner) ?Match {
-        while (self.pos + self.prefix.len < self.data.len) {
-            if (std.mem.startsWith(u8, self.data[self.pos..], self.prefix)) {
-                const payload_start = self.pos + self.prefix.len;
-                const payload_end = findOscTerminator(self.data, payload_start);
-                self.pos = payload_end;
-                return .{ .payload = self.data[payload_start..payload_end], .end = payload_end };
-            } else {
-                self.pos += 1;
+            // Decimal code up to the first `;`.
+            var code_end = code_start;
+            while (code_end < self.data.len and self.data[code_end] >= '0' and self.data[code_end] <= '9') {
+                code_end += 1;
             }
+            if (code_end == code_start or code_end >= self.data.len or self.data[code_end] != ';') {
+                self.pos = code_start;
+                continue;
+            }
+            const payload_start = code_end + 1;
+
+            // Terminator search. A partial OSC (no terminator before EOF)
+            // stops iteration entirely: bytes after an unterminated payload
+            // are opaque, so there's no safe way to continue scanning.
+            var end = payload_start;
+            var term_len: usize = 0;
+            while (end < self.data.len) : (end += 1) {
+                if (self.data[end] == 0x07) {
+                    term_len = 1;
+                    break;
+                }
+                if (self.data[end] == 0x1b and end + 1 < self.data.len and self.data[end + 1] == '\\') {
+                    term_len = 2;
+                    break;
+                }
+            }
+            if (term_len == 0) {
+                self.pos = self.data.len;
+                return null;
+            }
+
+            self.pos = end + term_len;
+            const code = std.fmt.parseInt(u32, self.data[code_start..code_end], 10) catch continue;
+            return .{
+                .code = code,
+                .payload = self.data[payload_start..end],
+                .term = self.data[end .. end + term_len],
+            };
         }
         return null;
     }
 };
 
-/// Scan data for OSC 51;E elisp eval sequences.
-/// OSC 51 format: ESC ] 51 ; E <quoted-args> (ST | BEL)
-/// Passes the payload (after 'E') to ghostel--osc51-eval for dispatch.
-fn extractOsc51(env: emacs.Env, data: []const u8) void {
-    var scanner = OscScanner{ .data = data, .prefix = "\x1b]51;" };
-    while (scanner.next()) |match| {
-        const payload = match.payload;
-        if (payload.len < 2) continue;
-        // Sub-command must be 'E'
-        if (payload[0] != 'E') continue;
-        _ = env.call1(
-            emacs.sym.@"ghostel--osc51-eval",
-            env.makeString(payload[1..]),
-        );
-    }
-}
-
-/// Scan data for OSC 7 sequences and set the terminal PWD.
-/// OSC 7 format: ESC ] 7 ; <url> (ST | BEL)
-fn extractAndSetPwd(term: *Terminal, data: []const u8) void {
-    var scanner = OscScanner{ .data = data, .prefix = "\x1b]7;" };
-    while (scanner.next()) |match| {
-        if (match.payload.len > 0) {
-            const gs = gt.GhosttyString{ .ptr = match.payload.ptr, .len = match.payload.len };
-            term.setPwd(&gs) catch {};
+/// Dispatch OSC 7 / 51 / 52 / 133 from `data` in document order.
+/// These are the sequences that libghostty-vt discards, so ghostel
+/// has to scan for them itself.  All four used to scan the buffer
+/// independently; one unified pass is strictly less work for bulk
+/// output and preserves source-order dispatch.
+///
+/// Runs AFTER `vtWrite` so libghostty has already seen the bytes —
+/// OSC 7 calls back into libghostty (`setPwd`) and the others call
+/// Elisp.
+fn dispatchPostWriteOscs(env: emacs.Env, term: *Terminal, data: []const u8) void {
+    var it = OscIterator{ .data = data };
+    while (it.next()) |osc| {
+        switch (osc.code) {
+            // OSC 7: working directory as a file:// URL.
+            7 => {
+                if (osc.payload.len == 0) continue;
+                const gs = gt.GhosttyString{ .ptr = osc.payload.ptr, .len = osc.payload.len };
+                term.setPwd(&gs) catch {};
+            },
+            // OSC 51;E: whitelisted Elisp eval (ghostel extension).
+            51 => {
+                if (osc.payload.len < 2 or osc.payload[0] != 'E') continue;
+                _ = env.call1(
+                    emacs.sym.@"ghostel--osc51-eval",
+                    env.makeString(osc.payload[1..]),
+                );
+            },
+            // OSC 52: clipboard set.  Queries ("?") are ignored.
+            52 => {
+                const semi = std.mem.indexOfScalar(u8, osc.payload, ';') orelse continue;
+                const selection = osc.payload[0..semi];
+                const b64 = osc.payload[semi + 1 ..];
+                if (b64.len == 0) continue;
+                if (b64.len == 1 and b64[0] == '?') continue;
+                _ = env.call2(
+                    emacs.sym.@"ghostel--osc52-handle",
+                    env.makeString(selection),
+                    env.makeString(b64),
+                );
+            },
+            // OSC 133: semantic prompt markers (A/B/C/D).
+            133 => {
+                if (osc.payload.len == 0) continue;
+                const marker_type = osc.payload[0];
+                if (marker_type != 'A' and marker_type != 'B' and marker_type != 'C' and marker_type != 'D') continue;
+                const has_param = osc.payload.len > 1 and osc.payload[1] == ';';
+                const param_data = if (has_param) osc.payload[2..] else &[_]u8{};
+                const type_str: [1]u8 = .{marker_type};
+                const param_val = if (has_param and param_data.len > 0)
+                    env.makeString(param_data)
+                else
+                    env.nil();
+                _ = env.call2(
+                    emacs.sym.@"ghostel--osc133-marker",
+                    env.makeString(&type_str),
+                    param_val,
+                );
+            },
+            else => {},
         }
-    }
-}
-
-/// Scan data for OSC 52 clipboard sequences.
-/// OSC 52 format: ESC ] 52 ; <selection> ; <base64-data> (ST | BEL)
-/// Calls ghostel--osc52-handle with the selection and base64 data.
-fn extractOsc52(env: emacs.Env, data: []const u8) void {
-    var scanner = OscScanner{ .data = data, .prefix = "\x1b]52;" };
-    while (scanner.next()) |match| {
-        const payload = match.payload;
-        // Find the ';' separating selection from data
-        const semi = std.mem.indexOfScalar(u8, payload, ';') orelse continue;
-        const selection = payload[0..semi];
-        const b64 = payload[semi + 1 ..];
-        if (b64.len == 0) continue;
-        // Ignore clipboard queries ('?')
-        if (b64.len == 1 and b64[0] == '?') continue;
-        _ = env.call2(
-            emacs.sym.@"ghostel--osc52-handle",
-            env.makeString(selection),
-            env.makeString(b64),
-        );
-    }
-}
-
-/// Scan data for OSC 133 semantic prompt markers.
-/// OSC 133 format: ESC ] 133 ; <type> [; <param>] (ST | BEL)
-/// type: A = prompt start, B = command start, C = output start, D = command finished
-/// For type D, param is the exit status.
-fn extractOsc133(env: emacs.Env, data: []const u8) void {
-    var scanner = OscScanner{ .data = data, .prefix = "\x1b]133;" };
-    while (scanner.next()) |match| {
-        const payload = match.payload;
-        if (payload.len == 0) continue;
-        const marker_type = payload[0];
-
-        // Only handle known types
-        if (marker_type != 'A' and marker_type != 'B' and marker_type != 'C' and marker_type != 'D') continue;
-
-        // Check for optional parameter after ';'
-        const has_param = payload.len > 1 and payload[1] == ';';
-        const param_data = if (has_param) payload[2..] else &[_]u8{};
-
-        const type_str: [1]u8 = .{marker_type};
-        const param_val = if (has_param and param_data.len > 0)
-            env.makeString(param_data)
-        else
-            env.nil();
-
-        _ = env.call2(
-            emacs.sym.@"ghostel--osc133-marker",
-            env.makeString(&type_str),
-            param_val,
-        );
     }
 }
 
@@ -375,13 +382,6 @@ fn sendPaletteColorReply(
     _ = env.call1(emacs.sym.@"ghostel--flush-output", env.makeString(written));
 }
 
-/// Parse a non-negative decimal integer.  Returns null on empty input,
-/// any non-digit byte, or numeric overflow of `u32`.
-fn parseDecimal(s: []const u8) ?u32 {
-    if (s.len == 0) return null;
-    return std.fmt.parseInt(u32, s, 10) catch null;
-}
-
 /// Scan data for OSC 4/10/11 color queries and emit responses in source
 /// order.  libghostty applies OSC 4/10/11 **sets** internally but silently
 /// drops the query form (`?` value), so ghostel scans the raw input and
@@ -402,72 +402,35 @@ fn extractOscColorQueries(env: emacs.Env, term: *Terminal, data: []const u8) voi
     var palette: [256]gt.ColorRgb = undefined;
     var palette_loaded = false;
 
-    var pos: usize = 0;
-    while (pos + 1 < data.len) {
-        // Find next OSC introducer "ESC ]".
-        const osc_rel = std.mem.indexOfPos(u8, data, pos, "\x1b]") orelse break;
-        const code_start = osc_rel + 2;
-
-        // Read the decimal OSC code up to the first ';'.
-        var code_end = code_start;
-        while (code_end < data.len and data[code_end] >= '0' and data[code_end] <= '9') {
-            code_end += 1;
-        }
-        if (code_end == code_start or code_end >= data.len or data[code_end] != ';') {
-            pos = code_start;
-            continue;
-        }
-        const payload_start = code_end + 1;
-
-        // Find the terminator (BEL or ST).  Require a real one — partial OSCs
-        // split across chunks are left for the next call so we don't reply
-        // before the client has finished writing its query.
-        var end = payload_start;
-        var term_len: usize = 0;
-        while (end < data.len) : (end += 1) {
-            if (data[end] == 0x07) {
-                term_len = 1;
-                break;
-            }
-            if (data[end] == 0x1b and end + 1 < data.len and data[end + 1] == '\\') {
-                term_len = 2;
-                break;
-            }
-        }
-        if (term_len == 0) break;
-
-        const payload = data[payload_start..end];
-        const term_bytes = data[end .. end + term_len];
-        pos = end + term_len;
-
-        const code = parseDecimal(data[code_start..code_end]) orelse continue;
-        switch (code) {
+    var it = OscIterator{ .data = data };
+    while (it.next()) |osc| {
+        switch (osc.code) {
             10 => {
-                if (!std.mem.eql(u8, payload, "?")) continue;
+                if (!std.mem.eql(u8, osc.payload, "?")) continue;
                 var fg: gt.ColorRgb = undefined;
                 if (!term.getColorForeground(&fg)) continue;
-                sendDynamicColorReply(env, 10, fg, term_bytes);
+                sendDynamicColorReply(env, 10, fg, osc.term);
             },
             11 => {
-                if (!std.mem.eql(u8, payload, "?")) continue;
+                if (!std.mem.eql(u8, osc.payload, "?")) continue;
                 var bg: gt.ColorRgb = undefined;
                 if (!term.getColorBackground(&bg)) continue;
-                sendDynamicColorReply(env, 11, bg, term_bytes);
+                sendDynamicColorReply(env, 11, bg, osc.term);
             },
             4 => {
                 // Payload is a ';'-separated list of `index;value` pairs.
                 // Reply only to pairs whose value is literally "?".
-                var it = std.mem.splitScalar(u8, payload, ';');
-                while (it.next()) |index_tok| {
-                    const value_tok = it.next() orelse break;
+                var sub = std.mem.splitScalar(u8, osc.payload, ';');
+                while (sub.next()) |index_tok| {
+                    const value_tok = sub.next() orelse break;
                     if (!std.mem.eql(u8, value_tok, "?")) continue;
-                    const idx = parseDecimal(index_tok) orelse continue;
+                    const idx = std.fmt.parseInt(u32, index_tok, 10) catch continue;
                     if (idx >= 256) continue;
                     if (!palette_loaded) {
                         if (!term.getColorPalette(&palette)) break;
                         palette_loaded = true;
                     }
-                    sendPaletteColorReply(env, @intCast(idx), palette[idx], term_bytes);
+                    sendPaletteColorReply(env, @intCast(idx), palette[idx], osc.term);
                 }
             },
             else => {},

--- a/src/render.zig
+++ b/src/render.zig
@@ -94,6 +94,12 @@ const RawTag = enum { unset, loaded, failed };
 
 /// Lazily populate `out` with the raw cell; memoizes success/failure
 /// in `tag` so repeated calls within one cell do not re-issue the get.
+///
+/// The cache assumes `cells_get(RAW)` is idempotent for a given
+/// iterator position (which it is in libghostty today — it returns a
+/// handle into already-materialized cell data).  If that ever
+/// changes, a failed first call would become sticky for the rest of
+/// the current cell.
 fn loadRawCell(cells: gt.RenderStateRowCells, out: *gt.c.GhosttyCell, tag: *RawTag) bool {
     switch (tag.*) {
         .unset => {
@@ -1291,8 +1297,18 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
     // rotation check. Reuse the start-of-redraw hash when it's still
     // valid (no rotation, no trim) — avoids a second scroll-to-top +
     // render_state_update round trip per redraw.
+    //
+    // If nothing was written AND we didn't populate `cached_row0_hash`
+    // at the top, row 0 cannot have moved since the previous redraw
+    // set `first_scrollback_row_hash`, so skip the compute entirely.
+    // This covers cursor-only redraws and idle-timer fires.
     if (term.scrollback_in_buffer > 0) {
-        term.first_scrollback_row_hash = cached_row0_hash orelse computeFirstScrollbackRowHash(term);
+        if (cached_row0_hash) |h| {
+            term.first_scrollback_row_hash = h;
+        } else if (term.wrote_since_redraw) {
+            term.first_scrollback_row_hash = computeFirstScrollbackRowHash(term);
+        }
+        // else: no writes, no cached hash → existing value is still current.
     } else {
         term.first_scrollback_row_hash = 0;
     }

--- a/src/render.zig
+++ b/src/render.zig
@@ -912,6 +912,12 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
     // A change means the top row is no longer the row we materialized
     // → wipe the buffer and let the delta-sync below re-fetch everything
     // fresh from libghostty.
+    //
+    // When the hash matches (no rotation), stash it in `cached_row0_hash`
+    // and reuse at end-of-redraw. Promotion / insert-at-tail don't shift
+    // row 0, so the start-of-redraw hash is still valid. Trim and
+    // rotation-erase invalidate the cache.
+    var cached_row0_hash: ?u64 = null;
     if (term.wrote_since_redraw and term.scrollback_in_buffer > 0 and term.first_scrollback_row_hash != 0) {
         const new_hash = computeFirstScrollbackRowHash(term);
         // computeFirstScrollbackRowHash scrolled libghostty's viewport to
@@ -926,6 +932,8 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
             term.scrollback_in_buffer = 0;
             term.first_scrollback_row_hash = 0;
             force_full = true;
+        } else {
+            cached_row0_hash = new_hash;
         }
     }
 
@@ -1030,7 +1038,9 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
         }
     } else if (libghostty_sb < term.scrollback_in_buffer) {
         // libghostty's scrollback cap evicted the oldest rows — trim the
-        // same number of lines from the top of the buffer.
+        // same number of lines from the top of the buffer. Trim shifts
+        // row 0 so the start-of-redraw hash is stale.
+        cached_row0_hash = null;
         const delta = term.scrollback_in_buffer - libghostty_sb;
         env.gotoCharN(1);
         if (env.forwardLine(@as(i64, @intCast(delta))) == 0) {
@@ -1278,10 +1288,11 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
     }
 
     // Update the cached first-scrollback-row hash for the next redraw's
-    // rotation check. Always re-sample (cheap) because previous-redraw
-    // promotion/insert/trim could have shifted the row at index 0.
+    // rotation check. Reuse the start-of-redraw hash when it's still
+    // valid (no rotation, no trim) — avoids a second scroll-to-top +
+    // render_state_update round trip per redraw.
     if (term.scrollback_in_buffer > 0) {
-        term.first_scrollback_row_hash = computeFirstScrollbackRowHash(term);
+        term.first_scrollback_row_hash = cached_row0_hash orelse computeFirstScrollbackRowHash(term);
     } else {
         term.first_scrollback_row_hash = 0;
     }

--- a/src/render.zig
+++ b/src/render.zig
@@ -86,6 +86,29 @@ fn formatColor(color: gt.ColorRgb, buf: *[7]u8) []const u8 {
     return buf[0..7];
 }
 
+/// Tri-state cache of the per-cell raw handle. Used by `buildRowContent`
+/// so cells that need both the semantic-content check (in-prompt) and
+/// the wide-spacer check (empty grapheme) only pay for one
+/// `cells_get(RAW)` call.
+const RawTag = enum { unset, loaded, failed };
+
+/// Lazily populate `out` with the raw cell; memoizes success/failure
+/// in `tag` so repeated calls within one cell do not re-issue the get.
+fn loadRawCell(cells: gt.RenderStateRowCells, out: *gt.c.GhosttyCell, tag: *RawTag) bool {
+    switch (tag.*) {
+        .unset => {
+            if (gt.c.ghostty_render_state_row_cells_get(cells, gt.c.GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_RAW, @ptrCast(out)) == gt.SUCCESS) {
+                tag.* = .loaded;
+                return true;
+            }
+            tag.* = .failed;
+            return false;
+        },
+        .loaded => return true,
+        .failed => return false,
+    }
+}
+
 /// Read the style for the current cell from the render state.
 fn readCellStyle(cells: gt.RenderStateRowCells) CellStyle {
     var style: CellStyle = .{};
@@ -493,16 +516,19 @@ fn buildRowContent(
             continue;
         }
 
+        // Raw cell handle, fetched lazily for the semantic-content and
+        // wide-spacer checks that each need it. Without the shared slot,
+        // empty prompt padding would pay for two cells_get(RAW) calls.
+        var raw_cell: gt.c.GhosttyCell = undefined;
+        var raw_tag: RawTag = .unset;
+
         // Track leading prompt characters via cell-level semantic content.
         if (in_prompt) {
-            var raw_cell: gt.c.GhosttyCell = undefined;
             var semantic: c_int = 0; // GHOSTTY_CELL_SEMANTIC_OUTPUT
-            if (gt.c.ghostty_render_state_row_cells_get(term.row_cells, gt.c.GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_RAW, @ptrCast(&raw_cell)) == gt.SUCCESS) {
+            if (loadRawCell(term.row_cells, &raw_cell, &raw_tag)) {
                 _ = gt.c.ghostty_cell_get(raw_cell, gt.c.GHOSTTY_CELL_DATA_SEMANTIC_CONTENT, @ptrCast(&semantic));
             }
-            if (semantic == gt.c.GHOSTTY_CELL_SEMANTIC_PROMPT) {
-                // Will be updated below after chars are counted
-            } else {
+            if (semantic != gt.c.GHOSTTY_CELL_SEMANTIC_PROMPT) {
                 in_prompt = false;
             }
         }
@@ -529,10 +555,9 @@ fn buildRowContent(
             // Wide-character spacer tails occupy a terminal cell but must
             // not produce output — the preceding wide cell already accounts
             // for 2 visual columns in Emacs.
-            var raw_cell_wide: gt.c.GhosttyCell = undefined;
             var wide: c_int = gt.c.GHOSTTY_CELL_WIDE_NARROW;
-            if (gt.c.ghostty_render_state_row_cells_get(term.row_cells, gt.c.GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_RAW, @ptrCast(&raw_cell_wide)) == gt.SUCCESS) {
-                _ = gt.c.ghostty_cell_get(raw_cell_wide, gt.c.GHOSTTY_CELL_DATA_WIDE, @ptrCast(&wide));
+            if (loadRawCell(term.row_cells, &raw_cell, &raw_tag)) {
+                _ = gt.c.ghostty_cell_get(raw_cell, gt.c.GHOSTTY_CELL_DATA_WIDE, @ptrCast(&wide));
             }
             if (wide == gt.c.GHOSTTY_CELL_WIDE_SPACER_TAIL) {
                 has_wide = true;

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -49,6 +49,18 @@ wrote_since_redraw: bool = false,
 /// into the redraw pass where `inhibit-redisplay` prevents flicker.
 resize_pending: bool = false,
 
+/// True iff the last byte of the previous `fnWriteInput` input was
+/// `\r`. Carries the bare-LF detection state across write-input calls
+/// so that a CR at the tail of one write and an LF at the head of the
+/// next don't get normalized into an extra `\r` (producing `\r\r\n`).
+///
+/// Named after the input stream rather than what was fed to libghostty
+/// because the two only differ in that the normalizer may insert a
+/// `\r` before a bare LF — it never drops or rewrites a trailing CR.
+/// Reset by `resize` since a reflow means the stream is effectively
+/// new.
+last_input_was_cr: bool = false,
+
 /// Hash of the first scrollback row's content, sampled at the end of
 /// each redraw that touched scrollback. Used to detect rotation
 /// (libghostty evicting the oldest row in lockstep with new ones being
@@ -226,6 +238,7 @@ pub fn resize(self: *Self, cols: u16, rows: u16) !void {
     self.scrollback_in_buffer = 0;
     self.first_scrollback_row_hash = 0;
     self.resize_pending = true;
+    self.last_input_was_cr = false;
 }
 
 /// Scroll the viewport.

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -643,6 +643,50 @@ than the full terminal `cols'."
       (should (equal 6 (car cur)))                          ; cursor col after LF
       (should (> (cdr cur) 0)))))                           ; cursor moved to row 1+
 
+(ert-deftest ghostel-test-crlf-split-across-writes ()
+  "CRLF pair split across two write-input calls must not double-insert \\r.
+Chunk A ends with \\r, chunk B starts with \\n.  Without cross-call
+state the normalizer would treat the leading \\n as bare and emit
+\\r\\r\\n to libghostty.  Visible effect: cursor lands on row 1 col 6
+after \"first\\r\" + \"\\nsecond\", exactly as if the pair were sent in
+one call; a bug would leave it on row 2 or otherwise desynced."
+  (let ((term (ghostel--new 25 80 1000))
+        (term-single (ghostel--new 25 80 1000)))
+    (ghostel--write-input term "first\r")
+    (ghostel--write-input term "\nsecond")
+    (ghostel--write-input term-single "first\r\nsecond")
+    (should (equal (ghostel-test--cursor term)
+                   (ghostel-test--cursor term-single)))))
+
+(ert-deftest ghostel-test-crlf-split-with-empty-chunk ()
+  "An empty write between \\r and \\n preserves the cross-call CR flag.
+Regression guard for a naive implementation that resets `last_input_was_cr'
+on every entry rather than only when input was consumed."
+  (let ((term (ghostel--new 25 80 1000))
+        (term-single (ghostel--new 25 80 1000)))
+    (ghostel--write-input term "first\r")
+    (ghostel--write-input term "")          ; empty chunk must not clear flag
+    (ghostel--write-input term "\nsecond")
+    (ghostel--write-input term-single "first\r\nsecond")
+    (should (equal (ghostel-test--cursor term)
+                   (ghostel-test--cursor term-single)))))
+
+(ert-deftest ghostel-test-crlf-standalone-cr-then-crlf ()
+  "A lone CR followed by a complete CRLF stays two logical line-endings.
+The normalizer must not collapse the trailing CR of write A and the
+leading \\r of write B's \\r\\n into a single sequence: the input
+\"a\\r\" + \"\\r\\nb\" is equivalent to sending \"a\\r\\r\\nb\" in one
+call.  (Bare \\n comes from Emacs PTYs lacking ONLCR; bare \\r from
+programs that explicitly emit a carriage return — both must be passed
+through without cross-call munging.)"
+  (let ((term (ghostel--new 25 80 1000))
+        (term-single (ghostel--new 25 80 1000)))
+    (ghostel--write-input term "a\r")
+    (ghostel--write-input term "\r\nb")
+    (ghostel--write-input term-single "a\r\r\nb")
+    (should (equal (ghostel-test--cursor term)
+                   (ghostel-test--cursor term-single)))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: raw key sequence fallback
 ;; -----------------------------------------------------------------------
@@ -992,6 +1036,25 @@ Mirrors the real zsh case where the directory still contains a
           (kill-ring nil))
       (ghostel--write-input term "\e]52;c;?\e\\")
       (should (equal nil kill-ring)))))                     ; osc52 query ignored
+
+(ert-deftest ghostel-test-osc-partial-does-not-starve-later ()
+  "A partial OSC must not cannibalize or starve a following complete OSC.
+Input \"\\e]7;PARTIAL\\e]52;c;aGVsbG8=\\a\" would, under a naive
+single-pass scanner, let the OSC 7 payload absorb the OSC 52's BEL
+terminator — yielding a garbage PWD dispatch and no clipboard.  The
+iterator must treat the intervening \\e] as a partial-OSC boundary,
+skip the OSC 7, and still dispatch the OSC 52."
+  (let ((term (ghostel--new 25 80 1000))
+        (ghostel-enable-osc52 t)
+        (kill-ring nil)
+        (pwd-before (ghostel--get-pwd (ghostel--new 25 80 1000))))
+    (ghostel--write-input term "\e]7;PARTIAL\e]52;c;aGVsbG8=\a")
+    ;; OSC 52 dispatched: "hello" in kill-ring.
+    (should kill-ring)
+    (should (equal "hello" (car kill-ring)))
+    ;; OSC 7 NOT dispatched with the garbage payload "PARTIAL\e]52;c;aGVsbG8="
+    ;; — the PWD should still be whatever a fresh terminal reports (nil).
+    (should (equal pwd-before (ghostel--get-pwd term)))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: OSC 4/10/11 color query responses


### PR DESCRIPTION
## Summary

Five self-contained, individually-tested perf and cleanup commits from an architectural review. Each was benchmarked against `main` before moving on.

- **Unify OSC scanning into one pass** — every PTY write used to get scanned five times (one scanner per of OSC 7 / 51 / 52 / 133 / 4-10-11). Replaced with a single `OscIterator` that yields `(code, payload, term)`; post-vtWrite dispatch handles 7/51/52/133 in document order.
- **Stream CRLF normalization** — the old path allocated up to 131 KB of stack scratch (with silent-truncation fallback on heap alloc failure) and did two passes over the input. Now streams directly into libghostty's VT parser — zero allocation, no truncation risk.
- **Share raw-cell fetch in `buildRowContent`** — a cell that hit both the in-prompt branch and the empty-grapheme branch used to pay for `cells_get(RAW)` twice. Lazy tri-state loader dedupes without penalizing cells that need neither.
- **Reuse scrollback row-0 hash within a redraw** — `redraw()` was calling `computeFirstScrollbackRowHash` twice in the common case. Cache the start-of-redraw value and reuse at end; invalidate only on trim / rotation-erase.
- **Consolidate module-load paths** — two near-duplicate loaders (top-level block + `ghostel--load-module`) merged into one, with a `prompt-user` flag selecting between warning (load-time) and `user-error` (interactive) failure modes.

## Bench delta (`make bench-quick`, ±10% noise)

| scenario                     | before    | after     | delta |
|------------------------------|-----------|-----------|-------|
| engine/plain/ghostel-incr    | 65.8 MB/s | 83.6 MB/s | +27%  |
| engine/styled/ghostel-incr   | 60.8 MB/s | 79.4 MB/s | +31%  |
| engine/unicode/ghostel-incr  | 40.1 MB/s | 47.7 MB/s | +19%  |
| stream/ghostel-incr          | 63.2 MB/s | 75.9 MB/s | +20%  |
| pty/plain/ghostel-incr       | 26.1 MB/s | 27.6 MB/s | noise (I/O-bound) |

Most of the engine/stream win is commit #1 alone; the remaining commits compound small improvements on top.

## Not done (originally in the review, rejected after deeper look)

- **Remove `ghostel--raw-key-sequence` fallback** — turned out to be defensive, not dead. `test/ghostel-test.el:4503` explicitly exercises it, and libghostty can legitimately return `SUCCESS` with 0 bytes written.
- **Marker-based scroll preservation** — markers can't replace the content-key system. The real problem is that Emacs autonomously clamps `window-start` to `point-min` when the buffer shrinks; content-keys recover across that. A marker-based substitution would still need the same content-search fallback, adding a code path rather than removing one.

## Test plan

- [x] `make -j4 all` — 30 + 68 + 126 = 224 tests green at every commit
- [x] `make bench-quick` — numbers above
- [ ] Manual smoke: open a ghostel, run `cat large_log`, scroll back, resize window
- [ ] Manual smoke: run a program that uses OSC 7 / 51 / 52 / 133 markers (e.g. the bundled shell integration)