### PR TITLE
Fix evil-ghostel cursor snapping into scrollback on normal-state entry

### DIFF
--- a/evil-ghostel.el
+++ b/evil-ghostel.el
@@ -43,13 +43,19 @@
 ;; ---------------------------------------------------------------------------
 
 (defun evil-ghostel--reset-cursor-point ()
-  "Move Emacs point to the terminal cursor position."
-  (when ghostel--term
+  "Move Emacs point to the terminal cursor position.
+`ghostel--cursor-position' returns row relative to the viewport
+(the last `ghostel--term-rows' lines of the buffer), so the row
+must be offset by the scrollback line count.  Mirrors the
+placement math the native module performs in `src/render.zig'."
+  (when (and ghostel--term ghostel--term-rows)
     (let ((pos (ghostel--cursor-position ghostel--term)))
       (when pos
-        (goto-char (point-min))
-        (forward-line (cdr pos))
-        (move-to-column (car pos))))))
+        (let ((scrollback (max 0 (- (line-number-at-pos (point-max))
+                                    ghostel--term-rows))))
+          (goto-char (point-min))
+          (forward-line (+ scrollback (cdr pos)))
+          (move-to-column (car pos)))))))
 
 (defun evil-ghostel--cursor-to-point ()
   "Move the terminal cursor to Emacs point by sending arrow keys."

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -28,6 +28,11 @@ Requires the native module."
      (with-temp-buffer
        (ghostel-mode)
        (setq-local ghostel--term term)
+       ;; Production wires `ghostel--term-rows' via `ghostel--resize';
+       ;; tests that drive the module directly must set it themselves so
+       ;; viewport-aware helpers (e.g. `evil-ghostel--reset-cursor-point')
+       ;; can translate viewport rows into buffer lines.
+       (setq-local ghostel--term-rows ,rows)
        (evil-local-mode 1)
        (evil-ghostel-mode 1)
        (let ((inhibit-read-only t))
@@ -40,6 +45,12 @@ Uses mocks for native functions."
   (declare (indent 0) (debug t))
   `(with-temp-buffer
      (ghostel-mode)
+     ;; Mock tests don't go through `ghostel--resize', so
+     ;; `ghostel--term-rows' stays nil by default.  Pick a value large
+     ;; enough that the viewport covers whatever text a mock test
+     ;; `insert's — the scrollback-offset computation then collapses to
+     ;; zero and matches pre-scrollback-fix behaviour.
+     (setq-local ghostel--term-rows 100)
      (evil-local-mode 1)
      (evil-ghostel-mode 1)
      ,@body))
@@ -105,6 +116,44 @@ Uses mocks for native functions."
                                   (goto-char (point-min))
                                   (evil-ghostel--reset-cursor-point)
                                   (should (= 2 (line-number-at-pos)))))
+
+(ert-deftest evil-ghostel-test-reset-cursor-point-with-scrollback ()
+  "Regression: reset-cursor-point must anchor to the viewport, not point-min.
+`ghostel--cursor-position' returns the row within the viewport (the
+last `ghostel--term-rows' lines of the buffer).  With scrollback
+present, interpreting the row as an offset from `point-min' lands
+point in the scrollback region instead of the visible viewport."
+  (let ((term (ghostel--new 5 40 1000)))
+    ;; Overflow a 5-row viewport with 12 lines so 7 scroll off.  The
+    ;; final row ("last-11") is in the viewport; earlier rows live in
+    ;; scrollback above.
+    (dotimes (i 12)
+      (ghostel--write-input term (format "row-%02d\r\n" i)))
+    (ghostel--write-input term "last-11")
+    (with-temp-buffer
+      (ghostel-mode)
+      (setq-local ghostel--term term)
+      (setq-local ghostel--term-rows 5)
+      (evil-local-mode 1)
+      (evil-ghostel-mode 1)
+      (let ((inhibit-read-only t))
+        (ghostel--redraw term t))
+      ;; Walk point back into the scrollback region.
+      (goto-char (point-min))
+      (should (string-match-p "row-00" (buffer-substring-no-properties
+                                         (line-beginning-position)
+                                         (line-end-position))))
+      ;; Reset must snap point into the viewport, not to scrollback row N.
+      (evil-ghostel--reset-cursor-point)
+      ;; The landing line is the one that contains the terminal cursor —
+      ;; "last-11" (the last written row before the trailing cursor).
+      (let ((line-text (buffer-substring-no-properties
+                        (line-beginning-position)
+                        (line-end-position))))
+        (should (string-match-p "last-11" line-text)))
+      ;; And the landing column matches the terminal cursor column.
+      (should (= (car (ghostel--cursor-position term))
+                 (current-column))))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: cursor-to-point (arrow key sending)


### PR DESCRIPTION
## Problem

`evil-ghostel--reset-cursor-point` uses `(cdr pos)` — the
viewport-relative row returned by `ghostel--cursor-position` — as a line
offset from `point-min`. That only works when the buffer has no
scrollback; with any scrollback accumulated, entering evil normal state
snaps point to row N of the **scrollback region** instead of row N of
the visible viewport.

Spotted when running Claude Code inside ghostel: Claude renders inline
(no alt-screen) so scrollback accumulates quickly, and every
`evil-normal-state` → `evil-insert-state` round-trip made point jump to
the top-left of the buffer instead of staying near Claude's input
prompt.

## Reproduction

1. Start any shell-heavy session in a ghostel buffer until there is ≥1
   screen of scrollback (running Claude Code, `cat` on a long file,
   etc.).
2. With `evil-ghostel-mode` on, trigger `evil-normal-state`.
3. Point snaps to the top-left of the buffer instead of the terminal
   cursor.

Re-entering insert state then moving further makes the display
"teleport" back down, because the terminal cursor is actually near the
bottom of the buffer.

## Fix

Offset the viewport row by the scrollback line count, mirroring the
placement math the native module performs in `src/render.zig`
(`gotoCharN(viewport_start_int)` followed by `forwardLine(cy)`, where
`viewport_start_int = point-min + forward-line scrollback_in_buffer`).

```elisp
(defun evil-ghostel--reset-cursor-point ()
  "..."
  (when (and ghostel--term ghostel--term-rows)
    (let ((pos (ghostel--cursor-position ghostel--term)))
      (when pos
        (let ((scrollback (max 0 (- (line-number-at-pos (point-max))
                                    ghostel--term-rows))))
          (goto-char (point-min))
          (forward-line (+ scrollback (cdr pos)))
          (move-to-column (car pos)))))))
```

Verified in a live buffer that `(evil-ghostel--reset-cursor-point)`
now lands on the same line as ghostel's own redraw cursor placement
(delta 0 against `(ghostel--redraw term t)`).
