### PR TITLE
Replace ghostel-enable-title-tracking with ghostel-set-title-function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ All notable changes to this project will be documented in this file.
   line number. Configurable via `ghostel-file-detection-regex`. Closes
   [#107](https://github.com/dakra/ghostel/issues/107)
   ([ed17efb](https://github.com/dakra/ghostel/commit/ed17efb)).
+- Replaced `ghostel-enable-title-tracking` (boolean) with
+  `ghostel-set-title-function`.  The new option holds the function
+  invoked on OSC 2 title changes; set to nil to disable title tracking,
+  or to a custom function to fully override the rename behaviour.
 
 ### Fixed
 - Top line no longer renders clipped after a terminal redraw when

--- a/ghostel-compile.el
+++ b/ghostel-compile.el
@@ -494,11 +494,6 @@ local machine happens to have)."
 
 ;;; Buffer management
 
-(defconst ghostel-compile--managed-buffer-sentinel :ghostel-compile
-  "Sentinel value used for `ghostel--managed-buffer-name' in compile buffers.
-When set, `ghostel--set-title' (OSC 2) skips auto-renaming the buffer — we
-don't want a compile command's title sequence to replace our fixed name.")
-
 (defun ghostel-compile--prepare-buffer (name dir)
   "Return the ghostel buffer named NAME, reset for a fresh run from DIR.
 If a buffer with NAME already exists, the run is prepared in place
@@ -564,13 +559,9 @@ so there is no remote-integration round-trip on TRAMP buffers."
       (let ((inhibit-read-only t))
         (erase-buffer))
       (setq ghostel--pending-output nil)
-      ;; Pin the buffer name so a compile command's OSC 2 title sequence
-      ;; can't rename the buffer mid-run.  `ghostel--set-title' only
-      ;; renames when `ghostel--managed-buffer-name' equals the current
-      ;; buffer name (see ghostel.el); a sentinel that can never match
-      ;; disables auto-renaming.
-      (setq ghostel--managed-buffer-name
-            ghostel-compile--managed-buffer-sentinel)
+      ;; Disable OSC 2 title tracking so a compile command's title
+      ;; sequence can't rename the buffer mid-run.
+      (setq-local ghostel-set-title-function nil)
       (setq ghostel--term (ghostel--new height width ghostel-max-scrollback))
       (setq ghostel--term-rows height)
       (ghostel--apply-palette ghostel--term)

--- a/ghostel-eshell.el
+++ b/ghostel-eshell.el
@@ -87,7 +87,7 @@ eshell."
         (setq-local ghostel-kill-buffer-on-exit
                     (bound-and-true-p eshell-destroy-buffer-when-process-dies))
         (unless ghostel-eshell-track-title
-          (setq-local ghostel-enable-title-tracking nil))
+          (setq-local ghostel-set-title-function nil))
         (add-hook 'ghostel-exit-functions
                   #'ghostel-eshell--visual-exit nil t))
       nil)))

--- a/ghostel.el
+++ b/ghostel.el
@@ -217,11 +217,13 @@ aggressive partial screen updates, but may use more CPU."
   "Default buffer name for ghostel terminals."
   :type 'string)
 
-(defcustom ghostel-enable-title-tracking t
-  "Automatically rename the buffer when the terminal title changes.
-When non-nil, OSC 2 title sequences update the buffer name to
-\"*ghostel: TITLE*\".  Set to nil to keep the buffer name fixed."
-  :type 'boolean)
+(defcustom ghostel-set-title-function #'ghostel--set-title-default
+  "Function called when the terminal reports a new title (OSC 2).
+Called with one argument, the title string, in the ghostel buffer.
+Set to nil to disable title tracking entirely.
+The default, `ghostel--set-title-default', renames the buffer to
+\"*ghostel: TITLE*\" unless the user has renamed it manually."
+  :type '(choice (const :tag "Disabled" nil) function))
 
 (defcustom ghostel-kill-buffer-on-exit t
   "Kill the buffer when the shell process exits."
@@ -2168,17 +2170,20 @@ This ensures terminal text is visible regardless of the Emacs theme."
                                  :foreground fg
                                  :background bg)))
 
-(defun ghostel--set-title (title)
+(defun ghostel--set-title-default (title)
   "Update the buffer name with TITLE from the terminal.
-Only acts when `ghostel-enable-title-tracking' is non-nil and the
-buffer has not been manually renamed by the user."
-  (when (and ghostel-enable-title-tracking
-             (or (null ghostel--managed-buffer-name)
-                 (equal (buffer-name) ghostel--managed-buffer-name)))
+Only acts when the buffer has not been manually renamed by the user."
+  (when (or (null ghostel--managed-buffer-name)
+            (equal (buffer-name) ghostel--managed-buffer-name))
     (let ((new-name (format "*ghostel: %s*" title)))
       (rename-buffer new-name t)
       ;; Keep the actual name because `rename-buffer' may uniquify it.
       (setq ghostel--managed-buffer-name (buffer-name)))))
+
+(defun ghostel--set-title (title)
+  "Dispatch TITLE changes to `ghostel-set-title-function'."
+  (when ghostel-set-title-function
+    (funcall ghostel-set-title-function title)))
 
 (defun ghostel--set-cursor-style (style visible)
   "Set the cursor style based on terminal state.

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -677,7 +677,7 @@ than the full terminal `cols'."
         (kill-buffer buf)))))
 
 (ert-deftest ghostel-test-title-tracking-disabled ()
-  "Test that title updates are ignored when `ghostel-enable-title-tracking' is nil."
+  "Test that title updates are ignored when `ghostel-set-title-function' is nil."
   (let (buf)
     (unwind-protect
         (cl-letf (((symbol-function 'ghostel--new)
@@ -686,7 +686,7 @@ than the full terminal `cols'."
                    (lambda (&rest _args) nil))
                   ((symbol-function 'ghostel--start-process)
                    (lambda () nil)))
-          (let ((ghostel-enable-title-tracking nil))
+          (let ((ghostel-set-title-function nil))
             (ghostel)
             (setq buf (current-buffer))
             (with-current-buffer buf


### PR DESCRIPTION
## Summary
- Replace the boolean `ghostel-enable-title-tracking` with a function-valued `ghostel-set-title-function`. `nil` disables OSC 2 title tracking (same behaviour as the old `nil`); any other function lets users fully override the rename logic.
- Split `ghostel--set-title` into a thin dispatcher (still the symbol Zig calls via `emacs_module_init`) plus `ghostel--set-title-default` holding the original rename-with-manual-rename-guard logic.
- `ghostel-compile` now disables title tracking via `(setq-local ghostel-set-title-function nil)` instead of stashing a sentinel in `ghostel--managed-buffer-name` — simpler, and also protects against user-provided custom title functions.
- Zig side (`src/module.zig`) is intentionally untouched; dispatch stays in Elisp.

## Test plan
- [x] `make -j4 all` — 93 native + 152 elisp tests, all passing
- [x] `make lint` clean (byte-compile, checkdoc, package-lint)
- [x] Verify with a shell that emits OSC 2 (e.g. `bash` with `PROMPT_COMMAND`) that buffer rename still happens with the default
- [x] Verify `(setq ghostel-set-title-function nil)` keeps the buffer name fixed
- [x] Verify a custom function (e.g. prefix-free rename) is invoked with the title string