### PR TITLE
Fix fish auto-inject ssh wrapper and XDG_DATA_DIRS leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 zig-out/
 .zig-cache/
+zig-pkg/
 *.dylib
 *.so
 *.elc
+ghostel-autoloads.el
+ghostel-pkg.el
 ghostel-module.*
 !ghostel-module.zig

--- a/etc/shell-integration/fish/vendor_conf.d/ghostel-integration.fish
+++ b/etc/shell-integration/fish/vendor_conf.d/ghostel-integration.fish
@@ -1,15 +1,21 @@
 # Ghostel shell integration auto-injection for fish.
-# Auto-loaded via XDG_DATA_DIRS.
+# Auto-loaded via XDG_DATA_DIRS.  Restores XDG_DATA_DIRS and then
+# chains to the real integration in etc/ghostel.fish (single source
+# of truth; also used by manual source and TRAMP).
 
 # Restore XDG_DATA_DIRS by removing our injected path.
+# Use a private variable name — fish pre-populates a local-scope
+# `xdg_data_dirs' (with `/fish' appended to each entry) for its own
+# vendor_conf.d lookup, which would otherwise leak through our
+# cleanup and end up exported back to every subprocess.
 if set -q GHOSTEL_SHELL_INTEGRATION_XDG_DIR
     if set -q XDG_DATA_DIRS
-        set --function --path xdg_data_dirs "$XDG_DATA_DIRS"
-        if set --function index (contains --index "$GHOSTEL_SHELL_INTEGRATION_XDG_DIR" $xdg_data_dirs)
-            set --erase --function xdg_data_dirs[$index]
+        set --function --path _ghostel_xdg_dirs "$XDG_DATA_DIRS"
+        if set --function index (contains --index "$GHOSTEL_SHELL_INTEGRATION_XDG_DIR" $_ghostel_xdg_dirs)
+            set --erase --function _ghostel_xdg_dirs[$index]
         end
-        if set -q xdg_data_dirs[1]
-            set --global --export --unpath XDG_DATA_DIRS "$xdg_data_dirs"
+        if set -q _ghostel_xdg_dirs[1]
+            set --global --export --unpath XDG_DATA_DIRS "$_ghostel_xdg_dirs"
         else
             set --erase --global XDG_DATA_DIRS
         end
@@ -19,47 +25,8 @@ end
 
 status --is-interactive; or exit 0
 
-# Report working directory to the terminal via OSC 7
-function __ghostel_osc7 --on-event fish_prompt
-    printf '\e]7;file://%s%s\e\\' (hostname) "$PWD"
-end
-
-# --- Semantic prompt markers (OSC 133) ---
-
-set -g __ghostel_prompt_shown 0
-
-function __ghostel_postexec --on-event fish_postexec
-    set -g __ghostel_last_status $status
-end
-
-# Emit "command finished" (D) + "prompt start" (A) before the prompt.
-function __ghostel_prompt_start --on-event fish_prompt
-    if test "$__ghostel_prompt_shown" = 1
-        printf '\e]133;D;%s\e\\' "$__ghostel_last_status"
-    end
-    printf '\e]133;A\e\\'
-end
-
-# Emit "prompt end / command start" (B) after the prompt.
-function __ghostel_prompt_end --on-event fish_prompt
-    printf '\e]133;B\e\\'
-    set -g __ghostel_prompt_shown 1
-end
-
-# Emit "command output start" (C) before command runs.
-function __ghostel_preexec --on-event fish_preexec
-    printf '\e]133;C\e\\'
-end
-
-# Call an Emacs Elisp function from the shell.
-# Usage: ghostel_cmd FUNCTION [ARGS...]
-# The function must be in `ghostel-eval-cmds'.
-function ghostel_cmd
-    set -l payload ""
-    for arg in $argv
-        set arg (string replace -a '\\' '\\\\' -- $arg)
-        set arg (string replace -a '"' '\\"' -- $arg)
-        set payload "$payload\"$arg\" "
-    end
-    printf '\e]51;E%s\e\\' "$payload"
+# Load the real integration (idempotent via __ghostel_osc7 guard in
+# etc/ghostel.fish).
+if set -q EMACS_GHOSTEL_PATH; and test -r "$EMACS_GHOSTEL_PATH/etc/ghostel.fish"
+    source "$EMACS_GHOSTEL_PATH/etc/ghostel.fish"
 end

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1031,6 +1031,69 @@ Mirrors the real zsh case where the directory still contains a
       (kill-buffer buf))))
 
 ;; -----------------------------------------------------------------------
