### PR TITLE
Refactor native rendering for correctness and robustness

### DIFF
--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -85,7 +85,7 @@ placement math the native module performs in `src/render.zig'."
   (when (and ghostel--term ghostel--term-rows)
     (let ((pos (ghostel--cursor-position ghostel--term)))
       (when pos
-        (let ((scrollback (max 0 (- (line-number-at-pos (point-max))
+        (let ((scrollback (max 0 (- (count-lines (point-min) (point-max))
                                     ghostel--term-rows))))
           (goto-char (point-min))
           (forward-line (+ scrollback (cdr pos)))

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -567,8 +567,6 @@ Bump this only when the Elisp code requires a newer native module
 ;; Declare native module functions for the byte compiler
 
 (declare-function ghostel--cursor-position "ghostel-module")
-(declare-function ghostel--cursor-pending-wrap-p "ghostel-module")
-(declare-function ghostel--cursor-on-empty-row-p "ghostel-module")
 (declare-function ghostel--encode-key "ghostel-module")
 (declare-function ghostel--focus-event "ghostel-module")
 (declare-function ghostel--mode-enabled "ghostel-module")
@@ -578,11 +576,11 @@ Bump this only when the Elisp code requires a newer native module
 (declare-function ghostel--mouse-event "ghostel-module")
 (declare-function ghostel--new "ghostel-module")
 (declare-function ghostel--redraw "ghostel-module" (term &optional full))
-(declare-function ghostel--scroll-bottom "ghostel-module")
 (declare-function ghostel--set-default-colors "ghostel-module")
 (declare-function ghostel--set-palette "ghostel-module")
 (declare-function ghostel--set-size "ghostel-module")
 (declare-function ghostel--write-input "ghostel-module")
+(declare-function ghostel--native-uri-at "ghostel-module")
 
 
 ;;; Automatic download and compilation of native module
@@ -1325,7 +1323,6 @@ when `ghostel-scroll-on-input' is nil.  Call from any path where
 the user's action implies \"show me the prompt\" — typed input,
 paste, yank, drop."
   (when (and ghostel-scroll-on-input ghostel--term)
-    (ghostel--scroll-bottom ghostel--term)
     (setq ghostel--snap-requested t)
     (setq ghostel--force-next-redraw t)))
 
@@ -1570,7 +1567,6 @@ pasted using bracketed paste."
     (ghostel--flush-pending-output)
     ;; CSI H = home, CSI 2 J = erase screen, CSI 3 J = erase scrollback.
     (ghostel--write-input ghostel--term "\e[H\e[2J\e[3J")
-    (ghostel--scroll-bottom ghostel--term)
     (setq ghostel--force-next-redraw t)
     ;; Scrollback is gone; any recorded scroll position no longer
     ;; refers to real content.  Reset so the next redraw anchors
@@ -1851,6 +1847,30 @@ stripped so the copied text matches the original terminal content."
     map)
   "Keymap for clickable hyperlinks in ghostel buffers.")
 
+(defun ghostel--native-link-help-echo (window _ pos)
+  "help-echo handler for OSC8 hyperlinks. Retrieves native URI from libghostty."
+  (with-current-buffer (window-buffer window)
+    (ghostel--native-uri-at-pos pos)))
+
+(defun ghostel--native-uri-at-pos (pos)
+  "Return the native OSC8 hyperlink URI at POS."
+  (save-excursion
+    (goto-char pos)
+    (let* ((line (line-number-at-pos nil t))
+           (total (line-number-at-pos (point-max) t))
+           (row-from-bottom (- total line))
+           (col (current-column)))
+      (ghostel--native-uri-at ghostel--term row-from-bottom col))))
+
+(defun ghostel--uri-at-pos (pos)
+  "Return the URI at POS.
+If the `help-echo' property is a string, return it; otherwise fetch
+the native OSC8 URI at that position."
+  (let ((help-echo (get-text-property pos 'help-echo)))
+    (if (stringp help-echo)
+        help-echo
+      (ghostel--native-uri-at-pos pos))))
+
 (defun ghostel--open-link (url)
   "Open URL, dispatching by scheme.
 file:// URIs open in Emacs; http(s) and other schemes use `browse-url'.
@@ -1879,13 +1899,12 @@ a line suffix opens at the start of the file or directory."
 (defun ghostel-open-link-at-click (event)
   "Open the hyperlink at the mouse click EVENT position."
   (interactive "e")
-  (ghostel--open-link
-   (get-text-property (posn-point (event-start event)) 'help-echo)))
+  (ghostel--open-link (ghostel--uri-at-pos (posn-point (event-start event)))))
 
 (defun ghostel-open-link-at-point ()
   "Open the hyperlink at point."
   (interactive)
-  (ghostel--open-link (get-text-property (point) 'help-echo)))
+  (ghostel--open-link (ghostel--uri-at-pos (point))))
 
 (defun ghostel--find-next-link (from)
   "Return start position of the first hyperlink after FROM, or nil.
@@ -3156,14 +3175,7 @@ position COL columns into the first matched line."
     (when (> tr 0)
       (save-excursion
         (goto-char (point-max))
-        ;; Partial redraws can leave a trailing \n after the last row.
-        ;; Step past it so `forward-line' counts only content rows, not
-        ;; the phantom empty line that would otherwise push the viewport
-        ;; one line too deep and clip the bottom row.
-        (when (and (not (bobp))
-                   (eq (char-before) ?\n))
-          (forward-char -1))
-        (forward-line (- (1- tr)))
+        (forward-line (- tr))
         (line-beginning-position)))))
 
 (defun ghostel--active-preedit-overlay ()
@@ -3310,47 +3322,13 @@ No-op when `ghostel--snap-requested' (user input overrides)."
                    (eq (window-buffer win) buffer))
           (ghostel--reconcile-saved-position win entry))))))
 
-(defun ghostel--anchor-window (win vs pt &optional exact-point)
+(defun ghostel--anchor-window (win vs pt)
   "Pin WIN to viewport-start VS and sync its point to PT.
 Also resets pixel vscroll (pixel-scroll-precision-mode may leave a
-partial offset that would clip the top line after a redraw).
-
-Two terminal-side configurations land PT at `point-max' on the last
-visible row in a position Emacs redisplay treats as off-screen — which
-makes `scroll-conservatively' shift `window-start' up by one row,
-fighting the viewport pin and hiding the block cursor:
-
- 1. Pending-wrap: the last printed character filled the rightmost
-    column and the next print will soft-wrap (issue #138).
-
- 2. CUP park onto an empty trailing row, no pending-wrap: the TUI
-    moved the cursor via absolute positioning to a row that has no
-    written cells, so the row renders to an empty buffer line and PT
-    lands at `point-max' (issue #157).
-
-Clamp `window-point' back by one in either case so it sits inside the
-viewport; buffer-point is unaffected and subsequent redraws recapture
-the real cursor.  We must NOT clamp for a plain shell prompt where the
-cursor is legitimately at `point-max' after typing — doing so would
-draw the block cursor on the last character instead of after it
-\(issue #146).
-
-When EXACT-POINT is non-nil, set `window-point' to PT exactly.  This is
-used while a GUI input method is displaying preedit text: the candidate
-window is anchored to point, and moving it by one character is visible
-as a jump."
+partial offset that would clip the top line after a redraw)."
   (set-window-start win vs t)
   (set-window-vscroll win 0 t)
-  (set-window-point win (if (and (not exact-point)
-                                 (= pt (point-max))
-                                 (> pt (point-min))
-                                 ghostel--term
-                                 (or (ghostel--cursor-pending-wrap-p
-                                      ghostel--term)
-                                     (ghostel--cursor-on-empty-row-p
-                                      ghostel--term)))
-                            (1- pt)
-                          pt)))
+  (set-window-point win pt))
 
 (defun ghostel--restore-scrollback-window (win state)
   "Restore WIN to ws/wp recorded in STATE and push STATE to scroll-positions.
@@ -3423,8 +3401,7 @@ the candidate window does not jump while text is streaming in."
                                 (eq win preedit-window))))
                       (ghostel--anchor-window
                        win vs
-                       (if preedit-win-p preedit-point pt)
-                       preedit-win-p))
+                       (if preedit-win-p preedit-point pt)))
                   (ghostel--restore-scrollback-window
                    win (assq win non-anchored-states))))
               (when preedit-point

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -224,6 +224,14 @@ pub const Env = struct {
         return self.call0(sym.@"line-end-position");
     }
 
+    pub fn lineBeginningPosition2(self: Env) Value {
+        return self.call1(sym.@"line-beginning-position", self.makeInteger(2));
+    }
+
+    pub fn pointMin(self: Env) Value {
+        return self.call0(sym.@"point-min");
+    }
+
     pub fn pointMax(self: Env) Value {
         return self.call0(sym.@"point-max");
     }
@@ -300,12 +308,15 @@ pub const Sym = struct {
     @"move-to-column": Value,
     @"erase-buffer": Value,
     @"line-end-position": Value,
+    @"line-beginning-position": Value,
+    @"point-min": Value,
     @"point-max": Value,
     @"delete-region": Value,
     @"char-before": Value,
     @"mark-marker": Value,
     @"marker-position": Value,
     @"set-marker": Value,
+    ding: Value,
 
     // Text property names
     face: Value,
@@ -330,7 +341,8 @@ pub const Sym = struct {
     @"ghostel--flush-output": Value,
     @"ghostel--set-title": Value,
     @"ghostel--debug-log-vt": Value,
-    ding: Value,
+    @"ghostel--native-uri-at": Value,
+    @"ghostel--native-link-help-echo": Value,
 };
 
 pub var sym: Sym = undefined;

--- a/src/module.zig
+++ b/src/module.zig
@@ -35,7 +35,6 @@ export fn emacs_module_init(runtime: *c.struct_emacs_runtime) callconv(.c) c_int
     env.bindFunction("ghostel--get-title", 1, 1, &fnGetTitle, "Get the terminal title.\n\n(ghostel--get-title TERM)");
     env.bindFunction("ghostel--get-pwd", 1, 1, &fnGetPwd, "Get the terminal's working directory from OSC 7.\n\n(ghostel--get-pwd TERM)");
     env.bindFunction("ghostel--redraw", 1, 2, &fnRedraw, "Redraw the terminal into the current buffer.\n\n(ghostel--redraw TERM &optional FULL)");
-    env.bindFunction("ghostel--scroll-bottom", 1, 1, &fnScrollBottom, "Scroll the terminal viewport to the bottom.\n\n(ghostel--scroll-bottom TERM)");
     env.bindFunction("ghostel--encode-key", 3, 4, &fnEncodeKey, "Encode a key event using the terminal's key encoder.\n\n(ghostel--encode-key TERM KEY MODS &optional UTF8)");
     env.bindFunction("ghostel--mouse-event", 6, 6, &fnMouseEvent, "Send a mouse event to the terminal.\n\n(ghostel--mouse-event TERM ACTION BUTTON ROW COL MODS)");
     env.bindFunction("ghostel--focus-event", 2, 2, &fnFocusEvent, "Send a focus event to the terminal.\n\n(ghostel--focus-event TERM GAINED)");
@@ -44,14 +43,13 @@ export fn emacs_module_init(runtime: *c.struct_emacs_runtime) callconv(.c) c_int
     env.bindFunction("ghostel--mode-enabled", 2, 2, &fnModeEnabled, "Return t if terminal DEC private MODE is enabled.\n\n(ghostel--mode-enabled TERM MODE)");
     env.bindFunction("ghostel--alt-screen-p", 1, 1, &fnAltScreen, "Return t if terminal is on the alternate screen buffer.\n\n(ghostel--alt-screen-p TERM)");
     env.bindFunction("ghostel--cursor-position", 1, 1, &fnCursorPosition, "Return terminal cursor position as (COL . ROW), 0-indexed.\n\n(ghostel--cursor-position TERM)");
-    env.bindFunction("ghostel--cursor-pending-wrap-p", 1, 1, &fnCursorPendingWrap, "Return t if the cursor is in pending-wrap state.\n\n(ghostel--cursor-pending-wrap-p TERM)");
-    env.bindFunction("ghostel--cursor-on-empty-row-p", 1, 1, &fnCursorOnEmptyRow, "Return t if the cursor row has no written cells or styled cells.\n\n(ghostel--cursor-on-empty-row-p TERM)");
     env.bindFunction("ghostel--debug-state", 1, 1, &fnDebugState, "Return debug info about terminal/render state.\n\n(ghostel--debug-state TERM)");
     env.bindFunction("ghostel--debug-feed", 2, 2, &fnDebugFeed, "Feed STR to terminal and return first row + cursor.\n\n(ghostel--debug-feed TERM STR)");
     env.bindFunction("ghostel--copy-all-text", 1, 1, &fnCopyAllText, "Return entire scrollback as plain text string.\n\n(ghostel--copy-all-text TERM)");
     env.bindFunction("ghostel--module-version", 0, 0, &fnModuleVersion, "Return the native module version string.\n\n(ghostel--module-version)");
     env.bindFunction("ghostel--enable-vt-log", 0, 0, &fnEnableVtLog, "Enable libghostty internal log routing to *ghostel-debug*.\n\n(ghostel--enable-vt-log)");
     env.bindFunction("ghostel--disable-vt-log", 0, 0, &fnDisableVtLog, "Disable libghostty internal log routing.\n\n(ghostel--disable-vt-log)");
+    env.bindFunction("ghostel--native-uri-at", 3, 3, &fnUriAt, "Get URI at ROW-from-bottom and COL.\n\n(ghostel--native-uri-at TERM ROW COL)");
 
     emacs.initSymbols(env);
     env.provide("ghostel-module");
@@ -183,23 +181,6 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
         term.vtWrite(raw[seg_start..]);
     }
     term.last_input_was_cr = prev_was_cr;
-
-    // Detect CSI 3 J (erase scrollback). libghostty processes it and clears
-    // its scrollback, but provides no notification. Set rebuild_pending so the
-    // next redraw erases the Emacs buffer and re-fetches from libghostty.
-    // The flag is necessary because CSI 3 J followed by enough new output to
-    // restore the same scrollback depth is undetectable by count or hash alone.
-    //
-    // This is a stateless substring scan over a single write, so it misses:
-    // (1) sequences split across two writes (ESC in one, "[3J" in the next);
-    // (2) non-canonical forms — parameter padding like `\x1B[03J`, or the
-    //     8-bit C1 form `\x9B3J`.
-    // libghostty's stateful VT parser still clears its scrollback in those
-    // cases, so the `libghostty_sb < scrollback_in_buffer` shrink check in
-    // redraw() is the fallback that catches them.
-    if (std.mem.indexOf(u8, raw, "\x1B[3J") != null) {
-        term.rebuild_pending = true;
-    }
 
     // Scan for OSC sequences that libghostty-vt discards (7, 51, 52, 133).
     // One pass, dispatched by code in document order.
@@ -539,9 +520,12 @@ fn sendDynamicColorReply(
         "\x1b]{d};rgb:{x:0>2}{x:0>2}/{x:0>2}{x:0>2}/{x:0>2}{x:0>2}{s}",
         .{
             osc_num,
-            color.r, color.r,
-            color.g, color.g,
-            color.b, color.b,
+            color.r,
+            color.r,
+            color.g,
+            color.g,
+            color.b,
+            color.b,
             term_bytes,
         },
     ) catch return;
@@ -561,9 +545,12 @@ fn sendPaletteColorReply(
         "\x1b]4;{d};rgb:{x:0>2}{x:0>2}/{x:0>2}{x:0>2}/{x:0>2}{x:0>2}{s}",
         .{
             index,
-            color.r, color.r,
-            color.g, color.g,
-            color.b, color.b,
+            color.r,
+            color.r,
+            color.g,
+            color.g,
+            color.b,
+            color.b,
             term_bytes,
         },
     ) catch return;
@@ -682,14 +669,6 @@ fn fnRedraw(raw_env: ?*c.emacs_env, nargs: isize, args: [*c]c.emacs_value, _: ?*
         defer vt_log_env = null;
     }
     render.redraw(env, term, force_full);
-    return env.nil();
-}
-
-/// (ghostel--scroll-bottom TERM)
-fn fnScrollBottom(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
-    const env = emacs.Env.init(raw_env.?);
-    const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
-    term.scrollViewport(gt.SCROLL_BOTTOM, 0);
     return env.nil();
 }
 
