### PR TITLE
Fix compile-start width mismatch and kill-compilation on live buffer

### DIFF
--- a/ghostel-compile.el
+++ b/ghostel-compile.el
@@ -573,7 +573,18 @@ so there is no remote-integration round-trip on TRAMP buffers."
             ghostel-compile--managed-buffer-sentinel)
       (setq ghostel--term (ghostel--new height width ghostel-max-scrollback))
       (setq ghostel--term-rows height)
-      (ghostel--apply-palette ghostel--term))
+      (ghostel--apply-palette ghostel--term)
+      ;; `kill-compilation' locates our buffer via `compilation-find-buffer',
+      ;; which requires `compilation-locs' to be buffer-local (see
+      ;; `compilation-buffer-internal-p').  During the run we stay in
+      ;; `ghostel-mode' so keystrokes reach the process, so `compilation-mode'
+      ;; hasn't installed that variable yet — declare it locally now, with
+      ;; the same hash-table shape `compilation-mode' uses so any code that
+      ;; reads the value (future or third-party) doesn't trip on nil.
+      ;; Finalize switches to `ghostel-compile-view-mode', which derives from
+      ;; `compilation-mode' and will reset `compilation-locs' properly.
+      (setq-local compilation-locs
+                  (make-hash-table :test 'equal :weakness 'value)))
     buffer))
 
 
@@ -609,6 +620,18 @@ honour custom compile-mode subclasses the caller passed to
             ghostel-compile--last-exit nil
             ghostel-compile--finalized nil
             ghostel-compile--view-mode-override finished-mode)
+      ;; `prepare-buffer' sized the VT from the selected window (no
+      ;; display-buffer had happened yet).  `display-buffer' above may
+      ;; have placed the buffer in a smaller window — reconcile the VT
+      ;; to the output window *before* rendering the header, otherwise
+      ;; the header and the command's early output wrap at the wrong
+      ;; column and look garbled until the user's first resize triggers
+      ;; `ghostel--window-adjust-process-window-size'.
+      (when (and outwin ghostel--term)
+        (let ((oh (max 1 (window-body-height outwin)))
+              (ow (max 1 (window-max-chars-per-line outwin))))
+          (ghostel--set-size ghostel--term oh ow)
+          (setq ghostel--term-rows oh)))
       ;; Render the compilation header into the terminal before spawning
       ;; the command, so the user sees the "Compilation started at ..."
       ;; banner *during* the run rather than only when it finishes (the
@@ -633,11 +656,15 @@ honour custom compile-mode subclasses the caller passed to
               (forward-line (cdr (ghostel--cursor-position ghostel--term)))
               (copy-marker (point))))
       (ghostel-compile--set-mode-line-running)
+      ;; Match the VT size computed above (or fall back to the selected
+      ;; window's own dimensions when `display-buffer' didn't surface a
+      ;; window, e.g. `allow-no-window').  Use `window-max-chars-per-line'
+      ;; as the canonical width measure, matching `ghostel--spawn-pty'.
       (let* ((height (max 1 (if outwin
                                 (window-body-height outwin)
                               (window-body-height))))
              (width (max 1 (if outwin
-                               (window-body-width outwin)
+                               (window-max-chars-per-line outwin)
                              (window-max-chars-per-line))))
              (proc (ghostel-compile--spawn command buffer height width)))
         ;; Match stock `compilation-start' ordering: hook fires before

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -3141,6 +3141,178 @@ normally."
         (let ((kill-buffer-query-functions nil))
           (kill-buffer buf-name))))))
 
