### PR TITLE
Snap hidden ghostel buffer to viewport on re-show (#177)

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -872,6 +872,14 @@ runs.  When nil, a redraw preserves the existing `window-start' if the
 user has scrolled into the scrollback, so live output and Emacs commands
 do not yank the view back to the prompt.")
 
+(defvar-local ghostel--windows-needing-snap nil
+  "List of windows that must anchor to the viewport on the next redraw.
+Populated by `ghostel--reshow-snap' when a window starts displaying
+this buffer, and cleared by `ghostel--delayed-redraw' after the anchor
+runs.  Per-window (rather than buffer-local like `ghostel--snap-requested')
+so opening a second window on a ghostel buffer does not yank peers the
+user has scrolled back for reading history (issue #177).")
+
 (defvar-local ghostel--last-anchor-position nil
   "Buffer position where the anchor last set `window-start'.
 Used by `ghostel--delayed-redraw' to tell windows that are following
@@ -3069,15 +3077,17 @@ position COL columns into the first matched line."
 (defsubst ghostel--window-anchored-p (win)
   "Non-nil if WIN is auto-following the viewport.
 A window counts as anchored when `ghostel--snap-requested' is set
-\(the user just typed), when no anchor has been recorded yet (first
-redraw), or when its `window-start' is at or past the prior anchor.
-During a resize-triggered redraw, a window absent from
+\(the user just typed), when WIN is in `ghostel--windows-needing-snap'
+\(WIN just gained this buffer), when no anchor has been recorded yet
+\(first redraw), or when its `window-start' is at or past the prior
+anchor.  During a resize-triggered redraw, a window absent from
 `ghostel--scroll-positions' also counts as anchored: the prior redraw
 left it following the viewport, so a drifted `window-start' below the
 anchor is Emacs redisplay (e.g. `keep-point-visible' when the
 minibuffer shrinks the window), not a user scroll."
   (let ((anchor ghostel--last-anchor-position))
     (or ghostel--snap-requested
+        (memq win ghostel--windows-needing-snap)
         (null anchor)
         (>= (window-start win) anchor)
         (and ghostel--redraw-resize-active
@@ -3230,7 +3240,8 @@ following the viewport."
                    win (assq win non-anchored-states))))
               (when vs
                 (setq ghostel--last-anchor-position vs))))
-          (setq ghostel--snap-requested nil))))))
+          (setq ghostel--snap-requested nil)
+          (setq ghostel--windows-needing-snap nil))))))
 
 (defun ghostel-force-redraw ()
   "Force a full terminal redraw (for debugging)."
@@ -3298,6 +3309,26 @@ PROCESS is the shell process, WINDOWS is the list of windows."
     ;; Return size — Emacs calls set-process-window-size (SIGWINCH)
     ;; after this function returns.  nil suppresses the call.
     size))