@@ -921,16 +900,24 @@ fn fnDebugState(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
     const env = emacs.Env.init(raw_env.?);
     const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
 
+    // Preserve viewport position
+    const saved_offset: ?usize = if (term.getScrollbar()) |sb| sb.offset else null;
+    defer if (saved_offset) |off| {
+        term.scrollViewport(gt.SCROLL_TOP, 0);
+        term.scrollViewport(gt.SCROLL_DELTA, @intCast(off));
+    };
+    term.scrollViewport(gt.SCROLL_BOTTOM, 0);
+
     var buf: [4096]u8 = undefined;
     var pos: usize = 0;
 
     // Try update
     const update_result = gt.c.ghostty_render_state_update(term.render_state, term.terminal);
-    pos += (std.fmt.bufPrint(buf[pos..], "update={d} ", .{update_result}) catch return env.nil()).len;
+    pos += (std.fmt.bufPrint(buf[pos..], "update={d}\n", .{update_result}) catch return env.nil()).len;
 
     // Read first row via iterator
     if (gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_ROW_ITERATOR, @ptrCast(&term.row_iterator)) != gt.SUCCESS) {
-        pos += (std.fmt.bufPrint(buf[pos..], "iter=FAIL", .{}) catch return env.nil()).len;
+        pos += (std.fmt.bufPrint(buf[pos..], "iter=FAIL\n", .{}) catch return env.nil()).len;
         return env.makeString(buf[0..pos]);
     }
 
@@ -939,7 +926,7 @@ fn fnDebugState(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
         if (row_idx >= 10) break;
 
         if (gt.c.ghostty_render_state_row_get(term.row_iterator, gt.RS_ROW_DATA_CELLS, @ptrCast(&term.row_cells)) != gt.SUCCESS) {
-            pos += (std.fmt.bufPrint(buf[pos..], "row{d}=FAIL ", .{row_idx}) catch break).len;
+            pos += (std.fmt.bufPrint(buf[pos..], "row{d}=FAIL\n ", .{row_idx}) catch break).len;
             continue;
         }
 
@@ -966,7 +953,7 @@ fn fnDebugState(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
             const enc_len = std.unicode.utf8Encode(cp, remaining) catch continue;
             pos += enc_len;
         }
-        pos += (std.fmt.bufPrint(buf[pos..], "\" ", .{}) catch break).len;
+        pos += (std.fmt.bufPrint(buf[pos..], "\"\n", .{}) catch break).len;
     }
 
     return env.makeString(buf[0..pos]);
