### PR TITLE
Fix manual-source gate so it works on remote hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,17 +149,17 @@ This is controlled by `ghostel-shell-integration` (default `t`).  Set it to
 
 **bash** — add to `~/.bashrc`:
 ```bash
-[[ "$INSIDE_EMACS" = 'ghostel' ]] && source "$EMACS_GHOSTEL_PATH/etc/shell/ghostel.bash"
+[[ "${INSIDE_EMACS%%,*}" = 'ghostel' ]] && source "$EMACS_GHOSTEL_PATH/etc/shell/ghostel.bash"
 ```
 
 **zsh** — add to `~/.zshrc`:
 ```zsh
-[[ "$INSIDE_EMACS" = 'ghostel' ]] && source "$EMACS_GHOSTEL_PATH/etc/shell/ghostel.zsh"
+[[ "${${INSIDE_EMACS-}%%,*}" = 'ghostel' ]] && source "$EMACS_GHOSTEL_PATH/etc/shell/ghostel.zsh"
 ```
 
 **fish** — add to `~/.config/fish/config.fish`:
 ```fish
-test "$INSIDE_EMACS" = 'ghostel'; and source "$EMACS_GHOSTEL_PATH/etc/shell/ghostel.fish"
+string match -qr '^ghostel(,|$)' -- "$INSIDE_EMACS"; and source "$EMACS_GHOSTEL_PATH/etc/shell/ghostel.fish"
 ```
 </details>
 
@@ -305,22 +305,69 @@ the terminal exits).  You can also enable it for specific shells only:
 
 Copy the integration scripts from ghostel's `etc/shell/` directory to
 each remote host (e.g. `~/.local/share/ghostel/`) and source them from
-your shell configuration:
+your shell configuration.  From a local shell:
+
+```bash
+ssh REMOTE 'mkdir -p ~/.local/share/ghostel'
+scp "$EMACS_GHOSTEL_PATH"/etc/shell/ghostel.{bash,zsh,fish} REMOTE:.local/share/ghostel/
+```
+
+(`$EMACS_GHOSTEL_PATH` is set inside ghostel buffers; outside, substitute
+the install path of the ghostel package.)
+
+Then add the appropriate gate to the remote shell config:
 
 **bash** — add to `~/.bashrc` on the remote host:
 ```bash
-[[ "$INSIDE_EMACS" = 'ghostel' ]] && source ~/.local/share/ghostel/ghostel.bash
+if [[ "${INSIDE_EMACS%%,*}" = 'ghostel' || "$TERM" = 'xterm-ghostty' ]]; then
+    source ~/.local/share/ghostel/ghostel.bash
+fi
 ```
 
 **zsh** — add to `~/.zshrc` on the remote host:
 ```zsh
-[[ "$INSIDE_EMACS" = 'ghostel' ]] && source ~/.local/share/ghostel/ghostel.zsh
+if [[ "${${INSIDE_EMACS-}%%,*}" = 'ghostel' || "$TERM" = 'xterm-ghostty' ]]; then
+    source ~/.local/share/ghostel/ghostel.zsh
+fi
 ```
 
 **fish** — add to `~/.config/fish/config.fish` on the remote host:
 ```fish
-test "$INSIDE_EMACS" = 'ghostel'; and source ~/.local/share/ghostel/ghostel.fish
+if string match -qr '^ghostel(,|$)' -- "$INSIDE_EMACS"; or test "$TERM" = 'xterm-ghostty'
+    source ~/.local/share/ghostel/ghostel.fish
+end
 ```
+
+The two-clause gate covers both ways a remote ghostel shell can be
+reached:
+- **TRAMP-launched ghostel** (`M-x ghostel` from a `/ssh:host:` path)
+  rewrites `INSIDE_EMACS` to `ghostel,tramp:VER` on the remote.  The
+  `${INSIDE_EMACS%%,*}` prefix match catches it.
+- **Plain `ssh REMOTE` from a local ghostel buffer** can't propagate
+  `INSIDE_EMACS` over ssh — `SetEnv` requires server-side `AcceptEnv`
+  to take effect.  Instead, the gate falls back on `TERM`, which the
+  SSH protocol *does* propagate natively.  Ghostel sets
+  `TERM=xterm-ghostty` in the local PTY shell environment (controlled
+  by `ghostel-term`, default `xterm-ghostty`), so any `ssh` spawned
+  from inside the buffer inherits and forwards that value.
+
+False positives — situations where the second clause matches but the
+session isn't actually ghostel — include any `ssh` from a non-ghostel
+ghostty terminal, nested ssh hops carrying the same `TERM` through,
+and anyone who manually exports `TERM=xterm-ghostty`.  Sourcing the
+integration in those cases is harmless (`OSC 7` / `OSC 133` work in
+plain ghostty too; `ghostel_cmd` becomes a no-op without ghostel on
+the other end).
+
+If you customize `ghostel-term` to something other than
+`xterm-ghostty`, the second clause won't match.  Drop it and rely on
+TRAMP-launched ghostel for remote integration, or replace it with a
+match against your customized `TERM`.  The wrapper-driven downgrade
+to `xterm-256color` (when `ghostel-ssh-install-terminfo`'s cache
+marks a host as skip, or `tic` install fails) also breaks the
+fallback for that host — a rare edge case, manageable by clearing
+the cache via `M-x ghostel-ssh-clear-terminfo-cache` once you've
+fixed the underlying terminfo install.
 
 The integration scripts provide directory tracking (OSC 7), prompt
 navigation (OSC 133), and `ghostel_cmd` for calling Elisp from the shell.
