### PR TITLE
Keep viewport anchored across resize when Emacs drifts window-start

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -738,6 +738,16 @@ Updated whenever the terminal is created or resized.")
 (defvar-local ghostel--force-next-redraw nil
   "When non-nil, redraw regardless of synchronized output mode.")
 
+(defvar ghostel--redraw-resize-active nil
+  "Dynamically bound to t inside a resize-triggered `ghostel--delayed-redraw'.
+Read by `ghostel--window-anchored-p' so the redraw keeps auto-following
+windows anchored even when Emacs redisplay drifted `window-start' below
+the anchor between redraws (e.g. via `keep-point-visible' when the
+minibuffer shrinks the window).  Not set for output-driven redraws,
+clear-scrollback, copy-exit, or snap-to-input — those either reset
+`ghostel--scroll-positions' or set `ghostel--snap-requested', both of
+which already produce the intended anchoring.")
+
 (defvar-local ghostel--snap-requested nil
   "When non-nil, the next redraw should anchor `window-start' to the viewport.
 Set by `ghostel--snap-to-input' on user-initiated input (typing, paste,
@@ -2642,11 +2652,18 @@ position COL columns into the first matched line."
   "Non-nil if WIN is auto-following the viewport.
 A window counts as anchored when `ghostel--snap-requested' is set
 \(the user just typed), when no anchor has been recorded yet (first
-redraw), or when its `window-start' is at or past the prior anchor."
+redraw), or when its `window-start' is at or past the prior anchor.
+During a resize-triggered redraw, a window absent from
+`ghostel--scroll-positions' also counts as anchored: the prior redraw
+left it following the viewport, so a drifted `window-start' below the
+anchor is Emacs redisplay (e.g. `keep-point-visible' when the
+minibuffer shrinks the window), not a user scroll."
   (let ((anchor ghostel--last-anchor-position))
     (or ghostel--snap-requested
         (null anchor)
-        (>= (window-start win) anchor))))
+        (>= (window-start win) anchor)
+        (and ghostel--redraw-resize-active
+             (not (assq win ghostel--scroll-positions))))))
 
 (defun ghostel--capture-window-state (win)
   "Return (WIN WS-KEY WP-KEY WP-COL) for WIN.
@@ -2806,7 +2823,12 @@ PROCESS is the shell process, WINDOWS is the list of windows."
           (when ghostel--redraw-timer
             (cancel-timer ghostel--redraw-timer)
             (setq ghostel--redraw-timer nil))
-          (ghostel--delayed-redraw buffer))))
+          ;; `ghostel--redraw-resize-active' lets `ghostel--window-anchored-p'
+          ;; treat Emacs-induced `window-start' drift (from `keep-point-visible'
+          ;; when a minibuffer-triggered resize shrinks the body) as drift,
+          ;; not as a user scroll.
+          (let ((ghostel--redraw-resize-active t))
+            (ghostel--delayed-redraw buffer)))))
     ;; Return size — Emacs calls set-process-window-size (SIGWINCH)
     ;; after this function returns, matching eat/vterm timing.
     size))

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -3091,6 +3091,15 @@ viewport.  After the fix, the scrolled-up view is preserved."
             (set-window-start (selected-window) (point-min) t)
             (goto-char (point-min))
             (set-window-point (selected-window) (point-min))
+            ;; Real-world flow: some PTY output arrives between the
+            ;; wheel-up and `M-x', so an output-driven redraw captures
+            ;; the scrolled window into `ghostel--scroll-positions'
+            ;; before the resize fires.  Without this intermediate
+            ;; capture the resize redraw's drift heuristic would
+            ;; (correctly, by that heuristic) classify this window as
+            ;; drifted-but-anchored and snap it back.
+            (ghostel--delayed-redraw buf)
+            (should (assq (selected-window) ghostel--scroll-positions))
             (let ((ws-before (window-start (selected-window)))
                   (wp-before (window-point (selected-window))))
 
@@ -3121,6 +3130,86 @@ viewport.  After the fix, the scrolled-up view is preserved."
               ;; The user's scrolled-up view must be preserved.
               (should (= ws-before (window-start (selected-window))))
               (should (= wp-before (window-point (selected-window)))))))
