### PR TITLE
Drop normal-state-entry hook — it clobbers post-operator point

### DIFF
--- a/evil-ghostel.el
+++ b/evil-ghostel.el
@@ -144,11 +144,6 @@ In alt-screen mode, defer to the terminal's cursor style."
   "When non-nil, skip arrow-key sync in the insert-state-entry hook.
 Set by the `I'/`A' advice which send Home/End directly.")
 
-(defun evil-ghostel--normal-state-entry ()
-  "Snap Emacs point to the terminal cursor when entering normal state."
-  (when (and (derived-mode-p 'ghostel-mode) (evil-ghostel--active-p))
-    (evil-ghostel--reset-cursor-point)))
-
 (defun evil-ghostel--insert-state-entry ()
   "Sync terminal cursor to Emacs point when entering `emacs-state'.
 Skipped when `evil-ghostel--sync-inhibit' is set (by I/A advice
@@ -364,8 +359,6 @@ state transitions."
   (if evil-ghostel-mode
       (progn
         (evil-ghostel--escape-stay)
-        (add-hook 'evil-normal-state-entry-hook
-                  #'evil-ghostel--normal-state-entry nil t)
         (add-hook 'evil-insert-state-entry-hook
                   #'evil-ghostel--insert-state-entry nil t)
         ;; Reuse the insert-state sync when entering emacs-state — both
@@ -385,8 +378,6 @@ state transitions."
         (advice-add 'ghostel--set-cursor-style :around
                     #'evil-ghostel--override-cursor-style)
         (evil-refresh-cursor))
-    (remove-hook 'evil-normal-state-entry-hook
-                 #'evil-ghostel--normal-state-entry t)
     (remove-hook 'evil-insert-state-entry-hook
                  #'evil-ghostel--insert-state-entry t)
     (remove-hook 'evil-emacs-state-entry-hook

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -63,21 +63,26 @@ Uses mocks for native functions."
   "Test that `evil-ghostel-mode' activates correctly."
   (evil-ghostel-test--with-evil-buffer
    (should evil-ghostel-mode)
-   (should (memq 'evil-ghostel--normal-state-entry
-                 evil-normal-state-entry-hook))
    (should (memq 'evil-ghostel--insert-state-entry
                  evil-insert-state-entry-hook))
    (should (advice--p (advice--symbol-function 'evil-insert-line)))
    (should (advice--p (advice--symbol-function 'ghostel--redraw)))
    (should (advice--p (advice--symbol-function 'ghostel--set-cursor-style)))))
 
+(ert-deftest evil-ghostel-test-mode-activation-no-normal-entry-hook ()
+  "`evil-ghostel-mode' does not install a `normal-state-entry-hook'.
+Point is synced on entry to `emacs'/`insert' and preserved through
+redraws in `normal'; re-syncing on every normal-state entry would
+overwrite the position evil assigns at operator/visual completion."
+  (evil-ghostel-test--with-evil-buffer
+   (should-not (memq 'evil-ghostel--normal-state-entry
+                     evil-normal-state-entry-hook))))
+
 (ert-deftest evil-ghostel-test-mode-deactivation ()
   "Test that `evil-ghostel-mode' cleans up on deactivation."
   (evil-ghostel-test--with-evil-buffer
    (evil-ghostel-mode -1)
    (should-not evil-ghostel-mode)
-   (should-not (memq 'evil-ghostel--normal-state-entry
-                     evil-normal-state-entry-hook))
    (should-not (memq 'evil-ghostel--insert-state-entry
                      evil-insert-state-entry-hook))))
 


### PR DESCRIPTION
## Problem

`evil-ghostel--normal-state-entry` snaps point to the terminal cursor on every normal-state entry.  `evil-normal-state-entry-hook` fires on **every** `(evil-normal-state)` call — including the no-op re-entries operators and ESC-from-visual perform at completion.

Evil's `evil-change-to-previous-state` also rewinds `evil-previous-state` through `evil-previous-state-alist` when operators finish, so even a gate like `(memq evil-previous-state '(emacs insert))` lets the bad case through.  Concretely:

- Move in normal, then `yy`: at the hook fire `this-command = evil-yank`, `evil-previous-state = emacs` (rewound from `operator`).  Snap discards the motion; point lands on the original TUI cursor row instead of the yanked line.
- `v..y`: point snapped off the yank start.
- `v..<escape>`: point snapped off visual-beginning.
- `yiW` worked correctly — text-object yanks don't round-trip through normal state.

## Why it's safe to remove

The snap is redundant in the legitimate cases too:

- `emacs → normal`: the redraw advice keeps point following the TUI cursor throughout `emacs-state`, and emacs-state-exit leaves point at the TUI cursor as `normal-state` begins.
- `insert → normal`: `evil-ghostel--insert-state-entry` is registered on `emacs`/`insert` entry; point is already at the TUI cursor until ESC.

Evil's operator/visual machinery places point correctly at every relevant transition.  Remove the function and its hook registration outright.

## Tests

- Flip the activation assertion to check the hook is NOT installed (regression guard).
- Drop the removed-function's test case.