### PR TITLE
Add ghostel-paste-string public API for bracketed paste

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1388,6 +1388,18 @@ Signals a `user-error' when called outside a ghostel buffer."
     (user-error "Must be called from a ghostel buffer"))
   (ghostel--send-encoded key-name (or mods "")))
 
+(defun ghostel-paste-string (string)
+  "Send STRING to the terminal using bracketed paste.
+Signals a `user-error' when called outside a ghostel buffer.
+
+Unlike `ghostel-send-string', this wraps STRING in bracketed paste
+markers (ESC [200~ / ESC [201~) when the terminal supports bracketed
+paste mode (mode 2004), so the shell treats the input as an atomic
+paste rather than character-by-character typed keystrokes."
+  (unless (derived-mode-p 'ghostel-mode)
+    (user-error "Must be called from a ghostel buffer"))
+  (ghostel--paste-text string))
+
 
 ;;; Terminal control commands (C-c prefix)
 

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -6477,6 +6477,21 @@ External packages may still call the old internal name."
         (ghostel--send-key "payload"))
       (should (equal sent "payload")))))
 
+(ert-deftest ghostel-test-paste-string-routes-to-paste-text ()
+  "`ghostel-paste-string' forwards its argument to `ghostel--paste-text'."
+  (with-temp-buffer
+    (ghostel-mode)
+    (let (received)
+      (cl-letf (((symbol-function 'ghostel--paste-text)
+                 (lambda (str) (setq received str))))
+        (ghostel-paste-string "hello world")
+        (should (equal received "hello world"))))))
+
+(ert-deftest ghostel-test-paste-string-errors-outside-ghostel-buffer ()
+  "`ghostel-paste-string' signals `user-error' when not in a ghostel buffer."
+  (with-temp-buffer
+    (should-error (ghostel-paste-string "x") :type 'user-error)))
+
 ;; -----------------------------------------------------------------------
 ;; Test: TRAMP integration
 ;; -----------------------------------------------------------------------
@@ -7518,6 +7533,8 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-send-key-routes-to-send-encoded
     ghostel-test-send-key-nil-mods-becomes-empty-string
     ghostel-test-send-key-errors-outside-ghostel-buffer
+    ghostel-test-paste-string-routes-to-paste-text
+    ghostel-test-paste-string-errors-outside-ghostel-buffer
     ghostel-test-local-host-p
     ghostel-test-update-directory-remote
     ghostel-test-get-shell-local


### PR DESCRIPTION
Add a public function `ghostel-paste-string` that sends arbitrary text to the terminal using bracketed paste markers (ESC [200~ / ESC [201~) when the terminal supports mode 2004.

This allows third-party code to inject strings into the terminal in a way that the shell treats as an atomic paste rather than character-by-character typed keystrokes.

Closes #187