### PR TITLE
Suppress spurious SIGWINCH on minibuffer-induced window shrink

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .ghostel,
-    .version = "0.16.1",
+    .version = "0.16.2",
     .paths = .{""},
     .fingerprint = 0x5a44bdd1198a0f4b,
     .dependencies = .{

--- a/evil-ghostel.el
+++ b/evil-ghostel.el
@@ -4,7 +4,7 @@
 
 ;; Author: Daniel Kraus <daniel@kraus.my>
 ;; URL: https://github.com/dakra/ghostel
-;; Version: 0.16.1
+;; Version: 0.16.2
 ;; Package-Requires: ((emacs "28.1") (evil "1.0") (ghostel "0.8.0"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/ghostel.el
+++ b/ghostel.el
@@ -4,7 +4,7 @@
 
 ;; Author: Daniel Kraus <daniel@kraus.my>
 ;; URL: https://github.com/dakra/ghostel
-;; Version: 0.16.1
+;; Version: 0.16.2
 ;; Keywords: terminals
 ;; Package-Requires: ((emacs "28.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
@@ -524,7 +524,7 @@ before sending the input."
 Customize this when downloading pre-built modules from a fork or mirror."
   :type 'string)
 
-(defconst ghostel--minimum-module-version "0.16.1"
+(defconst ghostel--minimum-module-version "0.16.2"
   "Minimum native module version required by this Elisp version.
 Bump this only when the Elisp code requires a newer native module
 \(e.g. new Zig-exported function or changed calling convention).")
@@ -537,6 +537,7 @@ Bump this only when the Elisp code requires a newer native module
 (declare-function ghostel--encode-key "ghostel-module")
 (declare-function ghostel--focus-event "ghostel-module")
 (declare-function ghostel--mode-enabled "ghostel-module")
+(declare-function ghostel--alt-screen-p "ghostel-module")
 (declare-function ghostel--copy-all-text "ghostel-module")
 (declare-function ghostel--module-version "ghostel-module")
 (declare-function ghostel--mouse-event "ghostel-module")
@@ -793,6 +794,10 @@ entry points so tests run without the module present."
 
 (defvar-local ghostel--term-rows nil
   "Row count of the native terminal, for viewport/scrollback arithmetic.
+Updated whenever the terminal is created or resized.")
+
+(defvar-local ghostel--term-cols nil
+  "Column count of the native terminal.
 Updated whenever the terminal is created or resized.")
 
 (defvar-local ghostel--copy-mode-active nil
@@ -3159,23 +3164,80 @@ PROCESS is the shell process, WINDOWS is the list of windows."
     (when (and size (buffer-live-p buffer))
       (with-current-buffer buffer
         (when ghostel--term
-          (ghostel--set-size ghostel--term (max 1 height) (max 1 width))
-          (setq ghostel--term-rows height)
-          (setq ghostel--force-next-redraw t)
-          ;; Redraw synchronously so the buffer is updated before
-          ;; Emacs displays the stale content at the new window size.
-          (when ghostel--redraw-timer
-            (cancel-timer ghostel--redraw-timer)
-            (setq ghostel--redraw-timer nil))
-          ;; `ghostel--redraw-resize-active' lets `ghostel--window-anchored-p'
-          ;; treat Emacs-induced `window-start' drift (from `keep-point-visible'
-          ;; when a minibuffer-triggered resize shrinks the body) as drift,
-          ;; not as a user scroll.
-          (let ((ghostel--redraw-resize-active t))
-            (ghostel--delayed-redraw buffer)))))
+          (cond
+           ;; No change — skip entirely.
+           ((and (eql height ghostel--term-rows)
+                 (eql width ghostel--term-cols))
+            (setq size nil))
+           ;; Crop: minibuffer is active, only height shrank, width unchanged, and the
+           ;; terminal is on the primary screen.  Defer the resize so no SIGWINCH is sent
+           ;; — the Emacs window naturally hides the bottom rows, just like a normal
+           ;; buffer.  Alt-screen apps (vim, htop) own the full viewport and must be told
+           ;; the real size to re-layout, so they take the normal-resize path.  If the
+           ;; user switches focus into the ghostel window while the minibuffer is still
+           ;; open, `ghostel--commit-cropped-size' commits the smaller size then.
+           ((and (> (minibuffer-depth) 0)
+                 (eql width ghostel--term-cols)
+                 (< height ghostel--term-rows)
+                 (not (ghostel--alt-screen-p ghostel--term)))
+            (setq size nil))
+           ;; Real resize — update the terminal model and redraw.
+           (t
+            (ghostel--set-size ghostel--term (max 1 height) (max 1 width))
+            (setq ghostel--term-rows height)
+            (setq ghostel--term-cols width)
+            (setq ghostel--force-next-redraw t)
+            ;; Redraw synchronously so the buffer is updated before
+            ;; Emacs displays the stale content at the new window size.
+            (when ghostel--redraw-timer
+              (cancel-timer ghostel--redraw-timer)
+              (setq ghostel--redraw-timer nil))
+            ;; `ghostel--redraw-resize-active' lets `ghostel--window-anchored-p'
+            ;; treat Emacs-induced `window-start' drift (from `keep-point-visible'
+            ;; when a minibuffer-triggered resize shrinks the body) as drift,
+            ;; not as a user scroll.
+            (let ((ghostel--redraw-resize-active t))
+              (ghostel--delayed-redraw buffer)))))))
     ;; Return size — Emacs calls set-process-window-size (SIGWINCH)
-    ;; after this function returns, matching eat/vterm timing.
+    ;; after this function returns.  nil suppresses the call.
     size))
+
+(defun ghostel--commit-cropped-size (window)
+  "Commit WINDOW's size if the user focused into a cropped ghostel window.
+When the minibuffer opens, `ghostel--window-adjust-process-window-size'
+skips the resize so the PTY keeps its original row count and the bottom
+rows are just hidden.  But if the user switches focus into the ghostel
+window while the minibuffer is still up, they are now actively using
+the smaller viewport — commit the size so the shell/app knows its real
+dimensions.
+
+Intended for buffer-local `window-selection-change-functions'.  When
+registered buffer-locally, Emacs calls this with WINDOW and makes its
+buffer current; we only commit when WINDOW has become the selected
+window (not when it has just been deselected)."
+  (when (and (> (minibuffer-depth) 0)
+             (window-live-p window)
+             (eq window (frame-selected-window (window-frame window)))
+             ghostel--term
+             ghostel--process
+             (process-live-p ghostel--process))
+    (let ((height (window-body-height window))
+          (width (window-max-chars-per-line window))
+          (buf (current-buffer)))
+      (unless (and (eql height ghostel--term-rows)
+                   (eql width ghostel--term-cols))
+        (ghostel--set-size ghostel--term
+                           (max 1 height) (max 1 width))
+        (setq ghostel--term-rows height
+              ghostel--term-cols width
+              ghostel--force-next-redraw t)
+        (set-process-window-size ghostel--process
+                                 (max 1 height) (max 1 width))
+        (when ghostel--redraw-timer
+          (cancel-timer ghostel--redraw-timer)
+          (setq ghostel--redraw-timer nil))
+        (let ((ghostel--redraw-resize-active t))
+          (ghostel--delayed-redraw buf))))))
 
 
 
@@ -3203,6 +3265,10 @@ PROCESS is the shell process, WINDOWS is the list of windows."
   (add-function :after after-focus-change-function #'ghostel--focus-change)
   (add-hook 'window-selection-change-functions #'ghostel--focus-change)
   (add-hook 'window-buffer-change-functions #'ghostel--focus-change)
+  ;; Buffer-local so it only fires for windows showing this buffer, and
+  ;; receives WINDOW directly (rather than FRAME as the default binding).
+  (add-hook 'window-selection-change-functions
+            #'ghostel--commit-cropped-size nil t)
   (ghostel--suppress-interfering-modes)
   (setq ghostel--scroll-intercept-active t)
   ;; Let C-g reach the keymap instead of triggering keyboard-quit.
@@ -3245,6 +3311,7 @@ displayed, so a mismatch at creation time self-corrects."
         (setq ghostel--term
               (ghostel--new height width ghostel-max-scrollback))
         (setq ghostel--term-rows height)
+        (setq ghostel--term-cols width)
         (ghostel--apply-palette ghostel--term))
       (ghostel--start-process))))
 
