### PR TITLE
Set list-buffers-directory in ghostel-mode and ghostel-compile-view-mode

### DIFF
--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -180,7 +180,8 @@ to a ghostel terminal."
   ;; the recorded output on the first JIT-lock pass.  Neutralise unfontify:
   ;; compilation-mode's keywords are applied once via `font-lock-ensure'
   ;; on a finalised, static buffer and don't need to be cleaned up.
-  (setq-local font-lock-unfontify-region-function #'ignore))
+  (setq-local font-lock-unfontify-region-function #'ignore)
+  (setq-local list-buffers-directory (expand-file-name default-directory))) ; expose cwd to buffer-menu/ibuffer
 
 (defun ghostel-compile--format-duration (seconds)
   "Format SECONDS (float) as a compilation-style duration string.

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2387,9 +2387,11 @@ file:// URL does not match the local machine, construct a TRAMP path."
         (if (file-remote-p path)
             ;; Trust the shell's report; skip file-directory-p to avoid
             ;; synchronous TRAMP connections on every cd.
-            (setq default-directory (file-name-as-directory path))
+            (setq default-directory (file-name-as-directory path)
+                  list-buffers-directory default-directory)
           (when (file-directory-p path)
-            (setq default-directory (file-name-as-directory path))))))))
+            (setq default-directory (file-name-as-directory path)
+                  list-buffers-directory default-directory)))))))
 
 
 ;;; Palette
@@ -3477,6 +3479,7 @@ window (not when it has just been deselected)."
   (setq-local truncate-lines t)
   (setq-local scroll-conservatively 101)
   (setq-local line-spacing 0)
+  (setq-local list-buffers-directory (expand-file-name default-directory)) ; expose cwd to buffer-menu/ibuffer
   (add-function :after after-focus-change-function #'ghostel--focus-change)
   (add-hook 'window-selection-change-functions #'ghostel--focus-change)
   (add-hook 'window-buffer-change-functions #'ghostel--focus-change)

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1168,15 +1168,38 @@ that collided with a fish-internal local variable, leaking
                                "/"
                              "")
                            url-path))
-         (default-directory default-directory))
+         (default-directory default-directory)
+         list-buffers-directory)
     (ghostel--update-directory dir)
     (should (equal dir default-directory))                 ; plain path
+    (should (equal dir list-buffers-directory))            ; mirrored
     (ghostel--update-directory file-url)
     (should (equal dir default-directory))                 ; file URL
+    (should (equal dir list-buffers-directory))            ; mirrored
     ;; Dedup: same path shouldn't re-trigger
     (let ((old ghostel--last-directory))
       (ghostel--update-directory file-url)
       (should (equal old ghostel--last-directory)))))       ; dedup
+
+;; -----------------------------------------------------------------------
+;; Test: cwd exposed via list-buffers-directory
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-list-buffers-directory ()
+  "Test that `ghostel-mode' exposes cwd via `list-buffers-directory'."
+  (let ((default-directory (file-name-as-directory
+                            (expand-file-name temporary-file-directory))))
+    (with-temp-buffer
+      (ghostel-mode)
+      (should (equal list-buffers-directory default-directory)))))
+
+(ert-deftest ghostel-test-compile-view-list-buffers-directory ()
+  "Test that `ghostel-compile-view-mode' exposes cwd via `list-buffers-directory'."
+  (let ((default-directory (file-name-as-directory
+                            (expand-file-name temporary-file-directory))))
+    (with-temp-buffer
+      (ghostel-compile-view-mode)
+      (should (equal list-buffers-directory default-directory)))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: OSC 7 end-to-end through libghostty
@@ -7631,6 +7654,8 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-send-event
     ghostel-test-raw-key-modified-specials
     ghostel-test-update-directory
+    ghostel-test-list-buffers-directory
+    ghostel-test-compile-view-list-buffers-directory
     ghostel-test-filter-soft-wraps
     ghostel-test-prompt-navigation
     ghostel-test-sync-theme


### PR DESCRIPTION
## Summary
ghostel buffers visit no file, so `list-buffers-directory` is the conventional way for them to expose their cwd to buffer-list consumers (`buffer-menu`, `ibuffer`, etc.). `eshell-mode` already does this in `esh-mode.el`; ghostel did not.

## Change
One `setq-local` in `ghostel-mode`, one in `ghostel-compile-view-mode`, both setting `list-buffers-directory` to `default-directory` at mode init.

## Tests
Two pure-elisp ert tests added under `test/ghostel-test.el` and registered in `ghostel-test--elisp-tests`. Run via:

    emacs --batch -Q -L lisp -L test -l ert -l test/ghostel-test.el \
      --eval '(ert-run-tests-batch-and-exit "list-buffers-directory")'

Both pass against the current branch.

## Compatibility
Behaviour is unchanged for any code path that does not consume `list-buffers-directory`.