### PR TITLE
Fix Emacs 30 package-vc-install + add reproducible debug harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,19 @@ If you prefer to build from source or need a different platform, you'll also nee
 
 ```elisp
 (use-package ghostel
-  :vc (:url "https://github.com/dakra/ghostel" :rev :newest))
+  :vc (:url "https://github.com/dakra/ghostel"
+       :lisp-dir "lisp"
+       :rev :newest))
 ```
+
+`:lisp-dir "lisp"` is required on Emacs 30.x — its `package-vc-install`
+doesn't propagate the auto-detected Lisp subdirectory through to the
+byte-compile / autoloads / main-file steps, so omitting the hint
+surfaces as a `(wrong-type-argument stringp nil)` error and
+byte-compile failures for secondary Lisp files.  Emacs 31 fixes both
+paths; the hint is harmless there (and in the evil-ghostel snippet
+below it's redundant because `:lisp-dir` already points at the
+extension's own subdir).
 
 ### use-package with load-path
 

--- a/docker/emacs30/Dockerfile
+++ b/docker/emacs30/Dockerfile
@@ -1,0 +1,22 @@
+# Reusable Emacs 30.2 sandbox for reproducing package-vc-install bugs
+# and anything else that needs a clean Emacs 30 environment.
+#
+# Build:  docker build -t ghostel-emacs30 docker/emacs30
+# Run:    see docker/emacs30/README.md
+FROM silex/emacs:30.2
+
+# package-vc-install needs git; ca-certificates so HTTPS clones work.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Isolated per-session user-emacs-directory, so the repo mount under /repo
+# is never touched by installed packages, caches, or autoloads.
+ENV HOME=/home/tester
+RUN useradd --create-home --shell /bin/bash tester
+USER tester
+WORKDIR /home/tester
+
+# Default to an interactive shell — override with a specific command when
+# automating (see test-package-vc.sh).
+CMD ["/bin/bash"]

--- a/docker/emacs30/test-package-vc.sh
+++ b/docker/emacs30/test-package-vc.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Reproduce `package-vc-install ghostel` on Emacs 30 inside a disposable
+# container.  The ghostel repo is mounted read-only at /repo so the test
+# uses the exact branch currently checked out on the host.
+#
+# Usage:
+#   docker/emacs30/test-package-vc.sh                # ghostel, current HEAD
+#   docker/emacs30/test-package-vc.sh <branch>       # specific branch
+#   docker/emacs30/test-package-vc.sh <branch> evil  # evil-ghostel too
+#
+# Re-runs reuse the built image (`ghostel-emacs30`); rebuild with
+#   docker build -t ghostel-emacs30 docker/emacs30
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BRANCH="${1:-$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)}"
+WITH_EVIL="${2:-}"
+
+if ! docker image inspect ghostel-emacs30 >/dev/null 2>&1; then
+    docker build -t ghostel-emacs30 "$REPO_ROOT/docker/emacs30"
+fi
+
+# package-vc uses vc-git-clone, which reads the source's .git directory.
+# If REPO_ROOT is a git submodule or worktree (.git is a file pointing
+# outside the mount), the container can't follow it.  Materialize a
+# self-contained clone on the host and mount that instead.
+CLONE_DIR=$(mktemp -d -t ghostel-clone)
+trap 'rm -rf "$CLONE_DIR"' EXIT
+git clone --quiet --local --no-hardlinks --branch "$BRANCH" \
+    "$REPO_ROOT" "$CLONE_DIR"
+
+# Wrap all forms in (progn ...) so --eval accepts them as a single
+# expression; single-quoted heredoc keeps the elisp verbatim.
+SCRIPT=$(cat <<'ELISP'
+(progn
+  (require 'package)
+  (require 'package-vc)
+  (setq package-archives
+        '(("gnu"    . "https://elpa.gnu.org/packages/")
+          ("nongnu" . "https://elpa.nongnu.org/nongnu/")
+          ("melpa"  . "https://melpa.org/packages/")))
+  (package-initialize)
+  (package-refresh-contents)
+
+  (message "\n===== installing ghostel from /repo (branch %s, lisp-dir=%s) =====" (getenv "GHOSTEL_BRANCH") (getenv "GHOSTEL_LISP_DIR"))
+  (let ((spec `(ghostel :url "/repo" :branch ,(getenv "GHOSTEL_BRANCH"))))
+    (when (equal (getenv "GHOSTEL_LISP_DIR") "lisp")
+      (setq spec (append spec '(:lisp-dir "lisp"))))
+    (condition-case err
+        (package-vc-install spec)
+      (error (message "package-vc-install signalled: %S" err))))
+
+  (message "\n===== post-install diagnostics =====")
+  (message "load-path entries containing 'ghostel': %S"
+           (seq-filter (lambda (p) (string-match-p "ghostel" p)) load-path))
+  (message "locate-library ghostel -> %s" (locate-library "ghostel"))
+  (message "(require 'ghostel): ...")
+  (condition-case err
+      (progn (require 'ghostel) (message "  OK, ghostel feature provided"))
+    (error (message "  FAIL: %S" err)))
+
+  (when (equal (getenv "WITH_EVIL") "evil")
+    (message "\n===== installing evil + evil-ghostel =====")
+    (package-install 'evil)
+    (package-vc-install
+     `(evil-ghostel :url "/repo"
+                    :branch ,(getenv "GHOSTEL_BRANCH")
+                    :lisp-dir "extensions/evil-ghostel"))))
+ELISP
+)
+
+docker run --rm \
+    -v "$CLONE_DIR:/repo:ro" \
+    -e "GHOSTEL_BRANCH=$BRANCH" \
+    -e "WITH_EVIL=$WITH_EVIL" \
+    -e "GHOSTEL_LISP_DIR=${GHOSTEL_LISP_DIR:-}" \
+    ghostel-emacs30 \
+    emacs --batch --eval "$SCRIPT"


### PR DESCRIPTION
## Summary

- Users on Emacs 30.x doing `package-vc-install` of ghostel hit byte-compile failures and a `(wrong-type-argument stringp nil)` crash (reported by @emil-e and Lucas). Root cause is two bugs in Emacs 30's `package-vc` that both disappear when the user passes `:lisp-dir \"lisp\"` in their `:vc` spec.
- README now shows the `:lisp-dir \"lisp\"` hint in the Emacs-30+ use-package snippet, with a short explanation.
- `docker/emacs30/` provides a reusable harness (Dockerfile + `test-package-vc.sh`) that reproduces the install in a clean Emacs 30.2 environment — useful for future Emacs-30 regressions too.

## What's broken on Emacs 30 (fixed on Emacs 31 by commit `573acd97`)

1. **Byte-compile step**: `package--compile` runs `byte-recompile-directory` on the checkout root. Without `:lisp-dir` in `pkg-spec`, `lisp/` isn't reliably added to `load-path` at compile time, so `(require 'ghostel)` in `lisp/ghostel-compile.el`, `-debug.el`, `-eshell.el` fails with \"Cannot open load file: No such file or directory, ghostel\".

2. **Final confirmation message**: `package-vc--main-file` does `(file-name-concat pkg-dir (plist-get pkg-spec :lisp-dir))`. When `:lisp-dir` isn't in `pkg-spec`, this concats `nil` → pkg-dir, looks for `pkg-dir/ghostel.el` (doesn't exist — it's in `lisp/`), and the fuzzy heuristic filters out `-pkg.el` / `-autoloads.el`, returning `nil`. That `nil` then flows into `vc-working-revision` → crash.

Both are silenced by adding `:lisp-dir \"lisp\"` to the user's install spec. Emacs 31 fixes both paths (compile scoped to `lisp-dir`, `package-vc--main-file` consults the auto-detect heuristic), so the hint is a no-op there.

## Docker repro harness

```bash
docker build -t ghostel-emacs30 docker/emacs30
docker/emacs30/test-package-vc.sh [branch]           # reproduces the bug
GHOSTEL_LISP_DIR=lisp docker/emacs30/test-package-vc.sh [branch]  # verifies the fix
```

Uses `silex/emacs:30.2` as base. The host repo is cloned to a temp dir first so a submodule layout (common in development) doesn't break the mount.

## Test plan

- [x] Reproduced Emil's exact error in the Docker harness on Emacs 30.2.
- [x] Verified `:lisp-dir \"lisp\"` fully fixes both byte-compile and the `vc-working-revision` crash on Emacs 30.2.
- [x] Verified the hint is a no-op on Emacs 31 (local smoke test).
- [x] `make -j4 test-all test-evil lint` green (no code changes under `lisp/`).

## Not included

Earlier in this investigation I added a `(eval-and-compile (add-to-list 'load-path …))` bootstrap to the three secondary Lisp files. Reverted — it only silenced the byte-compile half of the bug; the `vc-working-revision` crash still fires, so the net user outcome is unchanged. Documenting the user-side `:lisp-dir` hint is cleaner.