### PR TITLE
Commit deferred minibuffer crop on output (fix #191)

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -920,6 +920,25 @@ Updated whenever the terminal is created or resized.")
   "Column count of the native terminal.
 Updated whenever the terminal is created or resized.")
 
+(defvar-local ghostel--deferred-crop-size nil
+  "Pending (HEIGHT . WIDTH) from a deferred minibuffer-shrink crop.
+Set by the CROP branch of `ghostel--window-adjust-process-window-size'
+when the minibuffer shrinks the ghostel window — we suppress SIGWINCH
+for transient minibuffer flashes with a quiet terminal but record the
+size so it can be committed if anything would render at the wrong
+geometry.  Committed by `ghostel--commit-deferred-crop' when output
+arrives, and cleared without committing when the window grows back to
+or beyond `ghostel--term-rows' before output arrives.
+
+Without this, `ghostel--term-rows' stays at the original (pre-crop)
+size for the duration of the minibuffer.  When the minibuffer closes
+and the window grows back, `ghostel--window-adjust-process-window-size'
+sees `eql height ghostel--term-rows' and hits the \"no change\" branch,
+skipping the resize-aware redraw — `ghostel--window-anchored-p' then
+runs without `ghostel--redraw-resize-active', `keep-point-visible'
+drift can be misclassified as user scrollback, and the auto-follow
+predicate latches off (issue #191).")
+
 (defvar-local ghostel--copy-mode-active nil
   "Non-nil when copy mode is active.")
 
@@ -2990,6 +3009,11 @@ the redraw is performed immediately to minimize typing latency."
   (when (buffer-live-p (process-buffer process))
     (with-current-buffer (process-buffer process)
       (when ghostel--term
+        ;; If a minibuffer-triggered crop is still pending, commit it
+        ;; before this output renders.  Keeps `ghostel--term-rows' in
+        ;; sync with reality so a later minibuffer-close doesn't hit
+        ;; the no-change branch and skip the resize-aware redraw.
+        (ghostel--commit-deferred-crop)
         ;; Accumulate output for batched write-input at redraw time.
         (push output ghostel--pending-output)
         ;; Respond to OSC 4/10/11 color queries immediately: programs like
@@ -3924,9 +3948,11 @@ PROCESS is the shell process, WINDOWS is the list of windows."
       (with-current-buffer buffer
         (when ghostel--term
           (cond
-           ;; No change — skip entirely.
+           ;; No change — skip entirely.  Window has grown back to (or never
+           ;; left) `ghostel--term-rows', so any deferred crop is moot.
            ((and (eql height ghostel--term-rows)
                  (eql width ghostel--term-cols))
+            (setq ghostel--deferred-crop-size nil)
             (setq size nil))
            ;; Crop: minibuffer is active, only height shrank, width unchanged, and the
            ;; terminal is on the primary screen.  Defer the resize so no SIGWINCH is sent
@@ -3934,14 +3960,19 @@ PROCESS is the shell process, WINDOWS is the list of windows."
            ;; buffer.  Alt-screen apps (vim, htop) own the full viewport and must be told
            ;; the real size to re-layout, so they take the normal-resize path.  If the
            ;; user switches focus into the ghostel window while the minibuffer is still
-           ;; open, `ghostel--commit-cropped-size' commits the smaller size then.
+           ;; open, `ghostel--commit-cropped-size' commits the smaller size then.  If
+           ;; output arrives, `ghostel--commit-deferred-crop' commits before the next
+           ;; render so geometry matches reality.
            ((and (> (minibuffer-depth) 0)
                  (eql width ghostel--term-cols)
                  (< height ghostel--term-rows)
                  (not (ghostel--alt-screen-p ghostel--term)))
+            (setq ghostel--deferred-crop-size (cons height width))
             (setq size nil))
-           ;; Real resize — update the terminal model and redraw.
+           ;; Real resize — update the terminal model and redraw.  Any deferred
+           ;; crop is superseded by this size.
            (t
+            (setq ghostel--deferred-crop-size nil)
             (ghostel--set-size-with-cell-dims
              ghostel--term (max 1 height) (max 1 width))
             (setq ghostel--term-rows height)
@@ -3961,6 +3992,31 @@ PROCESS is the shell process, WINDOWS is the list of windows."
     ;; Return size — Emacs calls set-process-window-size (SIGWINCH)
     ;; after this function returns.  nil suppresses the call.
     size))
+
+(defun ghostel--commit-deferred-crop ()
+  "Commit a pending `ghostel--deferred-crop-size', if any.
+Sends SIGWINCH to bring the PTY in sync with the cropped Emacs window
+and runs a synchronous resize-aware redraw so `window-anchored-p'
+treats any `keep-point-visible' drift across the size change as drift,
+not user scrollback (issue #191).  No-op when nothing is pending."
+  (when (and ghostel--deferred-crop-size
+             ghostel--term ghostel--process
+             (process-live-p ghostel--process))
+    (let ((height (car ghostel--deferred-crop-size))
+          (width (cdr ghostel--deferred-crop-size)))
+      (setq ghostel--deferred-crop-size nil)
+      (ghostel--set-size-with-cell-dims
+       ghostel--term (max 1 height) (max 1 width))
+      (setq ghostel--term-rows height
+            ghostel--term-cols width
+            ghostel--force-next-redraw t)
+      (set-process-window-size ghostel--process
+                               (max 1 height) (max 1 width))
+      (when ghostel--redraw-timer
+        (cancel-timer ghostel--redraw-timer)
+        (setq ghostel--redraw-timer nil))
+      (let ((ghostel--redraw-resize-active t))
+        (ghostel--delayed-redraw (current-buffer))))))
 
 (defun ghostel--reshow-snap (window)
   "Mark WINDOW for viewport-snap on the next redraw.
@@ -4007,6 +4063,7 @@ window (not when it has just been deselected)."
           (buf (current-buffer)))
       (unless (and (eql height ghostel--term-rows)
                    (eql width ghostel--term-cols))
+        (setq ghostel--deferred-crop-size nil)
         (ghostel--set-size-with-cell-dims
          ghostel--term (max 1 height) (max 1 width))
         (setq ghostel--term-rows height

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -4083,6 +4083,101 @@ Emacs auto-scrolls to make point visible."
         (set-window-buffer (selected-window) orig-buf))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-191-deferred-crop-commit-prevents-anchor-latch ()
+  "Committing a deferred minibuffer-crop on output keeps anchor (issue #191).
+Auto-following windows survive Emacs redisplay drift across the
+crop because the commit runs a resize-aware redraw.
+
+The CROP branch of `ghostel--window-adjust-process-window-size'
+records the pending size in `ghostel--deferred-crop-size' instead of
+discarding it.  When output arrives, `ghostel--commit-deferred-crop'
+brings the PTY in sync with the cropped window via a resize-aware
+redraw.  The redraw sees `ghostel--redraw-resize-active' = t, so a
+`window-start' that has drifted below the anchor (Emacs redisplay
+during the crop) is treated as drift, not user scrollback — the
+window stays anchored and never enters `ghostel--scroll-positions'.
+
+Without the fix, `term-rows' lies about the geometry for the
+duration of the crop, the regrow on minibuffer-close hits the
+no-change branch and skips the resize-aware redraw, and the
+auto-follow predicate latches off."
+  (let ((buf (generate-new-buffer " *ghostel-test-191*"))
+        (orig-buf (window-buffer (selected-window))))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 12 40 200))
+                 (ghostel--term term)
+                 (ghostel--term-rows 12)
+                 (ghostel--term-cols 40)
+                 (ghostel--process 'fake-process)
+                 (sigwinch-calls nil)
+                 (ghostel--force-next-redraw nil)
+                 (inhibit-read-only t))
+            (dotimes (i 30)
+              (ghostel--write-input term (format "out-%02d\r\n" i)))
+            (ghostel--write-input term "prompt> ")
+            (ghostel--redraw term t)
+            (set-window-buffer (selected-window) buf)
+            (let ((vp (ghostel--viewport-start)))
+              (set-window-start (selected-window) vp t)
+              (setq ghostel--last-anchor-position vp))
+            (cl-letf (((symbol-function 'process-live-p) (lambda (_) t))
+                      ((symbol-function 'set-process-window-size)
+                       (lambda (&rest args) (push args sigwinch-calls) nil)))
+              (setq ghostel--deferred-crop-size (cons 6 40))
+              ;; Simulate `keep-point-visible' having drifted window-start
+              ;; below the anchor during the cropped phase.
+              (set-window-start (selected-window) (point-min) t)
+              (ghostel--commit-deferred-crop))
+            (should (eql 6 ghostel--term-rows))
+            (should (eql 40 ghostel--term-cols))
+            (should (null ghostel--deferred-crop-size))
+            (should (eql 1 (length sigwinch-calls)))
+            ;; The drift was treated as drift: window stayed anchored, no
+            ;; entry in `scroll-positions', `window-start' pinned to the
+            ;; new viewport-start.
+            (should (null ghostel--scroll-positions))
+            (let ((vp (ghostel--viewport-start))
+                  (ws (window-start (selected-window))))
+              (should vp)
+              (should (= ws vp)))))
+      (when (buffer-live-p orig-buf)
+        (set-window-buffer (selected-window) orig-buf))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-191-no-output-clears-deferred-crop-on-regrow ()
+  "Regrow without output clears the deferred crop (issue #191).
+Path: CROP defers a smaller size → no output during the cropped phase
+→ `ghostel--window-adjust-process-window-size' is called again with
+the original size as the window grows back → height matches
+`term-rows' → no-change branch fires → deferred-crop flag cleared,
+no SIGWINCH issued."
+  (let ((buf (generate-new-buffer " *ghostel-test-191-noop-regrow*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 12 40 200))
+                 (ghostel--term term)
+                 (ghostel--term-rows 12)
+                 (ghostel--term-cols 40)
+                 (ghostel--process 'fake-process)
+                 (sigwinch-calls nil)
+                 (window-adjust-process-window-size-function
+                  (lambda (&rest _) (cons 40 12))))
+            (cl-letf (((symbol-function 'process-buffer) (lambda (_) buf))
+                      ((symbol-function 'process-live-p) (lambda (_) t))
+                      ((symbol-function 'set-process-window-size)
+                       (lambda (&rest args) (push args sigwinch-calls) nil)))
+              (setq ghostel--deferred-crop-size (cons 6 40))
+              (let ((ret (ghostel--window-adjust-process-window-size
+                          'fake-process nil)))
+                (should (null ret)))
+              (should (null ghostel--deferred-crop-size))
+              (should (eql 12 ghostel--term-rows))
+              (should (null sigwinch-calls)))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-redraw-resets-vscroll ()
   "Redraw resets `window-vscroll' when point is in the viewport.
 Regression for issue #105: with `pixel-scroll-precision-mode',


### PR DESCRIPTION
## Summary

- Fixes #191: cursor following stops following the viewport after a minibuffer cycle (e.g. `M-x` with vertico) on a continuously-scrolling terminal.
- Root cause: the CROP branch of `ghostel--window-adjust-process-window-size` returned nil to suppress SIGWINCH but left `ghostel--term-rows` at the pre-crop size. When the minibuffer closed and the window grew back, the next adjust callback saw `eql height ghostel--term-rows` and hit the no-change branch, skipping the resize-aware redraw — `keep-point-visible` drift on `window-start` could then be misclassified as user scrollback, latching the auto-follow predicate off.
- Fix: the CROP branch now stores the pending size in a new buffer-local `ghostel--deferred-crop-size`. `ghostel--commit-deferred-crop` flushes it before the next render, called from `ghostel--filter` on the next chunk of output. The optimization (no SIGWINCH for a quiet minibuffer flash) is preserved — the deferred size is cleared without committing if the window grows back before any output arrives. The no-change / real-resize branches and `ghostel--commit-cropped-size` clear the flag when the deferred size is moot or superseded.

## Test plan

- [x] `make -j4 all` (zig build + 219 elisp + 103 native + 39 zig tests, lint, byte-compile)
- [x] `make test-evil` (39 evil-ghostel tests)
- [x] New test `ghostel-test-191-deferred-crop-commit-prevents-anchor-latch` — sets the deferred size, simulates `window-start` drift below the anchor, asserts post-commit: `term-rows` updated, flag cleared, exactly one SIGWINCH, `scroll-positions` empty, `window-start` pinned at the new viewport-start.
- [x] New test `ghostel-test-191-no-output-clears-deferred-crop-on-regrow` — exercises the no-output regrow path, asserts the no-change branch clears the flag without firing SIGWINCH.
- [x] Live verification: full-height frame, continuous-output process, `M-x` with vertico, `C-g` — confirm scrolling continues post-cancel and `ghostel--scroll-positions` stays empty.