### PR TITLE
Use keyword form for outbound ssh wrapper

### DIFF
--- a/etc/ghostel.bash
+++ b/etc/ghostel.bash
@@ -78,7 +78,11 @@ trap '__ghostel_preexec' DEBUG
 # Per-call escape hatch: prefix `ssh' with GHOSTEL_SSH_KEEP_TERM=1 to
 # bypass the wrapper entirely.
 if [[ -n "$GHOSTEL_SSH_INSTALL_TERMINFO" ]]; then
-    ssh() {
+    # `function NAME { … }' rather than `NAME() { … }' so a user alias
+    # on `ssh' (aliases expand at parse time in zsh, and bash when the
+    # alias is already active while sourcing this file) can't turn the
+    # definition into a parse error.
+    function ssh {
         # Escape hatch + need infocmp locally to do anything useful.
         if [[ -n "$GHOSTEL_SSH_KEEP_TERM" ]] || \
                ! builtin command -v infocmp >/dev/null 2>&1; then

--- a/etc/ghostel.zsh
+++ b/etc/ghostel.zsh
@@ -41,7 +41,11 @@ preexec_functions=(__ghostel_preexec "${preexec_functions[@]}")
 # Outbound `ssh' wrapper.  See etc/ghostel.bash for the full design
 # notes — this is the zsh port of the same install-and-cache logic.
 if [[ -n "$GHOSTEL_SSH_INSTALL_TERMINFO" ]]; then
-    ssh() {
+    # `function NAME { … }' rather than `NAME() { … }' so a user alias
+    # on `ssh' (aliases expand at parse time in zsh, and bash when the
+    # alias is already active while sourcing this file) can't turn the
+    # definition into a parse error.
+    function ssh {
         if [[ -n "$GHOSTEL_SSH_KEEP_TERM" ]] || \
                ! command -v infocmp >/dev/null 2>&1; then
             command ssh "$@"


### PR DESCRIPTION
## Summary
- Fix #155: `source ghostel.zsh` (and `ghostel.bash` in the same scenario) failed with `parse error near '('` when the user had `alias ssh=…` set beforehand, because zsh expands aliases at parse time against the `ssh()` function header.
- Switch both wrappers to `function ssh { … }` — the keyword form is not subject to alias expansion on the name token, so a pre-existing `ssh` alias no longer breaks sourcing.
- `etc/ghostel.fish` is unaffected (fish has no POSIX `()` form; aliases are themselves functions the later `function ssh` cleanly replaces).
- No body changes, no behavior change for users without an `ssh` alias.

## Test plan
- [x] `zsh -c 'alias ssh=…; export GHOSTEL_SSH_INSTALL_TERMINFO=1; source etc/ghostel.zsh'` sources without error (previously failed).
- [x] Equivalent repro for bash (`bash -i -c 'source …'` after `alias ssh=…`) sources without error (previously failed).
- [x] `make -j4 all` — 152/152 tests pass.
- [x] Manual: exercise the ssh wrapper path on a real remote with `GHOSTEL_SSH_INSTALL_TERMINFO=1` (no behavior change expected; listed for completeness).