### PR TITLE
Defer plain-text link detection after redraw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.18.1] — 2026-04-25
+
+### Added
+- `ghostel-plain-link-detection-delay` user option (default 0.1s)
+  controls how long ghostel waits after a redraw before scanning for
+  plain-text URLs and file paths.  Set to 0 to restore the previous
+  synchronous behavior
+  ([671d3ee](https://github.com/dakra/ghostel/commit/671d3ee)).
+
+### Changed
+- Plain-text link detection is now deferred off the redraw path and
+  coalesced via a single timer, so bursts of redraws collapse into one
+  scan instead of running detection on every dirty redraw.  Native
+  OSC-8 hyperlink spans continue to be handled inside the renderer.
+  The process sentinel cancels the pending detection timer so it
+  cannot fire against a buffer that is about to be killed
+  ([671d3ee](https://github.com/dakra/ghostel/commit/671d3ee)).
+- Scrollback rotation detection now snapshots the first scrollback
+  row directly (`std.mem.eql` over all `term.cols` cells) instead of
+  hashing the first 16 cells with FNV-1a.  Removes a small collision
+  probability and the arbitrary 16-cell sample that could miss
+  rotation when two rows shared the same opening cells; the
+  cached-read optimisation that skips the end-of-redraw round trip is
+  preserved
+  ([4b1a0ba](https://github.com/dakra/ghostel/commit/4b1a0ba)).
+
 ## [0.18.0] — 2026-04-24
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -892,24 +892,25 @@ terminal emulators: [vterm](https://github.com/akermu/emacs-libvterm) (native
 module), [eat](https://codeberg.org/akib/emacs-eat) (pure Elisp), and Emacs
 built-in `term`.
 
-The primary benchmark streams 5 MB of data through a real process pipe,
+The primary benchmark streams 1 MB of data through a real process pipe,
 matching actual terminal usage.  All backends are configured with ~1,000
 lines of scrollback (matching vterm's default).  Results on Apple M4 Max,
 Emacs 31.0.50:
 
 | Backend              | Plain ASCII | URL-heavy |
 |----------------------|------------:|----------:|
-| ghostel              |    87 MB/s  |  64 MB/s  |
-| ghostel (no detect)  |    86 MB/s  |  86 MB/s  |
-| vterm                |    35 MB/s  |  27 MB/s  |
-| eat                  |   4.7 MB/s  | 3.5 MB/s  |
-| term                 |   5.7 MB/s  | 4.7 MB/s  |
+| ghostel              |    81 MB/s  |  77 MB/s  |
+| ghostel (no detect)  |    78 MB/s  |  75 MB/s  |
+| vterm                |    34 MB/s  |  28 MB/s  |
+| eat                  |   4.9 MB/s  | 3.8 MB/s  |
+| term                 |   5.8 MB/s  | 4.9 MB/s  |
 
 Ghostel scans terminal output for URLs and file paths, making them clickable.
-The "no detect" row shows throughput with this detection disabled
-(`ghostel-enable-url-detection` / `ghostel-enable-file-detection`).  The other
-emulators do not have this feature, so their numbers are comparable to the "no
-detect" row.
+Detection runs on a coalesced timer outside the redraw hot path, so enabling
+it costs essentially nothing on the streaming throughput — the "no detect"
+row shows what you get with `ghostel-enable-url-detection` and
+`ghostel-enable-file-detection` set to nil.  The other emulators do not have
+this feature.
 
 ### Typing latency
 
@@ -970,7 +971,7 @@ powering Neovim's built-in terminal.
 | Drag-and-drop                 | Yes       | No      |
 | Auto module download          | Yes       | No      |
 | Scrollback default            | ~5,000    | 1,000   |
-| PTY throughput (plain ASCII)  | 70 MB/s   | 34 MB/s |
+| PTY throughput (plain ASCII)  | 81 MB/s   | 34 MB/s |
 | Default redraw rate           | ~30 fps   | ~10 fps |
 
 ### Key differences
@@ -997,13 +998,14 @@ bash, zsh, and fish — no shell RC changes needed.  vterm requires manually
 sourcing scripts in your shell configuration.  Both support Elisp eval from
 the shell and TRAMP-aware remote directory tracking.
 
-**Performance.**  In PTY throughput benchmarks (5 MB streamed through `cat`,
+**Performance.**  In PTY throughput benchmarks (1 MB streamed through `cat`,
 both backends configured with ~1,000 lines of scrollback), ghostel is
-roughly 2x faster than vterm on plain ASCII data (70 vs 34 MB/s).  On
-URL-heavy output ghostel pulls further ahead of vterm (56 vs 27 MB/s);
-with link detection disabled ghostel reaches 70 MB/s regardless of input.
-See the [Performance](#performance) section above for full numbers and how
-to run the benchmark suite yourself.
+roughly 2.4x faster than vterm on plain ASCII data (81 vs 34 MB/s).  On
+URL-heavy output ghostel pulls further ahead of vterm (77 vs 28 MB/s);
+plain-text link detection is deferred to a coalesced post-redraw timer,
+so enabling it has essentially no cost on the streaming path.  See the
+[Performance](#performance) section above for full numbers and how to run
+the benchmark suite yourself.
 
 **Installation.**  Ghostel can automatically download a pre-built native
 module or compile from source with [Zig](https://ziglang.org/).  vterm uses

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .ghostel,
-    .version = "0.18.0",
+    .version = "0.18.1",
     .paths = .{""},
     .fingerprint = 0x5a44bdd1198a0f4b,
     .dependencies = .{

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -4,7 +4,7 @@
 
 ;; Author: Daniel Kraus <daniel@kraus.my>
 ;; URL: https://github.com/dakra/ghostel
-;; Version: 0.18.0
+;; Version: 0.18.1
 ;; Package-Requires: ((emacs "28.1") (evil "1.0") (ghostel "0.8.0"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4,7 +4,7 @@
 
 ;; Author: Daniel Kraus <daniel@kraus.my>
 ;; URL: https://github.com/dakra/ghostel
-;; Version: 0.18.0
+;; Version: 0.18.1
 ;; Keywords: terminals
 ;; Package-Requires: ((emacs "28.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
@@ -364,6 +364,14 @@ candidate would require a remote `file-exists-p' round-trip per
 redraw."
   :type 'boolean)
 
+(defcustom ghostel-plain-link-detection-delay 0.1
+  "Delay in seconds before redraw-triggered plain-text link detection runs.
+Redraws queue URL/file detection through
+`ghostel--schedule-link-detection' so multiple updates can be
+coalesced into a single scan.  Set to 0 to scan immediately after each
+redraw.  Native OSC-8 hyperlinks remain applied during redraw."
+  :type 'number)
+
 (defcustom ghostel-file-detection-path-regex
   "[[:alnum:]_.-]*/[^] \t\n\r:\"<>(){}[`']+"
   "Regex matching the PATH portion of a file:line[:col] reference.
@@ -546,7 +554,7 @@ before sending the input."
 Customize this when downloading pre-built modules from a fork or mirror."
   :type 'string)
 
-(defconst ghostel--minimum-module-version "0.18.0"
+(defconst ghostel--minimum-module-version "0.18.1"
   "Minimum native module version required by this Elisp version.
 Bump this only when the Elisp code requires a newer native module
 \(e.g. new Zig-exported function or changed calling convention).")
@@ -850,6 +858,15 @@ Updated whenever the terminal is created or resized.")
 
 (defvar-local ghostel--redraw-timer nil
   "Timer for delayed redraw.")
+
+(defvar-local ghostel--plain-link-detection-timer nil
+  "Timer for delayed redraw-triggered plain-text link detection.")
+
+(defvar-local ghostel--plain-link-detection-begin nil
+  "Queued start bound for redraw-triggered plain-text link detection.")
+
+(defvar-local ghostel--plain-link-detection-end nil
+  "Queued end bound for redraw-triggered plain-text link detection.")
 
 (defvar-local ghostel--force-next-redraw nil
   "When non-nil, redraw regardless of synchronized output mode.")
@@ -1919,9 +1936,12 @@ Wraps to `point-max' when no link is found before point."
 BEGIN and END default to `point-min' and `point-max' respectively.
 Skips regions that already have a `help-echo' property (e.g. from OSC 8).
 Bounding the scan keeps streaming output from re-scanning the entire
-materialized scrollback on every redraw."
+materialized scrollback on every redraw.
+Binds `inhibit-read-only' so the scan can attach text properties even
+when called from the deferred-detection timer outside the redraw scope."
   (let ((begin (or begin (point-min)))
-        (end (or end (point-max))))
+        (end (or end (point-max)))
+        (inhibit-read-only t))
     (save-excursion
       ;; Pass 1: http(s) URLs
       (when ghostel-enable-url-detection
@@ -1972,6 +1992,37 @@ materialized scrollback on every redraw."
                                          (concat "fileref:" abs-path)))
                     (put-text-property beg mend 'mouse-face 'highlight)
                     (put-text-property beg mend 'keymap ghostel-link-map)))))))))))
+
+(defun ghostel--run-queued-plain-link-detection (buffer)
+  "Run any queued redraw-triggered plain-text link detection for BUFFER."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let ((begin ghostel--plain-link-detection-begin)
+            (end ghostel--plain-link-detection-end))
+        (setq ghostel--plain-link-detection-timer nil
+              ghostel--plain-link-detection-begin nil
+              ghostel--plain-link-detection-end nil)
+        (when (and begin end (<= begin end))
+          (ghostel--detect-urls begin end))))))
+
+(defun ghostel--queue-plain-link-detection (begin end)
+  "Coalesce redraw-triggered plain-text link detection for BEGIN..END."
+  (when (and begin end (<= begin end))
+    (setq ghostel--plain-link-detection-begin
+          (if ghostel--plain-link-detection-begin
+              (min ghostel--plain-link-detection-begin begin)
+            begin)
+          ghostel--plain-link-detection-end
+          (if ghostel--plain-link-detection-end
+              (max ghostel--plain-link-detection-end end)
+            end))
+    (unless ghostel--plain-link-detection-timer
+      (if (<= ghostel-plain-link-detection-delay 0)
+          (ghostel--run-queued-plain-link-detection (current-buffer))
+        (setq ghostel--plain-link-detection-timer
+              (run-with-timer ghostel-plain-link-detection-delay nil
+                              #'ghostel--run-queued-plain-link-detection
+                              (current-buffer)))))))
 
 
 (defun ghostel--compensate-wide-chars ()
@@ -2394,7 +2445,8 @@ Call this after changing the Emacs theme so terminals match."
         (ghostel--apply-palette ghostel--term)
         (when (not ghostel--copy-mode-active)
           (let ((inhibit-read-only t))
-            (ghostel--redraw ghostel--term)))))))
+            (ghostel--redraw ghostel--term)
+            (ghostel--schedule-link-detection)))))))
 
 (defun ghostel--on-theme-change (&rest _args)
   "Hook function to sync terminal colors after theme change."
@@ -2508,6 +2560,11 @@ PROCESS is the shell process, EVENT describes the state change."
         (when ghostel--input-timer
           (cancel-timer ghostel--input-timer)
           (setq ghostel--input-timer nil))
+        (when ghostel--plain-link-detection-timer
+          (cancel-timer ghostel--plain-link-detection-timer)
+          (setq ghostel--plain-link-detection-timer nil
+                ghostel--plain-link-detection-begin nil
+                ghostel--plain-link-detection-end nil))
         (run-hook-with-args 'ghostel-exit-functions buf event)
         (if ghostel-kill-buffer-on-exit
             (kill-buffer buf)
@@ -3086,6 +3143,17 @@ position COL columns into the first matched line."
         (forward-line (- (1- tr)))
         (line-beginning-position)))))
 
+(defun ghostel--schedule-link-detection (&optional begin end)
+  "Schedule deferred plain-text link detection over BEGIN..END.
+BEGIN defaults to the current viewport start (or `point-min' if the
+buffer has no viewport yet).  END defaults to `point-max'.  Covers
+plain-text URL and file:line detection; native OSC-8 hyperlink spans
+remain handled inside the renderer."
+  (when (or ghostel-enable-url-detection ghostel-enable-file-detection)
+    (ghostel--queue-plain-link-detection
+     (or begin (ghostel--viewport-start) (point-min))
+     (or end (point-max)))))
+
 (defsubst ghostel--window-anchored-p (win)
   "Non-nil if WIN is auto-following the viewport.
 A window counts as anchored when `ghostel--snap-requested' is set
@@ -3251,7 +3319,8 @@ following the viewport."
                   (ghostel--restore-scrollback-window
                    win (assq win non-anchored-states))))
               (when vs
-                (setq ghostel--last-anchor-position vs))))
+                (setq ghostel--last-anchor-position vs))
+              (ghostel--schedule-link-detection vs (point-max))))
           (setq ghostel--snap-requested nil)
           (setq ghostel--windows-needing-snap nil))))))
 
@@ -3263,7 +3332,8 @@ following the viewport."
     (let ((inhibit-read-only t))
       (ghostel--redraw ghostel--term ghostel-full-redraw))
     (when ghostel--has-wide-chars
-      (ghostel--compensate-wide-chars))))
+      (ghostel--compensate-wide-chars))
+    (ghostel--schedule-link-detection)))
 
 
 ;;; Window resize

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -319,7 +319,6 @@ pub const Sym = struct {
     // Ghostel symbols
     @"ghostel-link-map": Value,
     @"ghostel--set-buffer-face": Value,
-    @"ghostel--detect-urls": Value,
     @"ghostel--has-wide-chars": Value,
     @"ghostel--set-cursor-style": Value,
     @"ghostel--update-directory": Value,

--- a/src/module.zig
+++ b/src/module.zig
@@ -13,7 +13,7 @@ const input = @import("input.zig");
 const c = emacs.c;
 
 /// Module version — keep in sync with ghostel.el and build.zig.zon.
-const version = "0.18.0";
+const version = "0.18.1";
 
 // ---------------------------------------------------------------------------
 // Module entry point

--- a/src/render.zig
+++ b/src/render.zig
@@ -1270,16 +1270,7 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
         }
     }
 
-    // Auto-detect plain-text URLs — only on the viewport region. Scrollback
-    // rows are skipped to keep streaming O(viewport) per redraw instead of
-    // O(buffer); rows that have already scrolled past stay as plain text
-    // and remain searchable, just not clickable.
     if (dirty != gt.DIRTY_FALSE) {
-        _ = env.call2(
-            emacs.sym.@"ghostel--detect-urls",
-            env.makeInteger(viewport_start_int),
-            env.pointMax(),
-        );
         if (has_wide_chars) {
             _ = env.call2(env.intern("set"), emacs.sym.@"ghostel--has-wide-chars", env.t());
         }

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -310,22 +310,29 @@ are retained — only unwritten padding cells are trimmed."
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-scrollback-preserves-url-properties ()
-  "Verify URL text properties survive scrollback promotion.
+  "Verify delayed plain-link properties survive scrollback promotion.
 When libghostty pushes a row into scrollback, the redraw promotes the
 existing buffer text instead of fetching a fresh copy from libghostty,
-so any text properties the row earned while it was the viewport (URL
-detection, ghostel-prompt) stay attached."
+so any text properties the row earned while it was the viewport stay
+attached."
   (let ((buf (generate-new-buffer " *ghostel-test-sb-url*")))
     (unwind-protect
         (with-current-buffer buf
+          (ghostel-mode)
           (let* ((term (ghostel--new 5 80 1000))
+                 (ghostel--term term)
+                 (ghostel--term-rows 5)
+                 (ghostel-plain-link-detection-delay 0)
                  (inhibit-read-only t)
                  (ghostel-enable-url-detection t)
                  (ghostel-enable-file-detection nil))
             ;; Write a row with a URL while it's in the viewport.
             (ghostel--write-input term "see https://example.com here\r\n")
-            (ghostel--redraw term t)
-            ;; Sanity: detect-urls applied a help-echo while the row is visible.
+            ;; Run the supported redraw path; zero delay keeps the deferred
+            ;; post-processing deterministic while still exercising it.
+            (ghostel--delayed-redraw buf)
+            ;; Sanity: delayed plain-link detection applied a help-echo while
+            ;; the row is visible.
             (goto-char (point-min))
             (let ((url-pos (search-forward "https://example.com" nil t)))
               (should url-pos)
@@ -333,7 +340,7 @@ detection, ghostel-prompt) stay attached."
                              (get-text-property (- url-pos 19) 'help-echo))))
             ;; Now scroll the URL row off the active screen.
             (dotimes (_ 6) (ghostel--write-input term "filler\r\n"))
-            (ghostel--redraw term t)
+            (ghostel--delayed-redraw buf)
             ;; The URL row now lives in the scrollback region of the buffer.
             (goto-char (point-min))
             (let ((url-pos (search-forward "https://example.com" nil t)))
@@ -2224,6 +2231,177 @@ first real focus event."
           (ghostel--open-link (format "fileref:%s" test-file)))
         (should (equal test-file opened))
         (should (null moved))))))                    ; no line → no forward-line
+
+(ert-deftest ghostel-test-delayed-redraw-defers-plain-link-detection ()
+  "Redraw-triggered plain-text link detection should run after redraw."
+  (let ((buf (generate-new-buffer " *ghostel-test-delayed-link*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term t)
+                (ghostel-enable-url-detection t)
+                (ghostel-enable-file-detection nil)
+                (scheduled-count 0)
+                timer-delay timer-repeat timer-fn timer-args)
+            (cl-letf (((symbol-function 'run-with-timer)
+                       (lambda (delay repeat fn &rest args)
+                         (setq scheduled-count (1+ scheduled-count)
+                               timer-delay delay
+                               timer-repeat repeat
+                               timer-fn fn
+                               timer-args args)
+                         'ghostel-test-link-timer))
+                      ((symbol-function 'ghostel--flush-pending-output) #'ignore)
+                      ((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--correct-mangled-scroll-positions)
+                       #'ignore)
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--viewport-start)
+                       (lambda () nil))
+                      ((symbol-function 'get-buffer-window-list)
+                       (lambda (&rest _) nil)))
+              (let ((inhibit-read-only t))
+                (insert "see https://example.com here\n"))
+              (ghostel--delayed-redraw buf)
+              (goto-char (point-min))
+              (let* ((url "https://example.com")
+                     (url-end (search-forward url nil t))
+                     (url-beg (- url-end (length url))))
+                (should url-end)
+                (should (null (get-text-property url-beg 'help-echo)))
+                (should (= scheduled-count 1))
+                (should (numberp timer-delay))
+                (should (> timer-delay 0))
+                (should (null timer-repeat))
+                (should timer-fn)
+                (apply timer-fn timer-args)
+                (should (equal url
+                               (get-text-property url-beg 'help-echo)))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-delayed-redraw-coalesces-plain-link-detection ()
+  "Multiple redraws before the timer fires should share one detection pass."
+  (let ((buf (generate-new-buffer " *ghostel-test-coalesced-link*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term t)
+                (ghostel-enable-url-detection t)
+                (ghostel-enable-file-detection nil)
+                (scheduled-count 0)
+                timer-fn timer-args)
+            (cl-letf (((symbol-function 'run-with-timer)
+                       (lambda (_delay repeat fn &rest args)
+                         (setq scheduled-count (1+ scheduled-count)
+                               timer-fn fn
+                               timer-args args)
+                         (should (null repeat))
+                         'ghostel-test-link-timer))
+                      ((symbol-function 'ghostel--flush-pending-output) #'ignore)
+                      ((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--correct-mangled-scroll-positions)
+                       #'ignore)
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--viewport-start)
+                       (lambda () nil))
+                      ((symbol-function 'get-buffer-window-list)
+                       (lambda (&rest _) nil)))
+              (let ((inhibit-read-only t))
+                (insert "first https://first.example\n"))
+              (ghostel--delayed-redraw buf)
+              (let ((inhibit-read-only t))
+                (goto-char (point-max))
+                (insert "second https://second.example\n"))
+              (ghostel--delayed-redraw buf)
+              (goto-char (point-min))
+              (let* ((first-url "https://first.example")
+                     (first-end (search-forward first-url nil t))
+                     (first-beg (- first-end (length first-url)))
+                     (second-url "https://second.example")
+                     (second-end (search-forward second-url nil t))
+                     (second-beg (- second-end (length second-url))))
+                (should first-end)
+                (should second-end)
+                (should (null (get-text-property first-beg 'help-echo)))
+                (should (null (get-text-property second-beg 'help-echo)))
+                (should (= scheduled-count 1))
+                (should timer-fn)
+                (apply timer-fn timer-args)
+                (should (equal first-url
+                               (get-text-property first-beg 'help-echo)))
+                (should (equal second-url
+                               (get-text-property second-beg 'help-echo)))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-detect-urls-allows-read-only-buffers ()
+  "Plain-text link detection should still work in read-only buffers."
+  (let* ((root (ghostel--resource-root))
+         (test-file (file-relative-name
+                     (expand-file-name "lisp/ghostel.el" root)
+                     root)))
+    (with-temp-buffer
+      (let ((default-directory root))
+        (insert (format "see %s:1 for details" test-file))
+        (setq buffer-read-only t)
+        (let ((ghostel-enable-url-detection nil)
+              (ghostel-enable-file-detection t))
+          (should (eq 'ok
+                      (ignore-errors
+                        (ghostel--detect-urls)
+                        'ok)))
+          (should (string-prefix-p
+                   "fileref:"
+                   (get-text-property 5 'help-echo))))))))
+
+(ert-deftest ghostel-test-zero-delay-runs-plain-link-detection-synchronously ()
+  "With delay set to 0, plain-link detection runs without scheduling a timer."
+  (let ((buf (generate-new-buffer " *ghostel-test-zero-delay-link*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let ((ghostel-enable-url-detection t)
+                (ghostel-enable-file-detection nil)
+                (ghostel-plain-link-detection-delay 0)
+                (timer-scheduled nil)
+                (inhibit-read-only t))
+            (cl-letf (((symbol-function 'run-with-timer)
+                       (lambda (&rest _)
+                         (setq timer-scheduled t)
+                         'ghostel-test-zero-delay-timer)))
+              (insert "see https://example.com here\n")
+              (ghostel--queue-plain-link-detection (point-min) (point-max))
+              (should-not timer-scheduled)
+              (should-not ghostel--plain-link-detection-timer)
+              (goto-char (point-min))
+              (let* ((url "https://example.com")
+                     (url-end (search-forward url nil t))
+                     (url-beg (- url-end (length url))))
+                (should url-end)
+                (should (equal url
+                               (get-text-property url-beg 'help-echo)))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-sentinel-cancels-plain-link-detection-timer ()
+  "Process exit should cancel queued plain-text link detection timers."
+  (let ((buf (generate-new-buffer " *ghostel-test-sentinel-links*")))
+    (unwind-protect
+        (let ((proc (make-pipe-process :name "ghostel-test-sentinel-links"
+                                       :buffer buf
+                                       :noquery t)))
+          (with-current-buffer buf
+            (setq ghostel-kill-buffer-on-exit nil
+                  ghostel--plain-link-detection-timer
+                  (run-with-timer 60 nil #'ignore))
+            (ghostel--sentinel proc "finished\n")
+            (should-not ghostel--plain-link-detection-timer))
+          (when (process-live-p proc)
+            (delete-process proc)))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf
+          (when ghostel--plain-link-detection-timer
+            (cancel-timer ghostel--plain-link-detection-timer)))
+        (kill-buffer buf)))))
 
 (ert-deftest ghostel-test-hyperlink-navigation ()
   "Test `ghostel-next-hyperlink' / `ghostel-previous-hyperlink' search."
@@ -5017,34 +5195,44 @@ rendered by `ghostel--delayed-redraw'.  This is the exact real-world path."
 ;; -----------------------------------------------------------------------
 
 (ert-deftest ghostel-test-sync-theme ()
-  "Test that ghostel-sync-theme applies palette and redraws ghostel buffers."
+  "Test that ghostel-sync-theme reapplies palette and redraw post-processing."
   (let ((palette-calls nil)
-        (redraw-calls nil))
+        (redraw-calls nil)
+        (post-process-calls 0))
     (cl-letf (((symbol-function 'ghostel--apply-palette)
                (lambda (term) (push term palette-calls)))
               ((symbol-function 'ghostel--redraw)
-               (lambda (term) (push term redraw-calls))))
+               (lambda (term) (push term redraw-calls)))
+              ((symbol-function 'ghostel--schedule-link-detection)
+               (lambda (&rest _args)
+                 (setq post-process-calls (1+ post-process-calls)))))
       (let ((buf (generate-new-buffer " *ghostel-test-theme*"))
             (other (generate-new-buffer " *ghostel-test-other*")))
         (unwind-protect
-            (progn
-              ;; Set up a ghostel-mode buffer with a fake terminal
+            (cl-letf (((symbol-function 'buffer-list)
+                       (lambda () (list buf other))))
+              ;; Set up a ghostel-mode buffer with a fake terminal.
               (with-current-buffer buf
                 (ghostel-mode)
                 (setq ghostel--term 'fake-term)
-                (setq ghostel--copy-mode-active nil))
-              ;; other buffer is not ghostel-mode
+                (setq ghostel--copy-mode-active nil)
+                (setq ghostel-enable-url-detection t))
+              ;; `other' is not a ghostel buffer and should be ignored.
               (ghostel-sync-theme)
-              (should (memq 'fake-term palette-calls))    ; palette applied to ghostel buffer
-              (should (memq 'fake-term redraw-calls))     ; redraw called for ghostel buffer
+              (should (memq 'fake-term palette-calls))
+              (should (memq 'fake-term redraw-calls))
+              (should (= post-process-calls 1))
 
-              ;; Verify copy-mode skips redraw
-              (setq palette-calls nil redraw-calls nil)
+              ;; Verify copy-mode skips redraw.
+              (setq palette-calls nil
+                    redraw-calls nil
+                    post-process-calls 0)
               (with-current-buffer buf
                 (setq ghostel--copy-mode-active t))
               (ghostel-sync-theme)
-              (should (memq 'fake-term palette-calls))    ; palette still applied in copy mode
-              (should-not (memq 'fake-term redraw-calls))) ; redraw skipped in copy mode
+              (should (memq 'fake-term palette-calls))
+              (should-not (memq 'fake-term redraw-calls))
+              (should (= post-process-calls 0)))
           (kill-buffer buf)
           (kill-buffer other))))))
 
@@ -7604,6 +7792,11 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-environment-applies-to-compile
     ghostel-test-environment-honors-dir-locals
     ghostel-test-environment-rejects-unsafe-dir-locals
+    ghostel-test-delayed-redraw-defers-plain-link-detection
+    ghostel-test-delayed-redraw-coalesces-plain-link-detection
+    ghostel-test-detect-urls-allows-read-only-buffers
+    ghostel-test-zero-delay-runs-plain-link-detection-synchronously
+    ghostel-test-sentinel-cancels-plain-link-detection-timer
     ghostel-test-compile-prepare-buffer-sets-dir-before-mode
     ghostel-test-eshell-visual-command-mode-toggles-advice
     ghostel-test-eshell/ghostel-dispatches-to-exec-visual


### PR DESCRIPTION
## Summary
- defer plain-text URL/file detection until after redraw and coalesce repeated scans
- keep upstream file detection semantics and native OSC-8 hyperlink handling
- cover delayed scheduling, read-only safety, and sentinel cleanup with Elisp tests

## Testing
- `emacs --batch -Q -L lisp --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile lisp/ghostel.el`
- `emacs --batch -Q --eval "(setq load-prefer-newer t native-comp-jit-compilation nil native-comp-enable-subr-trampolines nil comp-enable-subr-trampolines nil)" -L . -L lisp -l ert -l test/ghostel-test.el -f ghostel-test-run-elisp`
- `zig build -Doptimize=ReleaseFast -Dcpu=baseline`