### PR TITLE
Return buffer from `ghostel` and `ghostel-project`

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3477,7 +3477,8 @@ buffer creation time — see `ghostel--buffer-identity'."
 With a non-numeric prefix arg, create a new buffer.
 With a numeric prefix ARG, switch to the buffer with that number or
 create it if it doesn't exist yet.
-The name of the buffer is determined by the value of `ghostel-buffer-name'."
+The name of the buffer is determined by the value of `ghostel-buffer-name'.
+Returns the buffer."
   (interactive "P")
   (ghostel--load-module t)
   (let* ((fresh (and arg (not (numberp arg))))
@@ -3493,7 +3494,8 @@ The name of the buffer is determined by the value of `ghostel-buffer-name'."
       (ghostel--prepare-buffer buffer identity))
     (pop-to-buffer buffer (append display-buffer--same-window-action
                                   '((category . comint))))
-    (ghostel--init-buffer buffer identity)))
+    (ghostel--init-buffer buffer identity)
+    buffer))
 
 (defun ghostel-exec (buffer program &optional args)
   "Run PROGRAM with ARGS as a ghostel terminal in BUFFER.
@@ -3534,7 +3536,8 @@ If a buffer already exists for this project, switch to it.
 Otherwise create a new Ghostel buffer.  ARG is passed through to
 `ghostel' and accepts the same universal argument conventions.
 To add this to `project-switch-commands':
-  (add-to-list \\='project-switch-commands \\='(ghostel-project \"Ghostel\") t)"
+  (add-to-list \\='project-switch-commands \\='(ghostel-project \"Ghostel\") t)
+Returns the buffer."
   (interactive "P")
   (let ((default-directory (project-root (project-current t)))
         (ghostel-buffer-name (project-prefixed-buffer-name

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -5309,6 +5309,43 @@ hand nil to the native module."
                          (buffer-local-value 'ghostel--buffer-identity buf))))
       (kill-buffer buf))))
 
+;; -----------------------------------------------------------------------
+;; Test: ghostel and ghostel-project return the buffer
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-returns-buffer ()
+  "`ghostel' returns the (live) Ghostel buffer."
+  (let* ((ghostel-buffer-name "*ghostel-return-test*")
+         result)
+    (cl-letf (((symbol-function 'ghostel--load-module) (lambda (&rest _) nil))
+              ((symbol-function 'ghostel--init-buffer) (lambda (&rest _) nil))
+              ((symbol-function 'pop-to-buffer) (lambda (&rest _) nil)))
+      (setq result (ghostel)))
+    (should (bufferp result))
+    (should (buffer-live-p result))
+    (should (string-match-p "ghostel-return-test" (buffer-name result)))
+    (kill-buffer result)))
+
+(ert-deftest ghostel-test-project-returns-buffer ()
+  "`ghostel-project' returns the (live) Ghostel buffer."
+  (require 'project)
+  (let* ((ghostel-buffer-name "*ghostel*")
+         result)
+    (cl-letf (((symbol-function 'project-current)
+               (lambda (&optional _) '(transient . "/tmp/retproj/")))
+              ((symbol-function 'project-root)
+               (lambda (proj) (cdr proj)))
+              ((symbol-function 'project-prefixed-buffer-name)
+               (lambda (name) (format "*retproj-%s*" name)))
+              ((symbol-function 'ghostel--load-module) (lambda (&rest _) nil))
+              ((symbol-function 'ghostel--init-buffer) (lambda (&rest _) nil))
+              ((symbol-function 'pop-to-buffer) (lambda (&rest _) nil)))
+      (setq result (ghostel-project)))
+    (should (bufferp result))
+    (should (buffer-live-p result))
+    (should (string-match-p "retproj" (buffer-name result)))
+    (kill-buffer result)))
+
 (ert-deftest ghostel-test-first-creation-respects-display-buffer-alist ()
   "First `ghostel' creation exposes `ghostel-mode' to display rules."
   (let ((saved (current-window-configuration))
@@ -7366,6 +7403,8 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-project-reuses-identity-match-after-rename
     ghostel-test-init-buffer-sets-identity
     ghostel-test-first-creation-respects-display-buffer-alist
+    ghostel-test-returns-buffer
+    ghostel-test-project-returns-buffer
     ghostel-test-copy-all
     ghostel-test-copy-mode-buffer-navigation
     ghostel-test-compile-module-invokes-zig-build


### PR DESCRIPTION
Both `ghostel` and `ghostel-project` now explicitly return the (live) buffer they create or switch to.  This allows callers to use the buffer programmatically without relying on `pop-to-buffer` side-effects.

### Changes

- **`ghostel`** — adds `buffer` as the final expression of the function body, so the buffer is returned instead of whatever `ghostel--init-buffer` falls through to
- **`ghostel-project`** — inherits the return value automatically since it calls `ghostel` as its final form
- **Docstrings** — both functions now document the return value; placed at the end of the docstring per Emacs convention
- **Tests** — two new tests verify the return value is a live buffer with the expected name

Closes #185
