### PR TITLE
Add OSC 9 / OSC 777 notification and progress support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,398 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- Desktop notifications via OSC 9 (iTerm2) and OSC 777 (rxvt `notify`),
+  plus ConEmu OSC 9;4 progress reports.  Notifications route through
+  `ghostel-notification-function` (default uses `notifications-notify`
+  with a `message` fallback); progress routes through
+  `ghostel-progress-function` (default shows `[42%]` / `[...]` /
+  `[err]` / `[paused]` in the mode line).  OSC 9;9 CWD reports are
+  handled the same way as OSC 7.  Closes
+  [#141](https://github.com/dakra/ghostel/issues/141).
+- `ghostel-compile` and `ghostel-recompile`: `M-x compile`-style workflow
+  backed by a real PTY, so commands that need a terminal (colour output,
+  progress bars, curses tools) work normally. Finished buffers support
+  `next-error` navigation and share `compile-command` / `compile-history`
+  with `M-x compile`; `g` recompiles in the original directory
+  ([5280db2](https://github.com/dakra/ghostel/commit/5280db2)).
+- `ghostel-debug-info` command collects environment and terminal state for
+  bug reports; resize and redraw events are now logged when debug mode is
+  on ([b5d7b4d](https://github.com/dakra/ghostel/commit/b5d7b4d)).
+- `ghostel-ignore-cursor-change` option to ignore terminal requests that
+  change cursor shape or visibility
+  ([c901c02](https://github.com/dakra/ghostel/commit/c901c02)).
+- `M-y` with no preceding yank now opens a `completing-read` browser over
+  the kill ring (works with consult/vertico)
+  ([e1e1896](https://github.com/dakra/ghostel/commit/e1e1896)).
+- `C-g` is now sent to the terminal instead of triggering `keyboard-quit`;
+  in copy mode it still exits copy mode
+  ([057fb1f](https://github.com/dakra/ghostel/commit/057fb1f)).
+- Module auto-download now works on systems that report `amd64`/`arm64`
+  in `system-configuration`
+  ([27dcec0](https://github.com/dakra/ghostel/commit/27dcec0)).
+- `evil-ghostel` included in `make checkdoc`
+  ([0a9faa1](https://github.com/dakra/ghostel/commit/0a9faa1)).
+
+### Changed
+- Linkified file paths in terminal output now also match bare relative
+  paths (e.g. `src/foo.rs:43:4`), paths wrapped in punctuation (Python
+  tracebacks, backticks, brackets), and an optional `:column` after the
+  line number. Configurable via `ghostel-file-detection-regex`. Closes
+  [#107](https://github.com/dakra/ghostel/issues/107)
+  ([ed17efb](https://github.com/dakra/ghostel/commit/ed17efb)).
+
+### Fixed
+- Top line no longer renders clipped after a terminal redraw when
+  `pixel-scroll-precision-mode` had left a partial pixel offset. Closes
+  [#105](https://github.com/dakra/ghostel/issues/105)
+  ([bfb6e7c](https://github.com/dakra/ghostel/commit/bfb6e7c)).
+
+## [0.14.0] — 2026-04-13
+
+### Added
+- `C-c C-l` binding in copy mode ([156a714](https://github.com/dakra/ghostel/commit/156a714)).
+
+### Changed
+- Decouple module downloads from package version ([36a1ad5](https://github.com/dakra/ghostel/commit/36a1ad5)).
+- Disable XON/XOFF flow control so `C-q` and `C-s` reach the shell ([a8a3034](https://github.com/dakra/ghostel/commit/a8a3034)).
+- Speed up test suite with early-return polling and parallel execution ([2d3bda7](https://github.com/dakra/ghostel/commit/2d3bda7)).
+- Wheel events now fall through to third-party scroll packages
+  (ultra-scroll, `pixel-scroll-precision-mode`, `mwheel`) when terminal
+  mouse tracking is inactive. Fixes
+  [#97](https://github.com/dakra/ghostel/issues/97)
+  ([3b6c980](https://github.com/dakra/ghostel/commit/3b6c980)).
+
+### Removed
+- Dead scroll commands ([156a714](https://github.com/dakra/ghostel/commit/156a714)).
+
+### Fixed
+- Blank first page of scrollback after initial output burst ([f01de74](https://github.com/dakra/ghostel/commit/f01de74)).
+- Keystrokes are now visible from the first character in bash sessions
+  (previously invisible on old bash, notably macOS `/bin/bash` 3.2).
+  Fixes [#101](https://github.com/dakra/ghostel/issues/101)
+  ([51705bd](https://github.com/dakra/ghostel/commit/51705bd)).
+
+## [0.13.0] — 2026-04-13
+
+### Added
+- VT log callback ([a3d043a](https://github.com/dakra/ghostel/commit/a3d043a)).
+
+### Changed
+- Build with Zig and vendored Emacs header ([4ca5770](https://github.com/dakra/ghostel/commit/4ca5770)).
+- Use env vars for Emacs header override ([cdcfa76](https://github.com/dakra/ghostel/commit/cdcfa76)).
+- Replace ghostty git submodule with Zig URL dependency ([b32308c](https://github.com/dakra/ghostel/commit/b32308c)).
+- Use `_get_multi` for render state queries ([a3d043a](https://github.com/dakra/ghostel/commit/a3d043a)).
+- Remove `zig build check` step and clean up stale references ([f19409e](https://github.com/dakra/ghostel/commit/f19409e)).
+
+### Fixed
+- musl cross-compilation; release builds now pass `-Dcpu=baseline` ([3e0776d](https://github.com/dakra/ghostel/commit/3e0776d)).
+
+## [0.12.2] — 2026-04-12
+
+### Changed
+- Rename `ghostel-evil` to `evil-ghostel` ([1c37fef](https://github.com/dakra/ghostel/commit/1c37fef)).
+
+### Fixed
+- Blank screen after idle when buffer gets out of sync ([0f60388](https://github.com/dakra/ghostel/commit/0f60388)).
+
+## [0.12.1] — 2026-04-12
+
+### Fixed
+- Cursor lands on the correct character for box-drawing and other glyphs
+  where Emacs' width calculation disagrees with the terminal (seen on
+  CJK/pgtk). Fixes [#86](https://github.com/dakra/ghostel/issues/86)
+  ([fcb8d3b](https://github.com/dakra/ghostel/commit/fcb8d3b)).
+
+## [0.12.0] — 2026-04-12
+
+### Added
+- `ghostel-enable-title-tracking` defcustom ([0102ad9](https://github.com/dakra/ghostel/commit/0102ad9)).
+
+### Changed
+- Defer buffer erasure on resize to eliminate blank flash ([5966043](https://github.com/dakra/ghostel/commit/5966043)).
+- Redraw synchronously on resize and anchor `window-start` ([6728ffc](https://github.com/dakra/ghostel/commit/6728ffc)).
+
+### Fixed
+- Stale horizontal scroll after window resize ([cc48ae3](https://github.com/dakra/ghostel/commit/cc48ae3)).
+
+## [0.11.0] — 2026-04-11
+
+### Added
+- Materialize libghostty scrollback into the Emacs buffer (vterm parity) ([34645e2](https://github.com/dakra/ghostel/commit/34645e2)).
+- Detect cap rotation via first-row hash to keep scrollback fresh ([9ed2a76](https://github.com/dakra/ghostel/commit/9ed2a76)).
+
+### Changed
+- Always insert trailing newline in `insertScrollbackRange` ([d3acea1](https://github.com/dakra/ghostel/commit/d3acea1)).
+- Trim trailing blank cells when rendering rows ([b3e86b5](https://github.com/dakra/ghostel/commit/b3e86b5)).
+- Update benchmark numbers after trailing-whitespace trim ([1a31d37](https://github.com/dakra/ghostel/commit/1a31d37)).
+
+### Fixed
+- OSC 51;E eval no longer crashes the process filter when the executed
+  command switches buffers, signals an error, or deselects the ghostel
+  window. Fixes [#82](https://github.com/dakra/ghostel/issues/82)
+  ([20cce42](https://github.com/dakra/ghostel/commit/20cce42)).
+
+## [0.10.1] — 2026-04-11
+
+### Added
+- Configurable TRAMP method for OSC 7 directory tracking ([1159a5b](https://github.com/dakra/ghostel/commit/1159a5b)).
+
+### Changed
+- Pass `-Dcpu=baseline` for native x86_64 builds ([11df11b](https://github.com/dakra/ghostel/commit/11df11b)).
+- Harden Claude review workflow for fork PRs ([f16d7b8](https://github.com/dakra/ghostel/commit/f16d7b8)).
+
+## [0.10.0] — 2026-04-11
+
+### Added
+- `evil-mode` integration: normal-mode navigation works in terminal
+  buffers with the cursor kept in sync on state transitions. Closes
+  [#52](https://github.com/dakra/ghostel/issues/52)
+  ([21d8439](https://github.com/dakra/ghostel/commit/21d8439)).
+- OSC 4/10/11 color query responses ([c57f281](https://github.com/dakra/ghostel/commit/c57f281), fixes [#75](https://github.com/dakra/ghostel/issues/75)).
+- SIGWINCH delivery tests for PTY resize ([500d978](https://github.com/dakra/ghostel/commit/500d978)).
+
+### Changed
+- Use per-process property for window resize handler ([dc102eb](https://github.com/dakra/ghostel/commit/dc102eb)).
+- Track `.elc` files as proper Make targets ([144c9ba](https://github.com/dakra/ghostel/commit/144c9ba)).
+- Use `executable-find` to locate bash in SIGWINCH tests ([ae06f8e](https://github.com/dakra/ghostel/commit/ae06f8e)).
+
+### Fixed
+- Remote zsh temp directory leak during session startup ([519f063](https://github.com/dakra/ghostel/commit/519f063)).
+- ncurses apps (htop, etc.) now redraw at the correct size after a
+  window resize instead of being frozen at their start-up dimensions.
+  Fixes [#67](https://github.com/dakra/ghostel/issues/67)
+  ([83d90f7](https://github.com/dakra/ghostel/commit/83d90f7)).
+- SIGWINCH baseline tests on Linux by using bash explicitly ([e5582d5](https://github.com/dakra/ghostel/commit/e5582d5)).
+- `wrong-number-of-arguments` in `ghostel-evil--around-delete` ([79a6b86](https://github.com/dakra/ghostel/commit/79a6b86)).
+
+## [0.9.0] — 2026-04-09
+
+### Added
+- TRAMP integration for remote shell spawning and directory tracking ([512a4db](https://github.com/dakra/ghostel/commit/512a4db)).
+- Scroll wheel inside TUI apps with mouse tracking (htop, less, etc.)
+  is now forwarded to the application; it still scrolls the viewport
+  when mouse tracking is off. Fixes
+  [#60](https://github.com/dakra/ghostel/issues/60)
+  ([a46c784](https://github.com/dakra/ghostel/commit/a46c784)).
+
+### Fixed
+- `ghostel-send-next-key` now works with prefix keys (`C-x`, `C-h`) and
+  Meta-modified keys (`M-x`). Fixes
+  [#62](https://github.com/dakra/ghostel/issues/62)
+  ([f9e7fc0](https://github.com/dakra/ghostel/commit/f9e7fc0)).
+- `claude-code-review` workflow write permissions ([63f5550](https://github.com/dakra/ghostel/commit/63f5550)).
+- Wide-char pixel overflow compensation for emoji ([4c191c3](https://github.com/dakra/ghostel/commit/4c191c3)).
+- Cursor visibility preserved in copy mode during redraws ([5d7be51](https://github.com/dakra/ghostel/commit/5d7be51)).
+
+## [0.8.0] — 2026-04-08
+
+### Added
+- `ghostel-project` function ([560776f](https://github.com/dakra/ghostel/commit/560776f)).
+- `ghostel-scroll-on-input` to jump to bottom on typing ([cabb939](https://github.com/dakra/ghostel/commit/cabb939)).
+- `ghostel--cursor-position` to query terminal cursor location ([e3852d8](https://github.com/dakra/ghostel/commit/e3852d8)).
+- `ghostel-copy-mode-recenter` (`C-l`) for copy mode ([6075b64](https://github.com/dakra/ghostel/commit/6075b64)).
+- Full scrollback copy mode and copy-all command ([d07f509](https://github.com/dakra/ghostel/commit/d07f509)).
+- `ghostel-copy-mode-auto-load-scrollback` option ([fc7fc94](https://github.com/dakra/ghostel/commit/fc7fc94)).
+
+### Changed
+- Bump minimum Emacs version for CI test to 28.2 ([cd3031d](https://github.com/dakra/ghostel/commit/cd3031d)).
+- Preserve manual ghostel buffer renames ([c6eb801](https://github.com/dakra/ghostel/commit/c6eb801)).
+- Rework how ghostel buffers are created ([cd7c043](https://github.com/dakra/ghostel/commit/cd7c043)).
+- Ignore byte-compiled elisp files ([cfb0112](https://github.com/dakra/ghostel/commit/cfb0112)).
+- Move `ghostel--suppress-interfering-modes` call inside `ghostel-mode` ([59b6928](https://github.com/dakra/ghostel/commit/59b6928)).
+- Display lint errors when checking locally ([628ecae](https://github.com/dakra/ghostel/commit/628ecae)).
+- Terminal buffers now respect `display-buffer-alist` rules (e.g.
+  `(derived-mode . ghostel-mode)`). Fixes
+  [#56](https://github.com/dakra/ghostel/issues/56)
+  ([85b3e5f](https://github.com/dakra/ghostel/commit/85b3e5f)).
+- Preserve column position when scrolling in copy mode ([0e7f904](https://github.com/dakra/ghostel/commit/0e7f904)).
+
+### Fixed
+- Lint warnings (and add test) ([20586fd](https://github.com/dakra/ghostel/commit/20586fd)).
+- Meta key combinations not forwarded to terminal ([43220db](https://github.com/dakra/ghostel/commit/43220db)).
+
+## [0.7.1] — 2026-04-06
+
+### Added
+- Prebuilt binaries for x86_64-macos and aarch64-linux (in addition to
+  the existing x86_64-linux and aarch64-macos). Closes
+  [#43](https://github.com/dakra/ghostel/issues/43)
+  ([d04afa6](https://github.com/dakra/ghostel/commit/d04afa6)).
+- MELPA installation instructions and source build notes ([c1d0daf](https://github.com/dakra/ghostel/commit/c1d0daf)).
+
+### Changed
+- Address MELPA review feedback ([416cf7a](https://github.com/dakra/ghostel/commit/416cf7a)).
+
+### Fixed
+- Build on musl-based distros (Alpine Linux) ([204164f](https://github.com/dakra/ghostel/commit/204164f)).
+- Scrollback defaults treated as bytes and not lines ([21abb3d](https://github.com/dakra/ghostel/commit/21abb3d)).
+- Module download URL when installed from MELPA ([cb74461](https://github.com/dakra/ghostel/commit/cb74461)).
+- Mouse scroll when `pixel-scroll-precision-mode` is enabled ([067af25](https://github.com/dakra/ghostel/commit/067af25)).
+- `ghostel-test-package-version` failure with stale `.elc` ([beb72d5](https://github.com/dakra/ghostel/commit/beb72d5)).
+
+## [0.7.0] — 2026-04-05
+
+### Changed
+- Use `grid_ref` API for hyperlink detection instead of HTML formatter ([23aa22a](https://github.com/dakra/ghostel/commit/23aa22a)).
+- Optimize release binaries: strip symbols and enable dead-code elimination ([f6f3ba3](https://github.com/dakra/ghostel/commit/f6f3ba3)).
+
+## [0.6.0] — 2026-04-05
+
+### Changed
+- Change ghostty submodule from ssh to https ([607beae](https://github.com/dakra/ghostel/commit/607beae)).
+
+### Fixed
+- `C-t` and other control keys not being sent to the terminal ([d4ac858](https://github.com/dakra/ghostel/commit/d4ac858)).
+
+## [0.5] — 2026-04-05
+
+### Added
+- Bind `s-v` (Cmd-V) to `ghostel-yank` on macOS ([4e43d38](https://github.com/dakra/ghostel/commit/4e43d38)).
+
+### Changed
+- Improve typing responsiveness with immediate redraw and input coalescing ([a30b53a](https://github.com/dakra/ghostel/commit/a30b53a)).
+
+### Fixed
+- Clicking ghostel buffer not switching window focus ([d030cbb](https://github.com/dakra/ghostel/commit/d030cbb)).
+- `struct_timespec` opaque type error on some Linux systems ([5e1660b](https://github.com/dakra/ghostel/commit/5e1660b)).
+- Dim/faint text (SGR 2) is now rendered by dimming the foreground
+  colour (previously used `:weight light`, which most monospace fonts
+  ignore). Closes [#27](https://github.com/dakra/ghostel/issues/27)
+  ([a644834](https://github.com/dakra/ghostel/commit/a644834)).
+- Backspace not working in fish shell ([36433fd](https://github.com/dakra/ghostel/commit/36433fd)).
+
+## [0.4] — 2026-04-04
+
+### Added
+- Claude Code GitHub Actions workflows ([23b7caa](https://github.com/dakra/ghostel/commit/23b7caa)).
+- Prompt to install native module when `ghostel` command is called ([57c6352](https://github.com/dakra/ghostel/commit/57c6352)).
+
+### Changed
+- Set default terminal fg/bg from Emacs theme colors ([e66a57d](https://github.com/dakra/ghostel/commit/e66a57d)).
+
+## [0.3] — 2026-04-04
+
+### Added
+- Module version check to detect stale native modules ([be5c399](https://github.com/dakra/ghostel/commit/be5c399)).
+- Shrink terminal when tall glyphs push content off-screen ([d913076](https://github.com/dakra/ghostel/commit/d913076)).
+
+### Changed
+- Compensate for wide-char pixel overflow by hiding trailing spaces ([e87d820](https://github.com/dakra/ghostel/commit/e87d820)).
+- Skip wide-character spacer cells to fix emoji line overflow ([40b23e1](https://github.com/dakra/ghostel/commit/40b23e1)).
+- Skip wide-char compensation when no wide characters are present ([691a752](https://github.com/dakra/ghostel/commit/691a752)).
+- Revert overflow detection — keep only viewport pinning ([d335346](https://github.com/dakra/ghostel/commit/d335346)).
+- Fix melpazoid warning ([ff6dc1b](https://github.com/dakra/ghostel/commit/ff6dc1b)).
+
+### Removed
+- `ghostel--pin-window-start` (caused emoji clipping) ([f029fbf](https://github.com/dakra/ghostel/commit/f029fbf)).
+
+### Fixed
+- Drag-and-drop by extracting drop data from correct event position ([794b5c8](https://github.com/dakra/ghostel/commit/794b5c8)).
+
+## [0.2] — 2026-04-02
+
+### Added
+- Automatic theme color synchronization ([eb545fa](https://github.com/dakra/ghostel/commit/eb545fa)).
+- ERT test for `ghostel-sync-theme` ([9668724](https://github.com/dakra/ghostel/commit/9668724)).
+- Performance benchmark suite comparing ghostel, vterm, and eat ([a184e34](https://github.com/dakra/ghostel/commit/a184e34)).
+- Emacs built-in `term` added to benchmark suite; README performance section ([2c86fb5](https://github.com/dakra/ghostel/commit/2c86fb5)).
+- Ghostel vs. vterm comparison section in README ([3c71314](https://github.com/dakra/ghostel/commit/3c71314)).
+- OSC 51 elisp eval from shell ([b3094b7](https://github.com/dakra/ghostel/commit/b3094b7)).
+- Table of contents in README ([ece4a52](https://github.com/dakra/ghostel/commit/ece4a52)).
+- `ghostel-full-redraw` option and force `window-start` pin ([1f299df](https://github.com/dakra/ghostel/commit/1f299df)).
+- Multi-version byte-compile job; warnings treated as errors ([97258ef](https://github.com/dakra/ghostel/commit/97258ef)).
+- Makefile ([835d878](https://github.com/dakra/ghostel/commit/835d878)).
+
+### Changed
+- Migrate test suite from custom framework to ERT ([bb986a2](https://github.com/dakra/ghostel/commit/bb986a2)).
+- Build with `ReleaseFast` for production performance ([7393e64](https://github.com/dakra/ghostel/commit/7393e64)).
+- Replace manual lint CI with melpazoid ([ede8f76](https://github.com/dakra/ghostel/commit/ede8f76)).
+- Remove `Package-Requires` from secondary file ([c47662c](https://github.com/dakra/ghostel/commit/c47662c)).
+- Fix melpazoid lint warnings ([9e0f076](https://github.com/dakra/ghostel/commit/9e0f076)).
+- Filter libghostty info log spam from benchmark output ([ae0e9b9](https://github.com/dakra/ghostel/commit/ae0e9b9)).
+- Overhaul README: installation, features, configuration ([1649771](https://github.com/dakra/ghostel/commit/1649771)).
+- Exit copy mode on normal key press ([2ee9d3b](https://github.com/dakra/ghostel/commit/2ee9d3b)).
+- Show cursor in copy-mode even when terminal app hid it ([c78b290](https://github.com/dakra/ghostel/commit/c78b290)).
+- Suppress `hl-line-mode` in terminal buffer to prevent prompt flicker ([a9a07f1](https://github.com/dakra/ghostel/commit/a9a07f1)).
+- Byte-compile warnings treated as errors in CI ([56ef155](https://github.com/dakra/ghostel/commit/56ef155)).
+
+### Fixed
+- Bottom lines cut off when TUI apps fill the screen ([f276f2d](https://github.com/dakra/ghostel/commit/f276f2d)).
+- `extractString` silently dropping data >= 64KB ([1f88bed](https://github.com/dakra/ghostel/commit/1f88bed)).
+- Missing `errdefer` for `mouse_encoder` in `Terminal.init` ([04ca152](https://github.com/dakra/ghostel/commit/04ca152)).
+- Heap fallback for HTML formatter buffer in `scanHyperlinks` ([08e2649](https://github.com/dakra/ghostel/commit/08e2649)).
+- `ghostel-dir` falling back to `default-directory` in `start-process` ([6d45a0d](https://github.com/dakra/ghostel/commit/6d45a0d)).
+- Missing double-quote escaping in zsh `ghostel_cmd` ([d398fec](https://github.com/dakra/ghostel/commit/d398fec)).
+- Copy-mode `M->` landing at bottom-right and exit not scrolling back ([4a9eb59](https://github.com/dakra/ghostel/commit/4a9eb59)).
+- `ghostel-clear` and `ghostel-clear-scrollback` ([6ac0ba2](https://github.com/dakra/ghostel/commit/6ac0ba2)).
+
+## [0.1] — 2026-03-31
+
+Initial tagged release.
+
+### Added
+- Initial skeleton: Emacs terminal module powered by libghostty-vt ([d0e0ee3](https://github.com/dakra/ghostel/commit/d0e0ee3)).
+- Styled rendering with colors, bold, italic, underline, etc. ([150e9e2](https://github.com/dakra/ghostel/commit/150e9e2)).
+- Key encoding via `GhosttyKeyEncoder` ([a8ad51b](https://github.com/dakra/ghostel/commit/a8ad51b)).
+- Scrollback, cursor style, and resize improvements ([f23290e](https://github.com/dakra/ghostel/commit/f23290e)).
+- Mouse input, paste, copy mode, directory tracking ([de8d2c7](https://github.com/dakra/ghostel/commit/de8d2c7)).
+- Test suite (61 tests) ([6be06f7](https://github.com/dakra/ghostel/commit/6be06f7)).
+- Incremental redraw using `DIRTY_PARTIAL` ([c8024ed](https://github.com/dakra/ghostel/commit/c8024ed)).
+- Focus event support gated by DEC mode 1004 ([3855df9](https://github.com/dakra/ghostel/commit/3855df9)).
+- ANSI 16-color palette customization ([b42321f](https://github.com/dakra/ghostel/commit/b42321f)).
+- Use face inheritance for ANSI color palette ([e75f897](https://github.com/dakra/ghostel/commit/e75f897)).
+- `INSIDE_EMACS=ghostel` in shell environment ([a496249](https://github.com/dakra/ghostel/commit/a496249)).
+- `ghostel-kill-buffer-on-exit` option ([6d31a99](https://github.com/dakra/ghostel/commit/6d31a99)).
+- Shell integration scripts for bash, zsh, and fish ([eddc7d8](https://github.com/dakra/ghostel/commit/eddc7d8)).
+- Auto-inject shell integration without requiring .bashrc changes ([593af8e](https://github.com/dakra/ghostel/commit/593af8e)).
+- Clear scrollback and clear screen commands ([f8c9a80](https://github.com/dakra/ghostel/commit/f8c9a80)).
+- `ghostel-send-next-key` escape hatch ([aa9207b](https://github.com/dakra/ghostel/commit/aa9207b)).
+- `ghostel-yank` and `ghostel-yank-pop` for kill-ring cycling ([6eaa60b](https://github.com/dakra/ghostel/commit/6eaa60b)).
+- `ghostel-exit-functions` hook ([0b5de44](https://github.com/dakra/ghostel/commit/0b5de44)).
+- OSC 52 clipboard support ([a7eb78a](https://github.com/dakra/ghostel/commit/a7eb78a)).
+- OSC 8 hyperlink support with click-to-open ([58f92e3](https://github.com/dakra/ghostel/commit/58f92e3)).
+- OSC 133 semantic prompt markers for prompt navigation ([052c3d7](https://github.com/dakra/ghostel/commit/052c3d7)).
+- URL auto-detection and `file://` link support ([b0d143c](https://github.com/dakra/ghostel/commit/b0d143c)).
+- Detect file:line references and open them in Emacs on click ([454b794](https://github.com/dakra/ghostel/commit/454b794)).
+- Separate defcustom for file:line detection ([457977b](https://github.com/dakra/ghostel/commit/457977b)).
+- Bracketed paste conditional on terminal mode 2004 ([e209445](https://github.com/dakra/ghostel/commit/e209445)).
+- Cache frequently-used Emacs symbols as global refs ([7103a56](https://github.com/dakra/ghostel/commit/7103a56)).
+- Synchronized output support and debounced resize ([0a2eb85](https://github.com/dakra/ghostel/commit/0a2eb85)).
+- Keyboard scrolling in copy mode ([83b7f44](https://github.com/dakra/ghostel/commit/83b7f44)).
+- `M-<` / `M->` to jump to top/bottom of scrollback in copy mode ([ea4353f](https://github.com/dakra/ghostel/commit/ea4353f)).
+- `C-e` in copy mode to stop at last non-whitespace character ([c2328dc](https://github.com/dakra/ghostel/commit/c2328dc)).
+- Preserve column position during `C-n`/`C-p` in copy mode ([7a04588](https://github.com/dakra/ghostel/commit/7a04588)).
+- Strip trailing whitespace from copied text in copy mode ([7d0de0f](https://github.com/dakra/ghostel/commit/7d0de0f)).
+- Filter soft-wrapped newlines in copy mode ([f384746](https://github.com/dakra/ghostel/commit/f384746)).
+- `ghostel-module-compile` command ([d75d9d1](https://github.com/dakra/ghostel/commit/d75d9d1)).
+- Cross-platform build support and module auto-download ([a734e8e](https://github.com/dakra/ghostel/commit/a734e8e)).
+- Rework module installation with interactive choice and defcustom ([f95fd8a](https://github.com/dakra/ghostel/commit/f95fd8a)).
+- Full native build in CI and add release workflow ([20bf1f6](https://github.com/dakra/ghostel/commit/20bf1f6)).
+- GitHub Actions CI with linting and tests ([3a190e3](https://github.com/dakra/ghostel/commit/3a190e3)).
+- Improve code quality, adaptive redraw, and CI coverage ([ebe6f8b](https://github.com/dakra/ghostel/commit/ebe6f8b)).
+- GPL3 license and expanded commentary section ([1d676df](https://github.com/dakra/ghostel/commit/1d676df)).
+- README with build instructions, features, and configuration ([c43bf6a](https://github.com/dakra/ghostel/commit/c43bf6a)).
+
+[Unreleased]: https://github.com/dakra/ghostel/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/dakra/ghostel/compare/v0.13.0...v0.14.0
+[0.13.0]: https://github.com/dakra/ghostel/compare/v0.12.2...v0.13.0
+[0.12.2]: https://github.com/dakra/ghostel/compare/v0.12.1...v0.12.2
+[0.12.1]: https://github.com/dakra/ghostel/compare/v0.12.0...v0.12.1
+[0.12.0]: https://github.com/dakra/ghostel/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/dakra/ghostel/compare/v0.10.1...v0.11.0
+[0.10.1]: https://github.com/dakra/ghostel/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/dakra/ghostel/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/dakra/ghostel/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/dakra/ghostel/compare/v0.7.1...v0.8.0
+[0.7.1]: https://github.com/dakra/ghostel/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/dakra/ghostel/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/dakra/ghostel/compare/v0.5...v0.6.0
+[0.5]: https://github.com/dakra/ghostel/compare/v0.4...v0.5
+[0.4]: https://github.com/dakra/ghostel/compare/v0.3...v0.4
+[0.3]: https://github.com/dakra/ghostel/compare/v0.2...v0.3
+[0.2]: https://github.com/dakra/ghostel/compare/v0.1...v0.2
+[0.1]: https://github.com/dakra/ghostel/releases/tag/v0.1

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ history — even outside copy mode.
 - **OSC 2** — title tracking (buffer is renamed from the terminal title)
 - **OSC 51** — call whitelisted Emacs functions from shell scripts (see [Calling Elisp from the Shell](#calling-elisp-from-the-shell))
 - **OSC 52** — clipboard support (opt-in, for remote sessions)
+- **OSC 9 / OSC 777** — desktop notifications and ConEmu progress reports (percentage shown in the mode line; see [Notifications and Progress](#notifications-and-progress))
 - `INSIDE_EMACS` and `EMACS_GHOSTEL_PATH` environment variables
 
 ### TRAMP (Remote Terminals)
@@ -358,6 +359,64 @@ if [[ "$INSIDE_EMACS" = 'ghostel' ]]; then
 fi
 ```
 
+### Notifications and Progress
+
+Ghostel recognises two notification protocols used by terminal programs:
+
+- **OSC 9** (iTerm2 form): `ESC ] 9 ; BODY ST` — body only.
+- **OSC 777** (rxvt `notify`): `ESC ] 777 ; notify ; TITLE ; BODY ST` — title + body.
+
+Both route to `ghostel-notification-function` with `(TITLE BODY)`.  The
+default handler, `ghostel-default-notify`, uses the
+[alert](https://github.com/jwiegley/alert) package when installed — it
+picks a sensible backend per platform (`osascript` on macOS, libnotify
+on Linux, Growl, terminal-notifier, etc.) and is configurable via
+`alert-default-style`.  Install it from MELPA with `M-x package-install
+RET alert RET`.
+
+When `alert` isn't available, ghostel falls back to `message`, which
+only appears in the echo area.  Set `ghostel-notification-function` to
+nil to silence notifications entirely, or to your own function to route
+them elsewhere.
+
+ConEmu's **OSC 9;4** progress protocol is also recognised: build tools,
+AI agents like Claude Code, and other long-running commands emit it to
+report completion percentage.  Ghostel dispatches these to
+`ghostel-progress-function` with `(STATE PROGRESS)` where STATE is one of
+`remove`, `set`, `error`, `indeterminate`, `pause` and PROGRESS is an
+integer 0-100 or nil.  The default handler, `ghostel-default-progress`,
+updates `mode-line-process` in the terminal buffer:
+
+- `[42%]` — running at 42% done
+- `[...]` — indeterminate progress
+- `[err 73%]` — error (shown in the `error` face)
+- `[paused 25%]` — paused
+- (cleared) — removed
+
+#### Example: spinner.el in the mode line
+
+For a fancier visual indicator during indeterminate progress, swap
+`ghostel-progress-function` for a handler backed by
+[spinner.el](https://github.com/Malabarba/spinner.el):
+
+```elisp
+(require 'spinner)
+(defvar-local my/ghostel-spinner nil)
+(defun my/ghostel-progress (state progress)
+  (pcase state
+    ((or 'set 'indeterminate)
+     (unless my/ghostel-spinner
+       (setq my/ghostel-spinner (spinner-create 'progress-bar t))
+       (spinner-start my/ghostel-spinner))
+     (when (eq state 'set)
+       (setq mode-line-process (format " [%d%%]" (or progress 0)))))
+    ((or 'remove 'error 'pause)
+     (when my/ghostel-spinner
+       (spinner-stop my/ghostel-spinner)
+       (setq my/ghostel-spinner nil)))))
+(setq ghostel-progress-function #'my/ghostel-progress)
+```
+
 ### Color Palette
 
 The 16 ANSI colors are defined as Emacs faces inheriting from `term-color-*`:
@@ -397,6 +456,8 @@ individual faces with `M-x customize-face`.
 | `ghostel-kill-buffer-on-exit`    | `t`                  | Kill buffer when shell exits                             |
 | `ghostel-eval-cmds`              | `(see above)`        | Whitelisted functions for OSC 51 eval                    |
 | `ghostel-enable-osc52`           | `nil`                | Allow apps to set clipboard via OSC 52                   |
+| `ghostel-notification-function`  | `ghostel-default-notify` | Handler for OSC 9 / OSC 777 desktop notifications (nil disables) |
+| `ghostel-progress-function`      | `ghostel-default-progress` | Handler for OSC 9;4 ConEmu progress reports (nil disables) |
 | `ghostel-enable-url-detection`   | `t`                  | Linkify plain-text URLs in terminal output               |
 | `ghostel-enable-file-detection`  | `t`                  | Linkify file:line references in terminal output          |
 | `ghostel-ignore-cursor-change`   | `nil`                | Ignore terminal-driven cursor shape/visibility changes   |

--- a/ghostel.el
+++ b/ghostel.el
@@ -246,6 +246,30 @@ Disabled by default for security: a malicious escape sequence in
 command output could silently overwrite your clipboard."
   :type 'boolean)
 
+(defcustom ghostel-notification-function #'ghostel-default-notify
+  "Function called for OSC 9 / OSC 777 desktop notifications.
+Called with two string arguments: TITLE and BODY.  Title is empty
+for iTerm2-style OSC 9 notifications, which only carry a body.
+Set to nil to ignore notifications.
+
+The handler is invoked asynchronously via `run-at-time', with the
+originating ghostel buffer as `current-buffer', so it may block or
+spawn processes freely without stalling the terminal."
+  :type '(choice (const :tag "Disabled" nil) function))
+
+(defcustom ghostel-progress-function #'ghostel-default-progress
+  "Function called for ConEmu OSC 9;4 progress reports.
+Called with two arguments: STATE (one of the symbols `remove',
+`set', `error', `indeterminate', `pause') and PROGRESS (an integer
+0-100, or nil when not reported).  Set to nil to ignore progress
+reports.
+
+The handler runs synchronously on the VT-parser callpath because
+progress updates are expected to feed the mode line or similar
+cheap UI.  A slow handler here will stall terminal output — defer
+expensive work via `run-at-time' on your own if you need it."
+  :type '(choice (const :tag "Disabled" nil) function))
+
 (defcustom ghostel-enable-url-detection t
   "Automatically detect and linkify URLs in terminal output.
 When non-nil, plain-text URLs (http:// and https://) are made
@@ -1984,6 +2008,99 @@ Only acts when `ghostel-enable-osc52' is non-nil."
         (kill-new text)
         (when (fboundp 'gui-set-selection)
           (gui-set-selection 'CLIPBOARD text))))))
+
+(defun ghostel-default-notify (title body)
+  "Default handler for OSC 9 / OSC 777 notifications.
+Uses the `alert' package (https://github.com/jwiegley/alert) when
+available - it picks a sensible backend per platform (osascript on
+macOS, libnotify on Linux, Growl, terminal-notifier, etc.).  Falls
+back to `message' when alert isn't installed.  TITLE is the
+notification summary; when empty (iTerm2-style OSC 9) the buffer
+name is used.  BODY is the notification text.
+
+Runs deferred off the VT-parser callpath by
+`ghostel--handle-notification' with the originating ghostel buffer
+current, so `buffer-name' here gives the terminal buffer's name."
+  (let ((summary (if (or (null title) (string-empty-p title))
+                     (buffer-name)
+                   title)))
+    (if (and (require 'alert nil t) (fboundp 'alert))
+        (alert body :title summary)
+      (message "%s: %s" summary body))))
+
+(defun ghostel-default-progress (state progress)
+  "Default handler for OSC 9;4 ConEmu progress reports.
+Updates `mode-line-process' to show the current STATE and
+PROGRESS (an integer 0-100 or nil).  STATE is one of the symbols
+`remove', `set', `error', `indeterminate', `pause'."
+  (let ((new-val
+         (pcase state
+           ('remove        nil)
+           ('set           (format " [%d%%]" (or progress 0)))
+           ('indeterminate " [...]")
+           ('error         (propertize (if progress
+                                           (format " [err %d%%]" progress)
+                                         " [err]")
+                                       'face 'error))
+           ('pause         (if progress
+                               (format " [paused %d%%]" progress)
+                             " [paused]"))
+           ;; Unknown state: keep the current mode-line value rather
+           ;; than silently clearing it, so a future Zig-side state is
+           ;; visible-but-stale instead of disappearing.
+           (_              mode-line-process))))
+    (unless (equal new-val mode-line-process)
+      (setq mode-line-process new-val)
+      (force-mode-line-update))))
+
+(defun ghostel--handle-notification (title body)
+  "Dispatch TITLE and BODY to `ghostel-notification-function'.
+Called synchronously from the native VT parser; the user handler
+is invoked off the callpath via `run-at-time' so a slow backend
+\(DBus, osascript, etc.) can't stall terminal output.  The
+originating ghostel buffer is made current for the handler, so
+`buffer-name' etc. report the terminal buffer and not whatever was
+current when the timer happened to fire.  Errors in the handler
+are caught and logged — an unhandled error in a timer callback
+does not crash the process filter, but it does produce a backtrace
+in batch runs."
+  (when ghostel-notification-function
+    (let ((buf (current-buffer))
+          (fn ghostel-notification-function))
+      (run-at-time
+       0 nil
+       (lambda ()
+         (when (buffer-live-p buf)
+           (with-current-buffer buf
+             ;; Only `error' is caught here — `quit' (C-g) is allowed
+             ;; to propagate so a user can interrupt a hung handler.
+             ;; Emacs' timer machinery swallows a propagated quit.
+             (condition-case err
+                 (funcall fn title body)
+               (error
+                (message "ghostel: notification handler error: %s"
+                         (error-message-string err)))))))))))
+
+(defun ghostel--osc-progress (state-str progress)
+  "Dispatch ConEmu OSC 9;4 progress to `ghostel-progress-function'.
+STATE-STR is the state name as a string (sent from the native
+module); it is converted to a known symbol via an explicit allowlist
+to avoid polluting the obarray if a future Zig-side typo sneaks in.
+Unknown state strings are silently dropped.
+PROGRESS is an integer 0-100 or nil."
+  (when ghostel-progress-function
+    (let ((state-sym (pcase state-str
+                       ("remove"        'remove)
+                       ("set"           'set)
+                       ("error"         'error)
+                       ("indeterminate" 'indeterminate)
+                       ("pause"         'pause))))
+      (when state-sym
+        (condition-case err
+            (funcall ghostel-progress-function state-sym progress)
+          (error
+           (message "ghostel: progress handler error: %s"
+                    (error-message-string err))))))))
 
 (defun ghostel--flush-output (data)
   "Write DATA back to the shell process (response from terminal)."

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -311,6 +311,8 @@ pub const Sym = struct {
     @"ghostel--osc51-eval": Value,
     @"ghostel--osc52-handle": Value,
     @"ghostel--osc133-marker": Value,
+    @"ghostel--handle-notification": Value,
+    @"ghostel--osc-progress": Value,
     @"ghostel--flush-output": Value,
     @"ghostel--set-title": Value,
     @"ghostel--debug-log-vt": Value,

--- a/src/module.zig
+++ b/src/module.zig
@@ -341,9 +341,168 @@ fn dispatchPostWriteOscs(env: emacs.Env, term: *Terminal, data: []const u8) void
                     param_val,
                 );
             },
+            // OSC 9: iTerm2 desktop notification, with ConEmu sub-codes
+            // carved out (see `dispatchOsc9`).
+            9 => dispatchOsc9(env, term, osc.payload),
+            // OSC 777: rxvt "notify" extension — `notify;TITLE;BODY`.
+            777 => dispatchOsc777(env, osc.payload),
             else => {},
         }
     }
+}
+
+/// Dispatch OSC 9.  The iTerm2 form is `9;<body>` with no title; ConEmu
+/// overloads the same code with `9;<subcode>[;...]` for unrelated things
+/// (progress, tab titles, env vars, etc.).  Ghostel implements two of the
+/// sub-codes — `9;4` progress reports (routed to `ghostel--osc-progress`)
+/// and `9;9` CWD reporting (routed through libghostty's `setPwd`, same as
+/// OSC 7).  Other recognised ConEmu sub-codes are silently dropped so
+/// stray control sequences don't pop spurious notifications.  Anything
+/// that isn't a valid ConEmu sub-code falls through to
+/// `ghostel--handle-notification` as an iTerm2 notification.  The
+/// validation rules here mirror ghostty-vt's osc9.zig so ghostel's
+/// drop/route/notify split stays consistent with upstream's parse.
+fn dispatchOsc9(env: emacs.Env, term: *Terminal, payload: []const u8) void {
+    if (payload.len == 0) return;
+
+    const first = payload[0];
+    if (first >= '0' and first <= '9') {
+        // Parse the leading digit run.
+        var i: usize = 0;
+        while (i < payload.len and payload[i] >= '0' and payload[i] <= '9') : (i += 1) {}
+        const subcode_str = payload[0..i];
+        const rest = payload[i..];
+        const subcode = std.fmt.parseInt(u16, subcode_str, 10) catch {
+            dispatchOsc9Notification(env, payload);
+            return;
+        };
+
+        // OSC 9;4: progress report.  Valid forms start with `;<digit>`;
+        // anything else falls through to the iTerm2 notification path.
+        if (subcode == 4 and rest.len >= 2 and rest[0] == ';') {
+            if (dispatchOsc9Progress(env, rest[1..])) return;
+        }
+
+        // OSC 9;9: ConEmu CWD reporting — same payload shape as OSC 7,
+        // so we route it through `term.setPwd` (libghostty-vt discards
+        // OSC 9, so this is the one place it gets picked up).
+        if (subcode == 9 and rest.len >= 2 and rest[0] == ';') {
+            const path = rest[1..];
+            if (path.len > 0) {
+                const gs = gt.GhosttyString{ .ptr = path.ptr, .len = path.len };
+                term.setPwd(&gs) catch {};
+            }
+            return;
+        }
+
+        // Other recognised ConEmu sub-codes — silently dropped.  Each
+        // check mirrors ghostty-vt's parser closely enough that payloads
+        // it would reject fall through to the notification path below
+        // (with two deliberate divergences — 9;5 and 9;12, see below).
+        const is_conemu = switch (subcode) {
+            1, 2, 3, 6, 7, 8, 11 => rest.len >= 1 and rest[0] == ';',
+            // `9;5` (wait-input) and `9;12` (prompt start) take no
+            // arguments.  ghostty-vt happens to consume trailing bytes
+            // too, but matching that would swallow iTerm2 notifications
+            // whose body starts with "5" or "12" (e.g. "5 minutes left")
+            // — a realistic UX footgun — so we only treat these as
+            // ConEmu when nothing follows the subcode.
+            5, 12 => rest.len == 0,
+            // `9;10` (bare) or `9;10;0..3[...]` → ConEmu xterm
+            // emulation.  Anything else (`9;10;4`, `9;10;`, `9;10;abc`)
+            // is invalid per ghostty-vt and must notify.  Matches
+            // upstream's lax treatment of trailing bytes after a valid
+            // first arg digit (e.g. `9;10;01`, `9;10;3x` → emulation).
+            10 => rest.len == 0 or
+                (rest.len >= 2 and rest[0] == ';' and
+                    rest[1] >= '0' and rest[1] <= '3'),
+            else => false,
+        };
+        if (is_conemu) return;
+    }
+
+    // Unrecognised `9;<digit>...` payloads fall through as iTerm2
+    // notifications with the raw body (digit run included).  That's
+    // intentional: the iTerm2 form has no sub-code namespace, so the
+    // body is whatever follows the `9;`.
+    dispatchOsc9Notification(env, payload);
+}
+
+fn dispatchOsc9Notification(env: emacs.Env, body: []const u8) void {
+    _ = env.call2(
+        emacs.sym.@"ghostel--handle-notification",
+        env.makeString(""),
+        env.makeString(body),
+    );
+}
+
+/// Parse the payload that follows `9;4;` and dispatch to Elisp.  Returns
+/// true if a progress event was emitted.
+///
+/// State semantics mirror ghostty-vt's parser at the protocol level:
+///   - `set`  (1) defaults progress to 0 when unreported.
+///   - `error` (2) / `pause` (4) accept an optional progress value.
+///   - `remove` (0) / `indeterminate` (3) ignore any trailing progress.
+///
+/// Trailing-semicolon handling is slightly more forgiving than upstream:
+/// `9;4;1;` and `9;4;1;50;` are treated the same as `9;4;1` and
+/// `9;4;1;50`, whereas ghostty-vt's parseUnsigned returns null on the
+/// trailing `;`.  Matters only for exotic emitters.
+fn dispatchOsc9Progress(env: emacs.Env, data: []const u8) bool {
+    if (data.len == 0) return false;
+    const state_digit = data[0];
+    const state_str: []const u8 = switch (state_digit) {
+        '0' => "remove",
+        '1' => "set",
+        '2' => "error",
+        '3' => "indeterminate",
+        '4' => "pause",
+        else => return false,
+    };
+
+    // Default progress: `set` starts at 0; all other states start nil.
+    var progress_val = if (state_digit == '1') env.makeInteger(0) else env.nil();
+    const accepts_progress = state_digit != '0' and state_digit != '3';
+
+    if (accepts_progress and data.len >= 3 and data[1] == ';') {
+        var tail = data[2..];
+        // Trim trailing `;` so `9;4;0;` and similar don't fail to parse.
+        while (tail.len > 0 and tail[tail.len - 1] == ';') tail.len -= 1;
+        if (tail.len > 0) {
+            // u64 is wide enough to absorb garbage like `99999999999`
+            // without overflowing parseInt; the result is clamped to 100
+            // regardless.
+            if (std.fmt.parseInt(u64, tail, 10)) |n| {
+                const clamped: i64 = @intCast(@min(n, 100));
+                progress_val = env.makeInteger(clamped);
+            } else |_| {}
+        }
+    }
+
+    _ = env.call2(
+        emacs.sym.@"ghostel--osc-progress",
+        env.makeString(state_str),
+        progress_val,
+    );
+    return true;
+}
+
+/// Dispatch OSC 777: `notify;TITLE;BODY`.  Any other extension is ignored
+/// (rxvt defines `notify` as the only one we care about).
+fn dispatchOsc777(env: emacs.Env, payload: []const u8) void {
+    const first_semi = std.mem.indexOfScalar(u8, payload, ';') orelse return;
+    if (!std.mem.eql(u8, payload[0..first_semi], "notify")) return;
+    const after_ext = payload[first_semi + 1 ..];
+    // Title and body are separated by the next `;`.  If no separator,
+    // treat the whole remainder as body with empty title.
+    const second_semi = std.mem.indexOfScalar(u8, after_ext, ';');
+    const title = if (second_semi) |s| after_ext[0..s] else "";
+    const body = if (second_semi) |s| after_ext[s + 1 ..] else after_ext;
+    _ = env.call2(
+        emacs.sym.@"ghostel--handle-notification",
+        env.makeString(title),
+        env.makeString(body),
+    );
 }
 
 /// Send `OSC N;rgb:RRRR/GGGG/BBBB <term>` for a dynamic color (OSC 10/11).

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1084,6 +1084,360 @@ Mirrors the real zsh case where the directory still contains a
       (ghostel--write-input term "\e]52;c;?\e\\")
       (should (equal nil kill-ring)))))                     ; osc52 query ignored
 
+(ert-deftest ghostel-test-osc9-notification ()
+  "OSC 9 iTerm2-style notifications reach `ghostel-notification-function'."
+  (let ((term (ghostel--new 25 80 1000))
+        (calls nil))
+    (cl-letf (((symbol-function 'ghostel--handle-notification)
+               (lambda (title body) (push (cons title body) calls))))
+      ;; Plain iTerm2 notification, ST terminator.
+      (ghostel--write-input term "\e]9;Hello world\e\\")
+      (should (equal '(("" . "Hello world")) calls))
+
+      ;; BEL terminator
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;bell form\a")
+      (should (equal '(("" . "bell form")) calls))
+
+      ;; Single-character body
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;X\e\\")
+      (should (equal '(("" . "X")) calls))
+
+      ;; Empty payload: no dispatch
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;\e\\")
+      (should (equal nil calls)))))
+
+(ert-deftest ghostel-test-osc9-conemu-suppressed ()
+  "ConEmu OSC 9 sub-codes must not fire a notification.
+Covers the forms that ghostty-vt's parser accepts as valid ConEmu
+sequences (sleep, message box, tab title, wait input, emulation
+mode, prompt start).  Payloads that ghostty-vt rejects fall through
+to the notification path — see `ghostel-test-osc9-invalid-conemu-notifies'."
+  (let ((term (ghostel--new 25 80 1000))
+        (calls nil))
+    (cl-letf (((symbol-function 'ghostel--handle-notification)
+               (lambda (title body) (push (cons title body) calls)))
+              ((symbol-function 'ghostel--osc-progress)
+               (lambda (_s _p) nil)))
+      ;; 9;1;<ms> sleep, 9;2;<msg> message box, 9;3;<title> tab title
+      (ghostel--write-input term "\e]9;1;500\e\\")
+      (ghostel--write-input term "\e]9;2;hello\e\\")
+      (ghostel--write-input term "\e]9;3;tab\e\\")
+      ;; 9;5 wait-input, 9;12 prompt start
+      (ghostel--write-input term "\e]9;5\e\\")
+      (ghostel--write-input term "\e]9;12\e\\")
+      ;; 9;10 xterm emulation — bare and with valid args 0-3
+      (ghostel--write-input term "\e]9;10\e\\")
+      (ghostel--write-input term "\e]9;10;0\e\\")
+      (ghostel--write-input term "\e]9;10;3\e\\")
+      ;; Trailing bytes after a valid first-arg digit are tolerated
+      ;; (matches ghostty-vt).
+      (ghostel--write-input term "\e]9;10;01\e\\")
+      (ghostel--write-input term "\e]9;10;3x\e\\")
+      (should (equal nil calls)))))
+
+(ert-deftest ghostel-test-osc9-invalid-conemu-notifies ()
+  "Malformed ConEmu payloads fall through to notification.
+Mirrors ghostty-vt's parser: e.g. `9;10;4' and `9;10;abc' are
+invalid emulation args and surface as notifications with the raw
+payload as body."
+  (let ((term (ghostel--new 25 80 1000))
+        (calls nil))
+    (cl-letf (((symbol-function 'ghostel--handle-notification)
+               (lambda (title body) (push (cons title body) calls)))
+              ((symbol-function 'ghostel--osc-progress)
+               (lambda (_s _p) nil)))
+      (ghostel--write-input term "\e]9;10;4\e\\")
+      (should (equal '(("" . "10;4")) calls))
+
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;10;\e\\")
+      (should (equal '(("" . "10;")) calls))
+
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;10;abc\e\\")
+      (should (equal '(("" . "10;abc")) calls))
+
+      ;; Realistic iTerm2 notifications whose body starts with "5" or
+      ;; "12" must not be swallowed by the ConEmu wait-input / prompt
+      ;; sub-codes (which only accept the bare form).
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;5 minutes left\e\\")
+      (should (equal '(("" . "5 minutes left")) calls))
+
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;12 monkeys\e\\")
+      (should (equal '(("" . "12 monkeys")) calls)))))
+
+(ert-deftest ghostel-test-osc9-cwd-routing ()
+  "OSC 9;9;PATH updates the terminal's working directory.
+ConEmu's CWD-reporting alias is routed through libghostty's `setPwd'
+\(the same plumbing OSC 7 uses), so `ghostel--get-pwd' reflects the
+reported path and no notification fires."
+  (let ((term (ghostel--new 25 80 1000))
+        (notifs nil))
+    (cl-letf (((symbol-function 'ghostel--handle-notification)
+               (lambda (title body) (push (cons title body) notifs))))
+      (ghostel--write-input term "\e]9;9;/tmp/ghostel-cwd\e\\")
+      (should (equal "/tmp/ghostel-cwd" (ghostel--get-pwd term)))
+      (should (equal nil notifs)))))
+
+(ert-deftest ghostel-test-osc9-progress ()
+  "OSC 9;4 progress reports reach `ghostel-progress-function'."
+  (let ((term (ghostel--new 25 80 1000))
+        (calls nil))
+    (cl-letf (((symbol-function 'ghostel--osc-progress)
+               (lambda (state progress) (push (list state progress) calls))))
+      ;; set, with progress
+      (ghostel--write-input term "\e]9;4;1;50\e\\")
+      (should (equal '(("set" 50)) calls))
+
+      ;; set without progress defaults to 0 (matches ghostty-vt)
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;4;1\e\\")
+      (should (equal '(("set" 0)) calls))
+
+      ;; remove
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;4;0\e\\")
+      (should (equal '(("remove" nil)) calls))
+
+      ;; remove ignores trailing progress (matches ghostty-vt's "remove
+      ;; ignores progress" test)
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;4;0;100\e\\")
+      (should (equal '(("remove" nil)) calls))
+
+      ;; error without progress
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;4;2\e\\")
+      (should (equal '(("error" nil)) calls))
+
+      ;; error with progress
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;4;2;73\e\\")
+      (should (equal '(("error" 73)) calls))
+
+      ;; indeterminate
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;4;3\e\\")
+      (should (equal '(("indeterminate" nil)) calls))
+
+      ;; indeterminate ignores trailing progress
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;4;3;50\e\\")
+      (should (equal '(("indeterminate" nil)) calls))
+
+      ;; pause with progress
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;4;4;25\e\\")
+      (should (equal '(("pause" 25)) calls))
+
+      ;; Trailing semicolon is tolerated (9;4;0;)
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;4;0;\e\\")
+      (should (equal '(("remove" nil)) calls))
+
+      ;; Progress overflow clamps to 100
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;4;1;999\e\\")
+      (should (equal '(("set" 100)) calls))
+
+      ;; Huge numbers beyond u16 still parse and clamp (would overflow
+      ;; u16, but parser uses u64).
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;4;1;99999999999\e\\")
+      (should (equal '(("set" 100)) calls))
+
+      ;; Non-numeric progress: value falls back to the state's default
+      ;; (0 for set, nil for error/pause).
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;4;1;foo\e\\")
+      (should (equal '(("set" 0)) calls))
+      (setq calls nil)
+      (ghostel--write-input term "\e]9;4;2;foo\e\\")
+      (should (equal '(("error" nil)) calls)))))
+
+(ert-deftest ghostel-test-osc-progress-dispatch ()
+  "`ghostel--osc-progress' converts the state string to a symbol."
+  (let ((calls nil))
+    (let ((ghostel-progress-function
+           (lambda (state progress) (push (list state progress) calls))))
+      (ghostel--osc-progress "set" 42)
+      (should (equal '((set 42)) calls))
+      (setq calls nil)
+      (ghostel--osc-progress "remove" nil)
+      (should (equal '((remove nil)) calls))
+      ;; Unknown state strings are dropped without invoking the handler
+      ;; (defends against a Zig-side typo polluting the obarray).
+      (setq calls nil)
+      (ghostel--osc-progress "bogus" 1)
+      (should (equal nil calls)))
+    ;; nil function → no call, no error
+    (let ((ghostel-progress-function nil))
+      (should-not (ghostel--osc-progress "set" 10)))))
+
+(ert-deftest ghostel-test-osc777-notification ()
+  "OSC 777 `notify;TITLE;BODY' reaches `ghostel-notification-function'."
+  (let ((term (ghostel--new 25 80 1000))
+        (calls nil))
+    (cl-letf (((symbol-function 'ghostel--handle-notification)
+               (lambda (title body) (push (cons title body) calls))))
+      (ghostel--write-input term "\e]777;notify;Subject;Body text\e\\")
+      (should (equal '(("Subject" . "Body text")) calls))
+
+      ;; BEL terminator
+      (setq calls nil)
+      (ghostel--write-input term "\e]777;notify;T;B\a")
+      (should (equal '(("T" . "B")) calls))
+
+      ;; Empty title, empty body
+      (setq calls nil)
+      (ghostel--write-input term "\e]777;notify;;\e\\")
+      (should (equal '(("" . "")) calls))
+
+      ;; Unknown extension is dropped
+      (setq calls nil)
+      (ghostel--write-input term "\e]777;bogus;a;b\e\\")
+      (should (equal nil calls)))))
+
+(ert-deftest ghostel-test-notification-dispatch ()
+  "`ghostel--handle-notification' honours `ghostel-notification-function'.
+`run-at-time' is stubbed synchronously since the dispatcher defers
+the handler off the VT-parser callpath."
+  (cl-letf (((symbol-function 'run-at-time)
+             (lambda (_secs _rep fn &rest args) (apply fn args))))
+    (let ((calls nil))
+      (let ((ghostel-notification-function
+             (lambda (title body) (push (cons title body) calls))))
+        (ghostel--handle-notification "T" "B")
+        (should (equal '(("T" . "B")) calls)))
+      ;; nil → silently ignored
+      (let ((ghostel-notification-function nil))
+        (should-not (ghostel--handle-notification "T" "B")))
+      ;; Error in handler is demoted to message (does not propagate)
+      (let ((ghostel-notification-function (lambda (_t _b) (error "Boom")))
+            (inhibit-message t)
+            (debug-on-error nil))
+        (should-not (condition-case _
+                        (progn (ghostel--handle-notification "T" "B") nil)
+                      (error t)))))))
+
+(ert-deftest ghostel-test-notification-dispatch-current-buffer ()
+  "Dispatcher re-enters the originating buffer before calling the handler.
+Even if the user has switched to a different buffer by the time
+the deferred timer fires, the handler sees the ghostel buffer
+that emitted the escape as `current-buffer'."
+  (cl-letf (((symbol-function 'run-at-time)
+             (lambda (_secs _rep fn &rest args)
+               ;; Simulate the timer firing later, from a different
+               ;; buffer.
+               (with-temp-buffer
+                 (rename-buffer " *unrelated*" t)
+                 (apply fn args)))))
+    (let ((captured-name nil))
+      (with-temp-buffer
+        (rename-buffer "*ghostel: origin*" t)
+        (let ((ghostel-notification-function
+               (lambda (_title _body) (setq captured-name (buffer-name)))))
+          (ghostel--handle-notification "" "hi")
+          (should (equal captured-name "*ghostel: origin*")))))))
+
+(ert-deftest ghostel-test-notification-dispatch-real-timer ()
+  "Async path runs end-to-end through a real `run-at-time'.
+Every other dispatcher test stubs `run-at-time' synchronously, so
+the closure capture, `buffer-live-p' guard, `with-current-buffer'
+re-entry, and `condition-case' all go uncovered unless this test
+actually yields the event loop and observes the delayed side effect."
+  (let ((captured nil))
+    (with-temp-buffer
+      (rename-buffer "*ghostel: real-timer*" t)
+      (let ((ghostel-notification-function
+             (lambda (title body)
+               (push (list title body (buffer-name)) captured))))
+        (ghostel--handle-notification "T" "B")
+        ;; Not fired yet — still scheduled.
+        (should (equal nil captured))
+        ;; Let the 0s timer run.  `sit-for' yields even in batch mode,
+        ;; which triggers pending `run-at-time 0 nil ...' callbacks.
+        (with-timeout (1.0 (error "Timer never fired"))
+          (while (null captured) (sit-for 0.01)))
+        (should (equal '(("T" "B" "*ghostel: real-timer*")) captured))))))
+
+(ert-deftest ghostel-test-notification-dispatch-buffer-killed ()
+  "Drop notifications whose originating buffer died before timer firing.
+Uses a second notification from a live buffer as a positive
+control so we can wait on *something* and then assert the
+killed-buffer one did not fire."
+  (let ((dead-fired nil)
+        (live-fired nil))
+    (let* ((dead (generate-new-buffer " *ghostel-test-killed*")))
+      (let ((ghostel-notification-function
+             (lambda (_t _b) (setq dead-fired t))))
+        (with-current-buffer dead
+          (ghostel--handle-notification "D" "D")))
+      (kill-buffer dead))
+    (with-temp-buffer
+      (rename-buffer " *ghostel-test-live*" t)
+      (let ((ghostel-notification-function
+             (lambda (_t _b) (setq live-fired t))))
+        (ghostel--handle-notification "L" "L")
+        (with-timeout (1.0 (error "Live timer never fired"))
+          (while (null live-fired) (sit-for 0.01)))))
+    (should live-fired)
+    (should (equal nil dead-fired))))
+
+(ert-deftest ghostel-test-osc-progress-dispatch-error-isolated ()
+  "Errors in `ghostel-progress-function' are caught and demoted."
+  (let ((ghostel-progress-function (lambda (_s _p) (error "Boom")))
+        (inhibit-message t)
+        (debug-on-error nil))
+    (should-not (condition-case _
+                    (progn (ghostel--osc-progress "set" 10) nil)
+                  (error t)))))
+
+(ert-deftest ghostel-test-default-notify-uses-alert ()
+  "Route notifications through `alert' when the package is available.
+`alert' is pre-provided so the branch fires under batch mode
+without the real package installed."
+  (provide 'alert)
+  (let ((captured nil))
+    (cl-letf (((symbol-function 'alert)
+               (lambda (msg &rest kw) (setq captured (cons msg kw)))))
+      (ghostel-default-notify "Title" "body text")
+      (should captured)
+      (should (equal (car captured) "body text"))
+      (should (equal (plist-get (cdr captured) :title) "Title")))))
+
+(ert-deftest ghostel-test-default-notify-empty-title-uses-buffer-name ()
+  "When TITLE is empty, the alert uses the current buffer's name."
+  (provide 'alert)
+  (let ((captured nil))
+    (cl-letf (((symbol-function 'alert)
+               (lambda (msg &rest kw) (setq captured (cons msg kw)))))
+      (with-temp-buffer
+        (rename-buffer "*ghostel: zsh*" t)
+        (ghostel-default-notify "" "hi")
+        (should (equal (plist-get (cdr captured) :title) (buffer-name)))))))
+
+(ert-deftest ghostel-test-default-progress-modeline ()
+  "`ghostel-default-progress' sets `mode-line-process' per state."
+  (with-temp-buffer
+    (ghostel-default-progress 'set 42)
+    (should (equal " [42%]" mode-line-process))
+    (ghostel-default-progress 'indeterminate nil)
+    (should (equal " [...]" mode-line-process))
+    (ghostel-default-progress 'pause 10)
+    (should (equal " [paused 10%]" mode-line-process))
+    (ghostel-default-progress 'pause nil)
+    (should (equal " [paused]" mode-line-process))
+    (ghostel-default-progress 'error 99)
+    (should (string-match-p "\\[err 99%\\]" mode-line-process))
+    (ghostel-default-progress 'remove nil)
+    (should (null mode-line-process))))
+
 (ert-deftest ghostel-test-osc-partial-does-not-starve-later ()
   "A partial OSC must not cannibalize or starve a following complete OSC.
 Input \"\\e]7;PARTIAL\\e]52;c;aGVsbG8=\\a\" would, under a naive
@@ -5600,6 +5954,15 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-osc51-eval
     ghostel-test-osc51-eval-unknown
     ghostel-test-osc51-eval-catches-errors
+    ghostel-test-osc-progress-dispatch
+    ghostel-test-osc-progress-dispatch-error-isolated
+    ghostel-test-notification-dispatch
+    ghostel-test-notification-dispatch-current-buffer
+    ghostel-test-notification-dispatch-real-timer
+    ghostel-test-notification-dispatch-buffer-killed
+    ghostel-test-default-notify-uses-alert
+    ghostel-test-default-notify-empty-title-uses-buffer-name
+    ghostel-test-default-progress-modeline
     ghostel-test-flush-pending-output-preserves-buffer
     ghostel-test-copy-mode-cursor
     ghostel-test-ignore-cursor-change


### PR DESCRIPTION
## Summary

Implements #141.

- OSC 9 (iTerm2) and OSC 777 (rxvt `notify`) desktop notifications → `ghostel-notification-function` (default: `notifications-notify` with a `message` fallback, dispatched via `run-at-time` so a slow DBus broker can't stall the VT parser).
- ConEmu OSC 9;4 progress reports → `ghostel-progress-function` (default: update `mode-line-process` as `[42%]`, `[...]`, `[err]`, `[paused]`).
- OSC 9;9 CWD reports are routed through libghostty's `setPwd`, same plumbing as OSC 7.
- Both custom variables accept `nil` to disable.
- Validation rules mirror ghostty-vt's OSC 9 parser: recognised ConEmu sub-codes (sleep, message box, tab title, wait input, emulation, prompt-start) are silently dropped; anything ghostty-vt would reject falls through to the notification path with the raw body. Progress states `remove` and `indeterminate` ignore any trailing PROGRESS value; `set` defaults to 0 when unreported.

See the new "Notifications and Progress" section in README.md for a spinner.el demo.

## Test plan

- [x] `make -j4 all` passes (32 upstream + 84 native + 130 elisp, checkdoc and package-lint clean)
- [x] Smoke-test iTerm2 notification via `printf '\e]9;hello\e\\'` in a ghostel buffer
- [x] Smoke-test progress via a tool that emits OSC 9;4 (e.g. Claude Code) and verify the percentage shows in the mode line
- [x] Smoke-test OSC 9;9 CWD sync by sourcing a fake emitter and confirming `default-directory` updates
- [x] Verify `(setq ghostel-notification-function nil)` silences notifications without errors

## Review notes

Agent-spawned `/review` caught several ghostty-vt protocol-contract divergences in the first pass (9;10 suppression too broad, 9;4 state 0/3 leaking progress, 9;9 CWD dropped silently, `set` default progress mismatch, DBus blocking the parser). All addressed in the committed version; tests cover the divergence points.