@@ -3297,6 +3364,7 @@ Signals `user-error' if BUFFER already has a live ghostel process."
         (setq ghostel--term
               (ghostel--new height width ghostel-max-scrollback))
         (setq ghostel--term-rows height)
+        (setq ghostel--term-cols width)
         (ghostel--apply-palette ghostel--term)
         (ghostel--spawn-pty program args height width
                             "erase '^?' iutf8 -ixon echo" nil remote-p)))))

--- a/src/module.zig
+++ b/src/module.zig
@@ -13,7 +13,7 @@ const input = @import("input.zig");
 const c = emacs.c;
 
 /// Module version — keep in sync with ghostel.el and build.zig.zon.
-const version = "0.16.1";
+const version = "0.16.2";
 
 // ---------------------------------------------------------------------------
 // Module entry point
@@ -42,6 +42,7 @@ export fn emacs_module_init(runtime: *c.struct_emacs_runtime) callconv(.c) c_int
     env.bindFunction("ghostel--set-palette", 2, 2, &fnSetPalette, "Set the ANSI color palette.\n\n(ghostel--set-palette TERM COLORS-STRING)");
     env.bindFunction("ghostel--set-default-colors", 3, 3, &fnSetDefaultColors, "Set default foreground and background colors.\n\n(ghostel--set-default-colors TERM FG-HEX BG-HEX)");
     env.bindFunction("ghostel--mode-enabled", 2, 2, &fnModeEnabled, "Return t if terminal DEC private MODE is enabled.\n\n(ghostel--mode-enabled TERM MODE)");
+    env.bindFunction("ghostel--alt-screen-p", 1, 1, &fnAltScreen, "Return t if terminal is on the alternate screen buffer.\n\n(ghostel--alt-screen-p TERM)");
     env.bindFunction("ghostel--cursor-position", 1, 1, &fnCursorPosition, "Return terminal cursor position as (COL . ROW), 0-indexed.\n\n(ghostel--cursor-position TERM)");
     env.bindFunction("ghostel--cursor-pending-wrap-p", 1, 1, &fnCursorPendingWrap, "Return t if the cursor is in pending-wrap state.\n\n(ghostel--cursor-pending-wrap-p TERM)");
     env.bindFunction("ghostel--debug-state", 1, 1, &fnDebugState, "Return debug info about terminal/render state.\n\n(ghostel--debug-state TERM)");
@@ -765,6 +766,14 @@ fn fnModeEnabled(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?
     const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
     const mode: gt.c.GhosttyMode = @intCast(env.extractInteger(args[1]));
     return if (term.isModeEnabled(mode)) env.t() else env.nil();
+}
+
+/// (ghostel--alt-screen-p TERM)
+/// Return t if the terminal is on the alternate screen buffer.
+fn fnAltScreen(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
+    const env = emacs.Env.init(raw_env.?);
+    const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
+    return if (term.isAltScreen()) env.t() else env.nil();
 }
 
 /// (ghostel--set-palette TERM COLORS-STRING)

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -278,6 +278,15 @@ pub fn isModeEnabled(self: *Self, mode: gt.c.GhosttyMode) bool {
     return enabled;
 }
 
+/// Returns true if the terminal is on the alternate screen buffer
+/// (DEC private modes 1049, 1047, or legacy 47 set).  Used to decide
+/// whether full-screen apps (vim, htop, less) own the viewport.
+pub fn isAltScreen(self: *Self) bool {
+    return self.isModeEnabled(@as(gt.c.GhosttyMode, 1049)) or
+        self.isModeEnabled(@as(gt.c.GhosttyMode, 1047)) or
+        self.isModeEnabled(@as(gt.c.GhosttyMode, 47));
+}
+
 /// Get the total number of rows (scrollback + active screen).
 pub fn getTotalRows(self: *Self) usize {
     var total: usize = 0;

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -3148,7 +3148,7 @@ normally."
 dimensions available before `display-buffer').  If the compile
 buffer ends up in a smaller window, the PTY's `set-process-window-size'
 agrees with the output window but the VT still thinks it has the
