### PR TITLE
Disable adaptive read buffering for PTY processes (#85)

### DIFF
--- a/ghostel-compile.el
+++ b/ghostel-compile.el
@@ -467,6 +467,9 @@ local machine happens to have)."
                         ;; Defeat pagers (git grep, etc.).
                         "PAGER=")
                   (copy-sequence process-environment)))
+         ;; See `ghostel--spawn-pty' for why these are set.
+         (process-adaptive-read-buffering nil)
+         (read-process-output-max (max read-process-output-max (* 1024 1024)))
          (proc (make-process
                 :name "ghostel-compile"
                 :buffer buffer

--- a/ghostel.el
+++ b/ghostel.el
@@ -2433,6 +2433,16 @@ matches the PTY window size, and stores the process in
             "COLORTERM=truecolor")
            extra-env
            process-environment))
+         ;; Large TUI redraws (Claude Code, pi on resize) can emit
+         ;; hundreds of KB in one write.  Before Emacs 31,
+         ;; `process-adaptive-read-buffering' defaults to t and
+         ;; throttles the filter to ~40 KB/s for bursty processes,
+         ;; making resize feel like a slow cascade.
+         ;; Also raise the per-read cap so one filter call can
+         ;; consume a full redraw frame.  Both are captured at
+         ;; `make-process' time, so they must be let-bound here.
+         (process-adaptive-read-buffering nil)
+         (read-process-output-max (max read-process-output-max (* 1024 1024)))
          (proc (make-process
                 :name "ghostel"
                 :buffer (current-buffer)

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -5176,6 +5176,49 @@ integration script runs, so input echo must be enabled before exec."
             (when (process-live-p proc)
               (delete-process proc))))))))
 
+(ert-deftest ghostel-test-spawn-pty-disables-adaptive-read-buffering ()
+  "`ghostel--spawn-pty' must disable adaptive read buffering and raise
+`read-process-output-max'.  Before Emacs 31 the former defaulted to t
+and throttled bursty TUI redraws."
+  (let ((captured-adaptive 'unset)
+        (captured-max nil)
+        (orig-make-process (symbol-function #'make-process)))
+    (cl-letf (((symbol-function #'make-process)
+               (lambda (&rest plist)
+                 (setq captured-adaptive process-adaptive-read-buffering
+                       captured-max read-process-output-max)
+                 (apply orig-make-process plist))))
+      (with-temp-buffer
+        (let ((proc (ghostel--spawn-pty "/bin/sh" nil 24 80
+                                        "-ixon" nil nil)))
+          (unwind-protect
+              (progn
+                (should (null captured-adaptive))
+                (should (>= captured-max (* 1024 1024))))
+            (when (process-live-p proc)
+              (delete-process proc))))))))
+
+(ert-deftest ghostel-test-compile-spawn-disables-adaptive-read-buffering ()
+  "`ghostel-compile--spawn' must disable adaptive read buffering and
+raise `read-process-output-max'.  Same reason as
+`ghostel--spawn-pty' (issue #85)."
+  (let ((captured-adaptive 'unset)
+        (captured-max nil)
+        (orig-make-process (symbol-function #'make-process)))
+    (cl-letf (((symbol-function #'make-process)
+               (lambda (&rest plist)
+                 (setq captured-adaptive process-adaptive-read-buffering
+                       captured-max read-process-output-max)
+                 (apply orig-make-process plist))))
+      (with-temp-buffer
+        (let ((proc (ghostel-compile--spawn "true" (current-buffer) 24 80)))
+          (unwind-protect
+              (progn
+                (should (null captured-adaptive))
+                (should (>= captured-max (* 1024 1024))))
+            (when (process-live-p proc)
+              (delete-process proc))))))))
+
 ;; -----------------------------------------------------------------------
 ;; Tests: window resize
 ;; -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix slow-cascade redraws on Emacs ≤30.x when large TUIs (Claude Code, pi-mono) emit 100s of KB in a single post-resize write. `process-adaptive-read-buffering` defaults to `t` there and throttles the filter to ~40 KB/s, turning a 570 KB frame into a ~15 s visible stream (issue #85).
- Let-bind `process-adaptive-read-buffering nil` and raise `read-process-output-max` to at least 1 MB around `make-process` in both `ghostel--spawn-pty` and `ghostel-compile--spawn`. Both values are captured at process-creation time, so they must be bound at the call site.
- Adds 2 regression tests using the existing `cl-letf` around `make-process` pattern.

## Background

- vterm sets `process-adaptive-read-buffering nil` for the same reason (vterm.el:772).
- Emacs 31+ already defaults the variable to `nil` (upstream commit `8a669b6be5`, 2025-02-09), so the first binding is a no-op there. The `read-process-output-max` bump still matters on every Emacs version — default is 64 KB, so a 570 KB frame otherwise splits into ~9 filter calls.
- Credit: diagnosis and fix proposed by @emil-e in issue #85.

## Test plan

- [x] `make -j4 all` passes (build + 125 tests + lint)
- [x] `ghostel-test-spawn-pty-disables-adaptive-read-buffering` — asserts both values captured at `make-process` time
- [x] `ghostel-test-compile-spawn-disables-adaptive-read-buffering` — same for compile spawn path
- [ ] Manual: reproduce issue #85 cascade on Emacs 30.x with Claude Code or pi-mono and confirm it's gone (requires a non-31 Emacs)

Closes related comments on #85. Does not fix the broader resize-reflow concerns tracked in #132.