### PR TITLE
Anchor window-point clamp via pos-visible-in-window-p

### DIFF
--- a/ghostel.el
+++ b/ghostel.el
@@ -3052,26 +3052,27 @@ No-op when `ghostel--snap-requested' (user input overrides)."
 Also resets pixel vscroll (pixel-scroll-precision-mode may leave a
 partial offset that would clip the top line after a redraw).
 
-When the TUI cursor is in pending-wrap state on the last visible row,
-PT equals `point-max' (one past the last character).  Emacs redisplay
-then classifies it as off-screen, and `scroll-conservatively' shifts
-`window-start' up by one row to make it visible — which fights the
-viewport pin and makes the block cursor disappear.  Clamp
+When PT equals `point-max' and Emacs considers that position
+off-screen given the just-pinned `window-start', redisplay would
+scroll `window-start' to bring PT into view — fighting the viewport
+pin and making the block cursor disappear (issue #138).  Clamp
 `window-point' back by one only in that case so it sits inside the
-viewport; buffer-point is unaffected and subsequent redraws recapture
-the real cursor.  We must NOT clamp for a plain shell prompt where the
-cursor is legitimately at `point-max' after typing — doing so would
-draw the block cursor on the last character instead of after it
-\(issue #146)."
+viewport; buffer-point is unaffected and subsequent redraws
+recapture the real cursor.  When PT is already visible (e.g. a shell
+prompt mid-window where the user just typed up to `point-max'),
+leave WP alone so the block cursor renders after the last character
+\(issue #146).
+
+This catches both pending-wrap (#138) and CUP placements that land
+the cursor at `point-max' on the last viewport row, e.g. TUIs that
+park the cursor at the bottom on focus-out."
   (set-window-start win vs t)
   (set-window-vscroll win 0 t)
-  (set-window-point win (if (and (= pt (point-max))
-                                 (> pt (point-min))
-                                 ghostel--term
-                                 (ghostel--cursor-pending-wrap-p
-                                  ghostel--term))
-                            (1- pt)
-                          pt)))
+  (set-window-point win pt)
+  (when (and (= pt (point-max))
+             (> pt (point-min))
+             (not (pos-visible-in-window-p pt win)))
+    (set-window-point win (1- pt))))
 
 (defun ghostel--restore-scrollback-window (win state)
   "Restore WIN to ws/wp recorded in STATE and push STATE to scroll-positions.


### PR DESCRIPTION
Fixes #157.

## Summary

- Replace the `ghostel--cursor-pending-wrap-p` predicate in `ghostel--anchor-window` with `(not (pos-visible-in-window-p pt win))`.
- `pending-wrap` is one way to land at `pt = point-max` on a position Emacs treats as off-screen, but not the only one — CUP placements to `(0, last-row)` reach the same state without setting pending-wrap, which lets the redisplay-induced `window-start` scroll re-emerge (variant of #138).
- The direct visibility check captures the actual precondition: clamp iff Emacs would otherwise scroll `window-start` to bring `pt` into view. `pending-wrap` becomes a special case of this, so the #138 fix is preserved; mid-window typing at a shell prompt continues to render the block cursor after the last character (#146).

See #157 for reproduction, evidence (focus-change/anchor-window log on Claude Code as the example TUI), and case-by-case coverage table.

## Test plan

- [x] Manual: original symptom (focus-shift on TUI buffer that parks cursor at bottom-left) is gone.
- [x] Manual: normal shell prompt typing renders the block cursor after the last character, including past the right margin.
- [ ] Add a regression test: place cursor at `(0, body-height - 1)` via CUP (not pending-wrap) with `pt = point-max`, assert `wp` is clamped.
- [ ] Confirm existing #138 / #146 tests still pass.

Marked draft pending the regression test and a maintainer sanity check on `pos-visible-in-window-p` performance inside the redraw path (called once per anchored window per redraw — likely fine but worth confirming against any existing benchmarks).