@@ -469,7 +516,7 @@ Add your own with:
 Example shell aliases (add to your `.bashrc` / `.zshrc`):
 
 ```sh
-if [[ "$INSIDE_EMACS" = 'ghostel' ]]; then
+if [[ "${INSIDE_EMACS%%,*}" = 'ghostel' ]]; then
     # Open a file in Emacs from the terminal
     e()   { ghostel_cmd find-file-other-window "$@"; }
 

--- a/etc/shell/ghostel.bash
+++ b/etc/shell/ghostel.bash
@@ -1,6 +1,15 @@
 # Ghostel shell integration for bash
-# Source this from your .bashrc:
-#   [[ "$INSIDE_EMACS" = 'ghostel' ]] && source /path/to/ghostel/etc/shell/ghostel.bash
+# Source this from your .bashrc.
+#
+# Local `~/.bashrc' (prefix match — TRAMP appends `,tramp:VER'):
+#   [[ "${INSIDE_EMACS%%,*}" = 'ghostel' ]] && source /path/to/ghostel/etc/shell/ghostel.bash
+#
+# Remote `~/.bashrc' (also gates on TERM, since ssh propagates it
+# natively and INSIDE_EMACS does not without server-side AcceptEnv):
+#   if [[ "${INSIDE_EMACS%%,*}" = 'ghostel' || "$TERM" = 'xterm-ghostty' ]]; then
+#       source ~/.local/share/ghostel/ghostel.bash
+#   fi
+# See the README "Manual setup" section for the full rationale.
 
 # Idempotency guard — skip if already loaded (e.g. auto-injected).
 [[ "$(type -t __ghostel_osc7)" = "function" ]] && return

--- a/etc/shell/ghostel.fish
+++ b/etc/shell/ghostel.fish
@@ -1,6 +1,15 @@
 # Ghostel shell integration for fish
-# Source this from your config.fish:
-#   test "$INSIDE_EMACS" = 'ghostel'; and source /path/to/ghostel/etc/shell/ghostel.fish
+# Source this from your config.fish.
+#
+# Local `config.fish' (anchored regex — TRAMP appends `,tramp:VER'):
+#   string match -qr '^ghostel(,|$)' -- "$INSIDE_EMACS"; and source /path/to/ghostel/etc/shell/ghostel.fish
+#
+# Remote `config.fish' (also gates on TERM, since ssh propagates it
+# natively and INSIDE_EMACS does not without server-side AcceptEnv):
+#   if string match -qr '^ghostel(,|$)' -- "$INSIDE_EMACS"; or test "$TERM" = 'xterm-ghostty'
+#       source ~/.local/share/ghostel/ghostel.fish
+#   end
+# See the README "Manual setup" section for the full rationale.
 
 # Idempotency guard — skip if already loaded (e.g. auto-injected).
 functions -q __ghostel_osc7; and return

--- a/etc/shell/ghostel.zsh
+++ b/etc/shell/ghostel.zsh
@@ -1,6 +1,18 @@
 # Ghostel shell integration for zsh
-# Source this from your .zshrc:
-#   [[ "$INSIDE_EMACS" = 'ghostel' ]] && source /path/to/ghostel/etc/shell/ghostel.zsh
+# Source this from your .zshrc.
+#
+# The `${var-}' fallback inside the trim is for users with `setopt
+# nounset' — zsh errors on `${unset%%pat}' without it (bash doesn't).
+#
+# Local `~/.zshrc' (prefix match — TRAMP appends `,tramp:VER'):
+#   [[ "${${INSIDE_EMACS-}%%,*}" = 'ghostel' ]] && source /path/to/ghostel/etc/shell/ghostel.zsh
+#
+# Remote `~/.zshrc' (also gates on TERM, since ssh propagates it
+# natively and INSIDE_EMACS does not without server-side AcceptEnv):
+#   if [[ "${${INSIDE_EMACS-}%%,*}" = 'ghostel' || "$TERM" = 'xterm-ghostty' ]]; then
+#       source ~/.local/share/ghostel/ghostel.zsh
+#   fi
+# See the README "Manual setup" section for the full rationale.
 
 # Idempotency guard — skip if already loaded (e.g. auto-injected).
 (( $+functions[__ghostel_osc7] )) && return

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -140,10 +140,14 @@ Also honored via `dir-locals.el' for per-project overrides.
 
 TRAMP caveats:
 - Entries with `=' are propagated to the remote shell.
