### PR TITLE
ghostel-mode: preserve per-cell face props under font-lock

### DIFF
--- a/evil-ghostel.el
+++ b/evil-ghostel.el
@@ -45,7 +45,7 @@
 (defun evil-ghostel--reset-cursor-point ()
   "Move Emacs point to the terminal cursor position.
 `ghostel--cursor-position' returns row relative to the viewport
-(the last `ghostel--term-rows' lines of the buffer), so the row
+\(the last `ghostel--term-rows' lines of the buffer), so the row
 must be offset by the scrollback line count.  Mirrors the
 placement math the native module performs in `src/render.zig'."
   (when (and ghostel--term ghostel--term-rows)

--- a/ghostel-compile.el
+++ b/ghostel-compile.el
@@ -171,7 +171,15 @@ to a ghostel terminal."
   (setq-local next-error-function #'compilation-next-error-function)
   ;; Make sure point lands at the top after a successful recompile (and
   ;; that future input doesn't inherit ghostel's terminal-style behaviour).
-  (setq-local window-point-insertion-type nil))
+  (setq-local window-point-insertion-type nil)
+  ;; The buffer text inherited from the ghostel run carries per-cell `face'
+  ;; text-properties written by the native module.  `compilation-mode'
+  ;; installs font-lock keywords for error highlighting, and the default
+  ;; unfontify function strips every `face' prop — wiping the colour from
+  ;; the recorded output on the first JIT-lock pass.  Neutralise unfontify:
+  ;; compilation-mode's keywords are applied once via `font-lock-ensure'
+  ;; on a finalised, static buffer and don't need to be cleaned up.
+  (setq-local font-lock-unfontify-region-function #'ignore))
 
 (defun ghostel-compile--format-duration (seconds)
   "Format SECONDS (float) as a compilation-style duration string.

--- a/ghostel.el
+++ b/ghostel.el
@@ -2819,6 +2819,14 @@ PROCESS is the shell process, WINDOWS is the list of windows."
   "Major mode for Ghostel terminal emulator."
   (buffer-disable-undo)
   (font-lock-mode -1)
+  ;; `font-lock-mode' can still be re-enabled by user configuration that
+  ;; forces `font-lock-defaults' globally (e.g. Doom Emacs).  When active,
+  ;; JIT-lock calls `font-lock-unfontify-region' on every redraw, which
+  ;; strips the per-cell `face' text-properties the native module writes.
+  ;; Neutralise the unfontify pass so face props survive regardless of
+  ;; whether font-lock ends up on.  `ghostel-mode' has no keywords, so
+  ;; skipping unfontify has no other effect.
+  (setq-local font-lock-unfontify-region-function #'ignore)
   (setq buffer-read-only nil)
   (setq-local scroll-margin 0)
   (setq-local auto-hscroll-mode nil)

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -519,6 +519,54 @@ scrolling libghostty's viewport."
       (kill-buffer buf))))
 
 ;; -----------------------------------------------------------------------
+;; Test: per-cell face props survive font-lock activation
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-face-props-survive-font-lock ()
+  "Regression: per-cell face text-properties must survive a font-lock pass.
+User configs that force `font-lock-defaults' on (notably Doom Emacs,
+which sets `(nil t)' globally) cause `font-lock-mode' to activate in
+ghostel buffers despite the mode body disabling it.  JIT-lock's
+fontify pass then calls `font-lock-unfontify-region' which, without
+the buffer-local override installed by `ghostel-mode', strips every
+`face' property the native module wrote."
+  (let ((buf (generate-new-buffer " *ghostel-test-fl*")))
+    (unwind-protect
+        (with-current-buffer buf
+          ;; Activate `ghostel-mode' so the fix under test (buffer-local
+          ;; `font-lock-unfontify-region-function' override) is installed.
+          (ghostel-mode)
+          (let* ((term (ghostel--new 5 40 100))
+                 (inhibit-read-only t))
+            (setq-local ghostel--term term)
+            ;; Known palette so the red SGR resolves predictably.
+            (let ((rest (apply #'concat (make-list 14 "#000000"))))
+              (ghostel--set-palette term
+                                    (concat "#000000" "#ff0000" rest
+                                            "#ffffff" "#000000")))
+            (ghostel--write-input term "\e[31mRED\e[0m normal")
+            (ghostel--redraw term t)
+            (goto-char (point-min))
+            (let ((face-before (get-text-property (point) 'face)))
+              (should face-before)
+              (should (plist-get face-before :foreground))
+              ;; Simulate a user config that force-enables font-lock.
+              ;; Without the buffer-local unfontify override installed
+              ;; by `ghostel-mode', the fontify pass would strip face
+              ;; props across the buffer.
+              (setq-local font-lock-defaults '(nil t))
+              (font-lock-mode 1)
+              (font-lock-ensure (point-min) (point-max))
+              ;; Face property for the coloured cell must still be there.
+              (goto-char (point-min))
+              (let ((face-after (get-text-property (point) 'face)))
+                (should face-after)
+                (should (plist-get face-after :foreground))
+                (should (equal (plist-get face-before :foreground)
+                               (plist-get face-after :foreground)))))))
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
 ;; Test: multi-byte character rendering (box drawing, Unicode)
 ;; -----------------------------------------------------------------------
 
@@ -1905,6 +1953,30 @@ Downstream consumers (notably `ghostel-compile') depend on it."
               (setq found t)))
           (forward-char 1)))
       (should found))))
+
+(ert-deftest ghostel-test-compile-finalize-preserves-face-props ()
+  "Regression: per-cell `face' text-properties baked in during the ghostel
+run must survive the transition to `ghostel-compile-view-mode'.
+`compilation-mode' installs font-lock keywords for error highlighting,
+and the default `font-lock-unfontify-region-function' strips every
+`face' property — wiping the colour of the recorded output on the first
+JIT-lock pass.  `ghostel-compile-view-mode' installs a buffer-local
+`#'ignore' override to preserve those props."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (setq ghostel-compile--command "make"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--scan-marker (copy-marker (point-max)))
+      (insert (propertize "RED" 'face '(:foreground "#ff0000")))
+      (insert " output\n/tmp/x.c:42:5: error: bad\n"))
+    (ghostel-compile--finalize buf 1 (current-time))
+    (font-lock-ensure (point-min) (point-max))
+    ;; The ghostel-painted face on "RED" must still be present.
+    (goto-char (point-min))
+    (re-search-forward "RED")
+    (let ((face (get-text-property (match-beginning 0) 'face)))
+      (should face)
+      (should (equal "#ff0000" (plist-get face :foreground))))))
 
 (ert-deftest ghostel-test-compile-finalize-does-not-double-count-errors ()
   "Regression: parsing must not count each error twice.
@@ -5424,6 +5496,7 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-compile-finalize-footer-on-failure
     ghostel-test-compile-finalize-trims-trailing-blank-rows
     ghostel-test-compile-finalize-colors-errors
+    ghostel-test-compile-finalize-preserves-face-props
     ghostel-test-compile-finalize-does-not-double-count-errors
     ghostel-test-compile-finalize-does-not-kill-buffer
     ghostel-test-compile-view-mode-n-p-navigate-without-opening


### PR DESCRIPTION
## Problem

Ghostel's native renderer writes inline `face` text-properties
(`:foreground` / `:background` per cell) via `applyStyle` in
`src/render.zig`. If `font-lock-mode` ends up active in a ghostel
buffer, JIT-lock's fontify pass calls `font-lock-unfontify-region`
which strips *all* `face` props in the region — output then renders in
the buffer's default fg only.

`ghostel-mode` already runs `(font-lock-mode -1)` in its body, but
that executes *before* `after-change-major-mode-hook`, and any
globalised minor mode that force-enables font-lock later (Doom Emacs
sets `font-lock-defaults = (nil t)` globally, which makes
`turn-on-font-lock-if-desired` activate font-lock in modes that have
no keywords) flips it back on. A subsequent redraw or JIT-lock pass
then wipes the face props.

## Reproduction

In a config that forces font-lock on (Doom, or
`(setq-default font-lock-defaults '(nil t))`), spawn a ghostel buffer
running any color-heavy program (Claude Code, `btop`, colored `ls`).
Output renders monochrome: `(get-text-property POINT 'face)` returns
`nil` across most of the buffer despite the module having written
inline foreground/background properties.

Instrumentation (count of colored text-property runs) confirms the
cycle on a live ghostel buffer:

- colored runs before fontify: `2431`
- after `(font-lock-mode 1)` + `(font-lock-ensure ...)`: `0` (all
  stripped)

## Fix

Neutralise the unfontify pass via a buffer-local override in
`ghostel-mode`:

```elisp
(setq-local font-lock-unfontify-region-function #'ignore)
```

With this, `font-lock-mode` can remain active (or be toggled on by
user configuration) without ghostel's face props being wiped.
`ghostel-mode` has no font-lock keywords, so the fontify side of the
equation has nothing to add — skipping unfontify is exactly what
preserves the module's output.

Verified with the same stress pass after the fix:

- colored runs before: `91`
- after `(font-lock-mode 1)` + `(font-lock-ensure ...)`: `91`
  (preserved)

Noticed while running Claude Code inside ghostel under Doom Emacs;
companion to the evil-ghostel viewport fix in #129.
