### PR TITLE
Rewrite ghostel-compile: spawn directly, add opt-in global mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,13 @@ footer, error highlighting, and `next-error` navigation — but backed by
 a real TTY so programs that probe `isatty(3)` (coloured output, progress
 bars, curses tools) behave as they do in a normal shell.
 
+Each invocation spawns a fresh process via
+`shell-file-name -c COMMAND` through a PTY owned by the ghostel
+renderer — no interactive shell sits between the command and the
+user, so multi-line shell scripts are passed through verbatim and
+no shell-integration setup is required.  The process sentinel
+delivers the real exit status.
+
 ```elisp
 (require 'ghostel-compile)
 
@@ -481,10 +488,11 @@ bars, curses tools) behave as they do in a normal shell.
 
 Commands:
 
-| Command                 | Description                                         |
-|-------------------------|-----------------------------------------------------|
-| `M-x ghostel-compile`   | Prompt for a command and run it (uses `compile-command`) |
-| `M-x ghostel-recompile` | Re-run the last command in its original directory   |
+| Command                      | Description                                              |
+|------------------------------|----------------------------------------------------------|
+| `M-x ghostel-compile`        | Prompt for a command and run it (uses `compile-command`) |
+| `M-x ghostel-recompile`      | Re-run the last command in its original directory        |
+| `M-x ghostel-compile-global-mode` | Route *all* `compile`-style calls through ghostel (opt-in) |
 
 What a run looks like — the buffer text matches `M-x compile`:
 
@@ -499,16 +507,15 @@ make -j4 test
 Compilation finished at Wed Apr 15 08:30:19, duration 8.20 s
 ```
 
-When the command finishes, the live shell and ghostel renderer are torn
-down and the buffer's major mode is switched to `ghostel-compile-view-mode`
-(derived from `compilation-mode`).  The buffer becomes a regular,
-read-only Emacs buffer with compile-mode's coloured error / line-number
-faces; the buffer never returns to an interactive ghostel terminal —
-a recompile discards it and starts fresh in the original directory.
-Point stays at the end of the output (where the renderer left it) so
-you see the latest output and the footer rather than jumping to the
-top.  `mode-line-process` shows `:run` while the command is running
-and `:exit [N]` afterwards, using the same faces `M-x compile` uses.
+When the command finishes, the live process and ghostel renderer are
+torn down and the buffer's major mode is switched to
+`ghostel-compile-view-mode` (derived from `compilation-mode`).  The
+buffer becomes a regular, read-only Emacs buffer with compile-mode's
+coloured error / line-number faces; the buffer never returns to an
+interactive ghostel terminal — a recompile discards it and starts
+fresh in the original directory.  `mode-line-process` shows
+`:run` while the command is running and `:exit [N]` afterwards, using
+the same faces `M-x compile` uses.
 
 Keybindings (in `ghostel-compile-view-mode`):
 
@@ -538,23 +545,35 @@ These standard `compile` options are honoured:
   `compilation-scroll-output` non-nil).
 
 `ghostel-recompile` runs in the directory the original `ghostel-compile`
-was invoked from, regardless of which buffer you're in when you press
-`g`.
+was invoked from, regardless of which buffer you're in when you press `g`.
+
+#### Make `compile` / `recompile` / `project-compile` use ghostel
+
+Enable `ghostel-compile-global-mode` to advise `compilation-start`
+so every caller that goes through it — `M-x compile`,
+`M-x recompile`, `M-x project-compile`, and any third-party command
+that uses `compilation-start` under the hood — runs in a ghostel
+buffer automatically.
+
+```elisp
+(require 'ghostel-compile)
+(ghostel-compile-global-mode 1)
+```
+
+`grep-mode` falls through to the stock `compilation-start`
+implementation by default, because its output parsing and
+window-management conventions don't fit a live TTY.  Extend
+`ghostel-compile-global-mode-excluded-modes` to opt other modes out.
 
 Ghostel-specific customisation:
 
-| Option                                | Effect                                                                                                             |
-|---------------------------------------|--------------------------------------------------------------------------------------------------------------------|
-| `ghostel-compile-buffer-name`         | Buffer name (default `*ghostel-compile*`)                                                                          |
-| `ghostel-compile-finished-major-mode` | Major mode to switch to after each run (default `ghostel-compile-view-mode`; set to nil to stay in `ghostel-mode`) |
-| `ghostel-compile-hide-prompts`        | Hide surrounding shell prompts (default `t`)                                                                       |
-| `ghostel-compile-clear-buffer`        | Clear the buffer before each run (default `t`)                                                                     |
-| `ghostel-compile-finish-functions`    | Ghostel-specific finish hook (runs alongside `compilation-finish-functions`)                                       |
-| `ghostel-compile-debug`               | Log every OSC 133 C/D event to `*Messages*` (default `nil`)                                                        |
-
-Completion is detected via the OSC 133 `D;<exit>` semantic prompt
-marker, so shell integration (`ghostel-shell-integration`, enabled by
-default) must be active.
+| Option                                       | Effect                                                                                                             |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| `ghostel-compile-buffer-name`                | Buffer name (default `*ghostel-compile*`)                                                                          |
+| `ghostel-compile-finished-major-mode`        | Major mode to switch to after each run (default `ghostel-compile-view-mode`; set to nil to stay in `ghostel-mode`) |
+| `ghostel-compile-finish-functions`           | Ghostel-specific finish hook (runs alongside `compilation-finish-functions`)                                       |
+| `ghostel-compile-global-mode-excluded-modes` | Modes for which the global advice falls through to stock `compile` (default `(grep-mode)`)                         |
+| `ghostel-compile-debug`                      | Log lifecycle events to `*Messages*` (default `nil`)                                                               |
 
 #### Hooks for your own integrations
 

--- a/ghostel-compile.el
+++ b/ghostel-compile.el
@@ -13,27 +13,30 @@
 ;; that detect a terminal (progress bars, colours, curses tools)
 ;; behave as they would in an interactive shell.
 ;;
+;; Each `ghostel-compile' invocation spawns a fresh process via
+;; `shell-file-name -c COMMAND' through a PTY owned by the ghostel
+;; renderer — no interactive shell sits between the command and the
+;; user.  Multi-line scripts are passed verbatim to the shell.  No
+;; OSC 133 / shell integration is required; completion is detected
+;; by the process sentinel, which delivers the real exit status.
+;;
 ;; The buffer mimics `compilation-mode': a "Compilation started at"
-;; header, a "Compilation finished at ..., duration ..." footer (with
-;; the same plain-text format and duration formula `M-x compile'
-;; uses), and surrounding shell prompts are hidden so only the
-;; command's own output is visible.  `mode-line-process' reflects
-;; run/exit state with the same faces `M-x compile' uses.
+;; header, a "Compilation finished at ..., duration ..." footer, and
+;; the same `mode-line-process' run/exit faces.
 ;;