+(ert-deftest ghostel-test-compile-reconciles-vt-size-to-outwin ()
+  "`ghostel-compile--start' must resize the VT to the output window.
+
+`prepare-buffer' sizes the VT from the selected window (the only
+dimensions available before `display-buffer').  If the compile
+buffer ends up in a smaller window, the PTY's `set-process-window-size'
+agrees with the output window but the VT still thinks it has the
+selected-window width, so early output wraps at the wrong column.
+`--start' must call `ghostel--set-size' with the output-window
+dimensions *before* rendering the header, and `--spawn' must receive
+the same dimensions so PTY and VT always agree."
+  (let* ((buf-name "*ghostel-test-compile-size*")
+         (set-size-calls nil)
+         (spawn-calls nil)
+         (call-order nil)
+         (inhibit-message t)
+         (save-some-buffers-default-predicate (lambda () nil))
+         (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil))
+        (kill-buffer buf-name)))
+    (unwind-protect
+        (cl-letf* (((symbol-function 'ghostel--load-module) #'ignore)
+                   ((symbol-function 'ghostel--new)
+                    (lambda (&rest _) 'fake-term))
+                   ((symbol-function 'ghostel--apply-palette) #'ignore)
+                   ((symbol-function 'ghostel--set-size)
+                    (lambda (_term rows cols)
+                      (push 'set-size call-order)
+                      (push (list rows cols) set-size-calls)))
+                   ((symbol-function 'ghostel-compile--render-header-live)
+                    (lambda (&rest _) (push 'render-header call-order)))
+                   ((symbol-function 'ghostel--cursor-position)
+                    (lambda (_term) (cons 0 0)))
+                   ((symbol-function 'ghostel-compile--spawn)
+                    (lambda (_cmd buf h w)
+                      (push 'spawn call-order)
+                      (push (list h w) spawn-calls)
+                      (let ((p (start-process "ghostel-test-size-fake"
+                                              buf "sleep" "100")))
+                        (set-process-sentinel p #'ignore)
+                        (set-process-query-on-exit-flag p nil)
+                        (with-current-buffer buf
+                          (setq ghostel--process p))
+                        p))))
+          (let ((buf (ghostel-compile--start "true" buf-name
+                                             default-directory)))
+            (with-current-buffer buf
+              ;; The reconcile call happened.
+              (should set-size-calls)
+              ;; Reconcile must precede the header render *and* the spawn —
+              ;; otherwise the header / early command output wraps at the
+              ;; pre-reconcile column.  `call-order' is LIFO, so chronological
+              ;; order is the reverse.
+              (let ((chronological (reverse call-order)))
+                (should (equal chronological
+                               '(set-size render-header spawn))))
+              ;; Final VT size equals what was handed to the process.
+              (let ((vt-size (car set-size-calls))
+                    (pty-size (car spawn-calls)))
+                (should (equal vt-size pty-size)))
+              ;; `ghostel--term-rows' tracks the final reconciled height.
+              (should (= (car (car set-size-calls)) ghostel--term-rows))
+              ;; Clean up the fake process.
+              (let ((p ghostel--process))
+                (when (process-live-p p)
+                  (setq compilation-in-progress
+                        (delq p compilation-in-progress))
+                  (delete-process p))))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil))
+          (kill-buffer buf-name))))))
+
+(ert-deftest ghostel-test-compile-reconciles-skips-when-no-outwin ()
+  "If `display-buffer' returns nil, reconcile is skipped safely.
+`allow-no-window' permits `display-buffer' to choose not to show the
+buffer at all.  The `(when (and outwin ...))' guard in `--start' must
+gate the `ghostel--set-size' call so we don't crash or pass bogus
+dimensions when no output window exists."
+  (let* ((buf-name "*ghostel-test-compile-no-outwin*")
+         (set-size-called nil)
+         (inhibit-message t)
+         (save-some-buffers-default-predicate (lambda () nil))
+         (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil))
+        (kill-buffer buf-name)))
+    (unwind-protect
+        (cl-letf* (((symbol-function 'ghostel--load-module) #'ignore)
+                   ((symbol-function 'ghostel--new)
+                    (lambda (&rest _) 'fake-term))
+                   ((symbol-function 'ghostel--apply-palette) #'ignore)
+                   ((symbol-function 'display-buffer) (lambda (&rest _) nil))
+                   ((symbol-function 'ghostel--set-size)
+                    (lambda (&rest _) (setq set-size-called t)))
+                   ((symbol-function 'ghostel-compile--render-header-live)
+                    #'ignore)
+                   ((symbol-function 'ghostel--cursor-position)
+                    (lambda (_term) (cons 0 0)))
+                   ((symbol-function 'ghostel-compile--spawn)
+                    (lambda (_cmd buf _h _w)
+                      (let ((p (start-process "ghostel-test-nowin-fake"
+                                              buf "sleep" "100")))
+                        (set-process-sentinel p #'ignore)
+                        (set-process-query-on-exit-flag p nil)
+                        (with-current-buffer buf
+                          (setq ghostel--process p))
+                        p))))
+          (let ((buf (ghostel-compile--start "true" buf-name
+                                             default-directory)))
+            (should (buffer-live-p buf))
+            (should-not set-size-called)
+            (with-current-buffer buf
+              (let ((p ghostel--process))
+                (when (process-live-p p)
+                  (setq compilation-in-progress
+                        (delq p compilation-in-progress))
+                  (delete-process p))))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil))
+          (kill-buffer buf-name))))))
+
+(ert-deftest ghostel-test-compile-kill-compilation-finds-live-buffer ()
+  "`kill-compilation' must locate a live ghostel-compile buffer.
+
+During the run the buffer stays in `ghostel-mode' so keystrokes reach
+the process, which means `compilation-mode' never runs.  `kill-compilation'
+calls `compilation-find-buffer' -> `compilation-buffer-internal-p',
+which is `(local-variable-p 'compilation-locs)'.  `prepare-buffer' must
+declare that variable buffer-locally so the live buffer qualifies."
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf-name "*ghostel-test-kill-compilation*")
+         (inhibit-message t)
+         (save-some-buffers-default-predicate (lambda () nil))
+         (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil))
+        (kill-buffer buf-name)))
+    (unwind-protect
+        (let ((buf (ghostel-compile--start "cat" buf-name
+                                           default-directory)))
+          (with-current-buffer buf
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () (eq 'run (process-status ghostel--process))))
+            ;; The live buffer passes `compilation-buffer-p' — which is
+            ;; the gate `kill-compilation' uses.
+            (should (compilation-buffer-p buf))
+            ;; From inside the buffer, `compilation-find-buffer' returns it.
+            (should (eq (compilation-find-buffer) buf))
+            ;; Also findable from an arbitrary buffer, via `next-error-find-
+            ;; buffer' — that's how `kill-compilation' reaches us when the
+            ;; user invokes it from elsewhere.
+            (should (with-temp-buffer (eq (compilation-find-buffer) buf)))
+            ;; And the buffer has a live process `kill-compilation' would
+            ;; deliver SIGINT to.
+            (should (process-live-p (get-buffer-process buf)))
+            ;; End-to-end: invoke `kill-compilation' from inside the buffer
+            ;; and wait for the process to die via SIGINT.  `cat' exits on
+            ;; SIGINT, the sentinel finalizes, and `--last-exit' reflects
+            ;; a non-zero status (signal-based termination).
+            (kill-compilation)
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () ghostel-compile--finalized) 10)
+            (should ghostel-compile--finalized)
+            (should (numberp ghostel-compile--last-exit))
+            (should-not (zerop ghostel-compile--last-exit))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil))
+          (kill-buffer buf-name))))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: prompt navigation
 ;; -----------------------------------------------------------------------
@@ -6465,6 +6637,8 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-compile-global-mode-falls-through-on-continue
     ghostel-test-compile-global-mode-falls-through-on-comint
     ghostel-test-compile-global-mode-excluded-custom-mode
+    ghostel-test-compile-reconciles-vt-size-to-outwin
+    ghostel-test-compile-reconciles-skips-when-no-outwin
     ghostel-test-viewport-start-skips-trailing-newline
     ghostel-test-anchor-window-no-clamp-without-pending-wrap
     ghostel-test-exec-errors-on-live-process


### PR DESCRIPTION
## Summary

Two user-reported regressions after #124:

- **Initial compile width was wrong.** `ghostel-compile--prepare-buffer` sized the VT from the selected window (the only dimensions available before `display-buffer`).  `display-buffer` then typically split the frame, so the compile buffer ended up in a smaller window.  The PTY got the smaller size via `set-process-window-size`, but the VT still thought it had the full selected-window width — so early output (including the header) wrapped at the wrong column and looked garbled until the user's first resize fired `ghostel--window-adjust-process-window-size`.  `--start` now reconciles the VT to the output window *before* rendering the header; `--spawn` receives the same dimensions using `window-max-chars-per-line` (matching `ghostel--spawn-pty`).
- **`M-x kill-compilation` was a no-op.** It locates its target via `compilation-buffer-internal-p`, which tests `(local-variable-p 'compilation-locs)`.  During a ghostel-compile run the buffer stays in `ghostel-mode` (so keys reach the process), so `compilation-mode` never installs that variable.  `prepare-buffer` now declares `compilation-locs` buffer-locally with the same hash-table shape `compilation-mode` uses, so any code that reads the value doesn't trip on nil.  Finalize switches to `ghostel-compile-view-mode` (derived from `compilation-mode`), which then resets it properly.

## Test plan

New tests:

- `ghostel-test-compile-reconciles-vt-size-to-outwin` (elisp, mocked) — reconcile must fire before both header render and spawn; VT and PTY end up with identical dimensions.
- `ghostel-test-compile-reconciles-skips-when-no-outwin` (elisp, mocked) — `allow-no-window` fallback must not call `ghostel--set-size`.
- `ghostel-test-compile-kill-compilation-finds-live-buffer` (native, live `cat` run) — buffer is findable via `compilation-buffer-p` / `compilation-find-buffer` (including from an unrelated buffer); actually invokes `kill-compilation` and waits for the sentinel to finalize the run with a non-zero exit.

Verification:
- [x] `make -j4 all` — 144 elisp + 89 native tests, 0 unexpected, lint clean
- [x] `make test-evil` — 32 tests pass