### PR TITLE
Use 80x24 default size when ghostel-exec target buffer is undisplayed

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3687,12 +3687,12 @@ Returns the buffer."
   "Run PROGRAM with ARGS as a ghostel terminal in BUFFER.
 
 BUFFER is switched into `ghostel-mode' (if not already) and a new
-terminal is created sized to the window displaying BUFFER, falling
-back to the selected window if BUFFER is not displayed.  No shell
-integration is applied — PROGRAM is exec'd directly via
-`ghostel--spawn-pty'.  PROGRAM is shell-quoted before it is passed
-to `/bin/sh -c', so shell metacharacters are not interpreted; pass
-extra tokens via ARGS, a list of strings.  Returns the process.
+terminal is created sized to the window displaying BUFFER, or
+80x24 if BUFFER is not currently displayed.  No shell integration
+is applied — PROGRAM is exec'd directly via `ghostel--spawn-pty'.
+PROGRAM is shell-quoted before it is passed to `/bin/sh -c', so
+shell metacharacters are not interpreted; pass extra tokens via
+ARGS, a list of strings.  Returns the process.
 
 Signals `user-error' if BUFFER already has a live ghostel process."
   (ghostel--load-module t)
@@ -3700,15 +3700,19 @@ Signals `user-error' if BUFFER already has a live ghostel process."
              (process-live-p (buffer-local-value 'ghostel--process buffer)))
     (user-error "Buffer %s already has a running ghostel process"
                 (buffer-name buffer)))
-  (let ((window (or (get-buffer-window buffer t) (selected-window))))
+  (let ((window (get-buffer-window buffer t)))
     (with-current-buffer buffer
       (ghostel--prepare-buffer buffer nil)
       ;; Use `window-screen-lines' (not `window-body-height') so the
       ;; height matches the unit `window-adjust-process-window-size-smallest'
       ;; uses — see `ghostel--init-buffer' for why.
-      (let* ((height (max 1 (with-selected-window window
-                              (floor (window-screen-lines)))))
-             (width (max 1 (window-max-chars-per-line window)))
+      (let* ((height (if window
+                         (max 1 (with-selected-window window
+                                  (floor (window-screen-lines))))
+                       24))
+             (width (if window
+                        (max 1 (window-max-chars-per-line window))
+                      80))
              (remote-p (file-remote-p default-directory)))
         (setq ghostel--term
               (ghostel--new height width ghostel-max-scrollback))

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -7831,6 +7831,29 @@ while :; do sleep 0.1; done'\n")
             (should (nth 6 captured))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-exec-uses-default-size-when-buffer-not-displayed ()
+  "`ghostel-exec' on an undisplayed buffer uses the 80x24 default.
+Falling back to (selected-window) sized the PTY from whatever window
+happened to be focused at call time, which rarely matches where the
+buffer eventually shows up."
+  (let ((buf (generate-new-buffer "ghostel-exec-test"))
+        captured)
+    (unwind-protect
+        (progn
+          ;; Sanity: the buffer is not displayed in any window.
+          (should-not (get-buffer-window buf t))
+          (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                    ((symbol-function 'ghostel--new)
+                     (lambda (&rest args) (setq captured args) 'fake-term))
+                    ((symbol-function 'ghostel--apply-palette) #'ignore)
+                    ((symbol-function 'ghostel--spawn-pty)
+                     (lambda (&rest _) 'fake-proc)))
+            (ghostel-exec buf "ls" nil)
+            ;; ghostel--new is called as (height width max-scrollback).
+            (should (equal (nth 0 captured) 24))
+            (should (equal (nth 1 captured) 80))))
+      (kill-buffer buf))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: ghostel-eshell integration
 ;; -----------------------------------------------------------------------
@@ -8092,6 +8115,7 @@ COLORTERM, INSIDE_EMACS, …) plus pass-through LANG/LC_*."
     ghostel-test-exec-errors-on-live-process
     ghostel-test-exec-calls-spawn-pty-with-expected-args
     ghostel-test-exec-threads-remote-p-from-tramp-dir
+    ghostel-test-exec-uses-default-size-when-buffer-not-displayed
     ghostel-test-environment-precedes-internal-env
     ghostel-test-environment-applies-to-compile
     ghostel-test-environment-honors-dir-locals


### PR DESCRIPTION
## Summary

- `ghostel-exec` previously fell back to `(selected-window)` when BUFFER was not displayed in any window — sizing the PTY from whatever window happened to be focused at call time, which rarely matches where BUFFER eventually shows up.
- Match `eat`'s behavior: when no window displays BUFFER, start at the universal 80x24 default. The displayed-buffer path is unchanged; SIGWINCH still resizes the PTY when the displaying window's dimensions differ from the initial size.
- Reported by a user running a programmatic flow that creates a buffer with `generate-new-buffer` and immediately calls `ghostel-exec` before displaying it — the agent (Pi) consistently got the wrong terminal dimensions.

## Test plan

- [x] `make -j4 all` passes (39 zig + 100 native + 193 elisp tests, lint clean).
- [x] New ERT test `ghostel-test-exec-uses-default-size-when-buffer-not-displayed` covers the fix and would fail under the old selected-window fallback.
- [x] Manual verification: in a live emacsclient session, invoke `ghostel-exec` on a freshly-created undisplayed buffer (e.g., `(let ((b (generate-new-buffer "x"))) (ghostel-exec b "less" '("/etc/hosts")) b)`) and confirm the buffer-local `ghostel--term-rows` / `ghostel--term-cols` are 24 / 80 before display, and that the program lays out correctly once the buffer is shown in a larger window.