+      (when (buffer-live-p orig-buf)
+        (set-window-buffer (selected-window) orig-buf))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-redraw-resize-preserves-anchor-when-emacs-drifts-ws ()
+  "Resize keeps the window anchored when Emacs drifted `window-start' below it.
+Regression test for issue #127: in TUIs whose cursor sits above the
+viewport bottom, opening the minibuffer shrinks the window body and
+Emacs's `keep-point-visible' moves `window-start' forward so the TUI
+cursor stays on screen.  The resulting `ws < anchor' looked identical
+to a real user scroll, so the force redraw captured a blank-row key,
+found it at `point-min', and jumped `window-start' to 1.
+
+With the fix, a force redraw classifies a window as anchored when it
+wasn't recorded in `ghostel--scroll-positions' at the prior redraw —
+so an Emacs-driven drift is treated as drift, not a scroll."
+  (let ((buf (generate-new-buffer " *ghostel-test-resize-anchor-drift*"))
+        (orig-buf (window-buffer (selected-window))))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 10 40 200))
+                 (ghostel--term term)
+                 (ghostel--term-rows 10)
+                 (inhibit-read-only t))
+            ;; Write enough blank-terminated lines that a drifted
+            ;; ws-key would ambiguously match near `point-min'.
+            (dotimes (i 30)
+              (ghostel--write-input term (format "row-%02d\r\n" i)))
+            (ghostel--redraw term t)
+            (set-window-buffer (selected-window) buf)
+            ;; Steady-state auto-follow; prior redraw seeds the anchor.
+            (goto-char (point-max))
+            (set-window-point (selected-window) (point-max))
+            (let ((vp (save-excursion
+                        (goto-char (point-max))
+                        (forward-line -9)
+                        (line-beginning-position))))
+              (set-window-start (selected-window) vp t))
+            (setq ghostel--force-next-redraw t)
+            (ghostel--delayed-redraw buf)
+            (should ghostel--last-anchor-position)
+            (should-not ghostel--scroll-positions)
+
+            ;; Simulate Emacs drift: `keep-point-visible' on a
+            ;; minibuffer-triggered resize slides `window-start' a
+            ;; couple rows below the anchor.  Point stays in the live
+            ;; viewport (TUI cursor on a row above the bottom).
+            (let ((drifted-ws (save-excursion
+                                (goto-char ghostel--last-anchor-position)
+                                (forward-line -2)
+                                (line-beginning-position))))
+              (should (< drifted-ws ghostel--last-anchor-position))
+              (set-window-start (selected-window) drifted-ws t))
+            ;; Window is NOT in `ghostel--scroll-positions' — it was
+            ;; auto-following, not user-scrolled.
+            (should-not ghostel--scroll-positions)
+
+            ;; Resize path (same harness as the scrolled-view test).
+            (cl-letf (((default-value 'window-adjust-process-window-size-function)
+                       (lambda (&rest _) (cons 40 6)))
+                      ((symbol-function 'set-process-window-size) #'ignore))
+              (setq ghostel--process
+                    (make-pipe-process :name "ghostel-test-fake"
+                                       :buffer buf
+                                       :noquery t
+                                       :filter #'ignore
+                                       :sentinel #'ignore))
+              (unwind-protect
+                  (ghostel--window-adjust-process-window-size
+                   ghostel--process
+                   (list (selected-window)))
+                (delete-process ghostel--process)
+                (setq ghostel--process nil)))
+
+            ;; Window must be re-anchored to the live viewport, NOT
+            ;; yanked to `point-min'.
+            (should (= (ghostel--viewport-start)
+                       (window-start (selected-window))))
+            (should (> (window-start (selected-window)) 1))))
       (when (buffer-live-p orig-buf)
         (set-window-buffer (selected-window) orig-buf))
       (kill-buffer buf))))


### PR DESCRIPTION
## Summary

- Fixes #127: in TUIs whose cursor sits above the viewport bottom, opening the minibuffer (`M-x`, vertico, etc.) can yank `window-start` to `point-min` or well above the viewport.
- Root cause: when a minibuffer-triggered resize shrinks the ghostel window body, Emacs's `keep-point-visible` drifts `window-start` forward below the prior anchor so the TUI cursor stays on screen. The resize-triggered force redraw then misclassifies the window as user-scrolled, captures a blank-row key, finds it at `point-min`, and jumps there.
- Fix: during a resize-triggered redraw, treat a window absent from `ghostel--scroll-positions` as still anchored. The prior redraw left it auto-following the viewport, so any drift below the anchor must be Emacs redisplay, not a user scroll. Narrowly scoped to the resize path via a new `ghostel--redraw-resize-active` dynamic variable — output-driven, clear-scrollback, copy-exit, and snap-to-input all have their own anchoring paths and are unaffected.

## Known edge case

If the user genuinely wheel-scrolls and then immediately hits `M-x` before any PTY output triggers an intermediate redraw, the resize redraw will snap them back to the viewport. Scrolling again recovers. In practice PTY output almost always intervenes, so this is rare.

## Test plan

- [x] `make -j4 all` — builds, 124 elisp + 75 native tests pass
- [x] `make test-evil` — 30 evil tests pass
- [x] `make lint` — no warnings
- [x] New test `ghostel-test-redraw-resize-preserves-anchor-when-emacs-drifts-ws` verified to FAIL without the fix and PASS with it
- [x] Existing `ghostel-test-redraw-preserves-scroll-across-window-resize` updated to insert an output-driven redraw between wheel-up and resize (matches real-world flow); still passes
- [x] Manual repro: Claude Code / opencode / codex in a ghostel buffer with populated scrollback, toggle `M-x` at varying widths — viewport stays anchored