### PR TITLE
Stabilize IME preedit anchor during redraw

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3166,6 +3166,69 @@ position COL columns into the first matched line."
         (forward-line (- (1- tr)))
         (line-beginning-position)))))
 
+(defun ghostel--active-preedit-overlay ()
+  "Return the active GUI preedit overlay in the current buffer, if any.
+GTK/PGTK input methods display uncommitted text with `x-preedit-overlay'
+or `pgtk-preedit-overlay'.  Those overlays are anchored at point, so a
+terminal redraw that moves point can make the candidate window jump."
+  (cl-loop for sym in '(x-preedit-overlay pgtk-preedit-overlay)
+           for ov = (and (boundp sym) (symbol-value sym))
+           for text = (and (overlayp ov) (overlay-get ov 'before-string))
+           when (and text
+                     (eq (overlay-buffer ov) (current-buffer))
+                     (stringp text)
+                     (> (length text) 0))
+           return ov))
+
+(defun ghostel--preedit-window (overlay)
+  "Return the window associated with preedit OVERLAY, if it is usable."
+  (let ((win (overlay-get overlay 'window)))
+    (cond
+     ((and (window-live-p win)
+           (eq (window-buffer win) (current-buffer)))
+      win)
+     ((eq (window-buffer (selected-window)) (current-buffer))
+      (selected-window)))))
+
+(defun ghostel--capture-preedit-state ()
+  "Capture active GUI preedit position before a redraw rewrites the buffer."
+  (when-let* ((overlay (ghostel--active-preedit-overlay)))
+    (let* ((pos (overlay-start overlay))
+           (viewport-start (ghostel--viewport-start))
+           (line (and viewport-start
+                      (>= pos viewport-start)
+                      (- (line-number-at-pos pos)
+                         (line-number-at-pos viewport-start))))
+           (column (save-excursion
+                     (goto-char pos)
+                     (current-column))))
+      (list :overlay overlay
+            :window (ghostel--preedit-window overlay)
+            :position pos
+            :viewport-line line
+            :column column))))
+
+(defun ghostel--restore-preedit-state (state viewport-start)
+  "Restore preedit overlay STATE after redraw.
+VIEWPORT-START is the post-redraw viewport-start position.
+Returns the buffer position that should be used as the composing
+window's point, or nil when the saved overlay is no longer live."
+  (let ((overlay (plist-get state :overlay)))
+    (when (and (overlayp overlay)
+               (eq (overlay-buffer overlay) (current-buffer)))
+      (let* ((line (plist-get state :viewport-line))
+             (column (plist-get state :column))
+             (pos (if (and viewport-start line)
+                      (save-excursion
+                        (goto-char viewport-start)
+                        (forward-line
+                         (min line (max 0 (1- (or ghostel--term-rows 1)))))
+                        (move-to-column column)
+                        (point))
+                    (min (plist-get state :position) (point-max)))))
+        (move-overlay overlay pos pos (current-buffer))
+        pos))))
+
 (defun ghostel--schedule-link-detection (&optional begin end)
   "Schedule deferred plain-text link detection over BEGIN..END.
 BEGIN defaults to the current viewport start (or `point-min' if the
@@ -3247,7 +3310,7 @@ No-op when `ghostel--snap-requested' (user input overrides)."
                    (eq (window-buffer win) buffer))
           (ghostel--reconcile-saved-position win entry))))))
 
-(defun ghostel--anchor-window (win vs pt)
+(defun ghostel--anchor-window (win vs pt &optional exact-point)
   "Pin WIN to viewport-start VS and sync its point to PT.
 Also resets pixel vscroll (pixel-scroll-precision-mode may leave a
 partial offset that would clip the top line after a redraw).
@@ -3270,10 +3333,16 @@ viewport; buffer-point is unaffected and subsequent redraws recapture
 the real cursor.  We must NOT clamp for a plain shell prompt where the
 cursor is legitimately at `point-max' after typing — doing so would
 draw the block cursor on the last character instead of after it
-\(issue #146)."
+\(issue #146).
+
+When EXACT-POINT is non-nil, set `window-point' to PT exactly.  This is
+used while a GUI input method is displaying preedit text: the candidate
+window is anchored to point, and moving it by one character is visible
+as a jump."
   (set-window-start win vs t)
   (set-window-vscroll win 0 t)
-  (set-window-point win (if (and (= pt (point-max))
+  (set-window-point win (if (and (not exact-point)
+                                 (= pt (point-max))
                                  (> pt (point-min))
                                  ghostel--term
                                  (or (ghostel--cursor-pending-wrap-p
@@ -3308,7 +3377,11 @@ frame mid-redraw) — in which case this is a no-op."
 Flushes pending PTY output, corrects any Emacs-side window-start
 mangling, runs the native redraw, then restores scroll state for
 windows that were reading scrollback and anchors windows that were
-following the viewport."
+following the viewport.
+
+When a GUI input method is composing preedit text in BUFFER, leaves
+buffer point on the preedit anchor instead of the terminal cursor so
+the candidate window does not jump while text is streaming in."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (setq ghostel--redraw-timer nil)
@@ -3320,7 +3393,9 @@ following the viewport."
           (setq ghostel--force-next-redraw nil)
           (setq ghostel--has-wide-chars nil)
           (ghostel--correct-mangled-scroll-positions buffer)
-          (let* ((all-windows (get-buffer-window-list buffer nil t))
+          (let* ((preedit-state (ghostel--capture-preedit-state))
+                 (preedit-window (plist-get preedit-state :window))
+                 (all-windows (get-buffer-window-list buffer nil t))
                  (anchored (cl-remove-if-not #'ghostel--window-anchored-p
                                              all-windows))
                  (non-anchored-states
@@ -3333,14 +3408,27 @@ following the viewport."
             (ghostel--redraw ghostel--term ghostel-full-redraw)
             (when ghostel--has-wide-chars
               (ghostel--compensate-wide-chars))
-            (let ((pt (point))
-                  (vs (ghostel--viewport-start)))
+            (let* ((pt (point))
+                   (vs (ghostel--viewport-start))
+                   (preedit-point
+                    (and preedit-state
+                         (ghostel--restore-preedit-state
+                          preedit-state vs))))
               (setq ghostel--scroll-positions nil)
               (dolist (win all-windows)
                 (if (and vs (memq win anchored))
-                    (ghostel--anchor-window win vs pt)
+                    (let ((preedit-win-p
+                           (and preedit-point
+                                preedit-window
+                                (eq win preedit-window))))
+                      (ghostel--anchor-window
+                       win vs
+                       (if preedit-win-p preedit-point pt)
+                       preedit-win-p))
                   (ghostel--restore-scrollback-window
                    win (assq win non-anchored-states))))
+              (when preedit-point
+                (goto-char preedit-point))
               (when vs
                 (setq ghostel--last-anchor-position vs))
               (ghostel--schedule-link-detection vs (point-max))))

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -4441,6 +4441,104 @@ skip the clamp entirely regardless of where PT sits."
         (set-window-buffer (selected-window) orig-buf))
       (kill-buffer buf))))
 
+;; Declared here so tests can rebind these without byte-compile warnings on
+;; non-X/non-PGTK builds where term/x-win.el and term/pgtk-win.el aren't loaded.
+(defvar x-preedit-overlay)
+(defvar pgtk-preedit-overlay)
+
+(ert-deftest ghostel-test-delayed-redraw-preserves-preedit-anchor ()
+  "Active GUI preedit text keeps its point anchor across redraws.
+GTK/PGTK input-method candidate windows are anchored to the preedit
+overlay at point.  During streaming TUI output, native redraws move
+point to the terminal cursor; while preedit text is visible, the
+composing window must instead keep the overlay and `window-point' at
+the same viewport row and column."
+  (let ((buf (generate-new-buffer " *ghostel-test-preedit-anchor*"))
+        (orig-buf (window-buffer (selected-window)))
+        (old-bound (boundp 'x-preedit-overlay))
+        (old-value (and (boundp 'x-preedit-overlay) x-preedit-overlay))
+        overlay)
+    (unwind-protect
+        (progn
+          (set-window-buffer (selected-window) buf)
+          (with-current-buffer buf
+            (ghostel-mode)
+            (setq-local ghostel--term 'fake-term
+                        ghostel--term-rows 5
+                        ghostel--force-next-redraw nil
+                        ghostel-enable-url-detection nil
+                        ghostel-enable-file-detection nil)
+            (insert "old-0\nold-1\nold-2\nold-3\nold-4")
+            (goto-char (point-max))
+            (setq overlay (make-overlay (point) (point) buf))
+            (overlay-put overlay 'before-string "ni")
+            (overlay-put overlay 'window (selected-window))
+            (setq x-preedit-overlay overlay)
+            (set-window-start (selected-window) (point-min) t)
+            (set-window-point (selected-window) (point)))
+          (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'ghostel--redraw)
+                     (lambda (&rest _)
+                       ;; Simulate a destructive native redraw that leaves
+                       ;; point at the terminal cursor on a different row.
+                       (erase-buffer)
+                       (insert "new-0\nnew-1\nnew-2\nnew-3\nnew-4")
+                       (goto-char (point-min))
+                       (forward-line 1)))
+                    ((symbol-function 'ghostel--cursor-pending-wrap-p)
+                     (lambda (&rest _)
+                       (error "Preedit anchor should bypass clamp checks")))
+                    ((symbol-function 'ghostel--cursor-on-empty-row-p)
+                     (lambda (&rest _)
+                       (error "Preedit anchor should bypass clamp checks"))))
+            (ghostel--delayed-redraw buf))
+          (with-current-buffer buf
+            (let ((expected (save-excursion
+                              (goto-char (point-min))
+                              (forward-line 4)
+                              (move-to-column 5)
+                              (point))))
+              (should (= expected (overlay-start overlay)))
+              (should (= expected (window-point (selected-window))))
+              (should (= expected (point))))))
+      (if old-bound
+          (setq x-preedit-overlay old-value)
+        (makunbound 'x-preedit-overlay))
+      (when (buffer-live-p orig-buf)
+        (set-window-buffer (selected-window) orig-buf))
+      (when (and overlay (overlayp overlay))
+        (delete-overlay overlay))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-preedit-window-fallback ()
+  "Verify the `selected-window' fallback in `ghostel--preedit-window'.
+This covers the pgtk-preedit-overlay shape, which has no `window'
+overlay property."
+  (let ((buf (generate-new-buffer " *ghostel-test-preedit-window*"))
+        (orig-buf (window-buffer (selected-window)))
+        overlay)
+    (unwind-protect
+        (with-current-buffer buf
+          (setq overlay (make-overlay (point-min) (point-min) buf))
+          ;; No 'window property — selected-window must show the buffer.
+          (set-window-buffer (selected-window) buf)
+          (should (eq (ghostel--preedit-window overlay) (selected-window)))
+          ;; Explicit 'window wins over the fallback.
+          (overlay-put overlay 'window (selected-window))
+          (should (eq (ghostel--preedit-window overlay) (selected-window)))
+          ;; Selected window showing some other buffer and no 'window
+          ;; property: nothing usable, return nil.
+          (overlay-put overlay 'window nil)
+          (when (buffer-live-p orig-buf)
+            (set-window-buffer (selected-window) orig-buf))
+          (should (null (ghostel--preedit-window overlay))))
+      (when (buffer-live-p orig-buf)
+        (set-window-buffer (selected-window) orig-buf))
+      (when (and overlay (overlayp overlay))
+        (delete-overlay overlay))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-cursor-pending-wrap-p ()
   "`ghostel--cursor-pending-wrap-p' tracks libghostty's pending-wrap flag."
   (let ((term (ghostel--new 5 10 100)))
@@ -7945,6 +8043,8 @@ COLORTERM, INSIDE_EMACS, …) plus pass-through LANG/LC_*."
     ghostel-test-compile-reconciles-skips-when-no-outwin
     ghostel-test-viewport-start-skips-trailing-newline
     ghostel-test-anchor-window-no-clamp-without-pending-wrap
+    ghostel-test-delayed-redraw-preserves-preedit-anchor
+    ghostel-test-preedit-window-fallback
     ghostel-test-exec-errors-on-live-process
     ghostel-test-exec-calls-spawn-pty-with-expected-args
     ghostel-test-exec-threads-remote-p-from-tramp-dir


### PR DESCRIPTION
## Description

This fixes IME candidate window jumping while high-throughput terminal apps such as Codex or Claude Code are
actively redrawing.

GTK/PGTK input methods display uncommitted text through preedit overlays anchored at Emacs point. Ghostel
redraws move point to the terminal cursor after each render, which can make the IME preedit/candidate window
jump while the user is composing Chinese text.

This change captures an active `x-preedit-overlay` / `pgtk-preedit-overlay` before redraw and restores it to
the same viewport row/column after the native redraw rewrites the buffer. The normal terminal cursor/window
anchoring behavior is unchanged when no preedit overlay is active.

## Changes

- Detect active X/PGTK preedit overlays in ghostel buffers.
- Preserve the composing window’s preedit overlay and `window-point` across redraws.
- Add an exact-point path to `ghostel--anchor-window` for active IME preedit state.
- Add a regression test for redraw preserving the preedit anchor.