@@ -977,6 +964,14 @@ fn fnDebugState(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
 fn fnDebugFeed(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
     const env = emacs.Env.init(raw_env.?);
     const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
+
+    // Preserve viewport position
+    const saved_offset: ?usize = if (term.getScrollbar()) |sb| sb.offset else null;
+    defer if (saved_offset) |off| {
+        term.scrollViewport(gt.SCROLL_TOP, 0);
+        term.scrollViewport(gt.SCROLL_DELTA, @intCast(off));
+    };
+    term.scrollViewport(gt.SCROLL_BOTTOM, 0);
 
     var stack_buf: [4096]u8 = undefined;
     const data = env.extractString(args[1], &stack_buf) orelse return env.nil();
@@ -1000,7 +995,7 @@ fn fnDebugFeed(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*a
 
     var buf: [2048]u8 = undefined;
     var pos: usize = 0;
-    pos += (std.fmt.bufPrint(buf[pos..], "cur=({d},{d}) row0=\"", .{ cx, cy }) catch return env.nil()).len;
+    pos += (std.fmt.bufPrint(buf[pos..], "cur=({d},{d})\n row0=\"", .{ cx, cy }) catch return env.nil()).len;
 
     if (gt.c.ghostty_render_state_row_iterator_next(term.row_iterator)) {
         if (gt.c.ghostty_render_state_row_get(term.row_iterator, gt.RS_ROW_DATA_CELLS, @ptrCast(&term.row_cells)) == gt.SUCCESS) {
@@ -1010,7 +1005,10 @@ fn fnDebugFeed(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*a
                 var gl: u32 = 0;
                 if (gt.c.ghostty_render_state_row_cells_get(term.row_cells, gt.RS_CELLS_DATA_GRAPHEMES_LEN, @ptrCast(&gl)) != gt.SUCCESS) continue;
                 if (gl == 0) {
-                    if (pos < buf.len) { buf[pos] = ' '; pos += 1; }
+                    if (pos < buf.len) {
+                        buf[pos] = ' ';
+                        pos += 1;
+                    }
                     continue;
                 }
                 var cp: [4]u32 = undefined;
@@ -1035,6 +1033,14 @@ fn fnCursorPosition(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _
     const env = emacs.Env.init(raw_env.?);
     const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
 
+    // Preserve viewport position.
+    const saved_offset: ?usize = if (term.getScrollbar()) |sb| sb.offset else null;
+    defer if (saved_offset) |off| {
+        term.scrollViewport(gt.SCROLL_TOP, 0);
+        term.scrollViewport(gt.SCROLL_DELTA, @intCast(off));
+    };
+    term.scrollViewport(gt.SCROLL_BOTTOM, 0);
+
     // Ensure render state is up to date
     _ = gt.c.ghostty_render_state_update(term.render_state, term.terminal);
 
@@ -1048,49 +1054,6 @@ fn fnCursorPosition(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _
     _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_CURSOR_VIEWPORT_Y, @ptrCast(&cy));
 
     return env.call2(emacs.sym.cons, env.makeInteger(@as(i64, cx)), env.makeInteger(@as(i64, cy)));
-}
-
-/// (ghostel--cursor-pending-wrap-p TERM)
-/// Return t if the terminal's active cursor is in pending-wrap state
-/// (i.e. the last printed character filled the rightmost column and the
-/// next print will soft-wrap), nil otherwise.
-fn fnCursorPendingWrap(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
-    const env = emacs.Env.init(raw_env.?);
-    const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
-
-    var pending: bool = false;
-    if (gt.c.ghostty_terminal_get(term.terminal, gt.DATA_CURSOR_PENDING_WRAP, @ptrCast(&pending)) != gt.SUCCESS) {
-        return env.nil();
-    }
-    return if (pending) env.t() else env.nil();
-}
-
-/// (ghostel--cursor-on-empty-row-p TERM)
-/// Return t if the row containing the active cursor has no written
-/// cells and no cells with non-default style — i.e. the row renders to
-/// an empty Emacs buffer line.  Used alongside pending-wrap by
-/// `ghostel--anchor-window' to detect TUI CUP parks onto a trailing
-/// empty row, which also land `point' at `point-max' on the last
-/// visible row and would otherwise provoke a redisplay-induced scroll.
-fn fnCursorOnEmptyRow(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
-    const env = emacs.Env.init(raw_env.?);
-    const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
-
-    if (gt.c.ghostty_render_state_update(term.render_state, term.terminal) != gt.SUCCESS) return env.nil();
-
-    // Use viewport-relative cursor Y so the row index matches the
-    // viewport iterator `isRowEmptyAt' walks. Falls back to nil when
-    // the cursor isn't visible in the current viewport (e.g. scrolled
-    // into scrollback), which is also the safe answer for the clamp.
-    var has_value: bool = false;
-    _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_CURSOR_VIEWPORT_HAS_VALUE, @ptrCast(&has_value));
-    if (!has_value) return env.nil();
-
-    var cy: u16 = 0;
-    if (gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_CURSOR_VIEWPORT_Y, @ptrCast(&cy)) != gt.SUCCESS) {
-        return env.nil();
-    }
-    return if (render.isRowEmptyAt(term, cy)) env.t() else env.nil();
 }
 
 /// (ghostel--copy-all-text TERM)
@@ -1258,4 +1221,44 @@ fn fnDisableVtLog(raw_env: ?*c.emacs_env, _: isize, _: [*c]c.emacs_value, _: ?*a
         vt_log_active = false;
     }
     return env.t();
+}
+
+fn fnUriAt(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
+    const env = emacs.Env.init(raw_env.?);
+    const term = env.getUserPtr(Terminal, args[0]) orelse return env.nil();
+    const row_from_bottom = env.extractInteger(args[1]);
+    const col = env.extractInteger(args[2]);
+    const total_rows = term.getTotalRows();
+
+    if (col < 0 or col >= term.cols) return env.nil();
+    // The Emacs buffer always carries a trailing newline, so the line
+    // immediately after the last content row produces row_from_bottom == 0.
+    if (row_from_bottom <= 0 or row_from_bottom > total_rows) return env.nil();
+    const row = total_rows - @as(usize, @intCast(row_from_bottom));
+
+    const point = gt.Point{ .tag = gt.c.GHOSTTY_POINT_TAG_SCREEN, .value = gt.PointValue{ .coordinate = gt.PointCoordinate{
+        .x = @intCast(col),
+        .y = @intCast(row),
+    } } };
+    var grid_ref = gt.GridRef{ .size = @sizeOf(gt.GridRef) };
+    if (gt.c.ghostty_terminal_grid_ref(term.terminal, point, &grid_ref) != gt.SUCCESS) {
+        return env.nil();
+    }
+
+    // Query hyperlink URI (stack buffer; heap fallback for long URIs).
+    var uri_stack: [2048]u8 = undefined;
+    var out_len: usize = 0;
+    var heap_uri: ?[]u8 = null;
+    defer if (heap_uri) |buf| std.heap.c_allocator.free(buf);
+
+    var result = gt.c.ghostty_grid_ref_hyperlink_uri(&grid_ref, &uri_stack, uri_stack.len, &out_len);
+    if (result == gt.OUT_OF_SPACE and out_len > uri_stack.len) {
+        const buf = std.heap.c_allocator.alloc(u8, out_len) catch return env.nil();
+        heap_uri = buf;
+        result = gt.c.ghostty_grid_ref_hyperlink_uri(&grid_ref, buf.ptr, buf.len, &out_len);
+    }
+
+    if (result != gt.SUCCESS or out_len == 0) return env.nil();
+    const uri = if (heap_uri) |buf| buf else &uri_stack;
+    return env.makeString(uri[0..out_len]);
 }

--- a/src/render.zig
+++ b/src/render.zig
@@ -1,12 +1,9 @@
 /// RenderState-based terminal rendering to Emacs buffers.
 ///
-/// Reads dirty rows/cells from the ghostty render state, extracts
-/// text and style attributes, and inserts propertized text into the
-/// current Emacs buffer.
-///
-/// Supports two modes:
-/// - DIRTY_FULL: erase buffer and redraw everything
-/// - DIRTY_PARTIAL: only update dirty rows in-place
+/// Reads rows/cells from the ghostty render state, extracts text and
+/// style attributes, and inserts propertized text into the current
+/// Emacs buffer.  See `redraw' below for the per-redraw algorithm
+/// (viewport parking, scrollback sync, dirty-row reuse).
 const std = @import("std");
 const emacs = @import("emacs.zig");
 const gt = @import("ghostty.zig");
@@ -23,6 +20,7 @@ const CellStyle = struct {
     underline_color: ?gt.ColorRgb = null,
     strikethrough: bool = false,
     inverse: bool = false,
+    hyperlink: bool = false,
 
     fn eql(a: CellStyle, b: CellStyle) bool {
         return colorEql(a.fg, b.fg) and
@@ -33,7 +31,8 @@ const CellStyle = struct {
             a.underline == b.underline and
             colorEql(a.underline_color, b.underline_color) and
             a.strikethrough == b.strikethrough and
-            a.inverse == b.inverse;
+            a.inverse == b.inverse and
+            a.hyperlink == b.hyperlink;
     }
 
     fn isDefault(self: CellStyle) bool {
@@ -44,7 +43,8 @@ const CellStyle = struct {
             !self.faint and
             self.underline == 0 and
             !self.strikethrough and
-            !self.inverse;
+            !self.inverse and
+            !self.hyperlink;
     }
 };
 
@@ -86,37 +86,8 @@ fn formatColor(color: gt.ColorRgb, buf: *[7]u8) []const u8 {
     return buf[0..7];
 }
 
-/// Tri-state cache of the per-cell raw handle. Used by `buildRowContent`
-/// so cells that need both the semantic-content check (in-prompt) and
-/// the wide-spacer check (empty grapheme) only pay for one
-/// `cells_get(RAW)` call.
-const RawTag = enum { unset, loaded, failed };
-
-/// Lazily populate `out` with the raw cell; memoizes success/failure
-/// in `tag` so repeated calls within one cell do not re-issue the get.
-///
-/// The cache assumes `cells_get(RAW)` is idempotent for a given
-/// iterator position (which it is in libghostty today — it returns a
-/// handle into already-materialized cell data).  If that ever
-/// changes, a failed first call would become sticky for the rest of
-/// the current cell.
-fn loadRawCell(cells: gt.RenderStateRowCells, out: *gt.c.GhosttyCell, tag: *RawTag) bool {
-    switch (tag.*) {
-        .unset => {
-            if (gt.c.ghostty_render_state_row_cells_get(cells, gt.c.GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_RAW, @ptrCast(out)) == gt.SUCCESS) {
-                tag.* = .loaded;
-                return true;
-            }
-            tag.* = .failed;
-            return false;
-        },
-        .loaded => return true,
-        .failed => return false,
-    }
-}
-
 /// Read the style for the current cell from the render state.
-fn readCellStyle(cells: gt.RenderStateRowCells) CellStyle {
+fn readCellStyle(cells: gt.RenderStateRowCells, raw: gt.c.GhosttyCell) CellStyle {
     var style: CellStyle = .{};
 
     // Read resolved FG color
@@ -132,7 +103,7 @@ fn readCellStyle(cells: gt.RenderStateRowCells) CellStyle {
     }
 
     // Read style attributes
-    var gs: gt.Style = std.mem.zeroes(gt.Style);
+    var gs: gt.Style = undefined;
     gs.size = @sizeOf(gt.Style);
     if (gt.c.ghostty_render_state_row_cells_get(cells, gt.RS_CELLS_DATA_STYLE, @ptrCast(&gs)) == gt.SUCCESS) {
         style.bold = gs.bold;
@@ -148,24 +119,33 @@ fn readCellStyle(cells: gt.RenderStateRowCells) CellStyle {
         }
     }
 
+    var hl: bool = undefined;
+    if (gt.c.ghostty_cell_get(raw, gt.c.GHOSTTY_CELL_DATA_HAS_HYPERLINK, @ptrCast(&hl)) == gt.SUCCESS) {
+        style.hyperlink = hl;
+    }
+
     return style;
 }
 
 /// Apply face properties to a region of the buffer.
 /// Uses (put-text-property START END 'face PLIST).
-fn applyStyle(env: emacs.Env, start: i64, end: i64, style: CellStyle, default_fg: gt.ColorRgb, default_bg: gt.ColorRgb) void {
+fn applyStyle(env: emacs.Env, start: i64, end: i64, style: CellStyle, default_colors: *const BgFg) void {
     if (style.isDefault()) return;
     if (start >= end) return;
 
-    var props: [24]emacs.Value = undefined;
-    var prop_count: usize = 0;
+    var face_props: [24]emacs.Value = undefined;
+    var face_prop_count: usize = 0;
+    const start_val = env.makeInteger(start);
+    const end_val = env.makeInteger(end);
 
     var fg_buf: [7]u8 = undefined;
     var bg_buf: [7]u8 = undefined;
     var dim_buf: [7]u8 = undefined;
 
-    const effective_fg = if (style.inverse) (style.bg orelse default_bg) else (style.fg orelse default_fg);
-    const effective_bg = if (style.inverse) (style.fg orelse default_fg) else (style.bg orelse default_bg);
+    const bg = style.bg orelse default_colors.bg;
+    const fg = style.fg orelse default_colors.fg;
+    const effective_fg = if (style.inverse) bg else fg;
+    const effective_bg = if (style.inverse) fg else bg;
 
     const s = &emacs.sym;
 
@@ -174,45 +154,45 @@ fn applyStyle(env: emacs.Env, start: i64, end: i64, style: CellStyle, default_fg
         // Always set :foreground since we modify the color itself.
         const dimmed = dimColor(effective_fg, effective_bg);
         const dim_str = formatColor(dimmed, &dim_buf);
-        props[prop_count] = s.@":foreground";
-        prop_count += 1;
-        props[prop_count] = env.makeString(dim_str);
-        prop_count += 1;
+        face_props[face_prop_count] = s.@":foreground";
+        face_prop_count += 1;
+        face_props[face_prop_count] = env.makeString(dim_str);
+        face_prop_count += 1;
     } else if (!colorEql(style.fg, null) or style.inverse) {
         const fg_str = formatColor(effective_fg, &fg_buf);
-        props[prop_count] = s.@":foreground";
-        prop_count += 1;
-        props[prop_count] = env.makeString(fg_str);
-        prop_count += 1;
+        face_props[face_prop_count] = s.@":foreground";
+        face_prop_count += 1;
+        face_props[face_prop_count] = env.makeString(fg_str);
+        face_prop_count += 1;
     }
 
     if (!colorEql(style.bg, null) or style.inverse) {
         const bg_str = formatColor(effective_bg, &bg_buf);
-        props[prop_count] = s.@":background";
-        prop_count += 1;
-        props[prop_count] = env.makeString(bg_str);
-        prop_count += 1;
+        face_props[face_prop_count] = s.@":background";
+        face_prop_count += 1;
+        face_props[face_prop_count] = env.makeString(bg_str);
+        face_prop_count += 1;
     }
 
     if (style.bold) {
-        props[prop_count] = s.@":weight";
-        prop_count += 1;
-        props[prop_count] = s.bold;
-        prop_count += 1;
+        face_props[face_prop_count] = s.@":weight";
+        face_prop_count += 1;
+        face_props[face_prop_count] = s.bold;
+        face_prop_count += 1;
     }
 
     if (style.italic) {
-        props[prop_count] = s.@":slant";
-        prop_count += 1;
-        props[prop_count] = s.italic;
-        prop_count += 1;
+        face_props[face_prop_count] = s.@":slant";
+        face_prop_count += 1;
+        face_props[face_prop_count] = s.italic;
+        face_prop_count += 1;
     }
 
     if (style.underline != 0) {
-        props[prop_count] = s.@":underline";
-        prop_count += 1;
+        face_props[face_prop_count] = s.@":underline";
+        face_prop_count += 1;
         if (style.underline == 1 and style.underline_color == null) {
-            props[prop_count] = env.t();
+            face_props[face_prop_count] = env.t();
         } else {
             var ul_props: [4]emacs.Value = undefined;
             var ul_count: usize = 0;
@@ -236,170 +216,27 @@ fn applyStyle(env: emacs.Env, start: i64, end: i64, style: CellStyle, default_fg
                 ul_count += 1;
             }
 
-            props[prop_count] = env.funcall(s.list, ul_props[0..ul_count]);
+            face_props[face_prop_count] = env.funcall(s.list, ul_props[0..ul_count]);
         }
-        prop_count += 1;
+        face_prop_count += 1;
     }
 
     if (style.strikethrough) {
-        props[prop_count] = s.@":strike-through";
-        prop_count += 1;
-        props[prop_count] = env.t();
-        prop_count += 1;
+        face_props[face_prop_count] = s.@":strike-through";
+        face_prop_count += 1;
+        face_props[face_prop_count] = env.t();
+        face_prop_count += 1;
     }
 
-    if (prop_count == 0) return;
-
-    const face = env.funcall(s.list, props[0..prop_count]);
-    const start_val = env.makeInteger(start);
-    const end_val = env.makeInteger(end);
-    env.putTextProperty(start_val, end_val, s.face, face);
-}
-
-/// A hyperlink span detected from the terminal grid.
-const HyperlinkSpan = struct {
-    row: u16,
-    col_start: u16,
-    col_end: u16,
-    uri_start: usize, // offset into uri_buf
-    uri_len: usize,
-};
-
-/// Result of hyperlink scanning.
-const HyperlinkResult = struct {
-    count: usize,
-    uri_used: usize,
-};
-
-/// Scan specific rows for hyperlinks using the grid_ref API.
-/// Queries each cell directly for its hyperlink URI, coalescing
-/// adjacent cells with the same URI into spans.
-fn scanHyperlinksFromGrid(
-    terminal: gt.Terminal,
-    cols: u16,
-    hyperlink_rows: []const u16,
-    spans: []HyperlinkSpan,
-    uri_buf: []u8,
-) HyperlinkResult {
-    var span_count: usize = 0;
-    var uri_used: usize = 0;
-
-    for (hyperlink_rows) |row| {
-        var in_link = false;
-        var link_start_col: u16 = 0;
-        var link_uri_start: usize = 0;
-        var link_uri_len: usize = 0;
-
-        for (0..cols) |col_idx| {
-            const col: u16 = @intCast(col_idx);
-
-            // Build viewport point for this cell
-            var point: gt.Point = undefined;
-            point.tag = gt.c.GHOSTTY_POINT_TAG_VIEWPORT;
-            point.value = .{ .coordinate = .{ .x = col, .y = @intCast(row) } };
-
-            // Resolve grid ref
-            var grid_ref = std.mem.zeroes(gt.GridRef);
-            grid_ref.size = @sizeOf(gt.GridRef);
-            if (gt.c.ghostty_terminal_grid_ref(terminal, point, &grid_ref) != gt.SUCCESS) {
-                if (in_link and span_count < spans.len and col > link_start_col) {
-                    spans[span_count] = .{ .row = row, .col_start = link_start_col, .col_end = col, .uri_start = link_uri_start, .uri_len = link_uri_len };
-                    span_count += 1;
-                }
-                in_link = false;
-                continue;
-            }
-
-            // Query hyperlink URI (stack buffer; heap fallback for long URIs)
-            var uri_stack: [2048]u8 = undefined;
-            var out_len: usize = 0;
-            var result = gt.c.ghostty_grid_ref_hyperlink_uri(&grid_ref, &uri_stack, uri_stack.len, &out_len);
-            var heap_uri: ?[]u8 = null;
-            defer if (heap_uri) |buf| std.heap.c_allocator.free(buf);
-
-            if (result == gt.OUT_OF_SPACE and out_len > uri_stack.len) {
-                if (std.heap.c_allocator.alloc(u8, out_len)) |buf| {
-                    heap_uri = buf;
-                    result = gt.c.ghostty_grid_ref_hyperlink_uri(&grid_ref, buf.ptr, buf.len, &out_len);
-                } else |_| {}
-            }
-
-            if (result == gt.SUCCESS and out_len > 0) {
-                const uri = if (heap_uri) |buf| buf[0..out_len] else uri_stack[0..out_len];
-                // Check if this extends the current span (same URI)
-                if (in_link and link_uri_len == out_len and
-                    std.mem.eql(u8, uri_buf[link_uri_start..link_uri_start + link_uri_len], uri))
-                {
-                    // Same URI — span continues
-                } else {
-                    // Close previous span if any
-                    if (in_link and span_count < spans.len and col > link_start_col) {
-                        spans[span_count] = .{ .row = row, .col_start = link_start_col, .col_end = col, .uri_start = link_uri_start, .uri_len = link_uri_len };
-                        span_count += 1;
-                    }
-                    // Start new span, copy URI to shared buffer
-                    if (uri_used + out_len <= uri_buf.len) {
-                        @memcpy(uri_buf[uri_used .. uri_used + out_len], uri);
-                        link_uri_start = uri_used;
-                        link_uri_len = out_len;
-                        uri_used += out_len;
-                        link_start_col = col;
-                        in_link = true;
-                    } else {
-                        in_link = false;
-                    }
-                }
-            } else {
-                // No hyperlink on this cell — close any open span
-                if (in_link and span_count < spans.len and col > link_start_col) {
-                    spans[span_count] = .{ .row = row, .col_start = link_start_col, .col_end = col, .uri_start = link_uri_start, .uri_len = link_uri_len };
-                    span_count += 1;
-                }
-                in_link = false;
-            }
-        }
-
-        // Close span at end of row
-        if (in_link and span_count < spans.len and cols > link_start_col) {
-            spans[span_count] = .{ .row = row, .col_start = link_start_col, .col_end = cols, .uri_start = link_uri_start, .uri_len = link_uri_len };
-            span_count += 1;
-        }
+    if (face_prop_count > 0) {
+        const face = env.funcall(s.list, face_props[0..face_prop_count]);
+        env.putTextProperty(start_val, end_val, s.face, face);
     }
 
-    return .{ .count = span_count, .uri_used = uri_used };
-}
-
-/// Apply hyperlink text properties to the Emacs buffer.
-/// Row indices are relative to the viewport — caller passes the char
-/// position of the first viewport line so we can resolve absolute rows.
-fn applyHyperlinks(
-    env: emacs.Env,
-    spans: []const HyperlinkSpan,
-    span_count: usize,
-    uri_buf: []const u8,
-    viewport_start: i64,
-) void {
-    if (span_count == 0) return;
-
-    const s = &emacs.sym;
-    // Cache the link keymap value
-    const link_map = env.call1(s.@"symbol-value", s.@"ghostel-link-map");
-
-    for (spans[0..span_count]) |span| {
-        const uri = uri_buf[span.uri_start..span.uri_start + span.uri_len];
-        if (uri.len == 0) continue;
-
-        // Navigate to span start (viewport-relative row -> absolute line)
-        env.gotoCharN(viewport_start);
-        _ = env.forwardLine(@as(i64, span.row));
-        env.moveToColumn(@as(i64, span.col_start));
-        const start = env.point();
-        env.moveToColumn(@as(i64, span.col_end));
-        const end = env.point();
-
-        env.putTextProperty(start, end, s.@"help-echo", env.makeString(uri));
-        env.putTextProperty(start, end, s.@"mouse-face", s.highlight);
-        env.putTextProperty(start, end, s.keymap, link_map);
+    if (style.hyperlink) {
+        env.putTextProperty(start_val, end_val, s.@"help-echo", s.@"ghostel--native-link-help-echo");
+        env.putTextProperty(start_val, end_val, s.@"mouse-face", s.highlight);
+        env.putTextProperty(start_val, end_val, s.keymap, env.call1(s.@"symbol-value", s.@"ghostel-link-map"));
     }
 }
 
@@ -423,91 +260,6 @@ fn isRowPrompt(term: *Terminal) bool {
     var semantic: c_int = 0;
     _ = gt.c.ghostty_row_get(raw_row, gt.ROW_DATA_SEMANTIC_PROMPT, @ptrCast(&semantic));
     return semantic != 0;
-}
-
-/// Return true if row `cy` (0-indexed, viewport-relative) renders to an
-/// empty Emacs buffer line — no cell has a grapheme and no cell has
-/// non-default styling.  Matches `buildRowContent`'s trim rules: a row
-/// for which this returns true produces `byte_len == 0`.
-///
-/// Assumes the caller has refreshed the render state (via
-/// `ghostty_render_state_update`).  Drives the row iterator, so callers
-/// must not rely on iterator position after this call.
-pub fn isRowEmptyAt(term: *Terminal, cy: u16) bool {
-    if (gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_ROW_ITERATOR, @ptrCast(&term.row_iterator)) != gt.SUCCESS) return false;
-
-    var ri: u16 = 0;
-    while (ri <= cy) : (ri += 1) {
-        if (!gt.c.ghostty_render_state_row_iterator_next(term.row_iterator)) return false;
-    }
-
-    if (gt.c.ghostty_render_state_row_get(term.row_iterator, gt.RS_ROW_DATA_CELLS, @ptrCast(&term.row_cells)) != gt.SUCCESS) {
-        return false;
-    }
-
-    while (gt.c.ghostty_render_state_row_cells_next(term.row_cells)) {
-        var graphemes_len: u32 = 0;
-        if (gt.c.ghostty_render_state_row_cells_get(term.row_cells, gt.RS_CELLS_DATA_GRAPHEMES_LEN, @ptrCast(&graphemes_len)) == gt.SUCCESS and graphemes_len > 0) {
-            return false;
-        }
-        // Mirror `buildRowContent`: wide-spacer-tail cells are skipped
-        // outright and never contribute to buffer content, even when
-        // they carry non-default styling.
-        var raw_cell: gt.c.GhosttyCell = undefined;
-        if (gt.c.ghostty_render_state_row_cells_get(term.row_cells, gt.c.GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_RAW, @ptrCast(&raw_cell)) == gt.SUCCESS) {
-            var wide: c_int = gt.c.GHOSTTY_CELL_WIDE_NARROW;
-            _ = gt.c.ghostty_cell_get(raw_cell, gt.c.GHOSTTY_CELL_DATA_WIDE, @ptrCast(&wide));
-            if (wide == gt.c.GHOSTTY_CELL_WIDE_SPACER_TAIL) continue;
-        }
-        if (!readCellStyle(term.row_cells).isDefault()) return false;
-    }
-    return true;
-}
-
-/// Read the first scrollback row's codepoints into `out` (one per cell,
-/// up to 512 entries). Returns true on success, false if there is no
-/// scrollback or anything fails. For terminals wider than 512 columns
-/// only the first 512 cells are compared — a practical limit since
-/// 512 columns exceeds any standard display.
-///
-/// Used to detect rotation: when libghostty's scrollback is plateaued at
-/// its byte cap, sustained writes evict the oldest row in lockstep with
-/// new rows being pushed, so `total_rows` doesn't change and the normal
-/// delta-detection sees no work to do. Comparing the full row lets us
-/// detect that the row at index 0 has changed underneath us.
-///
-/// Scrolls libghostty's viewport to the top to read the row, then
-/// restores the previous viewport offset. Gated by the caller to only
-/// run when rotation is suspected.
-fn readFirstScrollbackRow(term: *Terminal, out: *[512]u32) bool {
-    const sb = term.getScrollbar() orelse return false;
-    const saved_offset = sb.offset;
-
-    term.scrollViewport(gt.SCROLL_TOP, 0);
-    defer {
-        term.scrollViewport(gt.SCROLL_TOP, 0);
-        if (saved_offset > 0) {
-            term.scrollViewport(gt.SCROLL_DELTA, @intCast(saved_offset));
-        }
-    }
-
-    if (gt.c.ghostty_render_state_update(term.render_state, term.terminal) != gt.SUCCESS) return false;
-    if (gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_ROW_ITERATOR, @ptrCast(&term.row_iterator)) != gt.SUCCESS) return false;
-    if (!gt.c.ghostty_render_state_row_iterator_next(term.row_iterator)) return false;
-    if (gt.c.ghostty_render_state_row_get(term.row_iterator, gt.RS_ROW_DATA_CELLS, @ptrCast(&term.row_cells)) != gt.SUCCESS) return false;
-
-    @memset(out, 0);
-    var i: usize = 0;
-    const cols = @min(term.cols, 512);
-    while (i < cols and gt.c.ghostty_render_state_row_cells_next(term.row_cells)) : (i += 1) {
-        var graphemes_len: u32 = 0;
-        if (gt.c.ghostty_render_state_row_cells_get(term.row_cells, gt.RS_CELLS_DATA_GRAPHEMES_LEN, @ptrCast(&graphemes_len)) != gt.SUCCESS) continue;
-        if (graphemes_len == 0) continue;
-        var codepoints: [4]u32 = undefined;
-        if (gt.c.ghostty_render_state_row_cells_get(term.row_cells, gt.RS_CELLS_DATA_GRAPHEMES_BUF, @ptrCast(&codepoints)) != gt.SUCCESS) continue;
-        out[i] = codepoints[0];
-    }
-    return true;
 }
 
 /// Result from buildRowContent: byte length for make_string, char count for properties.
@@ -556,25 +308,21 @@ fn buildRowContent(
         if (gt.c.ghostty_render_state_row_cells_get(term.row_cells, gt.RS_CELLS_DATA_GRAPHEMES_LEN, @ptrCast(&graphemes_len)) != gt.SUCCESS) {
             continue;
         }
-
-        // Raw cell handle, fetched lazily for the semantic-content and
-        // wide-spacer checks that each need it. Without the shared slot,
-        // empty prompt padding would pay for two cells_get(RAW) calls.
         var raw_cell: gt.c.GhosttyCell = undefined;
-        var raw_tag: RawTag = .unset;
+        if (gt.c.ghostty_render_state_row_cells_get(term.row_cells, gt.c.GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_RAW, @ptrCast(&raw_cell)) != gt.SUCCESS) {
+            continue;
+        }
 
         // Track leading prompt characters via cell-level semantic content.
         if (in_prompt) {
             var semantic: c_int = 0; // GHOSTTY_CELL_SEMANTIC_OUTPUT
-            if (loadRawCell(term.row_cells, &raw_cell, &raw_tag)) {
-                _ = gt.c.ghostty_cell_get(raw_cell, gt.c.GHOSTTY_CELL_DATA_SEMANTIC_CONTENT, @ptrCast(&semantic));
-            }
+            _ = gt.c.ghostty_cell_get(raw_cell, gt.c.GHOSTTY_CELL_DATA_SEMANTIC_CONTENT, @ptrCast(&semantic));
             if (semantic != gt.c.GHOSTTY_CELL_SEMANTIC_PROMPT) {
                 in_prompt = false;
             }
         }
 
-        const cell_style = readCellStyle(term.row_cells);
+        const cell_style = readCellStyle(term.row_cells, raw_cell);
 
         // Flush run on style change
         if (char_len > run_start_char and !cell_style.eql(current_style)) {
@@ -597,9 +345,7 @@ fn buildRowContent(
             // not produce output — the preceding wide cell already accounts
             // for 2 visual columns in Emacs.
             var wide: c_int = gt.c.GHOSTTY_CELL_WIDE_NARROW;
-            if (loadRawCell(term.row_cells, &raw_cell, &raw_tag)) {
-                _ = gt.c.ghostty_cell_get(raw_cell, gt.c.GHOSTTY_CELL_DATA_WIDE, @ptrCast(&wide));
-            }
+            _ = gt.c.ghostty_cell_get(raw_cell, gt.c.GHOSTTY_CELL_DATA_WIDE, @ptrCast(&wide));
             if (wide == gt.c.GHOSTTY_CELL_WIDE_SPACER_TAIL) {
                 has_wide = true;
                 continue;
@@ -668,16 +414,36 @@ fn buildRowContent(
 /// Insert row text and apply style runs.
 fn insertAndStyle(
     env: emacs.Env,
-    text_buf: []const u8,
-    content: RowContent,
-    runs: []const RunInfo,
-    run_count: usize,
-    default_fg: gt.ColorRgb,
-    default_bg: gt.ColorRgb,
-) void {
-    if (content.byte_len == 0) return;
+    term: *Terminal,
+    default_colors: *const BgFg,
+) ?RowContent {
+    if (gt.c.ghostty_render_state_row_get(term.row_iterator, gt.RS_ROW_DATA_CELLS, @ptrCast(&term.row_cells)) != gt.SUCCESS) {
+        return null;
+    }
 
-    const insert_start = env.extractInteger(env.point());
+    var runs: [512]RunInfo = undefined;
+    var text_buf: [16384]u8 = undefined;
+    var run_count: usize = 0;
+    var content = buildRowContent(term, &text_buf, &runs, &run_count);
+
+    // Append the trailing newline to the row buffer so the row
+    // text + newline insert through a single env.insert call
+    // instead of two. This saves one Elisp FFI round-trip per
+    // inserted row, which is the dominant per-row cost in this
+    // hot loop. Style runs only cover the row's cells, so the
+    // unstyled trailing \n is harmless to insertAndStyle. If the
+    // row exactly filled text_buf, fall back to a separate
+    // env.insert("\n") so the "one row per line" invariant
+    // (relied on by the `after_insert - 1` property math below)
+    // always holds.
+    const newline_in_buf = content.byte_len < text_buf.len;
+    if (newline_in_buf) {
+        text_buf[content.byte_len] = '\n';
+        content.byte_len += 1;
+        content.char_len += 1;
+    }
+
+    const row_start = env.extractInteger(env.point());
     env.insert(text_buf[0..content.byte_len]);
 
     for (runs[0..run_count]) |run| {
@@ -685,134 +451,39 @@ fn insertAndStyle(
         const run_end = @min(run.end_char, content.char_len);
         if (run_end <= run.start_char) continue;
 
-        const prop_start = insert_start + @as(i64, @intCast(run.start_char));
-        const prop_end = insert_start + @as(i64, @intCast(run_end));
-        applyStyle(env, prop_start, prop_end, run.style, default_fg, default_bg);
-    }
-}
-
-/// Insert `count` libghostty rows starting at `first_row` (0 = top of
-/// scrollback) into the Emacs buffer at `point`. Each row is followed by
-/// a newline; soft-wrapped rows get the `ghostel-wrap` property on their
-/// trailing newline so copy-mode can filter them out.
-///
-/// Drives libghostty by scrolling its viewport through the requested range
-/// and re-querying the render state for each page. The caller is expected
-/// to save and restore the libghostty viewport position around this call.
-///
-/// Returns the number of rows actually inserted.
-fn insertScrollbackRange(
-    env: emacs.Env,
-    term: *Terminal,
-    first_row: usize,
-    count: usize,
-    default_fg: gt.ColorRgb,
-    default_bg: gt.ColorRgb,
-) usize {
-    if (count == 0) return 0;
-
-    // Position libghostty viewport at first_row.
-    term.scrollViewport(gt.SCROLL_TOP, 0);
-    if (first_row > 0) {
-        term.scrollViewport(gt.SCROLL_DELTA, @intCast(first_row));
+        const prop_start = row_start + @as(i64, @intCast(run.start_char));
+        const prop_end = row_start + @as(i64, @intCast(run_end));
+        applyStyle(env, prop_start, prop_end, run.style, default_colors);
     }
 
-    var runs: [512]RunInfo = undefined;
-    var text_buf: [16384]u8 = undefined;
-
-    var inserted: usize = 0;
-
-    while (inserted < count) {
-        const cur_sb = term.getScrollbar() orelse break;
-        const viewport_start = cur_sb.offset;
-
-        if (gt.c.ghostty_render_state_update(term.render_state, term.terminal) != gt.SUCCESS) break;
-        if (gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_ROW_ITERATOR, @ptrCast(&term.row_iterator)) != gt.SUCCESS) break;
-
-        const absolute_target = first_row + inserted;
-        const skip: usize = if (absolute_target > viewport_start) absolute_target - viewport_start else 0;
-        if (skip >= term.rows) break;
-        const take: usize = @min(term.rows - skip, count - inserted);
-        if (take == 0) break;
-
-        var row_in_page: usize = 0;
-        var took: usize = 0;
-        while (gt.c.ghostty_render_state_row_iterator_next(term.row_iterator)) {
-            defer row_in_page += 1;
-            if (row_in_page < skip) continue;
-            if (took >= take) break;
-
-            if (gt.c.ghostty_render_state_row_get(term.row_iterator, gt.RS_ROW_DATA_CELLS, @ptrCast(&term.row_cells)) != gt.SUCCESS) {
-                took += 1;
-                inserted += 1;
-                continue;
-            }
-
-            var run_count: usize = 0;
-            var content = buildRowContent(term, &text_buf, &runs, &run_count);
-
-            // Append the trailing newline to the row buffer so the row
-            // text + newline insert through a single env.insert call
-            // instead of two. This saves one Elisp FFI round-trip per
-            // inserted row, which is the dominant per-row cost in this
-            // hot loop. Style runs only cover the row's cells, so the
-            // unstyled trailing \n is harmless to insertAndStyle. If the
-            // row exactly filled text_buf, fall back to a separate
-            // env.insert("\n") so the "one row per line" invariant
-            // (relied on by the `after_insert - 1` property math below)
-            // always holds.
-            const newline_in_buf = content.byte_len < text_buf.len;
-            if (newline_in_buf) {
-                text_buf[content.byte_len] = '\n';
-                content.byte_len += 1;
-                content.char_len += 1;
-            }
-
-            const row_start = env.extractInteger(env.point());
-            insertAndStyle(env, &text_buf, content, &runs, run_count, default_fg, default_bg);
-            if (!newline_in_buf) {
-                env.insert("\n");
-            }
-            const after_insert = env.extractInteger(env.point());
-
-            if (content.prompt_char_len > 0) {
-                env.putTextProperty(
-                    env.makeInteger(row_start),
-                    env.makeInteger(row_start + @as(i64, @intCast(content.prompt_char_len))),
-                    emacs.sym.@"ghostel-prompt",
-                    env.t(),
-                );
-            } else if (isRowPrompt(term)) {
-                env.putTextProperty(
-                    env.makeInteger(row_start),
-                    env.makeInteger(after_insert - 1), // exclude trailing newline
-                    emacs.sym.@"ghostel-prompt",
-                    env.t(),
-                );
-            }
-
-            // Mark the trailing newline with ghostel-wrap if the row is
-            // soft-wrapped, so copy-mode can filter wrap newlines from
-            // copied text.
-            if (isRowWrapped(term)) {
-                env.putTextProperty(
-                    env.makeInteger(after_insert - 1),
-                    env.makeInteger(after_insert),
-                    emacs.sym.@"ghostel-wrap",
-                    env.t(),
-                );
-            }
-
-            took += 1;
-            inserted += 1;
-        }
-
-        if (inserted >= count) break;
-        // Advance viewport by a full page for the next iteration.
-        term.scrollViewport(gt.SCROLL_DELTA, @intCast(term.rows));
+    if (!newline_in_buf) {
+        env.insert("\n");
+    }
+    const after_insert = env.extractInteger(env.point());
+    if (isRowWrapped(term)) {
+        // Mark newlines from soft-wrapped rows so copy mode can filter them
+        const point = env.point();
+        const nl_pos = env.makeInteger(env.extractInteger(point) - 1);
+        env.putTextProperty(nl_pos, point, emacs.sym.@"ghostel-wrap", env.t());
     }
 
-    return inserted;
+    if (content.prompt_char_len > 0) {
+        env.putTextProperty(
+            env.makeInteger(row_start),
+            env.makeInteger(row_start + @as(i64, @intCast(content.prompt_char_len))),
+            emacs.sym.@"ghostel-prompt",
+            env.t(),
+        );
+    } else if (isRowPrompt(term)) {
+        env.putTextProperty(
+            env.makeInteger(row_start),
+            env.makeInteger(after_insert - 1), // exclude trailing newline
+            emacs.sym.@"ghostel-prompt",
+            env.t(),
+        );
+    }
+
+    return content;
 }
 
 /// Convert a terminal column to an Emacs character offset by iterating
@@ -879,242 +550,35 @@ fn positionCursorByCell(env: emacs.Env, term: *Terminal, cx: u16, cy: u16) bool 
     return true;
 }
 
-/// Redraw the terminal into the current Emacs buffer.
-///
-/// Maintains a "growing buffer" model where the Emacs buffer contains
-/// all materialized scrollback (above) and the current viewport (below).
-/// On each call we:
-///   1. Force libghostty's viewport to the bottom (active screen).
-///   2. Poll `getTotalRows()` against `term.scrollback_in_buffer` to
-///      detect rows that scrolled off the top of the viewport and promoted them
-///      to the scrollback part of the buffer
-///   3. Render the viewport into the tail of the buffer, anchored at
-///      the line that follows the last scrollback row.
-///
-/// When `force_full` is true, the viewport region is fully re-rendered
-/// instead of using the incremental dirty-row path.
-pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
-    // Snapshot the buffer's mark across the destructive ops below.  Both
-    // paths — full (eraseBuffer / deleteRegion over the viewport) and
-    // partial (per-row deleteRegion + insert) — move every marker in the
-    // buffer by standard Emacs marker rules.  Point is owned by the
-    // renderer and is placed at the TUI cursor on exit, but mark is user
-    // state (C-SPC, region commands) and must survive the redraw.  Other
-    // markers (e.g. evil's visual-beginning/end) remain the caller's
-    // responsibility to preserve in elisp.
-    const saved_mark: ?i64 = blk: {
-        const pos = env.markerPosition(env.markMarker());
-        if (!env.isNotNil(pos)) break :blk null;
-        break :blk env.extractInteger(pos);
+const BgFg = struct {
+    bg: gt.ColorRgb,
+    fg: gt.ColorRgb,
+};
+
+fn getDefaultColors(term: *Terminal) BgFg {
+    var bgfg = BgFg{ .fg = gt.ColorRgb{ .r = 204, .g = 204, .b = 204 }, .bg = gt.ColorRgb{ .r = 0, .g = 0, .b = 0 } };
+    const color_keys = [_]gt.c.GhosttyRenderStateData{
+        gt.RS_DATA_COLOR_FOREGROUND,
+        gt.RS_DATA_COLOR_BACKGROUND,
     };
-    defer {
-        if (saved_mark) |pos| {
-            const pmax = env.extractInteger(env.pointMax());
-            const clamped: i64 = if (pos > pmax) pmax else pos;
-            _ = env.setMarker(env.markMarker(), env.makeInteger(clamped));
-        }
-    }
+    var color_values = [_]?*anyopaque{
+        @ptrCast(&bgfg.fg),
+        @ptrCast(&bgfg.bg),
+    };
+    _ = gt.c.ghostty_render_state_get_multi(term.render_state, color_keys.len, &color_keys, @ptrCast(&color_values), null);
 
-    var force_full = force_full_arg;
+    return bgfg;
+}
 
-    // Lock the libghostty viewport to the bottom. Users navigate history
-    // through Emacs now, so any lingering scroll offset (e.g. from an
-    // explicit ghostel--scroll) would desync our scrollback tracker.
-    if (term.getScrollbar()) |sb| {
-        if (sb.len + sb.offset < sb.total) {
-            term.scrollViewport(gt.SCROLL_BOTTOM, 0);
-        }
-    }
+pub fn render(env: emacs.Env, term: *Terminal, render_state: gt.RenderState, skip: usize, force_full: bool) void {
+    const default_colors = getDefaultColors(term);
 
-    // Update render state from terminal
-    if (gt.c.ghostty_render_state_update(term.render_state, term.terminal) != gt.SUCCESS) {
-        return;
-    }
-
-    // Resolve default colors once — used for both the scrollback append
-    // path and the viewport render path.  These always succeed (the
-    // render state always has resolved default colors), so batching is safe.
-    var default_fg = gt.ColorRgb{ .r = 204, .g = 204, .b = 204 };
-    var default_bg = gt.ColorRgb{ .r = 0, .g = 0, .b = 0 };
-    {
-        const color_keys = [_]gt.c.GhosttyRenderStateData{
-            gt.RS_DATA_COLOR_FOREGROUND,
-            gt.RS_DATA_COLOR_BACKGROUND,
-        };
-        var color_values = [_]?*anyopaque{
-            @ptrCast(&default_fg),
-            @ptrCast(&default_bg),
-        };
-        _ = gt.c.ghostty_render_state_get_multi(term.render_state, color_keys.len, &color_keys, @ptrCast(&color_values), null);
-    }
-
-    // ---- Scrollback validity ------------------------------------------------
-    // Two signals can invalidate buffered scrollback and are collected here;
-    // a third (rotation) is checked below.
-    //
-    //   rebuild_pending: set by terminal.resize() and by the CSI 3 J scanner
-    //                    in vtWrite. Defers the Emacs-buffer erase into the
-    //                    redraw pass where inhibit-redisplay prevents a
-    //                    visible blank frame.
-    //
-    //   rotation:        checked below via a row-0 hash; only computed when
-    //                    rebuild_pending hasn't already fired.
-    var scrollback_stale = term.rebuild_pending;
-    term.rebuild_pending = false;
-
-    // ---- Rotation detection ------------------------------------------------
-    // When libghostty's scrollback cap is saturated, sustained writes evict
-    // the oldest rows. total_rows doesn't change, so the delta-sync below
-    // would see nothing to do — detect the churn by hashing the first
-    // scrollback row and comparing to the value sampled at the last redraw.
-    //
-    // Skip when scrollback is already known to be stale: the viewport scroll
-    // that sampling requires is wasted work if we are about to erase anyway.
-    // On a hash match, stash the value for reuse at end-of-redraw (promotion
-    // and insert-at-tail don't shift row 0, so it stays valid).
-    var cached_row0_valid = false;
-    if (!scrollback_stale and
-        term.wrote_since_redraw and
-        term.scrollback_in_buffer > 0 and
-        term.first_scrollback_row_valid)
-    {
-        var new_row: [512]u32 = undefined;
-        const read_ok = readFirstScrollbackRow(term, &new_row);
-        // readFirstScrollbackRow scrolled libghostty's viewport to
-        // sample row 0; the render state is now stale — refresh it.
-        if (gt.c.ghostty_render_state_update(term.render_state, term.terminal) != gt.SUCCESS) return;
-        const compare_cols = @min(term.cols, 512);
-        if (read_ok and !std.mem.eql(u32, new_row[0..compare_cols], term.first_scrollback_row[0..compare_cols])) {
-            scrollback_stale = true;
-        } else if (read_ok) {
-            cached_row0_valid = true;
-        }
-    }
-
-    // Compare counts: scrollback shrinking means the buffered rows are no
-    // longer valid (CSI 3 J or resize would have set rebuild_pending, but
-    // this catches any other unexpected reduction).
-    const total_rows = term.getTotalRows();
-    const libghostty_sb: usize = if (total_rows > term.rows) total_rows - term.rows else 0;
-    if (libghostty_sb < term.scrollback_in_buffer) scrollback_stale = true;
-
-    // If scrollback is stale for any reason, erase it completely.
-    if (scrollback_stale) {
-        env.eraseBuffer();
-        term.scrollback_in_buffer = 0;
-        term.first_scrollback_row_valid = false;
-        force_full = true;
-    }
-
-    // ---- Scrollback sync ---------------------------------------------------
-    // libghostty stores scrollback + active screen in a single row space.
-    // The rows "above" the viewport are scrollback; our invariant is that
-    // those rows are all materialized in the Emacs buffer, one per line.
-    //
-    // We compute the viewport-start char position at most once per redraw
-    // by walking from point-min and reusing point() after any insert/trim
-    // touches it. forwardLine is O(scrollback) so doing it twice would
-    // double the per-redraw cost in long-running sessions.
-
-    // Walk to the current viewport start (line scrollback_in_buffer + 1).
-    env.gotoCharN(1);
-    if (term.scrollback_in_buffer > 0) {
-        _ = env.forwardLine(@as(i64, @intCast(term.scrollback_in_buffer)));
-    }
-    var viewport_start_int = env.extractInteger(env.point());
-
-    if (libghostty_sb > term.scrollback_in_buffer) {
-        // New rows scrolled off in libghostty. Strategy:
-        //
-        // 1. Promote as many existing buffer rows as possible. The rows
-        //    that were at the top of the viewport in the previous redraw
-        //    are exactly the rows libghostty just pushed into scrollback,
-        //    so just bumping `scrollback_in_buffer` makes them scrollback
-        //    in our model too — no fetch, no re-render. Critically, any
-        //    text properties applied to those rows while they were in the
-        //    viewport (URL detection, ghostel-prompt, etc.) survive
-        //    automatically because we never touch the text.
-        //
-        // 2. If the buffer didn't have enough viewport rows to absorb the
-        //    full delta (bootstrap, post-resize, or a burst that scrolled
-        //    more rows than the viewport between redraws), fall back to
-        //    `insertScrollbackRange` for the remainder.
-        var delta = libghostty_sb - term.scrollback_in_buffer;
-
-        // Skip promotion when the entire previous viewport scrolled off
-        // during first materialization.  The buffer still contains the
-        // initial viewport (often mostly empty rows from before any
-        // output) which was overwritten at the cursor before scrolling
-        // off — promoted rows would be stale.  When delta < rows only
-        // the topmost rows scrolled off; those sat above the cursor and
-        // were not overwritten, so promotion is safe even on the first
-        // burst.  The stale old viewport tail gets cleaned up by the
-        // deleteRegion(viewport_start, pointMax) in the viewport
-        // renderer below.
-        var promoted: usize = 0;
-        if (term.scrollback_in_buffer > 0 or delta < term.rows) {
-            env.gotoCharN(viewport_start_int);
-            const remaining_lines = env.forwardLine(@as(i64, @intCast(delta)));
-            promoted = delta - @as(usize, @intCast(remaining_lines));
-
-            // forward-line counts the position right after the last buffer
-            // char as a moveable "line N+1" even when the buffer doesn't
-            // end in \n. That position corresponds to our terminal cursor
-            // row — a stale snapshot, NOT a real libghostty scrollback row.
-            // If we landed at pointMax with no trailing newline, peel one
-            // off the promoted count so we don't promote the cursor row.
-            if (promoted > 0 and env.extractInteger(env.point()) == env.extractInteger(env.pointMax())) {
-                const cb = env.call0(emacs.sym.@"char-before");
-                if (env.isNotNil(cb) and env.extractInteger(cb) != '\n') {
-                    promoted -= 1;
-                }
-            }
-
-            if (promoted > 0) {
-                term.scrollback_in_buffer += promoted;
-                // forward-line may have left point at pointMax even when it
-                // partially walked past complete lines, so always re-walk
-                // exactly `promoted` newline-bounded lines to anchor the new
-                // viewport_start at the start of the first un-promoted row.
-                env.gotoCharN(viewport_start_int);
-                _ = env.forwardLine(@as(i64, @intCast(promoted)));
-                viewport_start_int = env.extractInteger(env.point());
-                delta -= promoted;
-            }
-        }
-
-        if (delta > 0) {
-            // Bootstrap fallback: fetch the rest from libghostty.
-            env.gotoCharN(viewport_start_int);
-            const inserted = insertScrollbackRange(
-                env,
-                term,
-                term.scrollback_in_buffer,
-                delta,
-                default_fg,
-                default_bg,
-            );
-            term.scrollback_in_buffer += inserted;
-            viewport_start_int = env.extractInteger(env.point());
-
-            // insertScrollbackRange scrolled libghostty's viewport through
-            // the scrollback range — restore it to the active screen and
-            // refresh the render state for the viewport render below.
-            term.scrollViewport(gt.SCROLL_BOTTOM, 0);
-            if (gt.c.ghostty_render_state_update(term.render_state, term.terminal) != gt.SUCCESS) return;
-        }
-    }
-
-    // Check dirty state — cells are only redrawn when dirty, but cursor
-    // positioning always runs so that cursor-only movements are visible.
+    // Check dirty state.
     // force_full overrides: the buffer may have been erased by scrollback
     // sync / resize / rotation above, so we must rebuild even if
     // libghostty considers the cells clean.
     var dirty: c_int = gt.DIRTY_FALSE;
-    _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_DIRTY, @ptrCast(&dirty));
-    var has_hyperlinks: bool = false;
-    var hyperlink_rows: [256]u16 = undefined;
-    var hyperlink_row_count: usize = 0;
+    _ = gt.c.ghostty_render_state_get(render_state, gt.RS_DATA_DIRTY, @ptrCast(&dirty));
     var has_wide_chars: bool = false;
 
     if (dirty != gt.DIRTY_FALSE or force_full) {
@@ -1123,151 +587,50 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
         var bg_hex: [7]u8 = undefined;
         _ = env.call2(
             emacs.sym.@"ghostel--set-buffer-face",
-            env.makeString(formatColor(default_fg, &fg_hex)),
-            env.makeString(formatColor(default_bg, &bg_hex)),
+            env.makeString(formatColor(default_colors.fg, &fg_hex)),
+            env.makeString(formatColor(default_colors.bg, &bg_hex)),
         );
 
         // Get row iterator
-        if (gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_ROW_ITERATOR, @ptrCast(&term.row_iterator)) != gt.SUCCESS) {
+        if (gt.c.ghostty_render_state_get(render_state, gt.RS_DATA_ROW_ITERATOR, @ptrCast(&term.row_iterator)) != gt.SUCCESS) {
             return;
         }
 
         // Incremental redraw: only update dirty rows when possible.
         // force_full bypasses partial mode to avoid stale rows after scrolls.
-        const partial = (!force_full and dirty == gt.DIRTY_PARTIAL);
-        if (!partial) {
-            // Wipe only the viewport region; scrollback stays intact.
-            env.deleteRegion(env.makeInteger(viewport_start_int), env.pointMax());
-        }
-
-        // Shared buffers for row content
-        var runs: [512]RunInfo = undefined;
-        var text_buf: [16384]u8 = undefined;
-
+        const dirty_full = force_full or dirty == gt.DIRTY_FULL;
         var row_count: usize = 0;
-        var prev_wrapped: bool = false;
-        while (gt.c.ghostty_render_state_row_iterator_next(term.row_iterator)) {
-            if (partial) {
-                // Only process dirty rows
-                var row_dirty: bool = false;
-                _ = gt.c.ghostty_render_state_row_get(term.row_iterator, gt.RS_ROW_DATA_DIRTY, @ptrCast(&row_dirty));
-                if (!row_dirty) {
-                    row_count += 1;
-                    // Still need to track wrap state for next row
-                    prev_wrapped = isRowWrapped(term);
-                    continue;
-                }
-            }
-
-            // Get cells for this row
-            if (gt.c.ghostty_render_state_row_get(term.row_iterator, gt.RS_ROW_DATA_CELLS, @ptrCast(&term.row_cells)) != gt.SUCCESS) {
-                row_count += 1;
-                prev_wrapped = false;
-                continue;
-            }
-
-            // Check for hyperlinks (row-level flag, may have false positives)
-            {
-                var raw_row: gt.c.GhosttyRow = undefined;
-                if (gt.c.ghostty_render_state_row_get(term.row_iterator, gt.c.GHOSTTY_RENDER_STATE_ROW_DATA_RAW, @ptrCast(&raw_row)) == gt.SUCCESS) {
-                    var row_has_links: bool = false;
-                    _ = gt.c.ghostty_row_get(raw_row, gt.ROW_DATA_HYPERLINK, @ptrCast(&row_has_links));
-                    if (row_has_links and hyperlink_row_count < hyperlink_rows.len) {
-                        hyperlink_rows[hyperlink_row_count] = @intCast(row_count);
-                        hyperlink_row_count += 1;
-                        has_hyperlinks = true;
-                    }
-                }
-            }
-
-            if (partial) {
-                // Navigate to this row (viewport-relative) and clear its content.
-                env.gotoCharN(viewport_start_int);
-                const moved = env.forwardLine(@as(i64, @intCast(row_count)));
-                if (moved != 0) {
-                    // Row doesn't exist yet — fall through to append
-                    env.gotoChar(env.pointMax());
-                    env.insert("\n");
-                } else {
-                    env.deleteRegion(env.point(), env.lineEndPosition());
-                }
+        while (gt.c.ghostty_render_state_row_iterator_next(term.row_iterator)) : (row_count += 1) {
+            defer {
                 // Clear per-row dirty flag
                 const row_clean: bool = false;
                 _ = gt.c.ghostty_render_state_row_set(term.row_iterator, gt.RS_ROW_OPT_DIRTY, @ptrCast(&row_clean));
-            } else {
-                // Full redraw: insert newline between rows
-                if (row_count > 0) {
-                    const nl_start = env.point();
-                    env.insert("\n");
-                    // Mark newlines from soft-wrapped rows so copy mode can filter them
-                    if (prev_wrapped) {
-                        env.putTextProperty(nl_start, env.point(), emacs.sym.@"ghostel-wrap", env.t());
-                    }
+            }
+
+            if (row_count < skip) continue;
+
+            // Only process dirty rows
+            var dirty_row: bool = dirty_full;
+            if (!dirty_full) {
+                _ = gt.c.ghostty_render_state_row_get(term.row_iterator, gt.RS_ROW_DATA_DIRTY, @ptrCast(&dirty_row));
+            }
+
+            if (dirty_row) {
+                env.deleteRegion(env.point(), env.lineBeginningPosition2());
+                if (insertAndStyle(env, term, &default_colors)) |content| {
+                    has_wide_chars |= content.has_wide;
                 }
-            }
-
-            // Build row content
-            var run_count: usize = 0;
-            const content = buildRowContent(term, &text_buf, &runs, &run_count);
-            if (content.has_wide) has_wide_chars = true;
-
-            // Insert text and apply styles
-            const row_start = env.extractInteger(env.point());
-            insertAndStyle(env, &text_buf, content, &runs, run_count, default_fg, default_bg);
-
-            // Mark prompt portion (cell-level boundary), or entire row (row-level fallback).
-            if (content.prompt_char_len > 0) {
-                env.putTextProperty(
-                    env.makeInteger(row_start),
-                    env.makeInteger(row_start + @as(i64, @intCast(content.prompt_char_len))),
-                    emacs.sym.@"ghostel-prompt",
-                    env.t(),
-                );
-            } else if (isRowPrompt(term)) {
-                env.putTextProperty(
-                    env.makeInteger(row_start),
-                    env.point(),
-                    emacs.sym.@"ghostel-prompt",
-                    env.t(),
-                );
-            }
-
-            // Track whether this row is soft-wrapped for the next newline
-            prev_wrapped = isRowWrapped(term);
-            row_count += 1;
-        }
-
-        // Trim excess buffer lines beyond the terminal's row count.
-        // Partial redraws don't erase the viewport region, so stale
-        // trailing lines can accumulate after a resize or mode switch.
-        if (partial and row_count > 0) {
-            env.gotoCharN(viewport_start_int);
-            if (env.forwardLine(@as(i64, @intCast(row_count))) == 0) {
-                env.deleteRegion(env.point(), env.pointMax());
+            } else {
+                _ = env.forwardLine(1);
             }
         }
+
+        // If there's anything left below the viewport, delete it
+        env.deleteRegion(env.point(), env.pointMax());
 
         // Reset dirty state
         const dirty_false: c_int = gt.DIRTY_FALSE;
-        _ = gt.c.ghostty_render_state_set(term.render_state, gt.RS_OPT_DIRTY, @ptrCast(&dirty_false));
-    }
-
-    // Scan for hyperlinks and apply text properties (before cursor positioning).
-    // Uses the grid_ref API to query hyperlink URIs directly from cells,
-    // only for rows flagged with GHOSTTY_ROW_DATA_HYPERLINK.
-    if (dirty != gt.DIRTY_FALSE and has_hyperlinks) {
-        var hl_spans: [128]HyperlinkSpan = undefined;
-        var hl_uri_buf: [8192]u8 = undefined;
-        const hl = scanHyperlinksFromGrid(
-            term.terminal,
-            term.cols,
-            hyperlink_rows[0..hyperlink_row_count],
-            &hl_spans,
-            &hl_uri_buf,
-        );
-        if (hl.count > 0) {
-            applyHyperlinks(env, &hl_spans, hl.count, &hl_uri_buf, viewport_start_int);
-        }
+        _ = gt.c.ghostty_render_state_set(render_state, gt.RS_OPT_DIRTY, @ptrCast(&dirty_false));
     }
 
     if (dirty != gt.DIRTY_FALSE) {
@@ -1275,6 +638,14 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
             _ = env.call2(env.intern("set"), emacs.sym.@"ghostel--has-wide-chars", env.t());
         }
     }
+}
+
+pub fn renderCursor(env: emacs.Env, term: *Terminal) void {
+
+    // Walk to the current viewport start
+    env.gotoChar(env.pointMax());
+    _ = env.forwardLine(-@as(i64, @intCast(term.rows)));
+    const viewport_start_int = env.extractInteger(env.point());
 
     // Batch-fetch cursor style/visibility (always available).
     var cursor_visible: bool = true;
@@ -1314,30 +685,134 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
         env.makeInteger(@as(i64, cursor_style)),
         if (cursor_visible) env.t() else env.nil(),
     );
+}
+
+/// Redraw the terminal into the current Emacs buffer.
+///
+/// The Emacs buffer is a permanent record: all materialized scrollback sits
+/// above the active viewport and is never evicted, even when libghostty
+/// rotates rows out at the scrollback cap.
+///
+/// Detection relies on parking the libghostty viewport at `max_offset - 1`
+/// at the end of every render (see bottom of this function).  On the next
+/// call the parked position tells us two things:
+///   - If scrollback was cleared, the viewport will have snapped back to the
+///     bottom (`offset + len == total`), so we erase and rebuild.
+///   - Otherwise, advancing the viewport by 1 lands exactly at the new
+///     active area, and `total - offset` tells us how many rows to render.
+///
+/// When `force_full` is true, the viewport region is fully re-rendered
+/// instead of using the incremental dirty-row path.
+pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
+    // Snapshot the buffer's mark across the destructive ops below.  Both
+    // paths — full (eraseBuffer / deleteRegion over the viewport) and
+    // partial (per-row deleteRegion + insert) — move every marker in the
+    // buffer by standard Emacs marker rules.  Point is owned by the
+    // renderer and is placed at the TUI cursor on exit, but mark is user
+    // state (C-SPC, region commands) and must survive the redraw.  Other
+    // markers (e.g. evil's visual-beginning/end) remain the caller's
+    // responsibility to preserve in elisp.
+    const saved_mark: ?i64 = blk: {
+        const pos = env.markerPosition(env.markMarker());
+        if (!env.isNotNil(pos)) break :blk null;
+        break :blk env.extractInteger(pos);
+    };
+    defer {
+        if (saved_mark) |pos| {
+            const pmax = env.extractInteger(env.pointMax());
+            const clamped: i64 = if (pos > pmax) pmax else pos;
+            _ = env.setMarker(env.markMarker(), env.makeInteger(clamped));
+        }
+    }
+
+    var force_full = force_full_arg;
+
+    // ---- Scrollback validity ------------------------------------------------
+    // There are three cases where we clear scrollback:
+    // 1. It was explicitly requested through `rebuild_pending`
+    // 2. We had some scrollback but the scrollbar was reset from the parked
+    //    MAX - 1 position. This indicates that libghostty cleared its
+    //    scrollback and we follow after by clearing too.
+    // 3. We had some scrollback but the scrollbar ended up at offset = 0, which
+    //    means that we got so much scrolling that we scrolled all the way up
+    //    and do not know how much we missed.
+    var scrollbar = term.getScrollbar() orelse return;
+    const scrollbar_reset = term.scrollback_in_buffer > 0 and scrollbar.len + scrollbar.offset == scrollbar.total;
+    const scrollbar_hit_cap = term.scrollback_in_buffer > 0 and scrollbar.offset == 0;
+    if (term.rebuild_pending or scrollbar_reset or scrollbar_hit_cap) {
+        env.eraseBuffer();
+        term.scrollback_in_buffer = 0;
+        force_full = true;
+        term.rebuild_pending = false;
+    }
+
+    // Unpark the viewport. When we have scrollback the viewport is sitting at
+    // `max_offset - 1`; advance by 1 to reach the old active area, which is
+    // also where the Emacs buffer currently ends. When we have no scrollback
+    // there was no parking, so go to the top instead.
+    if (term.scrollback_in_buffer > 0) {
+        term.scrollViewport(gt.SCROLL_DELTA, 1);
+        scrollbar.offset += 1;
+        env.gotoChar(env.pointMax());
+        _ = env.forwardLine(-@as(i64, @intCast(scrollbar.len)));
+    } else {
+        term.scrollViewport(gt.SCROLL_TOP, 0);
+        scrollbar.offset = 0;
+        env.gotoChar(env.pointMin());
+    }
+
+    if (scrollbar.len == 0) return;
+    const offset_max = scrollbar.total - scrollbar.len;
+    // Walk from the current viewport position to offset_max in viewport-sized
+    // steps, rendering each chunk into the Emacs buffer. Consecutive positions
+    // overlap by `scrollbar.len - step` rows when the remaining range is
+    // smaller than a full viewport; `skip` tracks how many leading rows of the
+    // next position were already rendered at the tail of the previous one.
+    // After the loop the viewport sits at offset_max (the active area).
+    const total_range = scrollbar.total - scrollbar.offset;
+    const num_viewports = (total_range + scrollbar.len - 1) / scrollbar.len;
+    var skip: usize = 0;
+    var rendered_rows: usize = 0;
+    for (0..num_viewports) |_| {
+        if (gt.c.ghostty_render_state_update(term.render_state, term.terminal) != gt.SUCCESS) {
+            return;
+        }
+        render(env, term, term.render_state, skip, force_full);
+        rendered_rows += (scrollbar.len - skip);
+
+        const max_step = offset_max - scrollbar.offset;
+        const step = @min(max_step, scrollbar.len);
+        skip = scrollbar.len - step;
+
+        scrollbar.offset += step;
+        term.scrollViewport(gt.SCROLL_DELTA, @intCast(step));
+    }
+    // rendered_rows covers all rows from the old active area to the new bottom,
+    // so subtracting one viewport's worth gives the count of newly added
+    // scrollback rows.
+    term.scrollback_in_buffer += (rendered_rows - scrollbar.len);
+
+    // Evict old scrollback if libghostty also did
+    const libghostty_scrollback = term.getScrollbackRows();
+    if (libghostty_scrollback < term.scrollback_in_buffer) {
+        env.gotoChar(env.pointMin());
+        _ = env.forwardLine(@as(i64, @intCast(term.scrollback_in_buffer - libghostty_scrollback)));
+        env.deleteRegion(env.pointMin(), env.point());
+        term.scrollback_in_buffer = libghostty_scrollback;
+    }
+
+    renderCursor(env, term);
 
     // Update working directory from OSC 7
     if (term.getPwd()) |pwd| {
         _ = env.call1(emacs.sym.@"ghostel--update-directory", env.makeString(pwd));
     }
 
-    // Update the cached first-scrollback-row snapshot for the next redraw's
-    // rotation check. When the start-of-redraw check found no rotation,
-    // `term.first_scrollback_row` already holds the current value — skip
-    // the second round trip. If nothing was written at all, row 0 cannot
-    // have moved, so skip entirely. This covers cursor-only redraws and
-    // idle-timer fires.
-    if (term.scrollback_in_buffer > 0) {
-        if (cached_row0_valid) {
-            // term.first_scrollback_row is already current; nothing to do.
-        } else if (term.wrote_since_redraw) {
-            term.first_scrollback_row_valid = readFirstScrollbackRow(term, &term.first_scrollback_row);
-        }
-        // else: no writes, no cached row → existing value is still current.
-    } else {
-        term.first_scrollback_row_valid = false;
-    }
-
-    // Clear the write flag so the next redraw can detect "writes happened
-    // since last redraw" for the rotation check.
-    term.wrote_since_redraw = false;
+    // Park the viewport one row above the bottom. On the next render, if
+    // libghostty has cleared its scrollback the viewport will have snapped back
+    // to the bottom (`offset + len == total`), which we treat as the rebuild
+    // signal. If scrollback only grew, the parked position naturally points at
+    // the old active area, and advancing by 1 reaches the new one.
+    term.scrollViewport(gt.SCROLL_BOTTOM, 0);
+    term.scrollViewport(gt.SCROLL_DELTA, -1);
 }

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -36,12 +36,6 @@ rows: u16,
 /// libghostty's scrollback cap.
 scrollback_in_buffer: usize = 0,
 
-/// Set by `vtWrite`, cleared at the end of `redraw`. Used to detect that
-/// libghostty has been written to since the last redraw — required by
-/// the cap-bound stale-scrollback rebuild trigger to distinguish "no
-/// activity" from "writes happened but total_rows plateaued".
-wrote_since_redraw: bool = false,
-
 /// When true, the next redraw erases the Emacs buffer,
 /// resets scrollback state, and forces a full rebuild.  The erase is deferred
 /// so `inhibit-redisplay` can prevent a visible blank frame.
@@ -58,15 +52,6 @@ rebuild_pending: bool = false,
 /// Reset by `resize` since a reflow means the stream is effectively
 /// new.
 last_input_was_cr: bool = false,
-
-/// Snapshot of the first scrollback row's codepoints (one per cell, up
-/// to `cols` entries), sampled at the end of each redraw that touched
-/// scrollback. Used to detect rotation (libghostty evicting the oldest
-/// row in lockstep with new ones being pushed) when `total_rows` is
-/// plateaued at the cap. Only meaningful when `first_scrollback_row_valid`
-/// is true.
-first_scrollback_row: [512]u32 = [_]u32{0} ** 512,
-first_scrollback_row_valid: bool = false,
 
 /// Cached Emacs env pointer — only valid during a callback from Emacs.
 env: ?emacs.Env = null,
@@ -219,7 +204,6 @@ pub fn getColorBackground(self: *Self, out: *gt.ColorRgb) bool {
 /// Feed VT data from the PTY into the terminal.
 pub fn vtWrite(self: *Self, data: []const u8) void {
     gt.c.ghostty_terminal_vt_write(self.terminal, data.ptr, data.len);
-    self.wrote_since_redraw = true;
 }
 
 /// Resize the terminal.
@@ -290,6 +274,15 @@ pub fn getTotalRows(self: *Self) usize {
         return self.rows;
     }
     return total;
+}
+
+/// Get the number of scrollback rows.
+pub fn getScrollbackRows(self: *Self) usize {
+    var scrollback: usize = 0;
+    if (gt.c.ghostty_terminal_get(self.terminal, gt.DATA_SCROLLBACK_ROWS, @ptrCast(&scrollback)) != gt.SUCCESS) {
+        return self.rows;
+    }
+    return scrollback;
 }
 
 /// Get the scrollbar state (total, offset, len).

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -3,10 +3,10 @@
 ;;; Commentary:
 
 ;; Run with:
-;;   `emacs --batch -Q -L . -l ert -l test/ghostel-test.el -f ghostel-test-run'
+;;   `emacs --batch -Q -L lisp -l ert -l test/ghostel-test.el -f ghostel-test-run'
 ;;
 ;; Pure Elisp tests only (no native module):
-;;   `emacs --batch -Q -L . -l ert -l test/ghostel-test.el -f ghostel-test-run-elisp'
+;;   `emacs --batch -Q -L lisp -l ert -l test/ghostel-test.el -f ghostel-test-run-elisp'
 
 ;;; Code:
 
@@ -162,6 +162,36 @@ succeeds."
 ;; Test: erase sequences
 ;; -----------------------------------------------------------------------
 
+(ert-deftest ghostel-test-cursor-position-preserves-viewport ()
+  "`ghostel--cursor-position' must not move the viewport.
+The function temporarily scrolls to the bottom to query the cursor and
+must restore the previous offset.  If it leaves the viewport parked at
+`offset+len==total', the next `ghostel--redraw' mistakes that for a
+libghostty scrollback-clear and triggers a full erase + rebuild — which
+would collapse all buffer markers to `point-min'.  Anchor a marker in
+scrollback, call cursor-position, redraw, and assert the marker held."
+  (let ((buf (generate-new-buffer " *ghostel-test-cursor-pos-vp*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 80 1000))
+                 (inhibit-read-only t))
+            ;; Overflow the viewport so the buffer holds real scrollback.
+            (dotimes (i 12)
+              (ghostel--write-input term (format "row-%02d\r\n" i)))
+            (ghostel--redraw term t)
+            ;; Anchor a marker on a scrolled-off row, well past `point-min'.
+            (goto-char (point-min))
+            (search-forward "row-00")
+            (let* ((target (point))
+                   (m (copy-marker target)))
+              (unwind-protect
+                  (progn
+                    (ghostel--cursor-position term)
+                    (ghostel--redraw term)
+                    (should (= target (marker-position m))))
+                (set-marker m nil)))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-redraw-preserves-mark ()
   "`ghostel--redraw' must keep `mark' stable across the destructive ops.
 Full redraws call `eraseBuffer' and partial redraws `deleteRegion',
@@ -235,10 +265,8 @@ This is the vterm-style growing-buffer model that lets `isearch' and
               (should (string-match-p "row-05" content))
               ;; The most recent row is on the active screen.
               (should (string-match-p "row-11" content)))
-            ;; 12 distinct rows made it into the buffer.  The trailing
-            ;; empty cursor row is trimmed to nothing by the renderer
-            ;; and therefore contributes no additional line.
-            (should (= 12 (count-lines (point-min) (point-max))))))
+            ;; 12 distinct rows made it into the buffer + trailing newline
+            (should (= 13 (count-lines (point-min) (point-max))))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-scrollback-bootstrap-not-blank ()
@@ -353,6 +381,100 @@ attached."
                              (get-text-property (- url-pos 19) 'help-echo))))))
       (kill-buffer buf))))
 
+;; -----------------------------------------------------------------------
+;; Tests: OSC 8 on-demand URI lookup (native)
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-osc8-renders-native-link-handler ()
+  "OSC8 links set `help-echo' to the native handler symbol, not a URI string.
+After the refactor, render stores `ghostel--native-link-help-echo' as the
+`help-echo' text property so Emacs calls it lazily instead of embedding
+the URI in the buffer."
+  (let ((buf (generate-new-buffer " *ghostel-test-osc8-render*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 5 80 1000))
+                 (ghostel--term term)
+                 (ghostel--term-rows 5)
+                 (inhibit-read-only t))
+            (ghostel--write-input term "\e]8;;https://example.com\e\\link text\e]8;;\e\\")
+            (ghostel--redraw term t)
+            (goto-char (point-min))
+            (let* ((end (search-forward "link text" nil t))
+                   (link-pos (- end (length "link text"))))
+              (should end)
+              (should (eq #'ghostel--native-link-help-echo  ; function symbol, not string URI
+                          (get-text-property link-pos 'help-echo)))
+              (should (keymapp (get-text-property link-pos 'keymap))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-osc8-uri-at-pos-returns-uri ()
+  "`ghostel--native-uri-at-pos' queries libghostty and returns the OSC8 URI."
+  (let ((buf (generate-new-buffer " *ghostel-test-osc8-uri*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 5 80 1000))
+                 (ghostel--term term)
+                 (ghostel--term-rows 5)
+                 (inhibit-read-only t))
+            (ghostel--write-input term "\e]8;;https://example.com\e\\link text\e]8;;\e\\")
+            (ghostel--redraw term t)
+            (goto-char (point-min))
+            (let* ((end (search-forward "link text" nil t))
+                   (link-pos (- end (length "link text"))))
+              (should end)
+              (should (equal "https://example.com"
+                             (ghostel--native-uri-at-pos link-pos))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-osc8-uri-at-pos-nil-outside-link ()
+  "`ghostel--native-uri-at-pos' returns nil or empty for a non-link cell."
+  (let ((buf (generate-new-buffer " *ghostel-test-osc8-nolink*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 5 80 1000))
+                 (ghostel--term term)
+                 (ghostel--term-rows 5)
+                 (inhibit-read-only t))
+            (ghostel--write-input term "plain text")
+            (ghostel--redraw term t)
+            (goto-char (point-min))
+            (let ((uri (ghostel--native-uri-at-pos (point))))
+              (should (or (null uri) (string= "" uri))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-osc8-uri-at-pos-two-links ()
+  "`ghostel--native-uri-at-pos' returns the correct URI for each of two links."
+  (let ((buf (generate-new-buffer " *ghostel-test-osc8-two*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 5 80 1000))
+                 (ghostel--term term)
+                 (ghostel--term-rows 5)
+                 (inhibit-read-only t))
+            (ghostel--write-input
+             term
+             (concat "\e]8;;https://first.example\e\\first\e]8;;\e\\"
+                     " and "
+                     "\e]8;;https://second.example\e\\second\e]8;;\e\\"))
+            (ghostel--redraw term t)
+            (goto-char (point-min))
+            (let* ((first-end (search-forward "first" nil t))
+                   (first-pos (- first-end (length "first")))
+                   (second-end (search-forward "second" nil t))
+                   (second-pos (- second-end (length "second"))))
+              (should first-end)
+              (should second-end)
+              (should (equal "https://first.example"
+                             (ghostel--native-uri-at-pos first-pos)))
+              (should (equal "https://second.example"
+                             (ghostel--native-uri-at-pos second-pos))))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-scrollback-grows-incrementally ()
   "Successive redraws append newly-scrolled-off rows without losing history."
   (let ((buf (generate-new-buffer " *ghostel-test-sb-incr*")))
@@ -377,54 +499,6 @@ attached."
               (should (string-match-p "first-07" content))
               (should (string-match-p "second-00" content))
               (should (string-match-p "second-05" content)))))
-      (kill-buffer buf))))
-
-(ert-deftest ghostel-test-scrollback-rotation-rebuild ()
-  "Verify cap rotation triggers a rebuild so the buffer reflects libghostty.
-The test fills libghostty past its scrollback cap with EARLY markers,
-redraws once so the buffer matches the current libghostty state, then
-writes a much bigger batch of LATE markers (without an intervening
-redraw).  When the next redraw runs, libghostty's `total_rows' is
-plateaued at the cap so the normal delta-detection sees nothing to do
-— the rotation-detect path must kick in, notice the first scrollback
-row's hash has changed, erase the buffer, and let the bootstrap fetch
-re-sync from libghostty so the buffer reflects the LATE rows."
-  (let ((buf (generate-new-buffer " *ghostel-test-sb-rotate*")))
-    (unwind-protect
-        (with-current-buffer buf
-          (let* (;; 4 KB cap empirically holds ~920 rows of short content
-                 ;; in libghostty's compact storage.
-                 (term (ghostel--new 5 80 (* 4 1024)))
-                 (inhibit-read-only t))
-            ;; Phase 1: write 5000 EARLY rows. libghostty's scrollback
-            ;; saturates at ~920 rows so the surviving rows are
-            ;; early-04080..early-04999 (the most recent 920 of 5000).
-            (dotimes (i 5000)
-              (ghostel--write-input term (format "early-%05d\r\n" i)))
-            (ghostel--redraw term t)
-            ;; After this redraw, buffer's scrollback_in_buffer matches
-            ;; libghostty's count (~920) and contains those high-numbered
-            ;; early rows.
-            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
-              (should (string-match-p "early-04999" content)))
-            ;; Phase 2: write 5000 LATE rows WITHOUT redrawing in
-            ;; between. libghostty rotates: every new write evicts an
-            ;; early row and pushes a late row. After 5000 writes, all
-            ;; survivors are late-* (since 5000 > 920 cap).
-            (dotimes (i 5000)
-              (ghostel--write-input term (format "late-%05d\r\n" i)))
-            ;; Final redraw: total_rows hasn't changed (libghostty is
-            ;; still at the cap) but the content has fully rotated.
-            ;; Without rotation-detect this would be a no-op and the
-            ;; buffer would still show early-* rows.
-            (ghostel--redraw term t)
-            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
-              ;; Late rows must be present (libghostty kept the most
-              ;; recent ones, the rebuild fetched them into the buffer).
-              (should (string-match-p "late-04999" content))
-              ;; Early rows must NOT be present anywhere — libghostty
-              ;; evicted them AND the rebuild flushed our stale copy.
-              (should-not (string-match-p "early-" content)))))
       (kill-buffer buf))))
 
 ;; -----------------------------------------------------------------------
@@ -481,6 +555,74 @@ scrolling libghostty's viewport."
             (delete-process proc)))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-scrollback-eviction-chunked ()
+  "Scrollback eviction works when writing happens in little chunks with
+renders in between.  Writes a small batch, renders, then writes a large
+batch across many small writes interspersed with renders.  The accumulated
+scrollback from the second phase must evict the first phase from the
+Emacs buffer."
+  (let ((buf (generate-new-buffer " *ghostel-test-sb-evict*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 6 80 1024))
+                 (inhibit-read-only t))
+            ;; Write a small initial batch
+            (dotimes (i 20)
+              (ghostel--write-input term (format "early-%05d\r\n" i)))
+            (ghostel--redraw term t)
+            ;; Write a large batch in many small chunks with renders in between
+            (dotimes (x 200)
+              (dotimes (i 100)
+                (ghostel--write-input term (format "late-%05d\r\n" i)))
+              (ghostel--redraw term t))
+            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+              (should (string-match-p "late-" content))
+              (should-not (string-match-p "early-" content)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-scrollback-eviction-bulk ()
+  "Scrollback eviction works when a single large write pushes all rows
+out of libghostty's scrollback cap at once.  Writes a small batch,
+renders, then writes a massive amount in one go that gets evicted in
+one fell swoop.  The second redraw must evict the first-batch rows from
+the Emacs buffer."
+  (let ((buf (generate-new-buffer " *ghostel-test-sb-evict*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 6 80 1024))
+                 (inhibit-read-only t))
+            ;; Write a small initial batch
+            (dotimes (i 20)
+              (ghostel--write-input term (format "early-%05d\r\n" i)))
+            (ghostel--redraw term t)
+            ;; Write a huge amount in one shot
+            (dotimes (i 200000)
+              (ghostel--write-input term (format "late-%05d\r\n" i)))
+            (ghostel--redraw term t)
+            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+              (should (string-match-p "late-" content))
+              (should-not (string-match-p "early-" content)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-no-stale-lines-in-scrollback ()
+  "Rows that have been materialized in a previous render and are then modified
+and scrolled out in a single write should not scroll out the stale row."
+  (let ((buf (generate-new-buffer " *ghostel-test-sb-buffer*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 80 1000))
+                 (inhibit-read-only t))
+            (ghostel--write-input term "wrong\r\n")
+            (ghostel--redraw term t)
+            (ghostel--write-input term "\e[Hfoobar\e[5;0Hyolo\r\n")
+            (ghostel--redraw term t)
+            (goto-char (point-min))
+            (let ((line (buffer-substring-no-properties (line-beginning-position)
+                                                        (line-end-position))))
+              ;; Should now equal "foobar", not "wrong"
+              (should (string= line "foobar")))))
+      (kill-buffer buf))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: clear scrollback (ghostel-clear-scrollback)
 ;; -----------------------------------------------------------------------
@@ -515,15 +657,17 @@ scrolling libghostty's viewport."
 Scenario (5-row terminal, 10 before-* rows, CSI 3J, 5 after-* rows,
 single redraw):
   - After the first redraw: before-00..before-05 are in scrollback (6
-    rows scrolled off), before-06..before-09 fill the viewport.
-  - CSI 3J clears libghostty's scrollback; the viewport is unchanged.
+    rows scrolled off), before-06..before-09 fill the viewport.  The
+    redraw parks libghostty's viewport at `max_offset - 1'.
+  - CSI 3J clears libghostty's scrollback, which snaps the viewport
+    back to the bottom (`offset + len == total').
   - Five new after-* rows scroll before-06..before-09 and after-00 into
     libghostty's freshly-cleared scrollback (5 rows); after-01..after-04
     are left in the viewport.
-  - At the next redraw, libghostty_sb (5) < scrollback_in_buffer (6),
-    so count-based detection triggers a full rebuild.  The rebuild_pending
-    flag (set by the CSI 3J scanner in vtWrite) also fires, ensuring the
-    erase happens even in scenarios where counts happen to match."
+  - At the next redraw, the viewport-snap signal (`offset + len ==
+    total' rather than the parked `max - 1') tells the renderer that
+    libghostty cleared its scrollback, triggering an erase + full
+    rebuild from the current libghostty state."
   (let ((buf (generate-new-buffer " *ghostel-test-csi3j-refill*")))
     (unwind-protect
         (with-current-buffer buf
@@ -1977,9 +2121,7 @@ first real focus event."
               (should (string-match-p "line-B" content))       ; row1 preserved
               (should (string-match-p "line-C updated" content))) ; row2 updated
 
-            ;; 3 content rows + 2 trailing blank rows trimmed to
-            ;; empty strings = 4 newlines = 4 lines counted.
-            (should (equal 4 (count-lines (point-min) (point-max))))))
+            (should (equal 5 (count-lines (point-min) (point-max))))))
       (kill-buffer buf))))
 
 ;; -----------------------------------------------------------------------
@@ -2073,15 +2215,55 @@ first real focus event."
   (should (lookup-key ghostel-link-map [mouse-1]))         ; mouse-1 bound in link map
   (should (lookup-key ghostel-link-map (kbd "RET")))       ; RET bound in link map
   (should (commandp #'ghostel-open-link-at-point))         ; open-link-at-point is interactive
-  ;; Test that help-echo property is read correctly
-  (with-temp-buffer
-    (insert "click here")
-    (put-text-property 1 11 'help-echo "https://example.com")
-    (goto-char 5)
-    (should (equal "https://example.com"                   ; help-echo at point
-                   (get-text-property (point) 'help-echo))))
   (should (null (ghostel--open-link nil)))                 ; open-link returns nil for empty
   (should (null (ghostel--open-link 42))))                 ; open-link returns nil for non-string
+
+(ert-deftest ghostel-test-uri-at-pos-prefers-string-help-echo ()
+  "`ghostel--uri-at-pos' returns a string `help-echo' without calling native.
+Plain-text link detection stores URIs as strings; the native path must
+not be reached when the property is already a string."
+  (with-temp-buffer
+    (insert "click here")
+    (put-text-property 1 11 'help-echo "https://static.example.com")
+    (goto-char 5)
+    (let (native-called)
+      (cl-letf (((symbol-function 'ghostel--native-uri-at-pos)
+                 (lambda (_) (setq native-called t) "should-not-reach")))
+        (should (equal "https://static.example.com"
+                       (ghostel--uri-at-pos (point))))
+        (should-not native-called)))))
+
+(ert-deftest ghostel-test-uri-at-pos-calls-native-for-function-help-echo ()
+  "`ghostel--uri-at-pos' delegates to native when `help-echo' is a function.
+OSC8 links set `help-echo' to the symbol `ghostel--native-link-help-echo';
+`ghostel--uri-at-pos' must call `ghostel--native-uri-at-pos' in that case."
+  (with-temp-buffer
+    (insert "click here")
+    (put-text-property 1 11 'help-echo #'ghostel--native-link-help-echo)
+    (goto-char 5)
+    (cl-letf (((symbol-function 'ghostel--native-uri-at-pos)
+               (lambda (_pos) "native-uri")))
+      (should (equal "native-uri" (ghostel--uri-at-pos (point)))))))
+
+(ert-deftest ghostel-test-native-link-help-echo-calls-uri-at-pos ()
+  "`ghostel--native-link-help-echo' delegates to `ghostel--native-uri-at-pos'.
+The help-echo handler stored on OSC8 link text-properties must call the
+native URI lookup when Emacs invokes it for tooltip display or clicking."
+  (let ((buf (generate-new-buffer " *ghostel-test-echo-handler*"))
+        (orig-buf (window-buffer (selected-window))))
+    (unwind-protect
+        (progn
+          (set-window-buffer (selected-window) buf)
+          (with-current-buffer buf
+            (insert "test content")
+            (cl-letf (((symbol-function 'ghostel--native-uri-at-pos)
+                       (lambda (pos) (format "uri-at-%d" pos))))
+              (should (equal "uri-at-1"
+                             (ghostel--native-link-help-echo
+                              (selected-window) nil 1))))))
+      (when (buffer-live-p orig-buf)
+        (set-window-buffer (selected-window) orig-buf))
+      (kill-buffer buf))))
 
 (ert-deftest ghostel-test-url-detection ()
   "Test automatic URL detection in plain text."
@@ -2100,14 +2282,14 @@ first real focus event."
     (let ((ghostel-enable-url-detection nil))
       (ghostel--detect-urls))
     (should (null (get-text-property 7 'help-echo))))      ; url detection disabled
-  ;; Skips existing OSC 8 links
+  ;; Skips existing OSC 8 links (help-echo is the native handler function symbol)
   (with-temp-buffer
     (insert "Visit https://other.com for info")
-    (put-text-property 7 26 'help-echo "https://osc8.example.com")
+    (put-text-property 7 26 'help-echo #'ghostel--native-link-help-echo)
     (let ((ghostel-enable-url-detection t))
       (ghostel--detect-urls))
-    (should (equal "https://osc8.example.com"              ; osc8 link preserved
-                   (get-text-property 7 'help-echo))))
+    (should (eq #'ghostel--native-link-help-echo           ; osc8 handler not overwritten
+                (get-text-property 7 'help-echo))))
   ;; URL not ending in punctuation
   (with-temp-buffer
     (insert "See https://example.com/path.")
@@ -3455,6 +3637,7 @@ spawns `sh -c COMMAND' directly, so the shell parses the paragraph
 normally."
   (skip-unless (file-executable-p "/bin/sh"))
   (let* ((buf-name "*ghostel-test-multiline-compile*")
+         (shell-file-name "/bin/sh")
          (script "for i in 1 2 3; do\n  echo line-$i\ndone\nexit 7")
          (inhibit-message t)
          (save-some-buffers-default-predicate (lambda () nil)))
@@ -3861,7 +4044,7 @@ Emacs auto-scrolls to make point visible."
             ;; redraw anchored `window-start' at the viewport.
             (let ((vp-before (save-excursion
                                (goto-char (point-max))
-                               (forward-line -9)
+                               (forward-line -10)
                                (line-beginning-position))))
               (set-window-start (selected-window) vp-before t))
             (setq ghostel--force-next-redraw t)
@@ -3878,7 +4061,7 @@ Emacs auto-scrolls to make point visible."
                    (wp (window-point (selected-window)))
                    (vp-start (save-excursion
                                (goto-char (point-max))
-                               (forward-line -5)
+                               (forward-line -6)
                                (line-beginning-position))))
               (should (= ws vp-start))
               (should (>= wp vp-start)))))
@@ -4539,140 +4722,6 @@ overlay property."
         (delete-overlay overlay))
       (kill-buffer buf))))
 
-(ert-deftest ghostel-test-cursor-pending-wrap-p ()
-  "`ghostel--cursor-pending-wrap-p' tracks libghostty's pending-wrap flag."
-  (let ((term (ghostel--new 5 10 100)))
-    ;; Fresh terminal: cursor at (0,0), no pending wrap.
-    (should-not (ghostel--cursor-pending-wrap-p term))
-    ;; Write fewer chars than the row width: still no pending wrap.
-    (ghostel--write-input term "hello")
-    (should-not (ghostel--cursor-pending-wrap-p term))
-    ;; Fill the row exactly (10 columns): pending wrap is set.
-    (ghostel--write-input term "XYZXY")
-    (should (ghostel--cursor-pending-wrap-p term))))
-
-(ert-deftest ghostel-test-cursor-on-empty-row-p ()
-  "`ghostel--cursor-on-empty-row-p' tracks whether the cursor row is blank."
-  (let ((term (ghostel--new 3 10 100)))
-    ;; Fresh terminal: all rows empty, cursor at (0,0).
-    (should (ghostel--cursor-on-empty-row-p term))
-    ;; Write a character: cursor row 0 now has a grapheme.
-    (ghostel--write-input term "x")
-    (should-not (ghostel--cursor-on-empty-row-p term))
-    ;; CRLF twice: cursor now at (0,2) on an empty row.
-    (ghostel--write-input term "\r\n\r\n")
-    (should (ghostel--cursor-on-empty-row-p term))
-    ;; CUP back to row 0 (1-indexed: row 1).
-    (ghostel--write-input term "\e[1;1H")
-    (should-not (ghostel--cursor-on-empty-row-p term))))
-
-(ert-deftest ghostel-test-anchor-window-clamps-on-empty-row ()
-  "`ghostel--anchor-window' clamps when cursor is CUP-parked on an empty row.
-Regression test for #157: after `ad8536e' narrowed the clamp to
-pending-wrap only, TUIs that move the cursor via CUP to a trailing
-empty row (e.g. Claude Code on focus loss) again produced the #138
-symptom — PT at `point-max', pending-wrap nil, Emacs redisplay shifts
-`window-start' by one row.  The clamp must also fire on an empty
-cursor row, not just on pending-wrap."
-  (let ((buf (generate-new-buffer " *ghostel-test-anchor-empty-row*"))
-        (orig-buf (window-buffer (selected-window))))
-    (unwind-protect
-        (with-current-buffer buf
-          (ghostel-mode)
-          (let* ((term (ghostel--new 3 10 100))
-                 (ghostel--term term)
-                 (ghostel--term-rows 3)
-                 (inhibit-read-only t))
-            (set-window-buffer (selected-window) buf)
-            ;; Fill rows 0 and 1, then CR/LF to land on empty row 2.
-            (ghostel--write-input term "foo\r\nbar\r\n")
-            (should-not (ghostel--cursor-pending-wrap-p term))
-            (should (ghostel--cursor-on-empty-row-p term))
-            (ghostel--redraw term t)
-            (let ((win (selected-window))
-                  (pmax (point-max)))
-              ;; Precondition: PT really does land at point-max on the
-              ;; empty last row.
-              (should (= pmax (point)))
-              (ghostel--anchor-window win (point-min) pmax)
-              ;; Clamp fires: window-point pulled back by one.
-              (should (= (1- pmax) (window-point win))))))
-      (when (buffer-live-p orig-buf)
-        (set-window-buffer (selected-window) orig-buf))
-      (kill-buffer buf))))
-
-(ert-deftest ghostel-test-anchor-window-no-clamp-on-populated-last-row ()
-  "`ghostel--anchor-window' must NOT clamp when the cursor row has content.
-Complements the #157 regression: when the cursor sits at `point-max' on
-the last visible row but that row has a written grapheme (e.g. a shell
-prompt after typing), neither predicate fires and the block cursor must
-stay at PT so it renders after the last character (#146 contract)."
-  (let ((buf (generate-new-buffer " *ghostel-test-anchor-populated-last*"))
-        (orig-buf (window-buffer (selected-window))))
-    (unwind-protect
-        (with-current-buffer buf
-          (ghostel-mode)
-          (let* ((term (ghostel--new 3 10 100))
-                 (ghostel--term term)
-                 (ghostel--term-rows 3)
-                 (inhibit-read-only t))
-            (set-window-buffer (selected-window) buf)
-            ;; Walk to the last row and type a short prompt — cursor ends
-            ;; mid-row on content, well short of pending-wrap.
-            (ghostel--write-input term "\r\n\r\n$ ls")
-            (should-not (ghostel--cursor-pending-wrap-p term))
-            (should-not (ghostel--cursor-on-empty-row-p term))
-            (ghostel--redraw term t)
-            (let ((win (selected-window))
-                  (pmax (point-max)))
-              (should (= pmax (point)))
-              (ghostel--anchor-window win (point-min) pmax)
-              ;; No clamp: window-point stays at PT.
-              (should (= pmax (window-point win))))))
-      (when (buffer-live-p orig-buf)
-        (set-window-buffer (selected-window) orig-buf))
-      (kill-buffer buf))))
-
-(ert-deftest ghostel-test-anchor-window-clamps-on-pending-wrap ()
-  "`ghostel--anchor-window' clamps `window-point' only in pending-wrap state.
-Regression test for #138 (clamp must fire) and #146 (clamp must NOT fire
-otherwise).  Feeds enough characters to put the VT cursor in pending-wrap,
-then verifies the helper clamps; then feeds one more character to leave
-pending-wrap and verifies the helper leaves `window-point' alone."
-  (let ((buf (generate-new-buffer " *ghostel-test-anchor-pw*"))
-        (orig-buf (window-buffer (selected-window))))
-    (unwind-protect
-        (with-current-buffer buf
-          (ghostel-mode)
-          (let* ((term (ghostel--new 3 10 100))
-                 (ghostel--term term)
-                 (ghostel--term-rows 3)
-                 (inhibit-read-only t))
-            (set-window-buffer (selected-window) buf)
-            ;; Fill the last row to the width: cursor enters pending-wrap.
-            (ghostel--write-input term "\r\n\r\n1234567890")
-            (should (ghostel--cursor-pending-wrap-p term))
-            (ghostel--redraw term t)
-            (let ((win (selected-window))
-                  (pmax (point-max)))
-              (ghostel--anchor-window win (point-min) pmax)
-              ;; Clamp fires: window-point pulled back by one.
-              (should (= (1- pmax) (window-point win))))
-            ;; One more char soft-wraps; cursor leaves pending-wrap.
-            ;; This is the canonical #146 regression branch exercised
-            ;; via a real terminal: pt == point-max, term is live, but
-            ;; pending-wrap is false — the helper must NOT clamp.
-            (ghostel--write-input term "X")
-            (should-not (ghostel--cursor-pending-wrap-p term))
-            (ghostel--redraw term t)
-            (let ((win (selected-window))
-                  (pmax (point-max)))
-              (ghostel--anchor-window win (point-min) pmax)
-              (should (= pmax (window-point win))))))
-      (when (buffer-live-p orig-buf)
-        (set-window-buffer (selected-window) orig-buf))
-      (kill-buffer buf))))
-
 (ert-deftest ghostel-test-redraw-anchors-window-start-on-snap-request ()
   "Redraw anchors `window-start' to the viewport when snap is requested.
 `ghostel--snap-to-input' sets `ghostel--snap-requested' on typing/paste/
@@ -4739,7 +4788,7 @@ scrollback positions."
             ;; (not the first blank line in the buffer).
             (let ((target (save-excursion
                             (goto-char (point-max))
-                            (forward-line -25)
+                            (forward-line -26)
                             (line-beginning-position))))
               (set-window-start (selected-window) target t)
               (let ((pre-key (ghostel--line-key target)))
@@ -4835,8 +4884,6 @@ to restore to a missing line."
                               (list '("scroll-10") '("scroll-11") 0))))
             (setq ghostel--last-anchor-position 42)
             (cl-letf (((symbol-function 'ghostel--write-input)
-                       (lambda (&rest _) nil))
-                      ((symbol-function 'ghostel--scroll-bottom)
                        (lambda (&rest _) nil))
                       ((symbol-function 'ghostel--invalidate) #'ignore))
               (setq ghostel--process nil)
@@ -6242,11 +6289,8 @@ redraw and produce visible flicker, so point is left alone."
         (ghostel--force-next-redraw nil)
         (ghostel--snap-requested nil)
         (ghostel-scroll-on-input t)
-        (scroll-bottom-called nil)
         (sent-key nil))
-    (cl-letf (((symbol-function 'ghostel--scroll-bottom)
-               (lambda (_term) (setq scroll-bottom-called t)))
-              ((symbol-function 'ghostel--send-string)
+    (cl-letf (((symbol-function 'ghostel--send-string)
                (lambda (str) (setq sent-key str))))
       (with-temp-buffer
         (insert "scrollback\nscrollback\nscrollback\n")
@@ -6254,7 +6298,6 @@ redraw and produce visible flicker, so point is left alone."
         (let ((last-command-event ?a))
           (cl-letf (((symbol-function 'this-command-keys) (lambda () "a")))
             (ghostel--self-insert)))
-        (should scroll-bottom-called)
         (should ghostel--force-next-redraw)
         (should ghostel--snap-requested)
         (should (equal "a" sent-key))))))
@@ -6264,18 +6307,14 @@ redraw and produce visible flicker, so point is left alone."
   (let ((ghostel--term 'fake)
         (ghostel--force-next-redraw nil)
         (ghostel--snap-requested nil)
-        (ghostel-scroll-on-input t)
-        (scroll-bottom-called nil))
-    (cl-letf (((symbol-function 'ghostel--scroll-bottom)
-               (lambda (_term) (setq scroll-bottom-called t)))
-              ((symbol-function 'ghostel--send-encoded)
+        (ghostel-scroll-on-input t))
+    (cl-letf (((symbol-function 'ghostel--send-encoded)
                (lambda (_key _mods &optional _utf8) nil)))
       (with-temp-buffer
         (insert "scrollback\nscrollback\nscrollback\n")
         (goto-char (point-min))
         (let ((last-command-event (aref (kbd "<return>") 0)))
           (ghostel--send-event))
-        (should scroll-bottom-called)
         (should ghostel--force-next-redraw)
         (should ghostel--snap-requested)))))
 
@@ -6283,11 +6322,8 @@ redraw and produce visible flicker, so point is left alone."
   "Self-insert does not scroll when `ghostel-scroll-on-input' is nil."
   (let ((ghostel--term 'fake)
         (ghostel--force-next-redraw nil)
-        (ghostel-scroll-on-input nil)
-        (scroll-bottom-called nil))
-    (cl-letf (((symbol-function 'ghostel--scroll-bottom)
-               (lambda (_term) (setq scroll-bottom-called t)))
-              ((symbol-function 'ghostel--send-string)
+        (ghostel-scroll-on-input nil))
+    (cl-letf (((symbol-function 'ghostel--send-string)
                (lambda (_str) nil)))
       (with-temp-buffer
         (insert "scrollback\nscrollback\nscrollback\n")
@@ -6296,7 +6332,6 @@ redraw and produce visible flicker, so point is left alone."
           (cl-letf (((symbol-function 'this-command-keys) (lambda () "a")))
             (let ((last-command-event ?a))
               (ghostel--self-insert)))
-          (should-not scroll-bottom-called)
           (should-not ghostel--force-next-redraw)
           (should (= (point) start)))))))
 
@@ -6307,11 +6342,8 @@ redraw and produce visible flicker, so point is left alone."
         (ghostel--force-next-redraw nil)
         (ghostel--snap-requested nil)
         (ghostel-scroll-on-input t)
-        (scroll-bottom-called nil)
         (sent-text nil))
-    (cl-letf (((symbol-function 'ghostel--scroll-bottom)
-               (lambda (_term) (setq scroll-bottom-called t)))
-              ((symbol-function 'ghostel--bracketed-paste-p)
+    (cl-letf (((symbol-function 'ghostel--bracketed-paste-p)
                (lambda () nil))
               ((symbol-function 'process-live-p)
                (lambda (_p) t))
@@ -6321,7 +6353,6 @@ redraw and produce visible flicker, so point is left alone."
         (insert "scrollback\nscrollback\nscrollback\n")
         (goto-char (point-min))
         (ghostel--paste-text "hello")
-        (should scroll-bottom-called)
         (should ghostel--force-next-redraw)
         (should ghostel--snap-requested)
         (should (equal "hello" sent-text))))))
@@ -8062,7 +8093,10 @@ COLORTERM, INSIDE_EMACS, …) plus pass-through LANG/LC_*."
     ghostel-test-eshell/ghostel-dispatches-to-exec-visual
     ghostel-test-terminfo-directory-finds-bundled
     ghostel-test-debug-keypress-renders-capture
-    ghostel-test-debug-info-environment-section)
+    ghostel-test-debug-info-environment-section
+    ghostel-test-uri-at-pos-prefers-string-help-echo
+    ghostel-test-uri-at-pos-calls-native-for-function-help-echo
+    ghostel-test-native-link-help-echo-calls-uri-at-pos)
   "Tests that require only Elisp (no native module).")
 
 (defun ghostel-test-run-elisp ()


### PR DESCRIPTION
## Before

This PR refactors the native rendering code for correctness and readability. The old rendering code had several issues:

- The old code had a stale-line bug: rendered viewport lines were promoted to scrollback as-is, even if they had been modified since the last render. For example:
  1. Output `foo\r\n` to the top terminal line
  2. `[render]`
  3. Move cursor to home position
  4. Output `bar`
  5. Move cursor to bottom row
  6. Output `baz\r\n`
  7. `[render]`

  The old rendering code would now have `foo` in scrollback but it should be `bar`. The added `ghostel-test-no-stale-lines-in-scrollback` test covers this case.

- The old code relied only on scrollback length to determine scrolling, which made it impossible to detect scrolling when scrollback reaches cap and stops growing. Scrolling still happens but the old rows are evicted. This was handled by comparing row 0 to a stored copy to detect this, invalidating the entire thing when that happens.

- Since we had no means of detecting screen clearing (`CSI 3 J`), a separate scan was added on the input side to detect this specific escape sequence. However, there was no handling of the case when a sequence arrived split across two separate writes. In addition, if libghostty were to add support for other ways of clearing the scrollback, we would not be able to detect that.

## After

The new code uses a different algorithm that takes advantage of a very specific trick. At the end of every render pass, we position the terminal viewport at `max_offset - 1` so that the last row is just outside the viewport. This has two important properties:
- The viewport is no longer pinned to the active area and instead follows scrollback naturally, even when we reach the scrollback cap.
- If the scrollback is cleared, libghostty resets the viewport to the bottom (`offset + len == total`), which we detect and use as a signal to clear our materialized scrollback.

The viewport cannot be positioned at `max_offset - 1` if we don't have any scrollback. In that case, we don't need to detect scrollback clearing (it was already empty) and scrolling can be detected by simply checking the scrollback length.

A simplified version of the new algorithm is as follows:
1. If we had scrollback and the viewport position is now at the bottom, reset scrollback and force a full redraw.
2. Unpark the viewport:
   - If we had scrollback: move libghostty viewport `+1` to compensate for the `-1` position, and move Emacs point to the end of the materialized scrollback.
   - If we had no scrollback: move libghostty viewport to the top, and move Emacs point to the start of the buffer.
3. Walk from the current viewport position to the active area in viewport-sized steps, rendering each chunk. Consecutive positions overlap when the remaining range is smaller than a full viewport; overlapping rows are skipped since they were already rendered at the tail of the previous step.
4. After the walk, Emacs point and the libghostty viewport are both at the active area. Non-dirty rows in the first step (where the old active area was) are reused as-is; all other steps render fully.
5. Position viewport at `max_offset - 1` for the next render.

## Caveats
- Benchmarks show a slight increase in PTY performance, but a drop in performance in the chunked streaming tests. This is to be expected since we are no longer promoting incorrect rows. Still much faster than `vterm` but further work should go into see if we can win some performance back. Profiling shows two main culprits:
  - Reading libghostty cell properties - this is hard to get around
  - Comparing styles to separate style runs - this could potentially be optimized
  
  One future optimization could be to check if a line has any styling at all (libghostty has APIs for this) and skip cell checks entirely if it does not.

- When libghostty rotates rows out at the scrollback cap, those rows are not evicted from the Emacs buffer. This is intentional: the Emacs buffer serves as the permanent record, and libghostty's scrollback cap only bounds libghostty's memory use, not what is visible in Emacs.

- This PR also includes a change to how OSC8 links are handled. Rather than attaching the URI to separate URI runs, we can avoid the URI comparison entirely and just make "has URI" part of the style so it automatically gets treated as separating style runs. We then attach a lookup function instead of a string as `help-echo` that calls down into libghostty to fetch the URI only when hovered or clicked. This should really have been a separate PR but it was hard to separate from what has been a rather organic process. Apologies for that. If you really want it to be separate, I can try to make that happen.

- The buffer now always includes a trailing newline. This makes things more uniform (every line has a newline at the end) and makes the line math easier. It also removes the need for point-max-clamping, at least according to my tests.