### PR TITLE
Respect display-buffer-alist on first ghostel buffer

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3397,8 +3397,18 @@ prevent redraw flicker."
 
 ;;; Entry point
 
+(defun ghostel--prepare-buffer (buffer &optional identity)
+  "Put BUFFER into `ghostel-mode' and record its terminal identity.
+IDENTITY, if given, is stored as `ghostel--buffer-identity' so the
+buffer can be found again after title-tracking renames it."
+  (with-current-buffer buffer
+    (unless (derived-mode-p 'ghostel-mode)
+      (ghostel-mode)
+      (setq ghostel--managed-buffer-name (buffer-name))
+      (setq ghostel--buffer-identity (or identity (buffer-name))))))
+
 (defun ghostel--init-buffer (buffer &optional identity)
-  "Initialize BUFFER as a ghostel terminal if it isn't one already.
+  "Initialize BUFFER as a ghostel terminal if no terminal handle exists yet.
 Terminal dimensions come from BUFFER's displayed window when one
 exists, otherwise from the selected window.  The terminal resizes
 itself via `window-size-change-functions' once the buffer is
@@ -3406,10 +3416,8 @@ displayed, so a mismatch at creation time self-corrects.
 IDENTITY, if given, is stored as `ghostel--buffer-identity' so the
 buffer can be found again after title-tracking renames it."
   (with-current-buffer buffer
-    (unless (derived-mode-p 'ghostel-mode)
-      (ghostel-mode)
-      (setq ghostel--managed-buffer-name (buffer-name))
-      (setq ghostel--buffer-identity (or identity (buffer-name)))
+    (unless ghostel--term
+      (ghostel--prepare-buffer buffer identity)
       (let* ((w (or (get-buffer-window buffer t) (selected-window)))
              (height (if (window-live-p w) (window-body-height w) 24))
              (width  (if (window-live-p w) (window-max-chars-per-line w) 80)))
@@ -3448,6 +3456,8 @@ The name of the buffer is determined by the value of `ghostel-buffer-name'."
                      (generate-new-buffer ghostel-buffer-name)
                    (or (ghostel--find-buffer-by-identity identity)
                        (get-buffer-create identity)))))
+    (unless (with-current-buffer buffer (derived-mode-p 'ghostel-mode))
+      (ghostel--prepare-buffer buffer identity))
     (pop-to-buffer buffer (append display-buffer--same-window-action
                                   '((category . comint))))
     (ghostel--init-buffer buffer identity)))
@@ -3471,9 +3481,7 @@ Signals `user-error' if BUFFER already has a live ghostel process."
                 (buffer-name buffer)))
   (let ((window (or (get-buffer-window buffer t) (selected-window))))
     (with-current-buffer buffer
-      (unless (derived-mode-p 'ghostel-mode)
-        (ghostel-mode))
-      (setq ghostel--managed-buffer-name (buffer-name))
+      (ghostel--prepare-buffer buffer nil)
       (let* ((height (max 1 (window-body-height window)))
              (width (max 1 (window-max-chars-per-line window)))
              (remote-p (file-remote-p default-directory)))

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -5217,6 +5217,40 @@ hand nil to the native module."
                          (buffer-local-value 'ghostel--buffer-identity buf))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-first-creation-respects-display-buffer-alist ()
+  "First `ghostel' creation exposes `ghostel-mode' to display rules."
+  (let ((saved (current-window-configuration))
+        (origin (generate-new-buffer " *ghostel-test-origin*"))
+        (ghostel-buffer-name "*ghostel-test-display*"))
+    (unwind-protect
+        (progn
+          (delete-other-windows)
+          (switch-to-buffer origin)
+          (let ((display-buffer-alist
+                 `((,(lambda (buf _action)
+                       (with-current-buffer buf
+                         (derived-mode-p 'ghostel-mode)))
+                    (display-buffer-pop-up-window)))))
+            (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                      ((symbol-function 'ghostel--new)
+                       (lambda (&rest _) 'fake-term))
+                      ((symbol-function 'ghostel--apply-palette) #'ignore)
+                      ((symbol-function 'ghostel--start-process) #'ignore))
+              (ghostel)))
+          (let ((created (get-buffer ghostel-buffer-name)))
+            (should (buffer-live-p created))
+            (should (with-current-buffer created
+                      (derived-mode-p 'ghostel-mode)))
+            (should (get-buffer-window origin))
+            (should (get-buffer-window created))
+            (should (not (eq (get-buffer-window origin)
+                             (get-buffer-window created))))))
+      (when (get-buffer ghostel-buffer-name)
+        (kill-buffer ghostel-buffer-name))
+      (when (buffer-live-p origin)
+        (kill-buffer origin))
+      (set-window-configuration saved))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: ghostel-copy-all copies to kill ring
 ;; -----------------------------------------------------------------------
@@ -7239,6 +7273,7 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-reuses-identity-match-after-rename
     ghostel-test-project-reuses-identity-match-after-rename
     ghostel-test-init-buffer-sets-identity
+    ghostel-test-first-creation-respects-display-buffer-alist
     ghostel-test-copy-all
     ghostel-test-copy-mode-buffer-navigation
     ghostel-test-compile-module-invokes-zig-build


### PR DESCRIPTION
## Summary

- Adds `ghostel--prepare-buffer` to activate `ghostel-mode` (and record buffer identity) before `pop-to-buffer`, so `display-buffer-alist` rules using `(derived-mode . ghostel-mode)` match on the first invocation
- The early mode setup is skipped when the buffer already has `ghostel-mode` active (switching to an existing terminal), keeping it a no-op for that path
- Refactors `ghostel-exec` to use `ghostel--prepare-buffer` instead of the inline mode-setting it previously duplicated

Fixes #179 