+;; Test: fish auto-inject shim
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-fish-auto-inject-loads-integration ()
+  "Fish auto-inject shim must chain to etc/ghostel.fish and clean XDG_DATA_DIRS.
+Regression test: the vendor_conf.d shim previously (a) inlined a
+partial copy of the integration and silently dropped the outbound
+\\='ssh' wrapper, and (b) used a temp variable name (\\='xdg_data_dirs')
+that collided with a fish-internal local variable, leaking
+\\='/fish'-suffixed paths back to exported XDG_DATA_DIRS."
+  :tags '(:fish)
+  (skip-unless (executable-find "fish"))
+  (let* ((ghostel-dir (file-name-directory
+                       (or (locate-library "ghostel")
+                           load-file-name
+                           buffer-file-name)))
+         (integ-dir (directory-file-name
+                     (expand-file-name "etc/shell-integration" ghostel-dir)))
+         ;; Isolate from the dev's fish config: a user `function ssh' or
+         ;; pre-defined ghostel-like helpers would otherwise satisfy the
+         ;; assertions even if our shim didn't chain to etc/ghostel.fish.
+         ;; Pointing HOME and XDG_CONFIG_HOME at an empty temp dir skips
+         ;; config.fish, conf.d/, and functions/ autoload without
+         ;; disturbing XDG_DATA_DIRS (so vendor_conf.d still loads).
+         (fish-home (make-temp-file "ghostel-test-fish-home-" t)))
+    (unwind-protect
+        (let* ((probe (concat
+                       "functions -q __ghostel_osc7; and echo osc7=yes; or echo osc7=no\n"
+                       "functions -q ghostel_cmd; and echo cmd=yes; or echo cmd=no\n"
+                       "functions -q ssh; and echo ssh=yes; or echo ssh=no\n"
+                       "echo xdg=$XDG_DATA_DIRS\n"))
+               (process-environment
+                (append (list (format "HOME=%s" fish-home)
+                              (format "XDG_CONFIG_HOME=%s" fish-home)
+                              (format "EMACS_GHOSTEL_PATH=%s" ghostel-dir)
+                              "GHOSTEL_SSH_INSTALL_TERMINFO=1"
+                              (format "XDG_DATA_DIRS=%s:/usr/local/share:/usr/share"
+                                      integ-dir)
+                              (format "GHOSTEL_SHELL_INTEGRATION_XDG_DIR=%s"
+                                      integ-dir))
+                        process-environment))
+               ;; `call-process' inherits `default-directory' as the cwd.
+               ;; Avoid a path with tildes — `~' would expand against the
+               ;; overridden HOME above and point at a missing subdir.
+               (default-directory fish-home)
+               (output (with-temp-buffer
+                         (call-process "fish" nil (current-buffer) nil
+                                       "-i" "-c" probe)
+                         (buffer-string))))
+          ;; Shim must chain to etc/ghostel.fish so the integration loads.
+          (should (string-match-p "^osc7=yes$" output))
+          (should (string-match-p "^cmd=yes$" output))
+          ;; GHOSTEL_SSH_INSTALL_TERMINFO=1 must reach etc/ghostel.fish so
+          ;; the ssh install-and-cache wrapper is defined.
+          (should (string-match-p "^ssh=yes$" output))
+          ;; XDG cleanup must strip the injected integration dir without
+          ;; leaking fish's internal `/fish'-suffixed form.
+          (should (string-match "^xdg=\\(.*\\)$" output))
+          (should-not (string-match-p (regexp-quote integ-dir)
+                                      (match-string 1 output))))
+      (delete-directory fish-home t))))
+
+;; -----------------------------------------------------------------------
 ;; Test: update-directory
 ;; -----------------------------------------------------------------------
 
@@ -6958,6 +7021,7 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-local-host-p
     ghostel-test-update-directory-remote
     ghostel-test-get-shell-local
+    ghostel-test-fish-auto-inject-loads-integration
     ghostel-test-resize-window-adjust
     ghostel-test-resize-nil-size
     ghostel-test-resize-noop-same-dims


### PR DESCRIPTION
## Summary

- Fix fish auto-inject shim by chaining to `etc/ghostel.fish` (the pattern bash/zsh shims already use via `$EMACS_GHOSTEL_PATH`) instead of inlining a partial copy. The inlined copy was missing the outbound `ssh` install-and-cache wrapper gated on `$GHOSTEL_SSH_INSTALL_TERMINFO`, so local fish users on the default `ghostel-shell-integration t` path silently lacked the behavior bash/zsh users already had.
- Fix `XDG_DATA_DIRS` leak by renaming the cleanup's temp array from `xdg_data_dirs` to `_ghostel_xdg_dirs`. The old name collided with a fish-internal local variable that fish pre-populates inside `vendor_conf.d` with `/fish`-suffixed paths (for its own vendor lookup), which caused the cleanup to silently no-op and then re-export that internal form as `XDG_DATA_DIRS` — leaking mangled paths to every subprocess spawned from a ghostel fish session.
- Add `ghostel-test-fish-auto-inject-loads-integration`, an ERT regression test that spawns fish with the elisp-constructed env and asserts both fixes hold.

TRAMP is unaffected — it sources `etc/ghostel.fish` directly over the remote PTY and never touches the XDG shim path.

## Test plan

- [x] `make -j4 all` passes (elisp 156, native 93, evil 39, lint clean)
- [x] New test fails against the pre-fix shim (`ssh=no`, XDG still contains the `/fish`-suffixed injection dir) and passes with the fix — verified by temporarily reverting just the shim
- [x] Manually verified in an interactive ghostel fish session: `functions -q ssh` and `functions -q __ghostel_osc7` both succeed, `XDG_DATA_DIRS` is cleanly stripped
- [x] Confirmed non-ghostel fish sessions are untouched — the three guards (`GHOSTEL_SHELL_INTEGRATION_XDG_DIR`, `status --is-interactive`, `EMACS_GHOSTEL_PATH`) all short-circuit when the shim ends up on a persistent `XDG_DATA_DIRS`