-selected-window width, so early output wraps at the wrong column.
+width of the selected window, so early output wraps at the wrong column.
 `--start' must call `ghostel--set-size' with the output-window
 dimensions *before* rendering the header, and `--spawn' must receive
 the same dimensions so PTY and VT always agree."
@@ -6226,6 +6226,197 @@ It must also raise `read-process-output-max'.  Same reason as
           (should (null result))
           (should-not set-size-called))))))
 
+(ert-deftest ghostel-test-resize-noop-same-dims ()
+  "Resize to identical dims returns nil and skips set-size."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--term-rows 40)
+          (ghostel--term-cols 120)
+          (set-size-called nil))
+      (let ((cur-buf (current-buffer)))
+        (cl-letf (((symbol-function 'ghostel--set-size)
+                   (lambda (_term _h _w) (setq set-size-called t)))
+                  ((symbol-function 'ghostel--delayed-redraw) #'ignore)
+                  ((symbol-function 'process-buffer)
+                   (lambda (_proc) cur-buf))
+                  ((default-value 'window-adjust-process-window-size-function)
+                   (lambda (_proc _wins) '(120 . 40))))
+          (let ((result (ghostel--window-adjust-process-window-size
+                         'fake-proc '(fake-win))))
+            (should (null result))
+            (should-not set-size-called)))))))
+
+(ert-deftest ghostel-test-resize-minibuffer-crop ()
+  "Minibuffer-induced height shrink on primary screen is cropped (nil)."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--term-rows 40)
+          (ghostel--term-cols 120)
+          (set-size-called nil))
+      (let ((cur-buf (current-buffer)))
+        (cl-letf (((symbol-function 'ghostel--set-size)
+                   (lambda (_term _h _w) (setq set-size-called t)))
+                  ((symbol-function 'ghostel--delayed-redraw) #'ignore)
+                  ((symbol-function 'ghostel--alt-screen-p) (lambda (_t) nil))
+                  ((symbol-function 'minibuffer-depth) (lambda () 1))
+                  ((symbol-function 'process-buffer)
+                   (lambda (_proc) cur-buf))
+                  ((default-value 'window-adjust-process-window-size-function)
+                   (lambda (_proc _wins) '(120 . 25))))
+          (let ((result (ghostel--window-adjust-process-window-size
+                         'fake-proc '(fake-win))))
+            (should (null result))
+            (should-not set-size-called)))))))
+
+(ert-deftest ghostel-test-resize-minibuffer-alt-screen-commits ()
+  "Alt-screen apps (htop/vim) skip the crop path and resize normally."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--term-rows 40)
+          (ghostel--term-cols 120)
+          (set-size-args nil))
+      (let ((cur-buf (current-buffer)))
+        (cl-letf (((symbol-function 'ghostel--set-size)
+                   (lambda (_term h w) (setq set-size-args (list h w))))
+                  ((symbol-function 'ghostel--delayed-redraw) #'ignore)
+                  ((symbol-function 'ghostel--alt-screen-p) (lambda (_t) t))
+                  ((symbol-function 'minibuffer-depth) (lambda () 1))
+                  ((symbol-function 'process-buffer)
+                   (lambda (_proc) cur-buf))
+                  ((default-value 'window-adjust-process-window-size-function)
+                   (lambda (_proc _wins) '(120 . 25))))
+          (let ((result (ghostel--window-adjust-process-window-size
+                         'fake-proc '(fake-win))))
+            (should (equal '(120 . 25) result))
+            (should (equal '(25 120) set-size-args))
+            (should (eql ghostel--term-rows 25))))))))
+
+(ert-deftest ghostel-test-resize-minibuffer-width-only-shrink-commits ()
+  "Width-only shrink with minibuffer open skips the crop and resizes."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--term-rows 40)
+          (ghostel--term-cols 120)
+          (set-size-args nil))
+      (let ((cur-buf (current-buffer)))
+        (cl-letf (((symbol-function 'ghostel--set-size)
+                   (lambda (_term h w) (setq set-size-args (list h w))))
+                  ((symbol-function 'ghostel--delayed-redraw) #'ignore)
+                  ((symbol-function 'ghostel--alt-screen-p) (lambda (_t) nil))
+                  ((symbol-function 'minibuffer-depth) (lambda () 1))
+                  ((symbol-function 'process-buffer)
+                   (lambda (_proc) cur-buf))
+                  ;; width 100 < 120, height unchanged.
+                  ((default-value 'window-adjust-process-window-size-function)
+                   (lambda (_proc _wins) '(100 . 40))))
+          (let ((result (ghostel--window-adjust-process-window-size
+                         'fake-proc '(fake-win))))
+            (should (equal '(100 . 40) result))
+            (should (equal '(40 100) set-size-args))))))))
+
+(ert-deftest ghostel-test-commit-cropped-size-on-focus ()
+  "Focus return to a cropped ghostel window commits size and SIGWINCH."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--process 'fake-proc)
+          (ghostel--term-rows 40)
+          (ghostel--term-cols 120)
+          (ghostel--force-next-redraw nil)
+          (set-size-args nil)
+          (swsize-args nil)
+          (redraw-called nil))
+      (cl-letf (((symbol-function 'ghostel--set-size)
+                 (lambda (_term h w) (setq set-size-args (list h w))))
+                ((symbol-function 'ghostel--delayed-redraw)
+                 (lambda (_buf) (setq redraw-called t)))
+                ((symbol-function 'process-live-p) (lambda (_p) t))
+                ((symbol-function 'set-process-window-size)
+                 (lambda (_p h w) (setq swsize-args (list h w))))
+                ((symbol-function 'window-live-p) (lambda (_w) t))
+                ((symbol-function 'window-frame) (lambda (_w) 'test-frame))
+                ((symbol-function 'frame-selected-window)
+                 (lambda (_f) 'test-win))
+                ((symbol-function 'window-body-height) (lambda (&rest _) 25))
+                ((symbol-function 'window-max-chars-per-line) (lambda (&rest _) 120))
+                ((symbol-function 'minibuffer-depth) (lambda () 1)))
+        (ghostel--commit-cropped-size 'test-win)
+        (should (equal '(25 120) set-size-args))
+        (should (equal '(25 120) swsize-args))
+        (should (eql ghostel--term-rows 25))
+        (should (eql ghostel--term-cols 120))
+        (should ghostel--force-next-redraw)
+        (should redraw-called)))))
+
+(ert-deftest ghostel-test-commit-cropped-size-noop-outside-minibuffer ()
+  "Focus change outside the minibuffer does not resize."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--process 'fake-proc)
+          (ghostel--term-rows 40)
+          (ghostel--term-cols 120)
+          (set-size-called nil)
+          (swsize-called nil))
+      (cl-letf (((symbol-function 'ghostel--set-size)
+                 (lambda (_term _h _w) (setq set-size-called t)))
+                ((symbol-function 'ghostel--delayed-redraw) #'ignore)
+                ((symbol-function 'set-process-window-size)
+                 (lambda (_p _h _w) (setq swsize-called t)))
+                ((symbol-function 'minibuffer-depth) (lambda () 0)))
+        (ghostel--commit-cropped-size 'test-win)
+        (should-not set-size-called)
+        (should-not swsize-called)))))
+
+(ert-deftest ghostel-test-commit-cropped-size-noop-on-deselect ()
+  "Hook firing on WINDOW deselection does not resize."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--process 'fake-proc)
+          (ghostel--term-rows 40)
+          (ghostel--term-cols 120)
+          (set-size-called nil)
+          (swsize-called nil))
+      (cl-letf (((symbol-function 'ghostel--set-size)
+                 (lambda (_term _h _w) (setq set-size-called t)))
+                ((symbol-function 'ghostel--delayed-redraw) #'ignore)
+                ((symbol-function 'process-live-p) (lambda (_p) t))
+                ((symbol-function 'set-process-window-size)
+                 (lambda (_p _h _w) (setq swsize-called t)))
+                ((symbol-function 'window-live-p) (lambda (_w) t))
+                ((symbol-function 'window-frame) (lambda (_w) 'test-frame))
+                ;; Selected window is *not* our window — we're being deselected.
+                ((symbol-function 'frame-selected-window)
+                 (lambda (_f) 'other-win))
+                ((symbol-function 'minibuffer-depth) (lambda () 1)))
+        (ghostel--commit-cropped-size 'test-win)
+        (should-not set-size-called)
+        (should-not swsize-called)))))
+
+(ert-deftest ghostel-test-commit-cropped-size-noop-when-matched ()
+  "If the window already matches the committed size, do nothing."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--process 'fake-proc)
+          (ghostel--term-rows 40)
+          (ghostel--term-cols 120)
+          (set-size-called nil)
+          (swsize-called nil))
+      (cl-letf (((symbol-function 'ghostel--set-size)
+                 (lambda (_term _h _w) (setq set-size-called t)))
+                ((symbol-function 'ghostel--delayed-redraw) #'ignore)
+                ((symbol-function 'process-live-p) (lambda (_p) t))
+                ((symbol-function 'set-process-window-size)
+                 (lambda (_p _h _w) (setq swsize-called t)))
+                ((symbol-function 'window-live-p) (lambda (_w) t))
+                ((symbol-function 'window-frame) (lambda (_w) 'test-frame))
+                ((symbol-function 'frame-selected-window)
+                 (lambda (_f) 'test-win))
+                ((symbol-function 'window-body-height) (lambda (&rest _) 40))
+                ((symbol-function 'window-max-chars-per-line) (lambda (&rest _) 120))
+                ((symbol-function 'minibuffer-depth) (lambda () 1)))
+        (ghostel--commit-cropped-size 'test-win)
+        (should-not set-size-called)
+        (should-not swsize-called)))))
+
 ;;; SIGWINCH delivery tests — verify the PTY actually sends the signal
 
 ;; Uses ghostel-test--wait-for defined at the top of this file.
@@ -6593,6 +6784,14 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-get-shell-local
     ghostel-test-resize-window-adjust
     ghostel-test-resize-nil-size
+    ghostel-test-resize-noop-same-dims
+    ghostel-test-resize-minibuffer-crop
+    ghostel-test-resize-minibuffer-alt-screen-commits
+    ghostel-test-resize-minibuffer-width-only-shrink-commits
+    ghostel-test-commit-cropped-size-on-focus
+    ghostel-test-commit-cropped-size-noop-outside-minibuffer
+    ghostel-test-commit-cropped-size-noop-on-deselect
+    ghostel-test-commit-cropped-size-noop-when-matched
     ghostel-test-sigwinch-reaches-shell-basic
     ghostel-test-sigwinch-reaches-shell-ghostel-style
     ghostel-test-sigwinch-reaches-child-process


### PR DESCRIPTION
When the minibuffer opens (e.g. `M-x`, completion UIs like vertico/consult), Emacs shrinks the window displaying the terminal to make room. This triggers `window-configuration-change-hook` → `window--adjust-process-windows`, which calls `set-process-window-size` and delivers SIGWINCH to the shell process. When the minibuffer closes, the window grows back, sending a second SIGWINCH.

This causes visible problems in:

- **Fish shell** — repaints the entire prompt on SIGWINCH, causing it to disappear and reappear
- **Complex TUI applications** (e.g. Claude Code) — triggers a full-screen redraw for what the user perceives as a no-op

Normal (non-process) buffers simply get cropped when the minibuffer steals space — the bottom lines are hidden and reappear when the minibuffer closes. No signals, no redraws.

### Solution

When the minibuffer is active and only the height shrank (width unchanged), skip the PTY resize and return `nil` from the `adjust-window-size-function`. This suppresses `set-process-window-size` (no SIGWINCH). The Emacs window naturally hides the bottom rows. When the minibuffer closes and `window-configuration-change-hook` fires again, the size matches the committed PTY size, so again no signal is sent.

A new option `ghostel-crop-minibuffer-resize` (default `t`) controls this behavior.

Also tracks `ghostel--term-cols` alongside `ghostel--term-rows` to detect and skip no-op resize calls (e.g. when a window merely moves without changing dimensions).