### PR TITLE
Support tilde-prefixed paths in file detection

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -377,7 +377,7 @@ redraw.  Native OSC-8 hyperlinks remain applied during redraw."
   :type 'number)
 
 (defcustom ghostel-file-detection-path-regex
-  "[[:alnum:]_.-]*/[^] \t\n\r:\"<>(){}[`']+"
+  "[~[:alnum:]_.-]*/[^] \t\n\r:\"<>(){}[`']+"
   "Regex matching the PATH portion of a file:line[:col] reference.
 This is the middle of the full detection pattern; ghostel wraps it
 with a fixed leading path-boundary anchor (line start or any
@@ -386,10 +386,10 @@ is guaranteed to end in `:DIGITS'.
 
 The matched path is resolved against `default-directory'; linkification
 only applies when that file exists.  The default matches absolute
-paths, explicit `./' paths, and bare relative paths containing at
-least one `/' (e.g. compiler output like `src/main.rs').  Paths
-embedded in punctuation like `(/home/user/index.js:17:5)' are
-supported via the fixed anchor.
+paths, explicit `./' paths, tilde-prefixed paths like `~/file.el',
+and bare relative paths containing at least one `/' (e.g. compiler
+output like `src/main.rs').  Paths embedded in punctuation like
+`(/home/user/index.js:17:5)' are supported via the fixed anchor.
 
 Performance: each match triggers a filesystem check on every redraw.
 Broadening this pattern (for example to match bare `file.go' without
@@ -400,7 +400,7 @@ per-redraw scan stays cheap."
   :type 'regexp)
 
 (defconst ghostel--file-detection-leading-anchor
-  "\\(?:^\\|[^[:alnum:]_./-]\\)"
+  "\\(?:^\\|[^[:alnum:]_./~-]\\)"
   "Fixed anchor placed before `ghostel-file-detection-path-regex'.")
 
 (defconst ghostel--file-detection-tail

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -2347,7 +2347,7 @@ native URI lookup when Emacs invokes it for tooltip display or clicking."
           (should (null (find-fileref))))           ; nonexistent bare path skipped
         ;; Existing bare relative path: linkified with line AND column preserved
         (with-temp-buffer
-          (setq default-directory (file-name-parent-directory dir))
+          (setq default-directory (file-name-directory (directory-file-name dir)))
           (insert (format "  --> %s/%s:43:4\n"
                           (file-name-nondirectory (directory-file-name dir))
                           rel))
@@ -2378,6 +2378,19 @@ native URI lookup when Emacs invokes it for tooltip display or clicking."
             (should (and he (string-prefix-p "fileref:" he)))
             (should (and he (string-suffix-p test-file he)))    ; no wrapper tail
             (should (and he (not (string-suffix-p (cdr wrap) he)))))))
+      ;; Tilde-prefixed paths are detected and linkified.
+      (let* ((tilde-path "~/.emacs.d/init.el:42")
+             (tilde-file (expand-file-name ".emacs.d/init.el" (expand-file-name "~"))))
+        ;; Existing tilde path is linkified.
+        (with-temp-buffer
+          (insert (format "Error at %s bad" tilde-path))
+          (cl-letf (((symbol-function 'file-exists-p)
+                     (lambda (f) (equal f tilde-file))))
+            (let ((ghostel-enable-url-detection t))
+              (ghostel--detect-urls))
+            (let ((he (find-fileref)))
+              (should (and he (string-prefix-p "fileref:" he)))
+              (should (and he (string-suffix-p ":42" he)))))))
       ;; Bare filename without a slash must NOT match (avoids FS stat storms)
       (with-temp-buffer
         (setq default-directory (file-name-directory test-file))
@@ -8086,6 +8099,7 @@ COLORTERM, INSIDE_EMACS, …) plus pass-through LANG/LC_*."
     ghostel-test-delayed-redraw-defers-plain-link-detection
     ghostel-test-delayed-redraw-coalesces-plain-link-detection
     ghostel-test-detect-urls-allows-read-only-buffers
+    ghostel-test-url-detection
     ghostel-test-zero-delay-runs-plain-link-detection-synchronously
     ghostel-test-sentinel-cancels-plain-link-detection-timer
     ghostel-test-compile-prepare-buffer-sets-dir-before-mode


### PR DESCRIPTION
## Summary

This branch adds support for tilde-prefixed file paths (e.g. `~/some-file`) in ghostel's file detection logic.

### Changes
- Support tilde-prefixed paths in file detection
- Various rendering and cursor fixes along the way