### PR TITLE
Detect style run breaks via cheap CellStyleKey rather than full CellStyle comparison

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,12 +5,17 @@ const vendored_emacs_module_dir = "vendor";
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+    const ghostty_optimize = b.option(
+        std.builtin.OptimizeMode,
+        "ghostty-optimize",
+        "Optimization mode for the ghostty dependency (defaults to the main optimize option)",
+    ) orelse optimize;
     const is_release = optimize != .Debug;
     const target_os = target.result.os.tag;
     const emacs_module_dir = resolveEmacsModuleDir(b);
     const ghostty_dep = b.dependency("ghostty", .{
         .target = target,
-        .optimize = optimize,
+        .optimize = ghostty_optimize,
         .@"emit-lib-vt" = true,
     });
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .ghostel,
-    .version = "0.20.0",
+    .version = "0.20.1",
     .paths = .{""},
     .fingerprint = 0x5a44bdd1198a0f4b,
     .dependencies = .{

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -4,7 +4,7 @@
 
 ;; Author: Daniel Kraus <daniel@kraus.my>
 ;; URL: https://github.com/dakra/ghostel
-;; Version: 0.20.0
+;; Version: 0.20.1
 ;; Package-Requires: ((emacs "28.1") (evil "1.0") (ghostel "0.8.0"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4,7 +4,7 @@
 
 ;; Author: Daniel Kraus <daniel@kraus.my>
 ;; URL: https://github.com/dakra/ghostel
-;; Version: 0.20.0
+;; Version: 0.20.1
 ;; Keywords: terminals
 ;; Package-Requires: ((emacs "28.1"))
 ;; SPDX-License-Identifier: GPL-3.0-or-later
@@ -626,7 +626,7 @@ before sending the input."
 Customize this when downloading pre-built modules from a fork or mirror."
   :type 'string)
 
-(defconst ghostel--minimum-module-version "0.20.0"
+(defconst ghostel--minimum-module-version "0.20.1"
   "Minimum native module version required by this Elisp version.
 Bump this only when the Elisp code requires a newer native module
 \(e.g. new Zig-exported function or changed calling convention).")

--- a/src/module.zig
+++ b/src/module.zig
@@ -15,7 +15,7 @@ const sys = @import("sys.zig");
 const c = emacs.c;
 
 /// Module version — keep in sync with ghostel.el and build.zig.zon.
-const version = "0.20.0";
+const version = "0.20.1";
 
 // ---------------------------------------------------------------------------
 // Module entry point

--- a/src/render.zig
+++ b/src/render.zig
@@ -22,19 +22,6 @@ const CellStyle = struct {
     inverse: bool = false,
     hyperlink: bool = false,
 
-    fn eql(a: CellStyle, b: CellStyle) bool {
-        return colorEql(a.fg, b.fg) and
-            colorEql(a.bg, b.bg) and
-            a.bold == b.bold and
-            a.italic == b.italic and
-            a.faint == b.faint and
-            a.underline == b.underline and
-            colorEql(a.underline_color, b.underline_color) and
-            a.strikethrough == b.strikethrough and
-            a.inverse == b.inverse and
-            a.hyperlink == b.hyperlink;
-    }
-
     fn isDefault(self: CellStyle) bool {
         return self.fg == null and
             self.bg == null and
@@ -48,13 +35,18 @@ const CellStyle = struct {
     }
 };
 
+// Unique identifier for what we consider a style. Normally, you would only use
+// style_id for this but we also use Emacs text properties for hyperlinks so
+// we include "hyperlink-ness" here.
+const CellStyleKey = struct { style_id: gt.c.GhosttyStyleId, hyperlink: bool };
+
 /// Track style runs for propertizing after insertion.
 /// Positions are in characters (codepoints), not bytes, because
 /// Emacs put-text-property works with character positions.
 const RunInfo = struct {
     start_char: usize,
     end_char: usize,
-    style: CellStyle,
+    style: ?CellStyle,
 };
 
 fn colorEql(a: ?gt.ColorRgb, b: ?gt.ColorRgb) bool {
@@ -87,7 +79,7 @@ fn formatColor(color: gt.ColorRgb, buf: *[7]u8) []const u8 {
 }
 
 /// Read the style for the current cell from the render state.
-fn readCellStyle(cells: gt.RenderStateRowCells, raw: gt.c.GhosttyCell) CellStyle {
+fn readCellStyle(cells: gt.RenderStateRowCells, raw: gt.c.GhosttyCell) ?CellStyle {
     var style: CellStyle = .{};
 
     // Read resolved FG color
@@ -124,13 +116,12 @@ fn readCellStyle(cells: gt.RenderStateRowCells, raw: gt.c.GhosttyCell) CellStyle
         style.hyperlink = hl;
     }
 
-    return style;
+    return if (style.isDefault()) null else style;
 }
 
 /// Apply face properties to a region of the buffer.
 /// Uses (put-text-property START END 'face PLIST).
 fn applyStyle(env: emacs.Env, start: i64, end: i64, style: CellStyle, default_colors: *const BgFg) void {
-    if (style.isDefault()) return;
     if (start >= end) return;
 
     var face_props: [24]emacs.Value = undefined;
@@ -273,6 +264,13 @@ const RowContent = struct {
     has_wide: bool,
 };
 
+fn getStyleKey(cell: gt.c.GhosttyCell) CellStyleKey {
+    var key = CellStyleKey{ .style_id = 0, .hyperlink = false };
+    _ = gt.c.ghostty_cell_get(cell, gt.c.GHOSTTY_CELL_DATA_STYLE_ID, @ptrCast(&key.style_id));
+    _ = gt.c.ghostty_cell_get(cell, gt.c.GHOSTTY_CELL_DATA_HAS_HYPERLINK, @ptrCast(&key.hyperlink));
+    return key;
+}
+
 /// Build text content and style runs for the current row in the iterator.
 /// Style runs use character (codepoint) offsets for Emacs put-text-property.
 ///
@@ -299,9 +297,8 @@ fn buildRowContent(
     var prompt_char_len: usize = 0; // chars that are semantic prompt
     var in_prompt: bool = true; // track contiguous leading prompt cells
     var has_wide: bool = false;
+    var current_style_key: ?CellStyleKey = null;
     run_count.* = 0;
-    var current_style: CellStyle = .{};
-    var run_start_char: usize = 0;
 
     while (gt.c.ghostty_render_state_row_cells_next(term.row_cells)) {
         var graphemes_len: u32 = 0;
@@ -322,22 +319,21 @@ fn buildRowContent(
             }
         }
 
-        const cell_style = readCellStyle(term.row_cells, raw_cell);
-
-        // Flush run on style change
-        if (char_len > run_start_char and !cell_style.eql(current_style)) {
-            if (run_count.* < runs.len) {
-                runs[run_count.*] = .{
-                    .start_char = run_start_char,
-                    .end_char = char_len,
-                    .style = current_style,
-                };
-                run_count.* += 1;
-            }
-            run_start_char = char_len;
-            current_style = cell_style;
-        } else if (char_len == run_start_char) {
-            current_style = cell_style;
+        // We use a "key" that holds a minimum set of values that are cheap to
+        // read and compare to detect style run breaks. Only when we detect a
+        // break do we read the cell style, which is a more expensive operation
+        // in such a tight loop.
+        const style_key: CellStyleKey = getStyleKey(raw_cell);
+        if (!std.meta.eql(@as(?CellStyleKey, style_key), current_style_key) and run_count.* < runs.len) {
+            runs[run_count.*] = .{
+                .start_char = char_len,
+                .end_char = char_len + 1,
+                .style = readCellStyle(term.row_cells, raw_cell),
+            };
+            run_count.* += 1;
+            current_style_key = style_key;
+        } else {
+            runs[run_count.* - 1].end_char += 1;
         }
 
         if (graphemes_len == 0) {
@@ -347,6 +343,7 @@ fn buildRowContent(
             var wide: c_int = gt.c.GHOSTTY_CELL_WIDE_NARROW;
             _ = gt.c.ghostty_cell_get(raw_cell, gt.c.GHOSTTY_CELL_DATA_WIDE, @ptrCast(&wide));
             if (wide == gt.c.GHOSTTY_CELL_WIDE_SPACER_TAIL) {
+                runs[run_count.* - 1].end_char -= 1;
                 has_wide = true;
                 continue;
             }
@@ -358,7 +355,7 @@ fn buildRowContent(
             if (in_prompt) prompt_char_len = char_len;
             // Empty cells are blank for trim purposes unless their
             // style has a visible attribute (e.g. colored background).
-            if (!cell_style.isDefault()) {
+            if (runs[run_count.* - 1].style != null) {
                 trim_text_len = text_len;
                 trim_char_len = char_len;
             }
@@ -397,16 +394,6 @@ fn buildRowContent(
     text_len = trim_text_len;
     char_len = trim_char_len;
     if (prompt_char_len > char_len) prompt_char_len = char_len;
-
-    // Close final run
-    if (char_len > run_start_char and run_count.* < runs.len) {
-        runs[run_count.*] = .{
-            .start_char = run_start_char,
-            .end_char = char_len,
-            .style = current_style,
-        };
-        run_count.* += 1;
-    }
 
     return .{ .byte_len = text_len, .char_len = char_len, .prompt_char_len = prompt_char_len, .has_wide = has_wide };
 }
@@ -453,7 +440,9 @@ fn insertAndStyle(
 
         const prop_start = row_start + @as(i64, @intCast(run.start_char));
         const prop_end = row_start + @as(i64, @intCast(run_end));
-        applyStyle(env, prop_start, prop_end, run.style, default_colors);
+        if (run.style) |style| {
+            applyStyle(env, prop_start, prop_end, style, default_colors);
+        }
     }
 
     if (!newline_in_buf) {


### PR DESCRIPTION
## What

The hot inner loop in `buildRowContent` previously called `readCellStyle` on
every terminal cell and compared the result field-by-field with `CellStyle.eql()`
across all ten style attributes (fg, bg, bold, italic, faint, underline,
underline_color, strikethrough, inverse, hyperlink).

This PR replaces that with a two-field `CellStyleKey` (`style_id` + `hyperlink`)
that is cheap to read and compare. The full `readCellStyle` call is now deferred
to run boundaries only — once per style change rather than once per cell.

`style_id` is Ghostty's unique identifier for a cell's complete attribute set.
`hyperlink` is tracked separately because Ghostty does not fold hyperlink state
into the style ID, but Ghostel uses text properties for it.

Supporting changes:

- `RunInfo.style` becomes `?CellStyle` (null = default style), removing the
  `isDefault()` guard from `applyStyle` and making the null check explicit at
  the call site
- Wide-character spacer tails compensate with `end_char -= 1` after the style
  logic runs, preventing boundary overcounting that would otherwise bleed style
  from a styled wide character onto the following default-style cell
- `CellStyle.eql()` is removed; `std.meta.eql` on `CellStyleKey` replaces it
- The explicit "close final run" block at the end of the loop is no longer needed

## Benchmark

All runs: `zig build -Doptimize=ReleaseFast`, Elisp byte-compiled.  
Machine: Apple M5 Pro, macOS 26.4.1, Emacs 30.2.

### Streaming (chunked write + periodic redraw, no PTY)

| Scenario    | main   | branch | Δ        |
|-------------|-------:|-------:|---------:|
| stream/incr | 25 ms  | 20 ms  | **−20%** |
| stream/full | 26 ms  | 20 ms  | **−23%** |

### TUI frame rendering (full-screen rewrites)

| Scenario    | main       | branch     | Δ        |
|-------------|-----------:|-----------:|---------:|
| incr 24×80  | 11 379 fps | 13 466 fps | **+18%** |
| full 24×80  | 11 448 fps | 13 805 fps | **+21%** |
| incr 40×120 |  5 182 fps |  6 550 fps | **+26%** |
| full 40×120 |  5 285 fps |  6 539 fps | **+24%** |

### TUI partial update (bottom-row update over static screen)

| Scenario    | main        | branch      | Δ        |
|-------------|------------:|------------:|---------:|
| full 24×80  |  14 180 fps |  18 110 fps | **+28%** |
| full 40×120 |   6 801 fps |   9 634 fps | **+42%** |
| incr 24×80  | 124 031 fps | 133 969 fps |    +8%   |
| incr 40×120 |  87 782 fps |  99 775 fps |   +14%   |

### Engine micro-benchmarks (single bulk call, no PTY)

| Scenario     | main     | branch   | Δ     |
|--------------|----------:|---------:|------:|
| plain/incr   | 128 MB/s | 135 MB/s |  +5%  |
| styled/incr  |  89 MB/s |  95 MB/s |  +7%  |
| unicode/incr | 179 MB/s | 197 MB/s | +10%  |

### Real-world PTY (cat 1 MB through process pipe)

| Scenario   | main     | branch   | Δ    |
|------------|----------:|---------:|-----:|
| plain/incr | 105 MB/s | 111 MB/s | +6%  |
| plain/full | 107 MB/s | 110 MB/s | +3%  |

PTY improvements are modest: throughput there is dominated by process I/O and
timer overhead rather than per-cell render cost.