-;; When the command finishes, the live shell and ghostel renderer are
-;; torn down and the buffer's major mode is switched to
-;; `ghostel-compile-view-mode' (derived from `compilation-mode').  At
-;; that point the buffer is a regular, read-only Emacs buffer with
-;; standard error highlighting and `next-error' navigation.  It will
-;; not return to an interactive ghostel terminal — a recompile (`g',
-;; `M-x ghostel-recompile') discards it and starts fresh in the
-;; original `default-directory'.
+;; When the command finishes, the renderer is torn down and the
+;; buffer's major mode is switched to `ghostel-compile-view-mode'
+;; (derived from `compilation-mode').  At that point the buffer is a
+;; regular, read-only Emacs buffer with standard error highlighting
+;; and `next-error' navigation.  It will not return to an interactive
+;; ghostel terminal — a recompile (`g', `M-x ghostel-recompile')
+;; discards it and starts fresh in the original `default-directory'.
 ;;
-;; Completion is detected via the OSC 133 D semantic prompt marker,
-;; so shell integration (`ghostel-shell-integration') must be
-;; enabled — bundled bash, zsh and fish scripts emit those markers
-;; automatically.  `ghostel-compile-debug' logs every OSC 133 C/D
-;; event and the finalize call to *Messages* for diagnostics.
+;; Enable `ghostel-compile-global-mode' to route *all* `compile',
+;; `recompile', `project-compile', ... calls through ghostel.  It
+;; advises `compilation-start' so every caller benefits without any
+;; further configuration.  `grep-mode' (and comint mode) falls through
+;; to the stock implementation.
 ;;
 ;; Standard `compile' options honoured:
 ;;   `compile-command' / `compile-history' (shared with \\[compile])
@@ -55,7 +58,9 @@
 (require 'ghostel)
 (require 'compile)
 
-
+(declare-function ghostel--cursor-position "ghostel-module" (term))
+
+
 ;;; Customization
 
 (defgroup ghostel-compile nil
@@ -75,30 +80,15 @@ navigation and colored error text.
 
 Set to nil to skip the major-mode switch and leave the buffer in
 `ghostel-mode'.  Either way, finalization always tears down the live
-shell and ghostel rendering — the buffer never returns to an
+process and ghostel rendering — the buffer never returns to an
 interactive terminal."
   :type '(choice (const :tag "Compilation view (default)" ghostel-compile-view-mode)
                  (const :tag "Don't switch" nil)
                  (function :tag "Custom major mode")))
 
-(defcustom ghostel-compile-hide-prompts t
-  "When non-nil, hide OSC 133 prompt regions inside the scan range.
-The command echo line and the trailing prompt printed by the shell
-are marked invisible so only the command's own output is shown,
-similar to `M-x compile'."
-  :type 'boolean)
-
-(defcustom ghostel-compile-clear-buffer t
-  "When non-nil, clear the buffer (screen and scrollback) before each run.
-Mirrors `M-x compile's behaviour of starting each compilation with a
-fresh buffer.  Set to nil to keep previous runs visible above the
-new one."
-  :type 'boolean)
-
 (defcustom ghostel-compile-debug nil
-  "When non-nil, log OSC 133 C/D events from `ghostel-compile' to *Messages*.
-Useful for diagnosing wrong exit codes, missed events, or shell
-integration mismatches."
+  "When non-nil, log `ghostel-compile' lifecycle events to *Messages*.
+Useful for diagnosing wrong exit codes or missed events."
   :type 'boolean)
 
 (defcustom ghostel-compile-finish-functions nil
@@ -111,7 +101,7 @@ status message string (e.g. \"finished\\n\" or
 `compilation-finish-functions' is also run with the same arguments."
   :type 'hook)
 
-
+
 ;;; Internal variables
 
 (defvar-local ghostel-compile--command nil
@@ -131,39 +121,19 @@ status message string (e.g. \"finished\\n\" or
 Used by `ghostel-recompile' so the command re-runs in the same
 directory regardless of where the user is when they press `g'.")
 
-(defvar-local ghostel-compile--running nil
-  "State of the in-flight `ghostel-compile' command.
-- nil      : no command in flight (or finalize already ran)
-- `pending': command was sent, but no OSC 133 C marker seen yet
-- `armed'  : C marker seen; the next D marker will trigger finalize
-- `fired'  : a D was accepted, finalize is scheduled; later Ds ignored")
+(defvar-local ghostel-compile--finalized nil
+  "Non-nil once the sentinel has finalized this run.
+Second-chance guard: if the sentinel fires twice (process exit
+followed by teardown) we only run the heavy finalize path once.")
 
-(defvar-local ghostel-compile--header-marker nil
-  "Marker at the end of the inserted compilation header.")
-
-(defvar-local ghostel-compile--footer-marker nil
-  "Marker at the start of the inserted compilation footer.")
-
-(defvar-local ghostel-compile--finalize-timer nil
-  "Pending finalize timer scheduled by `ghostel-compile--on-finish'.
-Set when the first D marker after C is accepted; subsequent D
-markers within the deferred window are ignored (first-D-wins) so
-the real command's exit isn't overwritten by a follow-up prompt's
-D;0.  Cleared by `ghostel-compile--finalize' once it actually
-runs, or by `ghostel-compile-mode' on disable.")
-
-(defvar-local ghostel-compile--owns-compilation-minor-mode nil
-  "Non-nil if `ghostel-compile-mode' enabled `compilation-minor-mode'.
-Tracked so disabling our mode only turns off `compilation-minor-mode'
-when we were the ones who turned it on — never when the user (or
-some other minor mode) had it enabled independently.")
-
-(defvar ghostel-compile-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "g") #'ghostel-recompile)
-    map)
-  "Keymap for `ghostel-compile-mode'.
-Shadows `compilation-minor-mode-map' bindings that clash.")
+(defvar-local ghostel-compile--view-mode-override nil
+  "Buffer-local override for `ghostel-compile-finished-major-mode'.
+Set by the `compilation-start' advice when a caller passes a
+compile-mode subclass (e.g. a custom grep-mode-like mode) so that
+error-regexp and font-lock customisations the subclass installs
+survive into the `ghostel-compile-view-mode' buffer after finalize.
+Nil means finalize falls back to the global
+`ghostel-compile-finished-major-mode'.")
 
 (defvar ghostel-compile-view-mode-map
   (let ((map (make-sparse-keymap)))
@@ -181,15 +151,16 @@ just move point through errors without opening the source file
 in another window.  `g' runs `ghostel-recompile' instead of
 `recompile'.  RET still opens the error like in `compilation-mode'.")
 
-
-;;; Helper functions
+
+;;; Helpers
+
 (define-derived-mode ghostel-compile-view-mode
   compilation-mode "Compilation"
   "Major mode for a finished `ghostel-compile' buffer.
 
 A regular, read-only Emacs buffer.  `g' re-runs the command via
 `ghostel-recompile', `n'/`p' walk errors in the buffer (without
-opening files), RET jumps to the source.  The live shell and
+opening files), RET jumps to the source.  The live process and
 ghostel rendering have been torn down; the buffer will not return
 to a ghostel terminal."
   :group 'ghostel-compile
@@ -217,57 +188,14 @@ Matches the format used by `M-x compile'."
    ((numberp exit) (format "exited abnormally with code %d\n" exit))
    (t              "finished\n")))
 
-(defun ghostel-compile--hide-prompts (start end)
-  "Hide OSC 133 prompt regions and echoed command lines in START..END.
-A buffer line is marked invisible (together with its trailing
-newline) when either condition holds:
-
-1. Any character on the line carries the `ghostel-prompt' text
-   property — the OSC 133 A..B prompt region rendered by the
-   native renderer.
-
-2. The line ends with `ghostel-compile--command' — the shell's
-   PTY-echo of what we typed.  The native renderer applies
-   `ghostel-prompt' only to the prompt glyph itself (A..B), not
-   to the echoed command that follows on the same row, so without
-   this second check the user would see the header's command
-   followed by a duplicated `~/dir λ <cmd>' line right below it."
-  (save-excursion
-    (let ((cmd ghostel-compile--command))
-      (goto-char start)
-      (while (< (point) end)
-        (let* ((bol (line-beginning-position))
-               (eol (min end (line-end-position)))
-               (hide (or
-                      ;; 1. Prompt property anywhere on this line?
-                      (text-property-not-all bol eol
-                                             'ghostel-prompt nil)
-                      ;; 2. Line ends with the echoed command?
-                      (and cmd (not (string-empty-p cmd))
-                           (let ((tail-start
-                                  (max bol (- eol (length cmd)))))
-                             (string= cmd
-                                      (buffer-substring-no-properties
-                                       tail-start eol)))))))
-          (when hide
-            (add-text-properties bol eol '(invisible t))
-            (when (and (< eol end) (eq (char-after eol) ?\n))
-              (add-text-properties eol (1+ eol) '(invisible t)))))
-        (forward-line 1)))))
-
-(defun ghostel-compile--clear-markers ()
-  "Reset header/footer markers."
-  (when (markerp ghostel-compile--header-marker)
-    (set-marker ghostel-compile--header-marker nil))
-  (when (markerp ghostel-compile--footer-marker)
-    (set-marker ghostel-compile--footer-marker nil))
-  (setq ghostel-compile--header-marker nil
-        ghostel-compile--footer-marker nil))
-
 (defun ghostel-compile--header-text (command start-time)
   "Return the header string for COMMAND started at START-TIME.
-Plain text, matching the `M-x compile' header format."
-  (format "-*- mode: ghostel-compile -*-\nCompilation started at %s\n\n%s\n"
+Plain text, matching the `M-x compile' header format — including
+the `default-directory' file-local spec, so reloading the buffer
+restores its compilation directory."
+  (format "-*- mode: ghostel-compile; default-directory: %s -*-\n\
+Compilation started at %s\n\n%s\n"
+          (prin1-to-string (abbreviate-file-name default-directory))
           (substring (current-time-string start-time) 0 19)
           command))
 
@@ -312,11 +240,10 @@ Plain text, matching the `M-x compile' footer format."
           (error nil))))))
 
 (defun ghostel-compile--teardown-terminal ()
-  "Tear down the live shell and ghostel renderer in the current buffer.
+  "Tear down the live process and ghostel renderer in the current buffer.
 Replaces the sentinel and filter with no-ops before deleting the
-process.  Passing nil to `set-process-sentinel' restores the
-*default* sentinel, which writes \"Process NAME killed: N\" into
-the process buffer — exactly what we don't want."
+process so the default sentinel can't write \"Process NAME killed\"
+into our buffer."
   (when (and (bound-and-true-p ghostel--process)
              (process-live-p ghostel--process))
     (set-process-sentinel ghostel--process #'ignore)
@@ -347,9 +274,29 @@ separator line — matching `M-x compile's output format."
       (delete-region (point) (point-max))
       (insert "\n"))))
 
+(defun ghostel-compile--render-header-live (header)
+  "Feed HEADER to the ghostel terminal and commit the render synchronously.
+The buffer-side effect is that HEADER becomes part of the terminal
+scrollback immediately — the user sees the compilation banner while
+the command is running, matching `M-x compile's behaviour.
+
+Newlines in HEADER are rewritten as CRLF so the VT parser returns
+to column 0 at the start of each line; a bare LF only advances the
+cursor one row and would stack the lines diagonally."
+  (when (and ghostel--term (> (length header) 0))
+    (let ((crlf (replace-regexp-in-string "\n" "\r\n" header t t)))
+      (ghostel--write-input ghostel--term crlf))
+    (when ghostel--redraw-timer
+      (cancel-timer ghostel--redraw-timer)
+      (setq ghostel--redraw-timer nil))
+    (ghostel--delayed-redraw (current-buffer))))
+
 (defun ghostel-compile--finalize (buffer exit end-time)
-  "Insert header/footer, hide prompts, parse errors for BUFFER.
+  "Insert header/footer, parse errors, switch major mode for BUFFER.
 EXIT is the command exit status; END-TIME its completion time.
+Safe to call more than once — second and later calls are no-ops
+thanks to `ghostel-compile--finalized'.
+
 Switches the buffer's major mode to
 `ghostel-compile-finished-major-mode' (by default
 `ghostel-compile-view-mode') so the buffer becomes a regular,
@@ -361,240 +308,338 @@ Header and footer are inserted as plain buffer text (matching
 same as in any compilation buffer."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
-      (let* ((start (and ghostel-compile--scan-marker
-                         (marker-position ghostel-compile--scan-marker)))
-             (start-time ghostel-compile--start-time)
-             (command ghostel-compile--command)
-             (directory ghostel-compile--directory)
-             (header (ghostel-compile--header-text command start-time))
-             (footer (ghostel-compile--footer-text exit start-time end-time))
-             (inhibit-read-only t))
-        (setq ghostel-compile--last-exit exit
-              ghostel-compile--running nil
-              ghostel-compile--finalize-timer nil)
-        (when ghostel-compile-debug
-          (message "ghostel-compile: finalizing exit=%S buffer=%S"
-                   exit (buffer-name buffer)))
-        (when (and start ghostel-compile-hide-prompts)
-          (ghostel-compile--hide-prompts start (point-max)))
-        ;; Strip the blank terminal-grid rows the renderer committed
-        ;; after the real output — keeps a short command's footer
-        ;; right below its output instead of 20+ rows below it.
-        (when start
-          (ghostel-compile--trim-trailing-blanks start))
-        (ghostel-compile--clear-markers)
-        (ghostel-compile--teardown-terminal)
-        ;; Switch major mode now that the shell is dead.  Preserve state
-        ;; that `kill-all-local-variables' would otherwise wipe.
-        (let ((saved-command command)
-              (saved-start-time start-time)
-              (saved-directory directory))
-          (when ghostel-compile-finished-major-mode
-            (funcall ghostel-compile-finished-major-mode))
-          (setq-local ghostel-compile--command saved-command
-                      ghostel-compile--directory saved-directory
-                      ghostel-compile--start-time saved-start-time
-                      ghostel-compile--last-exit exit)
-          ;; Pin the buffer's `default-directory' to the directory the
-          ;; user invoked `ghostel-compile' from, so it doesn't drift if
-          ;; the shell happened to `cd' elsewhere during the run.
-          (when saved-directory
-            (setq default-directory saved-directory)))
-        ;; Anchor header at the start of THIS run's output, not at
-        ;; point-min — when `ghostel-compile-clear-buffer' is nil and
-        ;; older output remains in the buffer, the header should still
-        ;; bracket the right region.  Track the resulting parse-start
-        ;; so jit-lock doesn't pick up stale matches above the run.
-        (let* ((inhibit-read-only t)
-               (header-anchor (or start (point-min)))
-               (parse-start (copy-marker header-anchor)))
-          (save-excursion
-            (goto-char header-anchor)
-            (insert header)
-            (setq ghostel-compile--header-marker (point-marker))
-            (set-marker-insertion-type ghostel-compile--header-marker nil))
-          ;; Append footer at end-of-buffer; ensure separation from output.
-          (save-excursion
-            (goto-char (point-max))
-            (unless (or (= (point) (point-min)) (bolp))
-              (insert "\n"))
-            (setq ghostel-compile--footer-marker (point-marker))
-            (set-marker-insertion-type ghostel-compile--footer-marker nil)
-            (insert footer))
-          ;; Parse only this run's output.  Seed `compilation--parsed'
-          ;; at the start of the run so `compilation--ensure-parse'
-          ;; (and any later jit-lock pass) skip everything above it —
-          ;; otherwise old output left over by `--clear-buffer nil'
-          ;; would leak into `next-error' and the error count.  Note:
-          ;; `compilation-mode' initialises `compilation--parsed' to
-          ;; -1 (not a marker), so we set the marker ourselves.
-          (save-excursion
-            (save-restriction
-              (widen)
-              (setq-local compilation--parsed (copy-marker parse-start))
-              (condition-case err
-                  (compilation--ensure-parse (point-max))
-                (error
-                 (message "ghostel-compile: error scanning output: %s"
-                          (error-message-string err)))))))
-        ;; Put point at `point-max' — past the footer — so the user
-        ;; actually sees the "Compilation finished at ..., duration ..."
-        ;; line instead of having it scroll below the window bottom.
-        ;; Recenter each window on this buffer so that line is flush
-        ;; with the bottom of the window.
-        (goto-char (point-max))
-        (dolist (win (get-buffer-window-list buffer nil t))
-          (set-window-point win (point-max))
-          (with-selected-window win (recenter -1))))
-      (ghostel-compile--set-mode-line-exit exit)
-      (setq next-error-last-buffer buffer)
-      (ghostel-compile--auto-jump buffer)
-      (let ((msg (ghostel-compile--status-message exit)))
-        (run-hook-with-args 'compilation-finish-functions buffer msg)
-        (run-hook-with-args 'ghostel-compile-finish-functions buffer msg)))))
+      (unless ghostel-compile--finalized
+        (setq ghostel-compile--finalized t)
+        (let* ((start (and ghostel-compile--scan-marker
+                           (marker-position ghostel-compile--scan-marker)))
+               (start-time ghostel-compile--start-time)
+               (command ghostel-compile--command)
+               (directory ghostel-compile--directory)
+               (footer (ghostel-compile--footer-text exit start-time end-time))
+               (inhibit-read-only t))
+          (setq ghostel-compile--last-exit exit)
+          (when ghostel-compile-debug
+            (message "ghostel-compile: finalizing exit=%S buffer=%S"
+                     exit (buffer-name buffer)))
+          (when start
+            (ghostel-compile--trim-trailing-blanks start))
+          (ghostel-compile--teardown-terminal)
+          ;; Switch major mode now that the process is dead.  Preserve state
+          ;; that `kill-all-local-variables' would otherwise wipe.  A
+          ;; per-buffer override (set by the `compilation-start' advice
+          ;; when the caller passes a custom compile-mode subclass) wins
+          ;; over the global default — so error-regexp and font-lock
+          ;; customisations the subclass installs survive into the
+          ;; finished buffer.
+          (let* ((saved-command command)
+                 (saved-start-time start-time)
+                 (saved-directory directory)
+                 (target-mode (or ghostel-compile--view-mode-override
+                                  ghostel-compile-finished-major-mode)))
+            (when target-mode
+              (funcall target-mode))
+            (setq-local ghostel-compile--command saved-command
+                        ghostel-compile--directory saved-directory
+                        ghostel-compile--start-time saved-start-time
+                        ghostel-compile--last-exit exit
+                        ghostel-compile--finalized t)
+            ;; Pin the buffer's `default-directory' to the directory the
+            ;; user invoked `ghostel-compile' from, so it doesn't drift if
+            ;; the command happened to `cd' elsewhere during the run.
+            (when saved-directory
+              (setq default-directory saved-directory)))
+          ;; The header was rendered into the VT terminal pre-spawn, so
+          ;; it is already buffer text above `scan-marker'.  Append the
+          ;; footer and parse errors over the run's own output.
+          (let* ((inhibit-read-only t)
+                 (parse-start (copy-marker (or start (point-min)))))
+            (save-excursion
+              (goto-char (point-max))
+              ;; Start the footer on a fresh line, then leave a blank
+              ;; separator line between the last output and the footer
+              ;; — matches the `\n\nCompilation finished ...' format
+              ;; `M-x compile' uses.
+              (unless (or (= (point) (point-min)) (bolp))
+                (insert "\n"))
+              (insert "\n" footer))
+            (save-excursion
+              (save-restriction
+                (widen)
+                (setq-local compilation--parsed (copy-marker parse-start))
+                (condition-case err
+                    (compilation--ensure-parse (point-max))
+                  (error
+                   (message "ghostel-compile: error scanning output: %s"
+                            (error-message-string err)))))))
+          (goto-char (point-max))
+          (dolist (win (get-buffer-window-list buffer nil t))
+            (set-window-point win (point-max))
+            (with-selected-window win (recenter -1))))
+        (ghostel-compile--set-mode-line-exit exit)
+        (setq next-error-last-buffer buffer)
+        (ghostel-compile--auto-jump buffer)
+        (let ((msg (ghostel-compile--status-message exit)))
+          (run-hook-with-args 'compilation-finish-functions buffer msg)
+          (run-hook-with-args 'ghostel-compile-finish-functions buffer msg))))))
 
-(defun ghostel-compile--on-start (buffer)
-  "Hook function: arm finalize gating for BUFFER on OSC 133 C marker.
-A D marker is only treated as the user command's exit when a C
-marker has been seen since `ghostel-compile' was invoked.  This
-filters out spurious D markers from prompt redraws (e.g. shell
-clear-screen handlers after we send `\\f' to refresh the display).
 
-When we transition from `pending' to `armed', snap the scan
-marker to the current `point-max'.  The scan marker must land
-*after* any content the shell rendered in response to our clear
-\(the fresh prompt re-echo), which arrives asynchronously through
-the process filter — not synchronously during `ghostel-compile'.
-The C marker is emitted by the shell's preexec / DEBUG trap right
-before the user's command starts producing output, so point-max
-at that moment is exactly the boundary between \"pre-command
-noise\" and the command's real output."
-  (when (and (buffer-live-p buffer)
-             (buffer-local-value 'ghostel-compile-mode buffer))
-    (with-current-buffer buffer
-      (when ghostel-compile-debug
-        (message "ghostel-compile: OSC 133 C — running=%S"
-                 ghostel-compile--running))
-      (when (eq ghostel-compile--running 'pending)
-        (setq ghostel-compile--running 'armed
-              ghostel-compile--scan-marker (copy-marker (point-max)))))))
+;;; Spawning
 
-(defun ghostel-compile--on-finish (buffer exit)
-  "Hook function: schedule finalize for BUFFER with EXIT status.
-
-Runs deferred so any rendering from the same output batch settles
-first.  Only acts when `ghostel-compile--running' is `armed' (i.e.
-a C marker has been seen) — D markers from prompt redraws or other
-shell activity that haven't been preceded by a C are ignored.
-
-The first D after C wins.  Subsequent Ds before finalize actually
-fires are ignored, so a follow-up prompt's D;0 cannot overwrite
-the real command's exit status."
-  (when (and (buffer-live-p buffer)
-             (buffer-local-value 'ghostel-compile-mode buffer))
-    (with-current-buffer buffer
-      (when ghostel-compile-debug
-        (message "ghostel-compile: OSC 133 D;%S — running=%S"
-                 exit ghostel-compile--running))
-      (when (eq ghostel-compile--running 'armed)
-        (setq ghostel-compile--running 'fired
-              ghostel-compile--finalize-timer
-              (run-at-time 0.05 nil
-                           #'ghostel-compile--finalize
-                           buffer exit (current-time)))))))
-
-(define-minor-mode ghostel-compile-mode
-  "Minor mode that turns a ghostel buffer into a compilation buffer.
-
-When enabled, an OSC 133 D marker triggers an error scan over the
-command's output, a compilation-style header/footer is inserted,
-surrounding prompts are hidden, and the buffer's major mode is
-switched to `ghostel-compile-finished-major-mode' (by default
-`ghostel-compile-view-mode' — derived from `compilation-mode').
-Pressing \\<ghostel-compile-mode-map>\\[ghostel-recompile] re-runs
-the last command."
-  :lighter " gh-compile"
-  :keymap ghostel-compile-mode-map
-  (cond
-   (ghostel-compile-mode
-    (unless (derived-mode-p 'ghostel-mode)
-      (setq ghostel-compile-mode nil)
-      (user-error "`ghostel-compile-mode' can only be enabled in a ghostel buffer"))
-    ;; Only adopt `compilation-minor-mode' if it isn't already on, and
-    ;; remember whether we turned it on so we don't yank it from under
-    ;; some other consumer when our mode is disabled.
-    (setq ghostel-compile--owns-compilation-minor-mode
-          (not (bound-and-true-p compilation-minor-mode)))
-    (compilation-minor-mode 1)
-    (setq-local next-error-function #'compilation-next-error-function)
-    ;; Ensure our `g' binding wins over `compilation-minor-mode-map'.
-    (setq-local minor-mode-overriding-map-alist
-                (cons (cons 'ghostel-compile-mode ghostel-compile-mode-map)
-                      (assq-delete-all
-                       'ghostel-compile-mode
-                       minor-mode-overriding-map-alist)))
-    (add-hook 'ghostel-command-start-functions
-              #'ghostel-compile--on-start nil t)
-    (add-hook 'ghostel-command-finish-functions
-              #'ghostel-compile--on-finish nil t))
-   (t
-    (setq-local minor-mode-overriding-map-alist
-                (assq-delete-all
-                 'ghostel-compile-mode
-                 minor-mode-overriding-map-alist))
-    (remove-hook 'ghostel-command-start-functions
-                 #'ghostel-compile--on-start t)
-    (remove-hook 'ghostel-command-finish-functions
-                 #'ghostel-compile--on-finish t)
-    ;; Cancel any pending finalize and reset the in-flight state so
-    ;; turning the mode off mid-command doesn't leak `pending'/`armed'
-    ;; into the next enable cycle.
-    (when (timerp ghostel-compile--finalize-timer)
-      (cancel-timer ghostel-compile--finalize-timer))
-    (setq ghostel-compile--finalize-timer nil
-          ghostel-compile--running nil)
-    ;; Only turn off `compilation-minor-mode' (and the `next-error'
-    ;; wiring that goes with it) if WE turned it on; otherwise the
-    ;; user's pre-existing `compilation-minor-mode' would be left
-    ;; with its `next-error-function' yanked out from under it.
-    (when (and ghostel-compile--owns-compilation-minor-mode
-               (bound-and-true-p compilation-minor-mode))
-      (compilation-minor-mode -1)
-      (kill-local-variable 'next-error-function))
-    (setq ghostel-compile--owns-compilation-minor-mode nil))))
-
-(defun ghostel-compile--get-or-create-buffer ()
-  "Return a live ghostel-compile buffer, creating one if needed.
-Uses the caller's `default-directory' as the new buffer's working
-directory — captured before any buffer kill, so that
-`ghostel-recompile' (which kills the previous `view-mode' buffer)
-runs in the directory bound by its caller, not whatever buffer
-happens to be current after the kill."
-  (let ((existing (get-buffer ghostel-compile-buffer-name))
-        (dir default-directory))
-    (if (and existing
-             (with-current-buffer existing
-               (and (derived-mode-p 'ghostel-mode)
-                    ghostel--process
-                    (process-live-p ghostel--process))))
-        existing
-      (when existing
-        (kill-buffer existing))
-      ;; Create the buffer without displaying it — `ghostel-compile'
-      ;; places it via `display-buffer' afterwards.  Going through the
-      ;; interactive `ghostel' command would `pop-to-buffer' here,
-      ;; which hijacks the caller's window *and* pollutes the window's
-      ;; previous-buffers history (making later `display-buffer' calls
-      ;; pick the same window via `display-buffer-in-previous-window').
-      (ghostel--load-module t)
-      (let ((buffer (get-buffer-create ghostel-compile-buffer-name)))
+(defun ghostel-compile--sentinel (process _event)
+  "Sentinel for the compile PROCESS: finalize the buffer on exit."
+  (when (memq (process-status process) '(exit signal))
+    (let ((buffer (process-buffer process))
+          (exit (process-exit-status process)))
+      (when (buffer-live-p buffer)
         (with-current-buffer buffer
-          (setq-local default-directory dir))
-        (ghostel--init-buffer buffer)
-        buffer))))
+          (when ghostel-compile-debug
+            (message "ghostel-compile: sentinel exit=%S status=%S"
+                     exit (process-status process)))
+          ;; Flush pending bytes to the VT parser, then cancel any
+          ;; scheduled redraw and commit the current terminal state to
+          ;; the buffer synchronously.  Without this, a short-lived
+          ;; command (`echo`, `false`, `exit 7`) finishes before the
+          ;; ~16 ms redraw timer fires and its output is lost when
+          ;; `--teardown-terminal' destroys the renderer.
+          (when ghostel--term
+            (ghostel--flush-pending-output)
+            (when ghostel--redraw-timer
+              (cancel-timer ghostel--redraw-timer)
+              (setq ghostel--redraw-timer nil))
+            (ghostel--delayed-redraw buffer))
+          (setq compilation-in-progress
+                (delq process compilation-in-progress))
+          (when (fboundp 'compilation--update-in-progress-mode-line)
+            (compilation--update-in-progress-mode-line))
+          (ghostel-compile--finalize buffer exit (current-time)))))))
 
-
-;;; Public `ghostel-compile' entry point
+(defconst ghostel-compile--stty-flags "erase '^?' iutf8 -ixon -echo"
+  "`stty' flags for the compile PTY.
+Matches `ghostel--spawn-pty's flags for non-shell programs, with
+`echo' off so we don't render an echoed copy of the command (which
+users already see in the header).")
+
+(defun ghostel-compile--spawn (command buffer height width)
+  "Spawn COMMAND in BUFFER via a PTY sized HEIGHT rows by WIDTH columns.
+Installs `ghostel--filter' and `ghostel-compile--sentinel'.  Returns
+the process.
+
+COMMAND is passed verbatim to `shell-file-name' via
+`shell-command-switch', so multi-line scripts and shell
+metacharacters are handled the same way `M-x compile' handles
+them.  `/bin/sh' is used only to set PTY attributes (stty) before
+exec'ing the user's shell.
+
+For remote (TRAMP) `default-directory's, `shell-file-name' and
+`shell-command-switch' are resolved via `with-connection-local-variables'
+so the remote host's shell is used (not whatever zsh/bash path the
+local machine happens to have)."
+  (let* ((remote-p (file-remote-p default-directory))
+         (shell (if remote-p
+                    (with-connection-local-variables shell-file-name)
+                  shell-file-name))
+         (switch (if remote-p
+                     (with-connection-local-variables shell-command-switch)
+                   shell-command-switch))
+         (wrapper
+          (list "/bin/sh" "-c"
+                (concat
+                 "stty " ghostel-compile--stty-flags
+                 (format " rows %d columns %d" height width)
+                 " 2>/dev/null; "
+                 "exec "
+                 (shell-quote-argument shell) " "
+                 (shell-quote-argument switch) " "
+                 (shell-quote-argument command))))
+         (process-environment
+          (append compilation-environment
+                  (list (format "INSIDE_EMACS=%s,compile" emacs-version)
+                        "TERM=xterm-256color"
+                        "COLORTERM=truecolor"
+                        ;; Defeat pagers (git grep, etc.).
+                        "PAGER=")
+                  (copy-sequence process-environment)))
+         (proc (make-process
+                :name "ghostel-compile"
+                :buffer buffer
+                :command wrapper
+                :connection-type 'pty
+                :file-handler remote-p
+                :filter #'ghostel--filter
+                :sentinel #'ghostel-compile--sentinel)))
+    ;; Store the process on the buffer so `ghostel--self-insert'
+    ;; (and other ghostel-mode key handlers) can send keystrokes to
+    ;; it — that's how users interact with long-running programs
+    ;; (`htop', `less', test prompts, ...) during the compile.
+    (with-current-buffer buffer
+      (setq ghostel--process proc))
+    (set-process-coding-system proc 'binary 'binary)
+    (set-process-window-size proc height width)
+    (when compilation-always-kill
+      (set-process-query-on-exit-flag proc nil))
+    (process-put proc 'adjust-window-size-function
+                 #'ghostel--window-adjust-process-window-size)
+    proc))
+
+
+;;; Buffer management
+
+(defconst ghostel-compile--managed-buffer-sentinel :ghostel-compile
+  "Sentinel value used for `ghostel--managed-buffer-name' in compile buffers.
+When set, `ghostel--set-title' (OSC 2) skips auto-renaming the buffer — we
+don't want a compile command's title sequence to replace our fixed name.")
+
+(defun ghostel-compile--prepare-buffer (name dir)
+  "Return the ghostel buffer named NAME, reset for a fresh run from DIR.
+If a buffer with NAME already exists, the run is prepared in place
+— the buffer is erased and the terminal rebuilt, but the buffer
+object is preserved.  This keeps any window already displaying the
+buffer stable across recompiles (so `g' in a compile buffer reuses
+its window, matching `M-x recompile').
+
+If the existing buffer has a live process, prompt via `yes-or-no-p'
+before killing it, unless `compilation-always-kill' is non-nil or
+the process has its query-on-exit flag cleared.
+
+Creates the terminal directly — no interactive shell is spawned —
+so there is no remote-integration round-trip on TRAMP buffers."
+  (let ((existing (get-buffer name)))
+    (when existing
+      (with-current-buffer existing
+        (let ((proc (bound-and-true-p ghostel--process)))
+          (when (process-live-p proc)
+            (if (or (eq (process-query-on-exit-flag proc) nil)
+                    compilation-always-kill
+                    (yes-or-no-p
+                     (format "A %s process is running; kill it? "
+                             (buffer-name existing))))
+                (condition-case nil
+                    (progn
+                      ;; Our sentinel is what removes the process from
+                      ;; `compilation-in-progress'; we're about to
+                      ;; suppress it (replacing with `#'ignore'), so
+                      ;; do that bookkeeping ourselves now to avoid
+                      ;; leaking a dead entry.
+                      (setq compilation-in-progress
+                            (delq proc compilation-in-progress))
+                      (set-process-sentinel proc #'ignore)
+                      (set-process-filter proc #'ignore)
+                      (interrupt-process proc)
+                      (sit-for 0.1)
+                      (delete-process proc))
+                  (error nil))
+              (error "Cannot have two processes in `%s' at once"
+                     (buffer-name existing))))
+          (setq ghostel--process nil))
+        (when (bound-and-true-p ghostel--redraw-timer)
+          (cancel-timer ghostel--redraw-timer)
+          (setq ghostel--redraw-timer nil))
+        (when (bound-and-true-p ghostel--input-timer)
+          (cancel-timer ghostel--input-timer)
+          (setq ghostel--input-timer nil)))))
+  (ghostel--load-module t)
+  (let* ((buffer (get-buffer-create name))
+         (win (or (get-buffer-window buffer t) (selected-window)))
+         (height (if (window-live-p win) (window-body-height win) 24))
+         (width  (if (window-live-p win) (window-max-chars-per-line win) 80)))
+    (with-current-buffer buffer
+      ;; Reset to `ghostel-mode' unconditionally — on a recompile the
+      ;; buffer is in `ghostel-compile-view-mode' (derived from
+      ;; `compilation-mode', *not* `ghostel-mode'), so the previous
+      ;; `(unless derived-mode-p ghostel-mode) (ghostel-mode))' guard
+      ;; also fired, but also made state-reset implicit; make it
+      ;; explicit here so this helper doesn't have two code paths.
+      (ghostel-mode)
+      (setq-local default-directory dir)
+      (let ((inhibit-read-only t))
+        (erase-buffer))
+      (setq ghostel--pending-output nil)
+      ;; Pin the buffer name so a compile command's OSC 2 title sequence
+      ;; can't rename the buffer mid-run.  `ghostel--set-title' only
+      ;; renames when `ghostel--managed-buffer-name' equals the current
+      ;; buffer name (see ghostel.el); a sentinel that can never match
+      ;; disables auto-renaming.
+      (setq ghostel--managed-buffer-name
+            ghostel-compile--managed-buffer-sentinel)
+      (setq ghostel--term (ghostel--new height width ghostel-max-scrollback))
+      (setq ghostel--term-rows height)
+      (ghostel--apply-palette ghostel--term))
+    buffer))
+
+
+;;; Entry points
+
+(defun ghostel-compile--start (command buffer-name dir &optional finished-mode)
+  "Run COMMAND in BUFFER-NAME from DIR and return the buffer.
+Creates or resets the buffer, spawns COMMAND via `shell-file-name',
+and displays the buffer.  Used by both `ghostel-compile' and the
+`compilation-start' advice installed by `ghostel-compile-global-mode'.
+
+FINISHED-MODE, when non-nil, is the major mode to switch the
+buffer into after finalize (overriding
+`ghostel-compile-finished-major-mode').  The advice uses this to
+honour custom compile-mode subclasses the caller passed to
+`compilation-start'."
+  (unless (and command (not (string-blank-p command)))
+    (user-error "Empty compile command"))
+  (save-some-buffers (not compilation-ask-about-save)
+                     compilation-save-buffers-predicate)
+  (let* ((buffer (ghostel-compile--prepare-buffer buffer-name dir))
+         (outwin (display-buffer buffer '(nil (allow-no-window . t))))
+         (start-time (current-time)))
+    (with-current-buffer buffer
+      ;; During the run the buffer stays plain `ghostel-mode' so
+      ;; keystrokes reach the process for interactive programs like
+      ;; `htop', `less', or read prompts.  Compile-mode semantics
+      ;; (`g', `n'/`p', error nav) kick in at finalize when the
+      ;; buffer is switched to `ghostel-compile-view-mode'.
+      (setq ghostel-compile--command command
+            ghostel-compile--directory dir
+            ghostel-compile--start-time start-time
+            ghostel-compile--last-exit nil
+            ghostel-compile--finalized nil
+            ghostel-compile--view-mode-override finished-mode)
+      ;; Render the compilation header into the terminal before spawning
+      ;; the command, so the user sees the "Compilation started at ..."
+      ;; banner *during* the run rather than only when it finishes (the
+      ;; same behaviour `M-x compile' has).  Bytes are written as CRLF
+      ;; so the VT parser lands on column 0 after each line.
+      (ghostel-compile--render-header-live
+       (ghostel-compile--header-text command start-time))
+      ;; Place the scan marker at the buffer position right after the
+      ;; header — NOT at `point-max' — because the VT renderer pads
+      ;; the grid out to `ghostel--term-rows' lines, so `point-max'
+      ;; sits well below the command's first output row.  Anchoring
+      ;; here makes `--trim-trailing-blanks' correctly strip padding
+      ;; between the last output line and the footer.
+      ;;
+      ;; The VT cursor's row after the render is where output will go;
+      ;; use it directly (via `ghostel--cursor-position') rather than
+      ;; counting source newlines in the header text — a long command
+      ;; line that wraps in the terminal would desynchronise otherwise.
+      (setq ghostel-compile--scan-marker
+            (save-excursion
+              (goto-char (point-min))
+              (forward-line (cdr (ghostel--cursor-position ghostel--term)))
+              (copy-marker (point))))
+      (ghostel-compile--set-mode-line-running)
+      (let* ((height (max 1 (if outwin
+                                (window-body-height outwin)
+                              (window-body-height))))
+             (width (max 1 (if outwin
+                               (window-body-width outwin)
+                             (window-max-chars-per-line))))
+             (proc (ghostel-compile--spawn command buffer height width)))
+        ;; Match stock `compilation-start' ordering: hook fires before
+        ;; `compilation-in-progress' is updated, so hook functions can
+        ;; install filter-hooks / error-regexps before the next
+        ;; redisplay tick processes any output.
+        (run-hook-with-args 'compilation-start-hook proc)
+        (push proc compilation-in-progress)
+        (when (fboundp 'compilation--update-in-progress-mode-line)
+          (compilation--update-in-progress-mode-line))
+        (setq next-error-last-buffer buffer)))
+    buffer))
 
 ;;;###autoload
 (defun ghostel-compile (command)
@@ -602,20 +647,21 @@ happens to be current after the kill."
 
 Like \\[compile], but uses a ghostel buffer so programs that require
 a real TTY work correctly.  The buffer gets a compilation-mode-like
-header and footer, surrounding prompts are hidden, and when the
-command finishes (detected via the OSC 133 D semantic prompt marker)
-the major mode is switched to `ghostel-compile-finished-major-mode'
-\(by default `ghostel-compile-view-mode', derived from
-`compilation-mode').  Error locations become available through
-`next-error'.
+header and footer, and when the command finishes the major mode is
+switched to `ghostel-compile-finished-major-mode' (by default
+`ghostel-compile-view-mode', derived from `compilation-mode').
+Error locations become available through `next-error'.
+
+COMMAND is passed verbatim to `shell-file-name -c', so multi-line
+scripts work exactly as in \\[shell-command].  No shell-integration
+setup is required — the process sentinel reports the real exit
+status.
 
 Output always scrolls as it arrives (equivalent to
 `compilation-scroll-output' being non-nil).  `compilation-ask-about-save'
 and `compilation-auto-jump-to-first-error' are honoured.  The command
 default and history are shared with \\[compile] via `compile-command'
-and `compile-history'.
-
-Requires shell integration; see `ghostel-shell-integration'."
+and `compile-history'."
   (interactive
    (list
     (let ((default (eval compile-command t)))
@@ -627,31 +673,7 @@ Requires shell integration; see `ghostel-shell-integration'."
         default))))
   (unless (equal command (eval compile-command t))
     (setq compile-command command))
-  (save-some-buffers (not compilation-ask-about-save)
-                     compilation-save-buffers-predicate)
-  (let ((buffer (ghostel-compile--get-or-create-buffer)))
-    (with-current-buffer buffer
-      (when (bound-and-true-p ghostel--copy-mode-active)
-        (ghostel-copy-mode-exit))
-      (unless ghostel-compile-mode
-        (ghostel-compile-mode 1))
-      (ghostel-compile--clear-markers)
-      (when ghostel-compile-clear-buffer
-        (ghostel-clear-scrollback))
-      ;; The scan marker is snapped by `ghostel-compile--on-start' when
-      ;; the shell emits OSC 133 C — by then any async output from our
-      ;; clear-scrollback's `\\f' (the re-echoed prompt) has already
-      ;; landed, so the marker lands exactly at the command's own
-      ;; output boundary instead of above that noise.
-      (setq ghostel-compile--command command
-            ghostel-compile--directory default-directory
-            ghostel-compile--start-time (current-time)
-            ghostel-compile--last-exit nil
-            ghostel-compile--running 'pending
-            ghostel-compile--scan-marker nil)
-      (ghostel-compile--set-mode-line-running)
-      (ghostel--flush-output (concat command "\n")))
-    (display-buffer buffer '(nil (allow-no-window . t)))))
+  (ghostel-compile--start command ghostel-compile-buffer-name default-directory))
 
 (defun ghostel-recompile (&optional edit-command)
   "Re-run the last `ghostel-compile' command in its original directory.
@@ -659,16 +681,26 @@ If EDIT-COMMAND is non-nil, prompt for the command so the user can
 edit it before running — interactively this is triggered by a
 prefix arg, matching the convention of \\[recompile].
 
-Falls back to `compile-command' (and the current `default-directory')
-when no ghostel compile has run yet."
+When invoked from a ghostel-compile buffer (any buffer with a
+local `ghostel-compile--command'), re-runs into THAT buffer — the
+window showing it stays put.  This matches `M-x recompile' in a
+`*compilation*' buffer.  Otherwise falls back to
+`ghostel-compile-buffer-name', and ultimately to `compile-command'
+with the current `default-directory' when no prior run exists."
   (interactive "P")
-  (let* ((buf (get-buffer ghostel-compile-buffer-name))
-         (cmd (or (and (buffer-live-p buf)
-                       (buffer-local-value 'ghostel-compile--command buf))
+  (let* ((source (cond
+                  ((local-variable-p 'ghostel-compile--command)
+                   (current-buffer))
+                  ((get-buffer ghostel-compile-buffer-name))))
+         (cmd (or (and (buffer-live-p source)
+                       (buffer-local-value 'ghostel-compile--command source))
                   (eval compile-command t)))
-         (dir (or (and (buffer-live-p buf)
-                       (buffer-local-value 'ghostel-compile--directory buf))
-                  default-directory)))
+         (dir (or (and (buffer-live-p source)
+                       (buffer-local-value 'ghostel-compile--directory source))
+                  default-directory))
+         (name (if (buffer-live-p source)
+                   (buffer-name source)
+                 ghostel-compile-buffer-name)))
     (unless (and cmd (not (string-blank-p cmd)))
       (user-error "No previous `ghostel-compile' command to re-run"))
     (when edit-command
@@ -679,8 +711,84 @@ when no ghostel compile has run yet."
                    'compile-history)))
       (unless (equal cmd (eval compile-command t))
         (setq compile-command cmd)))
-    (let ((default-directory dir))
-      (ghostel-compile cmd))))
+    (ghostel-compile--start cmd name dir)))
+
+
+;;; ghostel-compile-global-mode — opt-in: advise compilation-start
+
+(defcustom ghostel-compile-global-mode-excluded-modes '(grep-mode)
+  "Modes for which `ghostel-compile-global-mode' falls through to stock `compile'.
+`grep-mode' is excluded by default because it has its own output
+parsing and window-management conventions that don't fit a TTY.
+Add your own compile-mode subclass to this list if you need to
+opt a specific caller out."
+  :type '(repeat symbol))
+
+(defun ghostel-compile--compilation-start-advice
+    (orig-fn command &optional mode name-function highlight-regexp continue)
+  "Around advice for `compilation-start': route COMMAND through ghostel.
+Falls back to ORIG-FN (with COMMAND, MODE, NAME-FUNCTION,
+HIGHLIGHT-REGEXP, CONTINUE unchanged) when:
+
+- MODE is t — `compilation-start' asks for a comint buffer, which
+  we don't emulate.
+- MODE is in `ghostel-compile-global-mode-excluded-modes' — e.g.
+  `grep-mode' by default.
+- CONTINUE is non-nil — the caller wants to append to an existing
+  compilation buffer; each `ghostel-compile' run replaces its
+  buffer from scratch, so we can't honour that.
+
+Otherwise routes COMMAND through `ghostel-compile--start', honouring
+NAME-FUNCTION for the buffer name and HIGHLIGHT-REGEXP for error
+highlighting."
+  (if (or (eq mode t)
+          continue
+          (memq mode ghostel-compile-global-mode-excluded-modes))
+      (funcall orig-fn command mode name-function highlight-regexp continue)
+    (let* ((actual-mode (or mode 'compilation-mode))
+           (name-of-mode
+            (replace-regexp-in-string "-mode\\'" ""
+                                      (symbol-name actual-mode)))
+           (buf-name (compilation-buffer-name
+                      name-of-mode actual-mode name-function))
+           ;; Pass a custom compile-mode subclass through so finalize
+           ;; can switch to it (honouring its error-regexp,
+           ;; font-lock keywords, keymap, etc.).  For plain
+           ;; `compilation-mode' we use nil so the default
+           ;; `ghostel-compile-finished-major-mode'
+           ;; (= `ghostel-compile-view-mode') kicks in, which derives
+           ;; from `compilation-mode' and adds our own keybindings.
+           (finished-mode (unless (eq actual-mode 'compilation-mode)
+                            actual-mode))
+           (buffer (ghostel-compile--start command buf-name
+                                           default-directory
+                                           finished-mode)))
+      (when highlight-regexp
+        (with-current-buffer buffer
+          (setq-local compilation-highlight-regexp highlight-regexp)))
+      buffer)))
+
+;;;###autoload
+(define-minor-mode ghostel-compile-global-mode
+  "Global minor mode: route all `compile'-style calls through ghostel.
+
+When enabled, advises `compilation-start' so that \\[compile],
+\\[recompile], \\[project-compile], and every other caller that
+goes through `compilation-start' runs in a ghostel terminal —
+giving you a real TTY for progress bars, colours, and curses tools
+without having to switch commands.
+
+Modes in `ghostel-compile-global-mode-excluded-modes' (by default,
+`grep-mode') still use the stock implementation, since their output
+parsers and window-management conventions don't fit a live TTY."
+  :global t
+  :group 'ghostel-compile
+  (if ghostel-compile-global-mode
+      (advice-add 'compilation-start :around
+                  #'ghostel-compile--compilation-start-advice)
+    (advice-remove 'compilation-start
+                   #'ghostel-compile--compilation-start-advice)))
+
 
 (provide 'ghostel-compile)
 

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -20,14 +20,13 @@
 ;;; Helpers
 
 (defmacro ghostel-test--with-compile-buffer (var &rest body)
-  "Run BODY in a fresh ghostel-mode buffer bound to VAR with compile-mode on."
+  "Run BODY in a fresh ghostel-mode buffer bound to VAR."
   (declare (indent 1))
   `(let ((,var (generate-new-buffer " *ghostel-test-compile*"))
          (inhibit-message t))
      (unwind-protect
          (with-current-buffer ,var
            (ghostel-mode)
-           (ghostel-compile-mode 1)
            ,@body)
        (kill-buffer ,var))))
 
@@ -1720,93 +1719,8 @@ bind `debug-on-error' to nil."
         (should later-ran)))))                                 ; second hook still fired
 
 ;; -----------------------------------------------------------------------
-;; Test: ghostel-compile-mode
+;; Test: ghostel-compile--finalize
 ;; -----------------------------------------------------------------------
-
-(ert-deftest ghostel-test-compile-mode-requires-ghostel-buffer ()
-  "`ghostel-compile-mode' must refuse to enable outside a ghostel buffer."
-  (with-temp-buffer
-    (should-error (ghostel-compile-mode 1) :type 'user-error)
-    (should-not ghostel-compile-mode)))                       ; mode stayed off
-
-(ert-deftest ghostel-test-compile-mode-sets-up-finish-hook ()
-  "Enabling `ghostel-compile-mode' adds the finish hook locally."
-  (let ((buf (generate-new-buffer " *ghostel-test-compile-mode*")))
-    (unwind-protect
-        (with-current-buffer buf
-          (ghostel-mode)
-          (ghostel-compile-mode 1)
-          (should ghostel-compile-mode)                       ; mode on
-          (should (memq #'ghostel-compile--on-finish
-                        ghostel-command-finish-functions))    ; hook installed
-          (ghostel-compile-mode -1)
-          (should-not (memq #'ghostel-compile--on-finish
-                            ghostel-command-finish-functions)))
-      (kill-buffer buf))))
-
-(ert-deftest ghostel-test-compile-mode-disable-is-reversible ()
-  "Disabling `ghostel-compile-mode' tears down its side effects."
-  (let ((buf (generate-new-buffer " *ghostel-test-compile-teardown*")))
-    (unwind-protect
-        (with-current-buffer buf
-          (ghostel-mode)
-          (ghostel-compile-mode 1)
-          (should compilation-minor-mode)                      ; compile-minor on
-          (should (eq next-error-function
-                      #'compilation-next-error-function))      ; next-error installed
-          (should (assq 'ghostel-compile-mode
-                        minor-mode-overriding-map-alist))      ; map override in
-          (ghostel-compile-mode -1)
-          (should-not compilation-minor-mode)                  ; compile-minor off
-          (should-not (local-variable-p 'next-error-function)) ; restored
-          (should-not (assq 'ghostel-compile-mode
-                            minor-mode-overriding-map-alist))) ; map override out
-      (kill-buffer buf))))
-
-(ert-deftest ghostel-test-compile-mode-respects-prior-compilation-minor ()
-  "Disabling our mode must not disturb an independent `compilation-minor-mode'.
-It must not turn off `compilation-minor-mode' or yank its
-`next-error-function' out from under it when the user enabled
-`compilation-minor-mode' independently before us."
-  (let ((buf (generate-new-buffer " *ghostel-test-compile-coexist*")))
-    (unwind-protect
-        (with-current-buffer buf
-          (ghostel-mode)
-          ;; User enables compilation-minor-mode independently first.
-          (compilation-minor-mode 1)
-          (should compilation-minor-mode)
-          (should (eq next-error-function
-                      #'compilation-next-error-function))
-          ;; Now enable, then disable, our mode.
-          (ghostel-compile-mode 1)
-          (ghostel-compile-mode -1)
-          ;; Independent compilation-minor-mode and its next-error
-          ;; wiring must both still be active.
-          (should compilation-minor-mode)                       ; preserved
-          (should (eq next-error-function
-                      #'compilation-next-error-function)))      ; preserved
-      (kill-buffer buf))))
-
-(ert-deftest ghostel-test-compile-mode-disable-cancels-pending ()
-  "Disabling the mode mid-flight resets state and cancels pending timers.
-This ensures a subsequent enable starts clean."
-  (let ((buf (generate-new-buffer " *ghostel-test-compile-cancel*"))
-        (cancelled 0))
-    (unwind-protect
-        (with-current-buffer buf
-          (ghostel-mode)
-          (ghostel-compile-mode 1)
-          ;; Pretend a command is in flight with a pending timer.
-          (cl-letf (((symbol-function 'cancel-timer)
-                     (lambda (_t) (setq cancelled (1+ cancelled))))
-                    ((symbol-function 'timerp) (lambda (_t) t)))
-            (setq ghostel-compile--running 'armed
-                  ghostel-compile--finalize-timer :stub-timer)
-            (ghostel-compile-mode -1)
-            (should (= 1 cancelled))                            ; cancelled
-            (should-not ghostel-compile--running)                ; reset
-            (should-not ghostel-compile--finalize-timer)))      ; cleared
-      (kill-buffer buf))))
 
 (ert-deftest ghostel-test-compile-finalize-scans-errors ()
   "`ghostel-compile--finalize' parses errors in the scan region."
@@ -1815,7 +1729,6 @@ This ensures a subsequent enable starts clean."
       (insert "pre-existing line\n")
       (setq ghostel-compile--command "make"
             ghostel-compile--start-time (current-time)
-            ghostel-compile--running 'armed
             ghostel-compile--scan-marker (copy-marker (point)))
       (insert "/tmp/foo.c:10:5: error: bad thing\n")
       (insert "done\n"))
@@ -1848,111 +1761,33 @@ This ensures a subsequent enable starts clean."
           (should-not (region-has-prop-p pre-bol pre-eol 'compilation-message)))))
     (should (eq buf next-error-last-buffer))))                ; next-error target set
 
-(ert-deftest ghostel-test-compile-finalize-inserts-header-and-footer ()
-  "Finalize inserts plain-text header/footer matching `M-x compile' format."
+(ert-deftest ghostel-test-compile-finalize-appends-footer ()
+  "Finalize appends the plain-text footer matching `M-x compile' format.
+The header is pre-rendered into the VT terminal by `--start' before
+the process spawns, so finalize only has to append the footer and
+parse errors below the scan marker.  This unit test simulates that
+pre-rendered state by inserting the header directly into the buffer."
   (ghostel-test--with-compile-buffer buf
     (let ((inhibit-read-only t)
           (ghostel-compile-finished-major-mode nil))
-      (insert "output line\n")
+      (insert "-*- mode: ghostel-compile -*-\n"
+              "Compilation started at fake-time\n\n"
+              "make -j4 test\n")
       (setq ghostel-compile--command "make -j4 test"
             ghostel-compile--start-time (time-subtract (current-time) 2)
-            ghostel-compile--running 'armed
-            ghostel-compile--scan-marker (copy-marker (point-min)))
+            ghostel-compile--scan-marker (copy-marker (point)))
+      (insert "output line\n")
       (ghostel-compile--finalize buf 0 (current-time))
       (let ((text (buffer-substring-no-properties (point-min) (point-max))))
-        (should (string-match-p "\\`-\\*- mode: ghostel-compile -\\*-" text))
-        (should (string-match-p "Compilation started at" text))
+        ;; Pre-rendered header is still there, exactly once.
+        (should (= 1 (cl-count-if (lambda (line)
+                                    (string-match-p "-\\*- mode:" line))
+                                  (split-string text "\n"))))
         (should (string-match-p "make -j4 test" text))
         (should (string-match-p "output line" text))
+        ;; Footer was appended by finalize.
         (should (string-match-p "Compilation finished at" text))
         (should (string-match-p "duration " text))))))
-
-(ert-deftest ghostel-test-compile-on-start-snaps-scan-marker ()
-  "OSC 133 C must snap `ghostel-compile--scan-marker' to current `point-max'.
-`ghostel-compile' sends `\\f' to refresh the prompt and then writes the
-command to the shell — the shell's response (fresh prompt re-echo,
-possibly A/B markers) arrives asynchronously through the process filter
-AFTER `ghostel-compile' returns.  If we captured the marker synchronously
-in `ghostel-compile' it would sit above that noise; snapping on C puts it
-exactly at the command-output boundary."
-  (ghostel-test--with-compile-buffer buf
-    (let ((inhibit-read-only t))
-      (setq ghostel-compile--running 'pending
-            ghostel-compile--scan-marker nil)
-      ;; Simulate the async echo of the refreshed prompt arriving
-      ;; after `ghostel-compile' already returned but BEFORE C.
-      (insert "$ ")
-      (let ((snap-point (point)))
-        (ghostel-compile--on-start buf)
-        (should (eq 'armed ghostel-compile--running))
-        (should (markerp ghostel-compile--scan-marker))
-        (should (= snap-point
-                   (marker-position ghostel-compile--scan-marker)))))))
-
-(ert-deftest ghostel-test-compile-clear-buffer-isolates-stale-errors ()
-  "Stale error-shaped lines above the scan-marker must not leak into the count.
-With `ghostel-compile-clear-buffer' t, stale error-shaped lines that
-linger in the buffer above the fresh scan-marker must not leak into the
-final error count.  This exercises the realistic flow: pre-existing
-content + \\f echo → C snaps scan-marker → command output → D → finalize
-— only the command's own errors count."
-  (ghostel-test--with-compile-buffer buf
-    (let ((inhibit-read-only t)
-          (ghostel-compile-finished-major-mode nil))
-      ;; Two leftover error-shaped lines from previous interactive
-      ;; commands that would otherwise be double-counted.
-      (insert "/tmp/old1.c:99:1: error: STALE-ONE\n"
-              "/tmp/old2.c:42:1: error: STALE-TWO\n")
-      ;; Mid-flight state as set by `ghostel-compile'.
-      (setq ghostel-compile--command "make"
-            ghostel-compile--start-time (current-time)
-            ghostel-compile--directory default-directory
-            ghostel-compile--last-exit nil
-            ghostel-compile--running 'pending
-            ghostel-compile--scan-marker nil)
-      ;; C arrives: scan-marker snaps here, past the stale content.
-      (ghostel-compile--on-start buf)
-      (should (markerp ghostel-compile--scan-marker))
-      ;; One real error in the run's output.
-      (insert "/tmp/new.c:1:1: error: real\n")
-      (ghostel-compile--finalize buf 1 (current-time))
-      ;; Stale lines are still in the buffer but not in the error count.
-      (let ((text (buffer-substring-no-properties (point-min) (point-max))))
-        (should (string-match-p "STALE-ONE" text))
-        (should (string-match-p "STALE-TWO" text)))
-      ;; Three error-shaped lines in the buffer, but only the one
-      ;; below the scan marker should count.
-      (should (= 1 compilation-num-errors-found)))))
-
-(ert-deftest ghostel-test-compile-finalize-anchors-header-at-scan-marker ()
-  "Header is anchored at the scan-marker, not at `point-min'.
-When pre-existing output is kept (`--clear-buffer nil'), the header must
-be inserted at the start of THIS run's output, not at point-min, so it
-stays attached to the region described.  Also: parsing must not pick up
-errors above the scan marker (would inflate
-`compilation-num-errors-found' with stale matches)."
-  (ghostel-test--with-compile-buffer buf
-    (let ((inhibit-read-only t)
-          (ghostel-compile-finished-major-mode nil))
-      ;; Pre-existing output that contains an error-shaped line —
-      ;; this is from a previous run that was kept around.
-      (insert "/tmp/old.c:99:1: error: STALE\n")
-      ;; Now start a fresh run from here.
-      (setq ghostel-compile--command "make"
-            ghostel-compile--start-time (current-time)
-            ghostel-compile--running 'armed
-            ghostel-compile--scan-marker (copy-marker (point-max)))
-      (insert "/tmp/new.c:1:1: error: real\n")
-      (ghostel-compile--finalize buf 1 (current-time))
-      (let ((text (buffer-substring-no-properties (point-min) (point-max))))
-        ;; Stale line is still present (we didn't clear).
-        (should (string-match-p "STALE" text))
-        ;; Header is anchored ABOVE the new run, BELOW the stale line.
-        (let ((stale-pos (string-match-p "STALE" text))
-              (header-pos (string-match-p "Compilation started at" text)))
-          (should (< stale-pos header-pos))))
-      ;; Only the current run's error is counted, not the stale one.
-      (should (= 1 compilation-num-errors-found)))))
 
 (ert-deftest ghostel-test-compile-finalize-footer-on-failure ()
   "Non-zero exit produces an \"exited abnormally\" footer in buffer text."
@@ -1962,50 +1797,11 @@ errors above the scan marker (would inflate
       (insert "boom\n")
       (setq ghostel-compile--command "false"
             ghostel-compile--start-time (current-time)
-            ghostel-compile--running 'armed
             ghostel-compile--scan-marker (copy-marker (point-min)))
       (ghostel-compile--finalize buf 2 (current-time))
       (should (string-match-p
                "exited abnormally with code 2"
                (buffer-substring-no-properties (point-min) (point-max)))))))
-
-(ert-deftest ghostel-test-compile-finalize-hides-prompts ()
-  "Finalize marks `ghostel-prompt' regions and the echoed command invisible.
-Users don't want to see `$ echo hi' right below the header's already-shown
-`echo hi'."
-  (ghostel-test--with-compile-buffer buf
-    (let ((inhibit-read-only t)
-          (ghostel-compile-finished-major-mode nil))
-      (setq ghostel-compile--command "echo hi"
-            ghostel-compile--start-time (current-time)
-            ghostel-compile--running 'armed
-            ghostel-compile--scan-marker (copy-marker (point-min)))
-      ;; Prompt + echoed command on the same line (only the `$ ' part
-      ;; carries the `ghostel-prompt' property; the command itself is
-      ;; past the OSC 133 B marker).
-      (let ((prompt-start (point)))
-        (insert "$ ")
-        (put-text-property prompt-start (point) 'ghostel-prompt t))
-      (insert "echo hi\n")
-      (insert "hi\n")
-      ;; Trailing prompt (no echoed command follows).
-      (let ((prompt2-start (point)))
-        (insert "$ ")
-        (put-text-property prompt2-start (point) 'ghostel-prompt t))
-      (ghostel-compile--finalize buf 0 (current-time))
-      ;; Prompt markers and the echoed command line should all be invisible.
-      (save-excursion
-        (goto-char (point-min))
-        (re-search-forward "\\$ " nil t)
-        (should (get-text-property (match-beginning 0) 'invisible))
-        ;; The echoed command on the same line must also be hidden.
-        (re-search-forward "echo hi" nil t)
-        (should (get-text-property (match-beginning 0) 'invisible)))
-      ;; The actual output line must still be visible.
-      (save-excursion
-        (goto-char (point-min))
-        (re-search-forward "^hi" nil t)
-        (should-not (get-text-property (match-beginning 0) 'invisible))))))
 
 (ert-deftest ghostel-test-compile-finalize-trims-trailing-blank-rows ()
   "Regression: short commands leave a mostly-empty terminal grid.
@@ -2019,7 +1815,6 @@ blank separator line before the footer matches `M-x compile'."
           (ghostel-compile-finished-major-mode nil))
       (setq ghostel-compile--command "echo test"
             ghostel-compile--start-time (current-time)
-            ghostel-compile--running 'armed
             ghostel-compile--scan-marker (copy-marker (point-max)))
       ;; Simulate what the grid commits: short output plus ~20
       ;; whitespace-only rows from unused terminal lines.
@@ -2036,56 +1831,6 @@ blank separator line before the footer matches `M-x compile'."
         (goto-char (match-beginning 0))
         (let ((gap (buffer-substring-no-properties after-test (point))))
           (should (<= (cl-count ?\n gap) 2)))))))
-
-(ert-deftest ghostel-test-compile-finalize-hides-echoed-command-without-prompt-property ()
-  "Regression: echoed command line is hidden even without the prompt property.
-When the native renderer puts `ghostel-prompt' only on the prompt glyph
-itself and NOT on the echoed command that follows on the same row,
-`--hide-prompts' must still hide the whole line by matching the line
-against `ghostel-compile--command'."
-  (ghostel-test--with-compile-buffer buf
-    (let ((inhibit-read-only t)
-          (ghostel-compile-finished-major-mode nil))
-      (setq ghostel-compile--command "make -j4 test"
-            ghostel-compile--start-time (current-time)
-            ghostel-compile--running 'armed
-            ghostel-compile--scan-marker (copy-marker (point-min)))
-      ;; Simulate the exact visual from the user report: a prompt +
-      ;; echoed command on one line, but NO `ghostel-prompt' property
-      ;; anywhere on the line.
-      (insert "~/.emacs.d/lib/ghostel λ make -j4 test\n")
-      (insert "output\n")
-      (ghostel-compile--finalize buf 0 (current-time))
-      (save-excursion
-        (goto-char (point-min))
-        ;; The echoed prompt + command line must be hidden.
-        (re-search-forward "~/\\.emacs\\.d/lib/ghostel" nil t)
-        (should (get-text-property (match-beginning 0) 'invisible)))
-      (save-excursion
-        (goto-char (point-min))
-        ;; The real output line must NOT be hidden.
-        (re-search-forward "^output$" nil t)
-        (should-not (get-text-property (match-beginning 0) 'invisible))))))
-
-(ert-deftest ghostel-test-compile-finalize-hide-prompts-nil ()
-  "When `ghostel-compile-hide-prompts' is nil, prompts stay visible."
-  (ghostel-test--with-compile-buffer buf
-    (let ((inhibit-read-only t)
-          (ghostel-compile-finished-major-mode nil)
-          (ghostel-compile-hide-prompts nil))
-      (setq ghostel-compile--command "echo hi"
-            ghostel-compile--start-time (current-time)
-            ghostel-compile--running 'armed
-            ghostel-compile--scan-marker (copy-marker (point-min)))
-      (let ((prompt-start (point)))
-        (insert "$ ")
-        (put-text-property prompt-start (point) 'ghostel-prompt t))
-      (insert "echo hi\nhi\n")
-      (ghostel-compile--finalize buf 0 (current-time))
-      ;; The prompt's `$ ' must NOT have `invisible' set.
-      (goto-char (point-min))
-      (re-search-forward "\\$ " nil t)
-      (should-not (get-text-property (match-beginning 0) 'invisible)))))
 
 (ert-deftest ghostel-test-command-finish-hook-runs-synchronously ()
   "Regression: `ghostel-command-finish-functions' must fire synchronously.
@@ -2111,7 +1856,6 @@ Downstream consumers (notably `ghostel-compile') depend on it."
     (let ((inhibit-read-only t))
       (setq ghostel-compile--command "make"
             ghostel-compile--start-time (current-time)
-            ghostel-compile--running 'armed
             ghostel-compile--scan-marker (copy-marker (point-max)))
       (insert "/tmp/x.c:42:5: error: bad\n"))
     (ghostel-compile--finalize buf 1 (current-time))
@@ -2162,55 +1906,6 @@ Downstream consumers (notably `ghostel-compile') depend on it."
           (forward-char 1)))
       (should found))))
 
-(ert-deftest ghostel-test-compile-spurious-d-without-c-is-ignored ()
-  "Regression: a D marker without a preceding C must not finalize.
-
-Some shells (notably zsh's clear-screen widget after we send `\\f'
-in `ghostel-clear-scrollback') redraw the prompt and re-fire precmd,
-which emits OSC 133 D with the *previous* command's exit (typically
-0).  Without C-gating we'd report `:exit [0]' even though the user's
-real command exited non-zero."
-  (let ((scheduled nil))
-    (cl-letf (((symbol-function 'run-at-time)
-               (lambda (_when _repeat fn &rest args)
-                 (push (cons fn args) scheduled)
-                 :timer-stub)))
-      (ghostel-test--with-compile-buffer buf
-        (setq ghostel-compile--command "make"
-              ghostel-compile--start-time (current-time)
-              ghostel-compile--running 'pending          ; just sent the cmd
-              ghostel-compile--scan-marker (copy-marker (point-max)))
-        ;; Spurious D from prompt redraw arrives BEFORE any C.
-        (ghostel-compile--on-finish buf 0)
-        (should-not scheduled)                           ; ignored
-        (should (eq 'pending ghostel-compile--running))  ; still pending
-        ;; Now the real command runs: C arrives, then D;2.
-        (ghostel-compile--on-start buf)
-        (should (eq 'armed ghostel-compile--running))    ; armed by C
-        (ghostel-compile--on-finish buf 2)
-        (should (= 1 (length scheduled)))                ; scheduled once
-        (should (equal 2 (nth 2 (car scheduled))))      ; with the real exit
-        (should (eq 'fired ghostel-compile--running))))))
-
-(ert-deftest ghostel-test-compile-on-finish-only-first-d-counts ()
-  "First D after C wins; subsequent Ds before finalize are ignored."
-  (let ((scheduled nil))
-    (cl-letf (((symbol-function 'run-at-time)
-               (lambda (_when _repeat fn &rest args)
-                 (push (cons fn args) scheduled)
-                 :timer-stub)))
-      (ghostel-test--with-compile-buffer buf
-        (setq ghostel-compile--command "make"
-              ghostel-compile--start-time (current-time)
-              ghostel-compile--running 'armed
-              ghostel-compile--scan-marker (copy-marker (point-max)))
-        (ghostel-compile--on-finish buf 2)                     ; real exit
-        (ghostel-compile--on-finish buf 0)                     ; spurious follow-up
-        (should (= 1 (length scheduled)))                      ; scheduled once
-        ;; entry is (FN BUFFER EXIT END-TIME) — exit at index 2
-        (should (equal 2 (nth 2 (car scheduled))))            ; real exit kept
-        (should (eq 'fired ghostel-compile--running))))))
-
 (ert-deftest ghostel-test-compile-finalize-does-not-double-count-errors ()
   "Regression: parsing must not count each error twice.
 
@@ -2223,7 +1918,6 @@ error count.  `compilation--ensure-parse' is the right entry point."
               "/tmp/b.c:2:2: error: oops\n")
       (setq ghostel-compile--command "make"
             ghostel-compile--start-time (current-time)
-            ghostel-compile--running 'armed
             ghostel-compile--scan-marker (copy-marker (point-min))))
     (ghostel-compile--finalize buf 1 (current-time))
     (should (= 2 compilation-num-errors-found))))             ; not 4
@@ -2242,7 +1936,6 @@ compile buffer that flashes open and disappears."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (ghostel-compile-mode 1)
           (setq proc (start-process "gh-compile-dummy" buf
                                     "/bin/sh" "-c" "sleep 5"))
           (set-process-query-on-exit-flag proc nil)
@@ -2250,8 +1943,7 @@ compile buffer that flashes open and disappears."
           (setq-local ghostel--process proc
                       ghostel-compile--command "sleep 5"
                       ghostel-compile--start-time (current-time)
-                      ghostel-compile--running 'armed
-                      ghostel-compile--scan-marker (copy-marker (point-max)))
+                                ghostel-compile--scan-marker (copy-marker (point-max)))
           ;; Finalize with a real process attached: must NOT kill the
           ;; buffer AND must NOT insert the default sentinel's
           ;; "Process NAME killed: N" line into it.
@@ -2272,13 +1964,17 @@ move point through compile messages without auto-opening files in
 another window.  RET/`compile-goto-error' is for opening."
   (ghostel-test--with-compile-buffer buf
     (let ((inhibit-read-only t))
-      (insert "/tmp/aa.c:1:1: error: first\n"
-              "blah\n"
-              "/tmp/bb.c:2:2: error: second\n")
+      ;; Simulate the pre-rendered header, then errors below it —
+      ;; matches the geometry the real flow leaves for `--finalize'.
+      (insert "-*- mode: ghostel-compile -*-\n"
+              "Compilation started at fake-time\n\n"
+              "make\n")
       (setq ghostel-compile--command "make"
             ghostel-compile--start-time (current-time)
-            ghostel-compile--running 'armed
-            ghostel-compile--scan-marker (copy-marker (point-min))))
+            ghostel-compile--scan-marker (copy-marker (point)))
+      (insert "/tmp/aa.c:1:1: error: first\n"
+              "blah\n"
+              "/tmp/bb.c:2:2: error: second\n"))
     (ghostel-compile--finalize buf 1 (current-time))
     ;; n/p should map to the navigation-only commands (no file open).
     (should (eq (lookup-key (current-local-map) "n")
@@ -2315,7 +2011,6 @@ scrolled below the window."
       (goto-char (point-max))
       (setq ghostel-compile--command "true"
             ghostel-compile--start-time (current-time)
-            ghostel-compile--running 'armed
             ghostel-compile--scan-marker (copy-marker (point-min))))
     (ghostel-compile--finalize buf 0 (current-time))
     (should (= (point) (point-max)))                           ; past footer
@@ -2326,32 +2021,11 @@ scrolled below the window."
               (max (point-min) (- (point-max) 200))
               (point-max))))))
 
-(ert-deftest ghostel-test-compile-bash-integration-saves-real-status ()
-  "The bash PROMPT_COMMAND wrapper must capture \\='$?\\=' before assignments.
-Bare assignments such as `__ghostel_in_prompt_command=1' reset $? to 0 in
-bash, so capturing $? must be the very first thing inside the wrapper.
-Otherwise OSC 133 D always reports exit 0."
-  (skip-unless (file-executable-p "/bin/bash"))
-  (let* ((script (expand-file-name "etc/ghostel.bash"
-                                   (file-name-directory
-                                    (locate-library "ghostel"))))
-         (cmd (format "source %s; \
-__ghostel_prompt_shown=1; \
-( exit 42 ); \
-output=$( __ghostel_wrapped_prompt_command 2>&1 ); \
-case \"$output\" in *$'\\033]133;D;42'*) echo OK ;; *) echo \"FAIL: $output\" ;; esac"
-                      (shell-quote-argument script))))
-    (with-temp-buffer
-      (let ((status (call-process "/bin/bash" nil t nil "-c" cmd)))
-        (should (zerop status))
-        (should (string-match-p "OK" (buffer-string)))))))
-
 (ert-deftest ghostel-test-compile-finalize-switches-major-mode ()
   "With the default option, finalize switches to `ghostel-compile-view-mode'."
   (ghostel-test--with-compile-buffer buf
     (setq ghostel-compile--command "true"
           ghostel-compile--start-time (current-time)
-          ghostel-compile--running 'armed
           ghostel-compile--scan-marker (copy-marker (point-max)))
     (should (derived-mode-p 'ghostel-mode))                    ; starts as ghostel
     (ghostel-compile--finalize buf 0 (current-time))
@@ -2362,15 +2036,10 @@ case \"$output\" in *$'\\033]133;D;42'*) echo OK ;; *) echo \"FAIL: $output\" ;;
     (should (eq next-error-function #'compilation-next-error-function))
     (should (equal "true" ghostel-compile--command))))          ; state preserved
 
-(ert-deftest ghostel-test-compile-recompile-key-binding ()
-  "`g' in `ghostel-compile-mode' is bound to `ghostel-recompile'."
-  (should (eq (lookup-key ghostel-compile-mode-map (kbd "g"))
-              #'ghostel-recompile)))                           ; direct map binding
-
-(ert-deftest ghostel-test-compile-recompile-overrides-compile-g ()
-  "Our `g' binding overrides `compilation-minor-mode-map's recompile."
-  (ghostel-test--with-compile-buffer buf
-    (should (eq (key-binding (kbd "g")) #'ghostel-recompile)))) ; shadow active
+(ert-deftest ghostel-test-compile-view-mode-recompile-key-binding ()
+  "`g' in `ghostel-compile-view-mode-map' is bound to `ghostel-recompile'."
+  (should (eq (lookup-key ghostel-compile-view-mode-map (kbd "g"))
+              #'ghostel-recompile)))
 
 (ert-deftest ghostel-test-compile-format-duration ()
   "Duration formatting matches `M-x compile's style."
@@ -2424,7 +2093,6 @@ case \"$output\" in *$'\\033]133;D;42'*) echo OK ;; *) echo \"FAIL: $output\" ;;
             (list (lambda (b m) (push (cons b m) c-calls)))))
       (setq ghostel-compile--command "true"
             ghostel-compile--start-time (current-time)
-            ghostel-compile--running 'armed
             ghostel-compile--scan-marker (copy-marker (point-max)))
       (ghostel-compile--finalize buf 0 (current-time))
       (should (equal 1 (length g-calls)))                     ; ghostel hook
@@ -2432,19 +2100,6 @@ case \"$output\" in *$'\\033]133;D;42'*) echo OK ;; *) echo \"FAIL: $output\" ;;
       (should (equal "finished\n" (cdar g-calls)))
       (should (equal 1 (length c-calls)))                     ; compile hook
       (should (equal "finished\n" (cdar c-calls))))))
-
-(ert-deftest ghostel-test-compile-finalize-ignored-when-not-running ()
-  "Finalize is a no-op when `--running' is nil (manual shell activity)."
-  (ghostel-test--with-compile-buffer buf
-    (let ((ghostel-compile-finished-major-mode nil)
-          (ghostel-compile--running nil))
-      ;; Call the hook dispatcher directly — should not schedule finalize.
-      (setq ghostel-compile--command "true"
-            ghostel-compile--start-time (current-time)
-            ghostel-compile--scan-marker (copy-marker (point-max)))
-      (ghostel-compile--on-finish buf 0)
-      ;; Finalize should not have run: last-exit stays nil.
-      (should-not ghostel-compile--last-exit))))
 
 (ert-deftest ghostel-test-compile-auto-jump-to-first-error ()
   "With `compilation-auto-jump-to-first-error' set, jump after parsing."
@@ -2457,79 +2112,55 @@ case \"$output\" in *$'\\033]133;D;42'*) echo OK ;; *) echo \"FAIL: $output\" ;;
                  (lambda (&rest _) (setq jumped t))))
         (setq ghostel-compile--command "make"
               ghostel-compile--start-time (current-time)
-              ghostel-compile--running 'armed
-              ghostel-compile--scan-marker (copy-marker (point-max)))
+                ghostel-compile--scan-marker (copy-marker (point-max)))
         (insert "/tmp/x.c:1:1: error: boom\n")
         (ghostel-compile--finalize buf 1 (current-time))
         (should jumped)))))                                    ; first-error called
 
-(ert-deftest ghostel-test-compile-clears-buffer-before-run ()
-  "`ghostel-compile' clears the buffer before sending the command."
-  (ghostel-test--with-compile-buffer buf
-    (let ((cleared nil)
-          (sent nil)
-          (ghostel-compile-buffer-name (buffer-name buf))
-          (ghostel-compile-clear-buffer t))
-      (cl-letf (((symbol-function 'ghostel-clear-scrollback)
-                 (lambda () (setq cleared t)))
-                ((symbol-function 'ghostel--flush-output)
-                 (lambda (data) (setq sent data)))
-                ((symbol-function 'ghostel-compile--get-or-create-buffer)
-                 (lambda () buf))
-                ((symbol-function 'display-buffer)
-                 (lambda (&rest _) nil))
-                ((symbol-function 'save-some-buffers)
-                 (lambda (&rest _) nil)))
-        (ghostel-compile "make test")
-        (should cleared)                                      ; clear was called
-        (should (equal "make test\n" sent))))))               ; then command sent
-
-(ert-deftest ghostel-test-compile-clear-disabled ()
-  "`ghostel-compile-clear-buffer' nil skips the clear."
-  (ghostel-test--with-compile-buffer buf
-    (let ((cleared nil)
-          (ghostel-compile-buffer-name (buffer-name buf))
-          (ghostel-compile-clear-buffer nil))
-      (cl-letf (((symbol-function 'ghostel-clear-scrollback)
-                 (lambda () (setq cleared t)))
-                ((symbol-function 'ghostel--flush-output)
-                 (lambda (_) nil))
-                ((symbol-function 'ghostel-compile--get-or-create-buffer)
-                 (lambda () buf))
-                ((symbol-function 'display-buffer)
-                 (lambda (&rest _) nil))
-                ((symbol-function 'save-some-buffers)
-                 (lambda (&rest _) nil)))
-        (ghostel-compile "make test")
-        (should-not cleared)))))                              ; clear skipped
-
 (ert-deftest ghostel-test-compile-recompile-uses-original-directory ()
-  "`ghostel-recompile' must run in the original `default-directory'.
+  "`ghostel-recompile' must pass the original `default-directory' to --start.
 
 The user's report: run `ghostel-compile' in /A, switch to a buffer
-in /B, switch back, press `g'.  Without preserving the directory,
-the new compile inherited /B (or whatever buffer was current after
-the kill-buffer in `--get-or-create-buffer')."
+in /B, switch back, press `g'.  The saved per-buffer directory must
+be what `--start' receives."
   (let ((dir-at-call nil)
         (buf (generate-new-buffer " *ghostel-test-recompile-dir*"))
         (inhibit-message t))
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (ghostel-compile-mode 1)
           ;; Simulate the post-finalize state of a previous run.
           (setq ghostel-compile--command "make"
                 ghostel-compile--directory "/some/project/")
-          (cl-letf (((symbol-function 'ghostel-compile)
-                     (lambda (_cmd) (setq dir-at-call default-directory)))
-                    ((symbol-function 'get-buffer)
-                     (lambda (name)
-                       (if (equal name ghostel-compile-buffer-name) buf
-                         (funcall (symbol-function 'get-buffer) name)))))
+          (cl-letf (((symbol-function 'ghostel-compile--start)
+                     (lambda (_cmd _name dir) (setq dir-at-call dir))))
             ;; Recompile from a buffer whose default-directory is somewhere else.
             (let ((default-directory "/elsewhere/"))
               (ghostel-recompile))
             (should (equal "/some/project/" dir-at-call))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-compile-recompile-reuses-current-buffer ()
+  "`ghostel-recompile' from a ghostel-compile buffer re-runs into it.
+
+When the user presses `g' in `*compilation*' (via global-mode) or
+any buffer whose `ghostel-compile--command' is set locally, the
+rerun must target the SAME buffer — not the default
+`ghostel-compile-buffer-name' — so the existing window isn't
+displaced by a new one."
+  (let ((name-at-call nil)
+        (buf (generate-new-buffer "*some-specific-name*"))
+        (inhibit-message t))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel-compile--command "make"
+                ghostel-compile--directory "/proj/")
+          (cl-letf (((symbol-function 'ghostel-compile--start)
+                     (lambda (_cmd name _dir) (setq name-at-call name))))
+            (ghostel-recompile))
+          ;; Buffer-name of the CURRENT buffer, not `ghostel-compile-buffer-name'.
+          (should (equal "*some-specific-name*" name-at-call)))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-compile-recompile-edit-command-prefix-arg ()
@@ -2541,35 +2172,26 @@ edited version, matching the behaviour of \\[recompile]."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (ghostel-compile-mode 1)
           (setq ghostel-compile--command "make old"
                 ghostel-compile--directory "/some/project/")
           (let ((cmd-at-call nil)
                 (prompt-default nil))
-            (cl-letf (((symbol-function 'ghostel-compile)
-                       (lambda (cmd) (setq cmd-at-call cmd)))
+            (cl-letf (((symbol-function 'ghostel-compile--start)
+                       (lambda (cmd _name _dir) (setq cmd-at-call cmd)))
                       ((symbol-function 'read-shell-command)
                        (lambda (_prompt default &rest _)
                          (setq prompt-default default)
-                         "make new"))
-                      ((symbol-function 'get-buffer)
-                       (lambda (name)
-                         (if (equal name ghostel-compile-buffer-name) buf
-                           (funcall (symbol-function 'get-buffer) name)))))
+                         "make new")))
               ;; With edit-command t: user is prompted, runs edited cmd.
               (ghostel-recompile t)
               (should (equal "make old" prompt-default))        ; default was the last cmd
               (should (equal "make new" cmd-at-call)))           ; chosen cmd is used
             ;; Without the prefix: no prompt, runs the last cmd verbatim.
             (setq cmd-at-call nil prompt-default nil)
-            (cl-letf (((symbol-function 'ghostel-compile)
-                       (lambda (cmd) (setq cmd-at-call cmd)))
+            (cl-letf (((symbol-function 'ghostel-compile--start)
+                       (lambda (cmd _name _dir) (setq cmd-at-call cmd)))
                       ((symbol-function 'read-shell-command)
-                       (lambda (&rest _) (setq prompt-default t) "never"))
-                      ((symbol-function 'get-buffer)
-                       (lambda (name)
-                         (if (equal name ghostel-compile-buffer-name) buf
-                           (funcall (symbol-function 'get-buffer) name)))))
+                       (lambda (&rest _) (setq prompt-default t) "never")))
               (ghostel-recompile)
               (should-not prompt-default)                        ; no prompt
               (should (equal "make old" cmd-at-call)))))         ; last cmd re-run
@@ -2584,7 +2206,6 @@ so `ghostel-recompile' (and other tooling) can rely on it."
     (setq ghostel-compile--command "make"
           ghostel-compile--directory "/pinned/dir/"
           ghostel-compile--start-time (current-time)
-          ghostel-compile--running 'armed
           ghostel-compile--scan-marker (copy-marker (point-max)))
     (setq default-directory "/drifted/somewhere/")
     (ghostel-compile--finalize buf 0 (current-time))
@@ -2600,76 +2221,54 @@ so `ghostel-recompile' (and other tooling) can rely on it."
 
 (ert-deftest ghostel-test-compile-uses-compile-command ()
   "`ghostel-compile' persists the run command to `compile-command'."
-  (ghostel-test--with-compile-buffer buf
-    (let ((compile-command "make old")
-          (ghostel-compile-buffer-name (buffer-name buf))
-          (ghostel-compile-clear-buffer nil))
-      (cl-letf (((symbol-function 'ghostel--flush-output)
-                 (lambda (_) nil))
-                ((symbol-function 'ghostel-compile--get-or-create-buffer)
-                 (lambda () buf))
-                ((symbol-function 'display-buffer)
-                 (lambda (&rest _) nil))
-                ((symbol-function 'save-some-buffers)
-                 (lambda (&rest _) nil)))
-        (ghostel-compile "make new")
-        (should (equal "make new" compile-command))))))       ; persisted
+  (let ((compile-command "make old"))
+    (cl-letf (((symbol-function 'ghostel-compile--start)
+               (lambda (&rest _) nil))
+              ((symbol-function 'save-some-buffers)
+               (lambda (&rest _) nil)))
+      (ghostel-compile "make new")
+      (should (equal "make new" compile-command)))))         ; persisted
 
 (ert-deftest ghostel-test-compile-interactive-uses-compile-history ()
   "`ghostel-compile's prompt uses `compile-history' as the history list."
-  (ghostel-test--with-compile-buffer buf
-    (let ((captured nil)
-          (compile-history '("old-cmd"))
-          (compile-command "make default")
-          (compilation-read-command t)
-          (ghostel-compile-buffer-name (buffer-name buf)))
-      (cl-letf (((symbol-function 'read-shell-command)
-                 (lambda (_prompt _default hist-sym &rest _)
-                   (setq captured hist-sym)
-                   "chosen-cmd"))
-                ((symbol-function 'ghostel--flush-output)
-                 (lambda (_) nil))
-                ((symbol-function 'ghostel-compile--get-or-create-buffer)
-                 (lambda () buf))
-                ((symbol-function 'display-buffer)
-                 (lambda (&rest _) nil))
-                ((symbol-function 'save-some-buffers)
-                 (lambda (&rest _) nil)))
-        (call-interactively #'ghostel-compile)
-        ;; History symbol should be (or directly reference) `compile-history'.
-        (should (or (eq captured 'compile-history)
-                    (and (consp captured)
-                         (eq (car captured) 'compile-history))))))))
+  (let ((captured nil)
+        (compile-history '("old-cmd"))
+        (compile-command "make default")
+        (compilation-read-command t))
+    (cl-letf (((symbol-function 'read-shell-command)
+               (lambda (_prompt _default hist-sym &rest _)
+                 (setq captured hist-sym)
+                 "chosen-cmd"))
+              ((symbol-function 'ghostel-compile--start)
+               (lambda (&rest _) nil))
+              ((symbol-function 'save-some-buffers)
+               (lambda (&rest _) nil)))
+      (call-interactively #'ghostel-compile)
+      ;; History symbol should be (or directly reference) `compile-history'.
+      (should (or (eq captured 'compile-history)
+                  (and (consp captured)
+                       (eq (car captured) 'compile-history)))))))
 
 (ert-deftest ghostel-test-compile-respects-compilation-read-command ()
   "When option `compilation-read-command' is nil, use `compile-command' silently."
-  (ghostel-test--with-compile-buffer buf
-    (let ((prompted nil)
-          (compile-command "make -C /tmp silent")
-          (compilation-read-command nil)
-          (ghostel-compile-buffer-name (buffer-name buf)))
-      (cl-letf (((symbol-function 'read-shell-command)
-                 (lambda (&rest _) (setq prompted t) "never"))
-                ((symbol-function 'ghostel--flush-output)
-                 (lambda (_) nil))
-                ((symbol-function 'ghostel-compile--get-or-create-buffer)
-                 (lambda () buf))
-                ((symbol-function 'display-buffer)
-                 (lambda (&rest _) nil))
-                ((symbol-function 'save-some-buffers)
-                 (lambda (&rest _) nil)))
-        (call-interactively #'ghostel-compile)
-        (should-not prompted)                                  ; no prompt
-        (should (equal ghostel-compile--command              ; command used as-is
-                       "make -C /tmp silent"))))))
+  (let ((prompted nil)
+        (captured-cmd nil)
+        (compile-command "make -C /tmp silent")
+        (compilation-read-command nil))
+    (cl-letf (((symbol-function 'read-shell-command)
+               (lambda (&rest _) (setq prompted t) "never"))
+              ((symbol-function 'ghostel-compile--start)
+               (lambda (cmd &rest _) (setq captured-cmd cmd) nil))
+              ((symbol-function 'save-some-buffers)
+               (lambda (&rest _) nil)))
+      (call-interactively #'ghostel-compile)
+      (should-not prompted)                                    ; no prompt
+      (should (equal "make -C /tmp silent" captured-cmd)))))   ; used as-is
 
-(ert-deftest ghostel-test-compile-get-or-create-buffer-no-window-side-effects ()
-  "`ghostel-compile--get-or-create-buffer' must create the buffer via
-`ghostel--init-buffer' without `pop-to-buffer' — i.e. without touching
-the caller's selected window or its `window-prev-buffers' history.
-This is the end-to-end coverage of the compile-side init path that
-`ghostel-test-compile-window-placement-matches-compile' stubs out."
-  (let* ((ghostel-compile-buffer-name "*ghostel-test-create*")
+(ert-deftest ghostel-test-compile-prepare-buffer-no-window-side-effects ()
+  "`ghostel-compile--prepare-buffer' must create the buffer without touching
+the caller's selected window or its `window-prev-buffers' history."
+  (let* ((name "*ghostel-test-create*")
          (origin (generate-new-buffer " *ghostel-test-origin*"))
          (saved (current-window-configuration)))
     (unwind-protect
@@ -2686,10 +2285,10 @@ This is the end-to-end coverage of the compile-side init path that
                        (lambda (&rest _) 'fake-term))
                       ((symbol-function 'ghostel--apply-palette) #'ignore)
                       ((symbol-function 'ghostel--start-process) #'ignore))
-              (setq created (ghostel-compile--get-or-create-buffer)))
+              (setq created (ghostel-compile--prepare-buffer name "/tmp/")))
             ;; Buffer was created, named, and initialized.
             (should (buffer-live-p created))
-            (should (equal (buffer-name created) ghostel-compile-buffer-name))
+            (should (equal (buffer-name created) name))
             (should (with-current-buffer created
                       (derived-mode-p 'ghostel-mode)))
             ;; Caller-supplied `default-directory' was carried into it.
@@ -2698,11 +2297,8 @@ This is the end-to-end coverage of the compile-side init path that
             ;; Caller's window and buffer are unchanged.
             (should (eq (selected-window) start-window))
             (should (eq (window-buffer start-window) origin))
-            ;; Crucially: the compile buffer was never popped into the
-            ;; caller's window even transiently — so it does NOT appear
-            ;; in `window-prev-buffers', which would otherwise make a
-            ;; later `display-buffer' reuse the caller's window via
-            ;; `display-buffer-in-previous-window'.
+            ;; The compile buffer was never popped into the caller's
+            ;; window — so it does NOT appear in `window-prev-buffers'.
             (should-not (memq created
                               (mapcar #'car (window-prev-buffers start-window))))
             (should (equal start-prev
@@ -2713,39 +2309,209 @@ This is the end-to-end coverage of the compile-side init path that
       (when (buffer-live-p origin) (kill-buffer origin))
       (set-window-configuration saved))))
 
-(ert-deftest ghostel-test-compile-window-placement-matches-compile ()
-  "`ghostel-compile' must display like `M-x compile': unselected new window,
-leaving the caller's window untouched, and disposable via `quit-window'."
+(ert-deftest ghostel-test-compile-finalize-is-idempotent ()
+  "Calling `ghostel-compile--finalize' twice must not double-insert."
   (ghostel-test--with-compile-buffer buf
-    (let* ((ghostel-compile-buffer-name (buffer-name buf))
-           (ghostel-compile-clear-buffer nil)
-           (saved-config (current-window-configuration))
-           (origin (generate-new-buffer " *ghostel-test-origin*")))
-      (unwind-protect
-          (progn
-            (delete-other-windows)
-            (switch-to-buffer origin)
-            (let ((origin-window (selected-window)))
-              (cl-letf (((symbol-function 'ghostel--flush-output)
-                         (lambda (_) nil))
-                        ((symbol-function 'ghostel-compile--get-or-create-buffer)
-                         (lambda () buf))
-                        ((symbol-function 'save-some-buffers)
-                         (lambda (&rest _) nil)))
-                (ghostel-compile "make"))
-              ;; Origin window unchanged — both buffer and selection.
-              (should (eq origin-window (selected-window)))
-              (should (eq (window-buffer origin-window) origin))
-              ;; Compile buffer is visible in a different window on
-              ;; this frame.
-              (let ((cwin (get-buffer-window buf)))
-                (should cwin)
-                (should-not (eq cwin origin-window))
-                ;; `quit-window' on that window disposes of it.
-                (with-selected-window cwin (quit-window))
-                (should-not (get-buffer-window buf)))))
-        (when (buffer-live-p origin) (kill-buffer origin))
-        (set-window-configuration saved-config)))))
+    (let ((inhibit-read-only t)
+          (ghostel-compile-finished-major-mode nil))
+      (insert "output\n")
+      (setq ghostel-compile--command "true"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--scan-marker (copy-marker (point-min))))
+    (ghostel-compile--finalize buf 0 (current-time))
+    (let ((after-first (buffer-string)))
+      ;; Second call is a no-op thanks to `--finalized'.
+      (ghostel-compile--finalize buf 0 (current-time))
+      (should (equal after-first (buffer-string))))))
+
+(ert-deftest ghostel-test-compile-global-mode-toggles-advice ()
+  "Enabling and disabling `ghostel-compile-global-mode' adds/removes the advice."
+  (let ((ghostel-compile-global-mode nil))
+    (unwind-protect
+        (progn
+          (ghostel-compile-global-mode 1)
+          (should (advice-member-p
+                   #'ghostel-compile--compilation-start-advice
+                   'compilation-start))
+          (ghostel-compile-global-mode -1)
+          (should-not (advice-member-p
+                       #'ghostel-compile--compilation-start-advice
+                       'compilation-start)))
+      (ghostel-compile-global-mode -1))))
+
+(ert-deftest ghostel-test-compile-global-mode-falls-through-for-grep ()
+  "`grep-mode' must fall through to the stock `compilation-start'."
+  (let ((orig-called nil)
+        (ghostel-called nil))
+    (cl-letf (((symbol-function 'ghostel-compile--start)
+               (lambda (&rest _) (setq ghostel-called t) nil)))
+      (ghostel-compile--compilation-start-advice
+       (lambda (&rest _) (setq orig-called t) nil)
+       "grep foo" 'grep-mode nil nil nil))
+    (should orig-called)                                        ; stock path ran
+    (should-not ghostel-called)))                              ; ours did not
+
+(ert-deftest ghostel-test-compile-global-mode-routes-to-ghostel-start ()
+  "For supported modes, the advice routes COMMAND through `ghostel-compile--start'."
+  (let ((captured nil))
+    (cl-letf (((symbol-function 'ghostel-compile--start)
+               (lambda (cmd name dir &optional _finished-mode)
+                 (setq captured (list cmd name dir))
+                 (generate-new-buffer " *ghostel-test-advice*"))))
+      (ghostel-compile--compilation-start-advice
+       (lambda (&rest _) (error "stock path should not run"))
+       "make test" nil nil nil nil))
+    (should (equal "make test" (nth 0 captured)))              ; command preserved
+    ;; Default buffer name for `compilation-mode' is "*compilation*".
+    (should (string-match-p "compilation" (nth 1 captured)))))
+
+(ert-deftest ghostel-test-compile-global-mode-threads-subclass-mode ()
+  "A custom compile-mode subclass passed as MODE is forwarded to finalize.
+
+The advice must pass a non-`compilation-mode' MODE through to
+`ghostel-compile--start' as its FINISHED-MODE argument so the
+subclass (with its error-regexp, font-lock keywords, etc.) is the
+major mode the buffer ends up in after finalize — and *not*
+override with the default `ghostel-compile-view-mode'."
+  (let ((captured-finished nil))
+    (cl-letf (((symbol-function 'ghostel-compile--start)
+               (lambda (_cmd _name _dir &optional finished-mode)
+                 (setq captured-finished finished-mode)
+                 nil)))
+      ;; Custom mode → threaded through.
+      (ghostel-compile--compilation-start-advice
+       (lambda (&rest _) (error "stock path should not run"))
+       "make" 'my-custom-compile-mode nil nil nil)
+      (should (eq 'my-custom-compile-mode captured-finished))
+      ;; Plain `compilation-mode' → nil (default view-mode kicks in).
+      (setq captured-finished :unchanged)
+      (ghostel-compile--compilation-start-advice
+       (lambda (&rest _) (error "stock path should not run"))
+       "make" 'compilation-mode nil nil nil)
+      (should-not captured-finished))))
+
+(ert-deftest ghostel-test-compile-global-mode-falls-through-on-continue ()
+  "Non-nil CONTINUE must fall through: `--start' recreates the buffer."
+  (let ((orig-called nil)
+        (ghostel-called nil))
+    (cl-letf (((symbol-function 'ghostel-compile--start)
+               (lambda (&rest _) (setq ghostel-called t) nil)))
+      (ghostel-compile--compilation-start-advice
+       (lambda (&rest _) (setq orig-called t) nil)
+       "make" 'compilation-mode nil nil t))         ; continue=t
+    (should orig-called)
+    (should-not ghostel-called)))
+
+(ert-deftest ghostel-test-compile-global-mode-falls-through-on-comint ()
+  "MODE=t (comint) must fall through."
+  (let ((orig-called nil))
+    (cl-letf (((symbol-function 'ghostel-compile--start)
+               (lambda (&rest _) (error "should not run"))))
+      (ghostel-compile--compilation-start-advice
+       (lambda (&rest _) (setq orig-called t) nil)
+       "make" t nil nil nil))
+    (should orig-called)))
+
+(ert-deftest ghostel-test-compile-global-mode-excluded-custom-mode ()
+  "A custom mode added to `ghostel-compile-global-mode-excluded-modes' falls through."
+  (let ((orig-called nil)
+        (ghostel-compile-global-mode-excluded-modes '(my-fake-grep-mode)))
+    (cl-letf (((symbol-function 'ghostel-compile--start)
+               (lambda (&rest _) (error "ghostel path should not run"))))
+      (ghostel-compile--compilation-start-advice
+       (lambda (&rest _) (setq orig-called t) nil)
+       "whatever" 'my-fake-grep-mode nil nil nil))
+    (should orig-called)))
+
+(ert-deftest ghostel-test-compile-allows-interactive-input-during-run ()
+  "Regression: during a run the buffer must be interactive.
+
+`ghostel-compile--start' must not enable `compilation-minor-mode'
+on the live buffer — that minor mode's keymap shadows
+`ghostel-mode's self-insert, so letters like `q', `a', `g' would
+stop reaching the process (breaking `htop', `less', read prompts
+etc.).  And `--spawn' must set `ghostel--process' so
+`ghostel--self-insert' has a process to send keystrokes to.
+
+Run a long-lived `cat', verify both conditions, then send bytes
+through the process to confirm they land in the buffer."
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf-name "*ghostel-test-interactive-compile*")
+         (inhibit-message t)
+         (save-some-buffers-default-predicate (lambda () nil))
+         (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil))
+        (kill-buffer buf-name)))
+    (unwind-protect
+        (let ((buf (ghostel-compile--start "cat" buf-name default-directory)))
+          (with-current-buffer buf
+            ;; Wait for the process to be alive.
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () (eq 'run (process-status ghostel--process))))
+            ;; The live buffer must be plain `ghostel-mode' — no compile
+            ;; minor mode stealing keys.
+            (should (eq major-mode 'ghostel-mode))
+            (should-not (bound-and-true-p compilation-minor-mode))
+            ;; Plain letters route through ghostel-mode's self-insert,
+            ;; not through compilation-mode's navigation commands.
+            (should (eq (key-binding "q") #'ghostel--self-insert))
+            (should (eq (key-binding "a") #'ghostel--self-insert))
+            ;; `ghostel--process' is populated, so `ghostel--self-insert'
+            ;; has a process to send to.
+            (should (process-live-p ghostel--process))
+            ;; Round-trip: send a line, expect it back (cat echoes stdin).
+            (process-send-string ghostel--process "ghosttel-ping\n")
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda ()
+               (cl-some (lambda (s) (string-match-p "ghosttel-ping" s))
+                        ghostel--pending-output)))
+            ;; Shut cat down so the test doesn't leak a process.
+            (process-send-eof ghostel--process)
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () ghostel-compile--finalized) 10)))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil))
+          (kill-buffer buf-name))))))
+
+(ert-deftest ghostel-test-compile-multiline-end-to-end ()
+  "Regression: a multi-line shell paragraph run through `ghostel-compile'
+lands in the buffer intact and reports the real exit status.
+
+This is the end-to-end proof for the core PR change: the old design
+typed the command into a live shell and each embedded newline was
+parsed as a RET press, mangling multi-line scripts.  The new design
+spawns `sh -c COMMAND' directly, so the shell parses the paragraph
+normally."
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf-name "*ghostel-test-multiline-compile*")
+         (script "for i in 1 2 3; do\n  echo line-$i\ndone\nexit 7")
+         (inhibit-message t)
+         (save-some-buffers-default-predicate (lambda () nil)))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil))
+        (kill-buffer buf-name)))
+    (unwind-protect
+        (let ((buf (ghostel-compile--start script buf-name
+                                           default-directory)))
+          (with-current-buffer buf
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () ghostel-compile--finalized)
+             10)
+            (should (equal 7 ghostel-compile--last-exit))
+            (let ((text (buffer-substring-no-properties
+                         (point-min) (point-max))))
+              (should (string-match-p "line-1" text))
+              (should (string-match-p "line-2" text))
+              (should (string-match-p "line-3" text))
+              (should (string-match-p "exited abnormally with code 7" text)))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil))
+          (kill-buffer buf-name))))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: prompt navigation
@@ -5588,52 +5354,42 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-command-finish-hook
     ghostel-test-command-finish-hook-error-caught
     ghostel-test-command-finish-hook-error-isolated
-    ghostel-test-compile-mode-requires-ghostel-buffer
-    ghostel-test-compile-mode-sets-up-finish-hook
-    ghostel-test-compile-mode-disable-is-reversible
-    ghostel-test-compile-mode-respects-prior-compilation-minor
-    ghostel-test-compile-mode-disable-cancels-pending
-    ghostel-test-compile-finalize-hide-prompts-nil
     ghostel-test-command-finish-hook-runs-synchronously
     ghostel-test-command-start-hook-runs-synchronously
     ghostel-test-compile-finalize-scans-errors
-    ghostel-test-compile-finalize-inserts-header-and-footer
-    ghostel-test-compile-on-start-snaps-scan-marker
-    ghostel-test-compile-clear-buffer-isolates-stale-errors
-    ghostel-test-compile-finalize-anchors-header-at-scan-marker
+    ghostel-test-compile-finalize-appends-footer
     ghostel-test-compile-finalize-footer-on-failure
-    ghostel-test-compile-finalize-hides-prompts
-    ghostel-test-compile-finalize-hides-echoed-command-without-prompt-property
     ghostel-test-compile-finalize-trims-trailing-blank-rows
     ghostel-test-compile-finalize-colors-errors
-    ghostel-test-compile-spurious-d-without-c-is-ignored
-    ghostel-test-compile-on-finish-only-first-d-counts
     ghostel-test-compile-finalize-does-not-double-count-errors
     ghostel-test-compile-finalize-does-not-kill-buffer
     ghostel-test-compile-view-mode-n-p-navigate-without-opening
     ghostel-test-compile-finalize-leaves-point-at-end
-    ghostel-test-compile-bash-integration-saves-real-status
     ghostel-test-compile-finalize-pins-default-directory
     ghostel-test-compile-recompile-uses-original-directory
+    ghostel-test-compile-recompile-reuses-current-buffer
     ghostel-test-compile-recompile-edit-command-prefix-arg
     ghostel-test-compile-finalize-switches-major-mode
-    ghostel-test-compile-recompile-key-binding
-    ghostel-test-compile-recompile-overrides-compile-g
+    ghostel-test-compile-view-mode-recompile-key-binding
     ghostel-test-compile-format-duration
     ghostel-test-compile-status-message
     ghostel-test-compile-mode-line-running
     ghostel-test-compile-mode-line-exit
     ghostel-test-compile-finish-hooks-fire
-    ghostel-test-compile-finalize-ignored-when-not-running
     ghostel-test-compile-auto-jump-to-first-error
-    ghostel-test-compile-clears-buffer-before-run
-    ghostel-test-compile-clear-disabled
     ghostel-test-compile-recompile-without-history
     ghostel-test-compile-uses-compile-command
     ghostel-test-compile-interactive-uses-compile-history
     ghostel-test-compile-respects-compilation-read-command
-    ghostel-test-compile-get-or-create-buffer-no-window-side-effects
-    ghostel-test-compile-window-placement-matches-compile
+    ghostel-test-compile-prepare-buffer-no-window-side-effects
+    ghostel-test-compile-finalize-is-idempotent
+    ghostel-test-compile-global-mode-toggles-advice
+    ghostel-test-compile-global-mode-falls-through-for-grep
+    ghostel-test-compile-global-mode-routes-to-ghostel-start
+    ghostel-test-compile-global-mode-threads-subclass-mode
+    ghostel-test-compile-global-mode-falls-through-on-continue
+    ghostel-test-compile-global-mode-falls-through-on-comint
+    ghostel-test-compile-global-mode-excluded-custom-mode
     ghostel-test-viewport-start-skips-trailing-newline
     ghostel-test-exec-errors-on-live-process
     ghostel-test-exec-calls-spawn-pty-with-expected-args


### PR DESCRIPTION
## Summary

Addresses [@dalgong's comment on #104](https://github.com/dakra/ghostel/pull/104#issuecomment-4269770964): multi-line shell paragraphs don't work well with the current `ghostel-compile`, and the OSC 133 / shell-integration dependency is fragile.

- **Spawn the command directly.** `ghostel-compile` now runs `shell-file-name -c COMMAND` via `make-process` through a PTY owned by the ghostel renderer — no interactive shell between the command and the user. Multi-line scripts are passed verbatim. Completion is detected by the process sentinel, so no OSC 133 markers (or shell integration) are required.
- **Add opt-in `ghostel-compile-global-mode`.** Advises `compilation-start` so `compile`, `recompile`, `project-compile`, and every other `compilation-start` caller run in ghostel automatically. `grep-mode` falls through by default; customisable via `ghostel-compile-global-mode-excluded-modes`.
- **Simplify.** Drops `ghostel-compile-hide-prompts` and `ghostel-compile-clear-buffer` (no shell = no prompts to hide, buffer is always recreated fresh). Drops the `--running` state machine, finalize-timer gating, OSC 133 C/D handlers, and the bash shell-integration exit-status regression test.

## Behaviour changes for users

- No shell-integration required for `ghostel-compile` to work.
- Multi-line shell paragraphs work (main bug report).
- Customs gone: `ghostel-compile-hide-prompts`, `ghostel-compile-clear-buffer`.
- New toggle: `M-x ghostel-compile-global-mode` — opt-in, routes all compile-style commands through ghostel.

## Test plan

- [x] `make -j4 all` — 120 elisp tests + 72 native tests, lint clean
- [x] `make test-evil` — 30 tests pass
- [x] Live: multi-line script (`for i in 1 2 3; do echo $i; done; exit 7`) runs, reports exit 7, output visible
- [x] Live: `ghostel-recompile` re-runs the last command
- [x] Live: `ghostel-compile-global-mode 1` → `M-x compile` routes through ghostel (`*compilation*` buffer in `ghostel-compile-view-mode`)
- [x] Live: error output gets parsed — `/tmp/x.c:12:3: error: ...` picked up, mode-line shows `:exit [1]`
- [x] New tests covering: multi-line shell, idempotent finalize, global-mode advice add/remove, grep-mode fallthrough, custom mode exclusions, advice routing