+
+(defun ghostel--reshow-snap (window)
+  "Mark WINDOW for viewport-snap on the next redraw.
+Intended for buffer-local `window-buffer-change-functions'.  Fires
+whenever this buffer becomes WINDOW's buffer: both on the classic
+hide-then-show transition and when an additional window opens on
+the same buffer (`split-window', `display-buffer', etc.).  While
+the buffer is hidden `ghostel--last-anchor-position' keeps advancing
+with each redraw, so the pre-show `window-start' that Emacs restores
+falls behind the anchor and is misclassified as scrollback (issue
+#177).  Recording WINDOW (rather than setting a buffer-level flag)
+forces the next redraw to anchor only that window, leaving peer
+windows the user may have scrolled back undisturbed.
+`ghostel--invalidate' schedules the redraw even when no new PTY
+output is arriving."
+  (when (and (window-live-p window)
+             (eq (window-buffer window) (current-buffer))
+             ghostel--term)
+    (cl-pushnew window ghostel--windows-needing-snap)
+    (ghostel--invalidate)))
 
 (defun ghostel--commit-cropped-size (window)
   "Commit WINDOW's size if the user focused into a cropped ghostel window.
@@ -3371,6 +3402,8 @@ window (not when it has just been deselected)."
   ;; receives WINDOW directly (rather than FRAME as the default binding).
   (add-hook 'window-selection-change-functions
             #'ghostel--commit-cropped-size nil t)
+  (add-hook 'window-buffer-change-functions
+            #'ghostel--reshow-snap nil t)
   (ghostel--suppress-interfering-modes)
   (setq ghostel--scroll-intercept-active t)
   ;; Let C-g reach the keymap instead of triggering keyboard-quit.

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -3818,6 +3818,98 @@ it through mangling."
         (set-window-buffer (selected-window) orig-buf))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-hidden-buffer-snaps-on-reshow ()
+  "Buffer re-shown after output-while-hidden snaps to the viewport (issue #177).
+Dispatches through `window-buffer-change-functions' so the hook
+wiring — not just `ghostel--reshow-snap' in isolation — is exercised."
+  (let ((buf (generate-new-buffer " *ghostel-test-177-snap*"))
+        (other (get-buffer-create "*ghostel-test-177-other*"))
+        (orig-buf (window-buffer (selected-window))))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 10 40 200))
+                 (ghostel--term term)
+                 (ghostel--term-rows 10)
+                 (inhibit-read-only t)
+                 (win (selected-window)))
+            (dotimes (i 30)
+              (ghostel--write-input term (format "pre-%02d\r\n" i)))
+            (ghostel--write-input term "prompt> ")
+            (ghostel--redraw term t)
+            (set-window-buffer win buf)
+            (goto-char (point-max))
+            (set-window-point win (point-max))
+            (set-window-start win (ghostel--viewport-start) t)
+            (setq ghostel--force-next-redraw t)
+            (ghostel--delayed-redraw buf)
+            (let ((pre-hide-ws (window-start win)))
+              ;; Hide; output arrives while hidden so the anchor advances.
+              (set-window-buffer win other)
+              (dotimes (i 30)
+                (ghostel--write-input term (format "hidden-%02d\r\n" i)))
+              (setq ghostel--force-next-redraw t)
+              (ghostel--delayed-redraw buf)
+              ;; Re-show with the stale pre-hide `window-start', then
+              ;; dispatch the hook the way redisplay would.
+              (set-window-buffer win buf)
+              (set-window-start win pre-hide-ws t)
+              (run-hook-with-args 'window-buffer-change-functions win)
+              (setq ghostel--force-next-redraw t)
+              (ghostel--delayed-redraw buf)
+              (should (= (window-start win) (ghostel--viewport-start)))
+              ;; The snap entry was consumed and cleared.
+              (should-not ghostel--windows-needing-snap))))
+      (when (buffer-live-p orig-buf)
+        (set-window-buffer (selected-window) orig-buf))
+      (kill-buffer buf)
+      (when (buffer-live-p other) (kill-buffer other)))))
+
+(ert-deftest ghostel-test-second-window-does-not-disturb-scrollback ()
+  "Opening a second window on a ghostel buffer does not yank peer windows.
+Issue #177 regression guard for the multi-window case: a window
+already scrolled back for reading history must stay put when a new
+window opens on the same buffer."
+  (let ((buf (generate-new-buffer " *ghostel-test-177-multi*"))
+        (orig-config (current-window-configuration))
+        (orig-buf (window-buffer (selected-window))))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 10 40 200))
+                 (ghostel--term term)
+                 (ghostel--term-rows 10)
+                 (inhibit-read-only t)
+                 (win-a (selected-window)))
+            (dotimes (i 30)
+              (ghostel--write-input term (format "pre-%02d\r\n" i)))
+            (ghostel--write-input term "prompt> ")
+            (ghostel--redraw term t)
+            (set-window-buffer win-a buf)
+            (set-window-start win-a (ghostel--viewport-start) t)
+            (setq ghostel--force-next-redraw t)
+            (ghostel--delayed-redraw buf)
+            ;; Scroll win-a into the scrollback.
+            (set-window-start win-a (point-min) t)
+            (setq ghostel--force-next-redraw t)
+            (ghostel--delayed-redraw buf)
+            (let ((scrollback-ws (window-start win-a))
+                  (win-b (split-window win-a)))
+              (set-window-buffer win-b buf)
+              (set-window-start win-b (point-min) t)
+              ;; Simulate the callback redisplay fires for the new window.
+              (run-hook-with-args 'window-buffer-change-functions win-b)
+              (setq ghostel--force-next-redraw t)
+              (ghostel--delayed-redraw buf)
+              ;; win-b snapped; win-a's scrollback is untouched.
+              (should (= (window-start win-b) (ghostel--viewport-start)))
+              (should (= (window-start win-a) scrollback-ws))
+              (should-not ghostel--windows-needing-snap))))
+      (set-window-configuration orig-config)
+      (when (buffer-live-p orig-buf)
+        (set-window-buffer (selected-window) orig-buf))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-redraw-preserves-scroll-during-live-output ()
   "Scrollback view is preserved when live PTY output triggers a redraw.
 Before the fix, any redraw timer firing while the user was reading


### PR DESCRIPTION
## Summary

- Closes #177: a ghostel buffer that receives output while hidden no longer leaves `window-start` stuck on the pre-hide screen when re-shown.
- Fix is per-window: opening a second window on a ghostel buffer (split, `display-buffer`) does not disturb a peer window the user has scrolled back for reading history.

## Root cause

While the buffer has zero windows, `ghostel--delayed-redraw` still advances `ghostel--last-anchor-position` on every redraw. On re-show, the `window-start` Emacs restores now falls behind the anchor and `ghostel--window-anchored-p` misclassifies the window as scrollback.

## Fix

Buffer-locally hook `window-buffer-change-functions` in `ghostel-mode`. When a window starts showing this buffer, `ghostel--reshow-snap`:
1. pushes it onto a per-window `ghostel--windows-needing-snap` list, and
2. calls `ghostel--invalidate` to schedule a redraw (needed because no new PTY output arrives after re-show when the command finished while hidden).

`ghostel--window-anchored-p` treats membership in that list as anchored; `ghostel--delayed-redraw` clears the list after consuming it. Peers that the user scrolled back are classified by the existing anchor/scrollback logic and left alone.

## Test plan

- [x] `make -j4 all` — build + 95 elisp + 171 native + 39 evil tests + lint, all green
- [x] New ERT: `ghostel-test-hidden-buffer-snaps-on-reshow` (dispatches through `window-buffer-change-functions` to exercise the hook wiring)
- [x] New ERT: `ghostel-test-second-window-does-not-disturb-scrollback` (regression guard for the multi-window case)
- [x] Live verification via emacsclient: `sleep 2 && seq 1 80`, switch away, switch back — window snaps to viewport; command output visible