-- `TERM' and `INSIDE_EMACS' are *always* reset by TRAMP to
-  `tramp-terminal-type' and TRAMP's own marker respectively (see
+- `TERM' is always reset by TRAMP to `tramp-terminal-type' (see
   `tramp-handle-make-process'); overrides in `ghostel-environment'
   do not win remotely.
+- `INSIDE_EMACS' is rewritten by TRAMP via `tramp-inside-emacs',
+  which appends `,tramp:VER' to whatever value is in scope.  For
+  ghostel that means the remote shell sees `ghostel,tramp:VER'
+  rather than the bare `ghostel' set locally — the leading
+  `ghostel' segment is preserved.
 - Bare \"KEY\" unset works for TRAMP-sh methods (`ssh', `sudo', ...)
   which emit `unset KEY' in the remote wrapper, but is dropped by
   the generic handler used by `adb' and `sshfs'.

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -6920,6 +6920,21 @@ setting it to nil forces off."
                                         captured-env)))
                 (when (process-live-p proc) (delete-process proc))))))))))
 
+(ert-deftest ghostel-test-tramp-inside-emacs-preserves-ghostel-prefix ()
+  "TRAMP rewrites INSIDE_EMACS but must preserve the user-set prefix.
+The README's manual remote-integration gate
+  [[ \"${INSIDE_EMACS%%,*}\" = \\='ghostel\\=' ]]
+relies on `tramp-inside-emacs' appending `,tramp:VER' to the
+existing `INSIDE_EMACS' value rather than wholly overwriting it.
+If TRAMP ever changes that contract, the gate silently stops
+matching on TRAMP-launched ghostel remotes — this canary catches it."
+  (require 'tramp)
+  (let ((process-environment
+         (cons "INSIDE_EMACS=ghostel" process-environment)))
+    (let ((rewritten (tramp-inside-emacs)))
+      (should (string-prefix-p "ghostel," rewritten))
+      (should (string-match-p ",tramp:" rewritten)))))
+
 (ert-deftest ghostel-test-environment-precedes-internal-env ()
   "`ghostel-environment' entries must come before ghostel's own env vars.
 When a user sets TERM via `ghostel-environment', it must win over the
@@ -7752,6 +7767,7 @@ while :; do sleep 0.1; done'\n")
     ghostel-test-update-directory-remote
     ghostel-test-get-shell-local
     ghostel-test-fish-auto-inject-loads-integration
+    ghostel-test-tramp-inside-emacs-preserves-ghostel-prefix
     ghostel-test-resize-window-adjust
     ghostel-test-resize-nil-size
     ghostel-test-resize-noop-same-dims


### PR DESCRIPTION
## Summary

The README told users to gate their remote `~/.bashrc` source line on `[[ "$INSIDE_EMACS" = 'ghostel' ]]`, but the literal-equals match never triggered remotely:

- **TRAMP-launched ghostel** — `tramp-inside-emacs` (in `trampver.el`) appends `,tramp:VER` to the value in scope, so the remote shell sees `INSIDE_EMACS=ghostel,tramp:VER`, not the bare `ghostel`. The leading `ghostel` segment *is* preserved — the existing `ghostel-environment` docstring overstated this as a "wholly overrides".
- **Plain `ssh REMOTE` from a local ghostel buffer** — ssh doesn't propagate arbitrary env vars by default. `SetEnv` exists but per `ssh_config(5)` requires server-side `AcceptEnv` to actually take effect, so it doesn't help out-of-the-box.

This PR:
- Loosens the local manual-source gate to a prefix match (`${INSIDE_EMACS%%,*}` / anchored regex for fish), which works for both `ghostel` and `ghostel,tramp:VER`.
- Updates the remote manual-source gate to a hybrid `INSIDE_EMACS prefix OR TERM=xterm-ghostty`. The `TERM` fallback rides the SSH protocol's native propagation; ghostel's outbound-ssh wrapper already sets `TERM=xterm-ghostty` when `ghostel-ssh-install-terminfo` is on (the default). Documents the false-positive (direct ghostty connections from outside Emacs) and the opt-out condition.
- Fixes a stale literal-equals gate in the "Example shell aliases" section.
- Corrects the `ghostel-environment` TRAMP-caveat docstring.
- Adds an ERT canary asserting `tramp-inside-emacs` preserves the user-supplied prefix, so a future TRAMP refactor that drops it surfaces immediately.

No changes to elisp behavior or the shell-integration scripts beyond the source-comment header — the recommended gate is the only thing that changes.

## Test plan

- [x] `make -j4 all` — 182/182 tests pass + lint clean
- [ ] Manual: source `etc/shell/ghostel.bash` in a TRAMP-launched ghostel remote shell and verify the gate fires (`INSIDE_EMACS=ghostel,tramp:VER`).
- [ ] Manual: from a local ghostel buffer with `ghostel-ssh-install-terminfo` on, run `ssh REMOTE` and verify the integration loads on the remote via the `TERM=xterm-ghostty` clause.
- [ ] Manual: from a local ghostel buffer with `ghostel-ssh-install-terminfo` set to `nil`, verify the integration does NOT load (expected — opt-out).