### PR TITLE
Only rebuild scrollback on column size changes

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4023,18 +4023,6 @@ PROCESS is the shell process, WINDOWS is the list of windows."
            ((and (eql height ghostel--term-rows)
                  (eql width ghostel--term-cols))
             (setq size nil))
-           ;; Crop: minibuffer is active, only height shrank, width unchanged, and the
-           ;; terminal is on the primary screen.  Defer the resize so no SIGWINCH is sent
-           ;; — the Emacs window naturally hides the bottom rows, just like a normal
-           ;; buffer.  Alt-screen apps (vim, htop) own the full viewport and must be told
-           ;; the real size to re-layout, so they take the normal-resize path.  If the
-           ;; user switches focus into the ghostel window while the minibuffer is still
-           ;; open, `ghostel--commit-cropped-size' commits the smaller size then.
-           ((and (> (minibuffer-depth) 0)
-                 (eql width ghostel--term-cols)
-                 (< height ghostel--term-rows)
-                 (not (ghostel--alt-screen-p ghostel--term)))
-            (setq size nil))
            ;; Real resize — update the terminal model and redraw.
            (t
             (ghostel--set-size-with-cell-dims
@@ -4077,43 +4065,6 @@ output is arriving."
     (cl-pushnew window ghostel--windows-needing-snap)
     (ghostel--invalidate)))
 
-(defun ghostel--commit-cropped-size (window)
-  "Commit WINDOW's size if the user focused into a cropped ghostel window.
-When the minibuffer opens, `ghostel--window-adjust-process-window-size'
-skips the resize so the PTY keeps its original row count and the bottom
-rows are just hidden.  But if the user switches focus into the ghostel
-window while the minibuffer is still up, they are now actively using
-the smaller viewport — commit the size so the shell/app knows its real
-dimensions.
-
-Intended for buffer-local `window-selection-change-functions'.  When
-registered buffer-locally, Emacs calls this with WINDOW and makes its
-buffer current; we only commit when WINDOW has become the selected
-window (not when it has just been deselected)."
-  (when (and (> (minibuffer-depth) 0)
-             (window-live-p window)
-             (eq window (frame-selected-window (window-frame window)))
-             ghostel--term
-             ghostel--process
-             (process-live-p ghostel--process))
-    (let ((height (with-selected-window window
-                    (floor (window-screen-lines))))
-          (width (window-max-chars-per-line window))
-          (buf (current-buffer)))
-      (unless (and (eql height ghostel--term-rows)
-                   (eql width ghostel--term-cols))
-        (ghostel--set-size-with-cell-dims
-         ghostel--term (max 1 height) (max 1 width))
-        (setq ghostel--term-rows height
-              ghostel--term-cols width
-              ghostel--force-next-redraw t)
-        (set-process-window-size ghostel--process
-                                 (max 1 height) (max 1 width))
-        (when ghostel--redraw-timer
-          (cancel-timer ghostel--redraw-timer)
-          (setq ghostel--redraw-timer nil))
-        (let ((ghostel--redraw-resize-active t))
-          (ghostel--delayed-redraw buf))))))
 
 ;;; Major mode
 
@@ -4145,10 +4096,6 @@ window (not when it has just been deselected)."
   (add-function :after after-focus-change-function #'ghostel--focus-change)
   (add-hook 'window-selection-change-functions #'ghostel--focus-change)
   (add-hook 'window-buffer-change-functions #'ghostel--focus-change)
-  ;; Buffer-local so it only fires for windows showing this buffer, and
-  ;; receives WINDOW directly (rather than FRAME as the default binding).
-  (add-hook 'window-selection-change-functions
-            #'ghostel--commit-cropped-size nil t)
   (add-hook 'window-buffer-change-functions
             #'ghostel--reshow-snap nil t)
   (ghostel--suppress-interfering-modes)

--- a/src/input.zig
+++ b/src/input.zig
@@ -59,8 +59,8 @@ pub fn encodeAndSendMouse(env: emacs.Env, term: *Terminal, action: i64, button: 
     // Set size: 1 pixel = 1 cell so Emacs cell coords map directly
     var size: gt.c.GhosttyMouseEncoderSize = .{
         .size = @sizeOf(gt.c.GhosttyMouseEncoderSize),
-        .screen_width = term.cols,
-        .screen_height = term.rows,
+        .screen_width = term.size.cols,
+        .screen_height = term.size.rows,
         .cell_width = 1,
         .cell_height = 1,
         .padding_top = 0,

--- a/src/kitty_graphics.zig
+++ b/src/kitty_graphics.zig
@@ -102,7 +102,7 @@ fn emitOnePlacement(
     // row is viewport_row + scrollback_in_buffer.  Compute it on this side
     // so the elisp callback can do a single forward-line from point-min.
     const abs_row: i64 = @as(i64, @intCast(info.viewport_row)) +
-        @as(i64, @intCast(term.scrollback_in_buffer));
+        @as(i64, @intCast(term.rows_in_buffer - term.size.rows));
     var args = [_]emacs.Value{
         img_val,
         if (emacs_data.is_png) env.t() else env.nil(),

--- a/src/module.zig
+++ b/src/module.zig
@@ -209,7 +209,6 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
     // pair split across two writes — chunk A ending with \r, chunk B
     // starting with \n — is not mis-normalized into \r\r\n.  The final
     // value is persisted back for the next call. An empty input
-
     // round-trips the flag unchanged.
     var seg_start: usize = 0;
     var prev_was_cr: bool = term.last_input_was_cr;
@@ -692,14 +691,7 @@ fn fnSetSize(raw_env: ?*c.emacs_env, nargs: isize, args: [*c]c.emacs_value, _: ?
         break :blk std.math.cast(u32, raw) orelse 1;
     } else 1;
 
-    term.resize(cols, rows, cell_w, cell_h) catch {
-        env.signalError("ghostel: resize failed");
-        return env.nil();
-    };
-    // Reflow invalidates the materialized scrollback — terminal.resize()
-    // sets rebuild_pending so the next redraw() erases and rebuilds under
-    // inhibit-redisplay, avoiding a visible blank frame.
-
+    term.resize(cols, rows, cell_w, cell_h);
     return env.nil();
 }
 
@@ -1230,8 +1222,8 @@ fn deviceAttributesCallback(_: gt.Terminal, _: ?*anyopaque, out: [*c]gt.DeviceAt
 fn sizeCallback(_: gt.Terminal, userdata: ?*anyopaque, out: [*c]gt.SizeReportSize) callconv(.c) bool {
     const term: *Terminal = @ptrCast(@alignCast(userdata));
     out[0] = .{
-        .rows = term.rows,
-        .columns = term.cols,
+        .rows = term.size.rows,
+        .columns = term.size.cols,
         .cell_width = term.cell_width_px,
         .cell_height = term.cell_height_px,
     };
@@ -1333,7 +1325,7 @@ fn fnUriAt(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*anyop
     const col = env.extractInteger(args[2]);
     const total_rows = term.getTotalRows();
 
-    if (col < 0 or col >= term.cols) return env.nil();
+    if (col < 0 or col >= term.size.cols) return env.nil();
     // The Emacs buffer always carries a trailing newline, so the line
     // immediately after the last content row produces row_from_bottom == 0.
     if (row_from_bottom <= 0 or row_from_bottom > total_rows) return env.nil();

--- a/src/render.zig
+++ b/src/render.zig
@@ -611,7 +611,11 @@ fn getDefaultColors(term: *Terminal) BgFg {
     return bgfg;
 }
 
-pub fn render(env: emacs.Env, term: *Terminal, render_state: gt.RenderState, skip: usize, force_full: bool) void {
+pub fn render(env: emacs.Env, term: *Terminal, skip: usize, force_full: bool) void {
+    if (gt.c.ghostty_render_state_update(term.render_state, term.terminal) != gt.SUCCESS) {
+        return;
+    }
+
     const default_colors = getDefaultColors(term);
 
     // Check dirty state.
@@ -619,7 +623,7 @@ pub fn render(env: emacs.Env, term: *Terminal, render_state: gt.RenderState, ski
     // sync / resize / rotation above, so we must rebuild even if
     // libghostty considers the cells clean.
     var dirty: c_int = gt.DIRTY_FALSE;
-    _ = gt.c.ghostty_render_state_get(render_state, gt.RS_DATA_DIRTY, @ptrCast(&dirty));
+    _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_DIRTY, @ptrCast(&dirty));
     var has_wide_chars: bool = false;
 
     if (dirty != gt.DIRTY_FALSE or force_full) {
@@ -633,7 +637,7 @@ pub fn render(env: emacs.Env, term: *Terminal, render_state: gt.RenderState, ski
         );
 
         // Get row iterator
-        if (gt.c.ghostty_render_state_get(render_state, gt.RS_DATA_ROW_ITERATOR, @ptrCast(&term.row_iterator)) != gt.SUCCESS) {
+        if (gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_ROW_ITERATOR, @ptrCast(&term.row_iterator)) != gt.SUCCESS) {
             return;
         }
 
@@ -671,7 +675,7 @@ pub fn render(env: emacs.Env, term: *Terminal, render_state: gt.RenderState, ski
 
         // Reset dirty state
         const dirty_false: c_int = gt.DIRTY_FALSE;
-        _ = gt.c.ghostty_render_state_set(render_state, gt.RS_OPT_DIRTY, @ptrCast(&dirty_false));
+        _ = gt.c.ghostty_render_state_set(term.render_state, gt.RS_OPT_DIRTY, @ptrCast(&dirty_false));
     }
 
     if (dirty != gt.DIRTY_FALSE) {
@@ -684,9 +688,8 @@ pub fn render(env: emacs.Env, term: *Terminal, render_state: gt.RenderState, ski
 pub fn renderCursor(env: emacs.Env, term: *Terminal) void {
 
     // Walk to the current viewport start
-    env.gotoChar(env.pointMax());
-    _ = env.forwardLine(-@as(i64, @intCast(term.rows)));
-    const viewport_start_int = env.extractInteger(env.point());
+    gotoActiveStart(env, term);
+    const active_start_int = env.extractInteger(env.point());
 
     // Batch-fetch cursor style/visibility (always available).
     var cursor_visible: bool = true;
@@ -703,7 +706,7 @@ pub fn renderCursor(env: emacs.Env, term: *Terminal) void {
         _ = gt.c.ghostty_render_state_get_multi(term.render_state, cursor_keys.len, &cursor_keys, @ptrCast(&cursor_values), null);
     }
 
-    // Position cursor (viewport-relative row -> absolute line).
+    // Position cursor (active-relative row -> absolute line).
     // X/Y are only valid when HAS_VALUE is true, so query separately
     // to avoid stopping the style batch above on NO_VALUE.
     var cursor_has_value: bool = false;
@@ -714,7 +717,7 @@ pub fn renderCursor(env: emacs.Env, term: *Terminal) void {
         _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_CURSOR_VIEWPORT_X, @ptrCast(&cx));
         _ = gt.c.ghostty_render_state_get(term.render_state, gt.RS_DATA_CURSOR_VIEWPORT_Y, @ptrCast(&cy));
 
-        env.gotoCharN(viewport_start_int);
+        env.gotoCharN(active_start_int);
         _ = env.forwardLine(@as(i64, cy));
         if (!positionCursorByCell(env, term, cx, cy)) {
             env.moveToColumn(@as(i64, cx));
@@ -726,6 +729,59 @@ pub fn renderCursor(env: emacs.Env, term: *Terminal) void {
         env.makeInteger(@as(i64, cursor_style)),
         if (cursor_visible) env.t() else env.nil(),
     );
+}
+
+// Render content from the current viewport scroll position all the way to
+// the active area at the current Emacs point.
+fn renderToEnd(env: emacs.Env, term: *Terminal, force_full: bool) usize {
+    const scrollbar = term.getScrollbar() orelse return 0;
+    if (scrollbar.len == 0) return 0;
+    const offset_max = scrollbar.total - scrollbar.len;
+    // Walk from the current viewport position to offset_max in viewport-sized
+    // steps, rendering each chunk into the Emacs buffer. Consecutive positions
+    // overlap by `scrollbar.len - step` rows when the remaining range is
+    // smaller than a full viewport; `skip` tracks how many leading rows of the
+    // next position were already rendered at the tail of the previous one.
+    // After the loop the viewport sits at offset_max (the active area).
+    const total_range = scrollbar.total - scrollbar.offset;
+    const num_viewports = (total_range + scrollbar.len - 1) / scrollbar.len;
+    var skip: usize = 0;
+    var rendered_rows: usize = 0;
+    var current_offset = scrollbar.offset;
+    for (0..num_viewports) |_| {
+        render(env, term, skip, force_full);
+        rendered_rows += (scrollbar.len - skip);
+
+        const max_step = offset_max - current_offset;
+        const step = @min(max_step, scrollbar.len);
+        skip = scrollbar.len - step;
+
+        current_offset += step;
+        term.scrollViewport(gt.SCROLL_DELTA, @intCast(step));
+    }
+
+    return rendered_rows;
+}
+
+fn commitResize(term: *Terminal) void {
+    if (term.pending_resize) |resize| {
+        _ = gt.c.ghostty_terminal_resize(
+            term.terminal,
+            resize.cols,
+            resize.rows,
+            term.cell_width_px,
+            term.cell_height_px,
+        );
+        term.size = resize;
+        term.pending_resize = null;
+    }
+}
+
+/// Position the Emacs point at the start of the active area: `term.size.rows`
+/// lines back from `point-max`.
+fn gotoActiveStart(env: emacs.Env, term: *Terminal) void {
+    env.gotoChar(env.pointMax());
+    _ = env.forwardLine(-@as(i64, @intCast(term.size.rows)));
 }
 
 /// Redraw the terminal into the current Emacs buffer.
@@ -766,80 +822,74 @@ pub fn redraw(env: emacs.Env, term: *Terminal, force_full_arg: bool) void {
         }
     }
 
-    var force_full = force_full_arg;
+    var force_full = false;
 
     // ---- Scrollback validity ------------------------------------------------
     // There are three cases where we clear scrollback:
-    // 1. It was explicitly requested through `rebuild_pending`
+    // 1. The terminal width/cols changed.
     // 2. We had some scrollback but the scrollbar was reset from the parked
     //    MAX - 1 position. This indicates that libghostty cleared its
     //    scrollback and we follow after by clearing too.
     // 3. We had some scrollback but the scrollbar ended up at offset = 0, which
     //    means that we got so much scrolling that we scrolled all the way up
     //    and do not know how much we missed.
-    var scrollbar = term.getScrollbar() orelse return;
-    const scrollbar_reset = term.scrollback_in_buffer > 0 and scrollbar.len + scrollbar.offset == scrollbar.total;
-    const scrollbar_hit_cap = term.scrollback_in_buffer > 0 and scrollbar.offset == 0;
-    if (term.rebuild_pending or scrollbar_reset or scrollbar_hit_cap) {
+    const scrollbar = term.getScrollbar() orelse return;
+    const cols_changed = if (term.pending_resize) |resize| resize.cols != term.size.cols else false;
+    const had_scrollback = term.rows_in_buffer > scrollbar.len;
+    const scrollbar_reset = had_scrollback and scrollbar.len + scrollbar.offset == scrollbar.total;
+    const scrollbar_hit_cap = had_scrollback and scrollbar.offset == 0;
+    if (force_full_arg or cols_changed or scrollbar_reset or scrollbar_hit_cap) {
         env.eraseBuffer();
-        term.scrollback_in_buffer = 0;
+        // Commit any pending resize since we're doing a rebuild anyway.
+        commitResize(term);
+
+        term.rows_in_buffer = 0;
         force_full = true;
-        term.rebuild_pending = false;
     }
 
     // Unpark the viewport. When we have scrollback the viewport is sitting at
     // `max_offset - 1`; advance by 1 to reach the old active area, which is
     // also where the Emacs buffer currently ends. When we have no scrollback
     // there was no parking, so go to the top instead.
-    if (term.scrollback_in_buffer > 0) {
+    if (term.rows_in_buffer > term.size.rows) {
         term.scrollViewport(gt.SCROLL_DELTA, 1);
-        scrollbar.offset += 1;
         env.gotoChar(env.pointMax());
         _ = env.forwardLine(-@as(i64, @intCast(scrollbar.len)));
     } else {
         term.scrollViewport(gt.SCROLL_TOP, 0);
-        scrollbar.offset = 0;
         env.gotoChar(env.pointMin());
     }
 
-    if (scrollbar.len == 0) return;
-    const offset_max = scrollbar.total - scrollbar.len;
-    // Walk from the current viewport position to offset_max in viewport-sized
-    // steps, rendering each chunk into the Emacs buffer. Consecutive positions
-    // overlap by `scrollbar.len - step` rows when the remaining range is
-    // smaller than a full viewport; `skip` tracks how many leading rows of the
-    // next position were already rendered at the tail of the previous one.
-    // After the loop the viewport sits at offset_max (the active area).
-    const total_range = scrollbar.total - scrollbar.offset;
-    const num_viewports = (total_range + scrollbar.len - 1) / scrollbar.len;
-    var skip: usize = 0;
-    var rendered_rows: usize = 0;
-    for (0..num_viewports) |_| {
-        if (gt.c.ghostty_render_state_update(term.render_state, term.terminal) != gt.SUCCESS) {
-            return;
-        }
-        render(env, term, term.render_state, skip, force_full);
-        rendered_rows += (scrollbar.len - skip);
-
-        const max_step = offset_max - scrollbar.offset;
-        const step = @min(max_step, scrollbar.len);
-        skip = scrollbar.len - step;
-
-        scrollbar.offset += step;
-        term.scrollViewport(gt.SCROLL_DELTA, @intCast(step));
+    const rendered_rows = renderToEnd(env, term, force_full);
+    // Now that we rendered, even if we cleared the buffer above, we now have at
+    // least the rows in the active area:
+    term.rows_in_buffer = @max(term.rows_in_buffer, term.size.rows);
+    // But we might also have added scrollback rows - that is, rows that we
+    // rendered that was not active area. Guard the subtraction: when
+    // renderToEnd is a no-op (scrollbar.len == 0 or empty range) it returns 0,
+    // and there are no new scrollback rows to add.
+    if (rendered_rows > term.size.rows) {
+        term.rows_in_buffer += rendered_rows - term.size.rows;
     }
-    // rendered_rows covers all rows from the old active area to the new bottom,
-    // so subtracting one viewport's worth gives the count of newly added
-    // scrollback rows.
-    term.scrollback_in_buffer += (rendered_rows - scrollbar.len);
+
+    // If we have a pending resize, commit it now and just rerender the active
+    // since the scrollback is already up to date.
+    if (term.pending_resize != null) {
+        commitResize(term);
+        term.scrollViewport(gt.SCROLL_BOTTOM, 0);
+        gotoActiveStart(env, term);
+        render(env, term, 0, false);
+        // There is now at least term.size.rows number of rows
+        term.rows_in_buffer = @max(term.rows_in_buffer, term.size.rows);
+    }
 
     // Evict old scrollback if libghostty also did
-    const libghostty_scrollback = term.getScrollbackRows();
-    if (libghostty_scrollback < term.scrollback_in_buffer) {
+    const libghostty_rows = term.getTotalRows();
+    if (libghostty_rows < term.rows_in_buffer) {
         env.gotoChar(env.pointMin());
-        _ = env.forwardLine(@as(i64, @intCast(term.scrollback_in_buffer - libghostty_scrollback)));
+        _ = env.forwardLine(@as(i64, @intCast(term.rows_in_buffer - libghostty_rows)));
         env.deleteRegion(env.pointMin(), env.point());
-        term.scrollback_in_buffer = libghostty_scrollback;
+        term.rows_in_buffer = libghostty_rows;
     }
 
     renderCursor(env, term);

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -25,9 +25,11 @@ key_encoder: gt.c.GhosttyKeyEncoder,
 /// Mouse encoder for translating mouse events to escape sequences.
 mouse_encoder: gt.c.GhosttyMouseEncoder,
 
-/// Terminal dimensions.
-cols: u16,
-rows: u16,
+/// Terminal viewport dimensions.
+size: ViewportSize,
+
+/// Any pending resize as `.{cols, rows}`. Resizes are comitted on next redraw.
+pending_resize: ?ViewportSize = null,
 
 /// Cell pixel dimensions, used to answer XTWINOPS CSI 14/16/18 t
 /// queries.  Updated on every resize.  Initialized to 1x1 — apps
@@ -36,16 +38,10 @@ rows: u16,
 cell_width_px: u32 = 1,
 cell_height_px: u32 = 1,
 
-/// Number of libghostty scrollback rows already materialized into the
-/// Emacs buffer above the viewport. Polled on each redraw; kept in sync
-/// by appending newly-scrolled-off rows and trimming rows evicted by
-/// libghostty's scrollback cap.
-scrollback_in_buffer: usize = 0,
-
-/// When true, the next redraw erases the Emacs buffer,
-/// resets scrollback state, and forces a full rebuild.  The erase is deferred
-/// so `inhibit-redisplay` can prevent a visible blank frame.
-rebuild_pending: bool = false,
+/// Number of libghostty rows already materialized into the Emacs buffer. Polled
+/// on each redraw; kept in sync by appending newly-scrolled-off rows and
+/// trimming rows evicted by libghostty's scrollback cap.
+rows_in_buffer: usize = 0,
 
 /// True iff the last byte of the previous `fnWriteInput` input was
 /// `\r`. Carries the bare-LF detection state across write-input calls
@@ -61,6 +57,8 @@ last_input_was_cr: bool = false,
 
 /// Cached Emacs env pointer — only valid during a callback from Emacs.
 env: ?emacs.Env = null,
+
+const ViewportSize = struct { cols: u16, rows: u16 };
 
 /// Create a new terminal with the given dimensions and scrollback.
 pub fn init(cols: u16, rows: u16, max_scrollback: usize) !Self {
@@ -113,8 +111,7 @@ pub fn init(cols: u16, rows: u16, max_scrollback: usize) !Self {
         .row_cells = row_cells,
         .key_encoder = key_encoder,
         .mouse_encoder = mouse_encoder,
-        .cols = cols,
-        .rows = rows,
+        .size = .{ .cols = cols, .rows = rows },
     };
 }
 
@@ -246,27 +243,13 @@ pub fn vtWrite(self: *Self, data: []const u8) void {
     gt.c.ghostty_terminal_vt_write(self.terminal, data.ptr, data.len);
 }
 
-/// Resize the terminal.
-///
-/// Also sets `rebuild_pending` so the next `redraw()` erases the Emacs buffer
-/// under `inhibit-redisplay` and rebuilds scrollback from scratch — avoiding
-/// a visible blank frame between the resize and the first repaint.
-pub fn resize(self: *Self, cols: u16, rows: u16, cell_w: u32, cell_h: u32) !void {
-    if (gt.c.ghostty_terminal_resize(
-        self.terminal,
-        cols,
-        rows,
-        cell_w,
-        cell_h,
-    ) != gt.SUCCESS) {
-        return error.ResizeFailed;
-    }
-    self.cols = cols;
-    self.rows = rows;
+/// Resize the terminal. The col/row size gets committed on next redraw in order
+/// to ensure that the we fully render the very latest state in case any rows
+/// get promoted to scrollback due to vertical shrinking of the viewport.
+pub fn resize(self: *Self, cols: u16, rows: u16, cell_w: u32, cell_h: u32) void {
+    self.pending_resize = .{ .cols = cols, .rows = rows };
     self.cell_width_px = cell_w;
     self.cell_height_px = cell_h;
-    self.rebuild_pending = true;
-    self.last_input_was_cr = false;
 }
 
 /// Scroll the viewport.
@@ -319,7 +302,7 @@ pub fn isAltScreen(self: *Self) bool {
 pub fn getTotalRows(self: *Self) usize {
     var total: usize = 0;
     if (gt.c.ghostty_terminal_get(self.terminal, gt.DATA_TOTAL_ROWS, @ptrCast(&total)) != gt.SUCCESS) {
-        return self.rows;
+        return self.size.rows;
     }
     return total;
 }
@@ -328,7 +311,7 @@ pub fn getTotalRows(self: *Self) usize {
 pub fn getScrollbackRows(self: *Self) usize {
     var scrollback: usize = 0;
     if (gt.c.ghostty_terminal_get(self.terminal, gt.DATA_SCROLLBACK_ROWS, @ptrCast(&scrollback)) != gt.SUCCESS) {
-        return self.rows;
+        return self.size.rows;
     }
     return scrollback;
 }

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -29,6 +29,28 @@
            ,@body)
        (kill-buffer ,var))))
 
+(defun ghostel-test--mark-all-lines-clean ()
+  "Mark every line in the current buffer with `ghostel-test-clean' property.
+Used with `ghostel-test--line-clean-p' to detect whether the redrawer
+rebuilt a line: a rebuild calls `delete-region' on the line, stripping
+all text properties including this sentinel."
+  (let ((inhibit-read-only t))
+    (save-excursion
+      (goto-char (point-min))
+      (while (not (eobp))
+        (put-text-property (point) (1+ (point)) 'ghostel-test-clean t)
+        (forward-line 1)))))
+
+(defun ghostel-test--line-clean-p (n)
+  "Return non-nil if line N (0-indexed from `point-min') was not rebuilt.
+The `ghostel-test-clean' property is placed by
+`ghostel-test--mark-all-lines-clean' and is stripped by the redrawer's
+`delete-region' call when a line is rebuilt."
+  (save-excursion
+    (goto-char (point-min))
+    (forward-line n)
+    (get-text-property (point) 'ghostel-test-clean)))
+
 (defun ghostel-test--row0 (term)
   "Return the first row text from the render state of TERM."
   (let ((state (ghostel--debug-state term)))
@@ -702,6 +724,161 @@ single redraw):
               ;; after-00 scrolled into scrollback; after-01..after-04 in viewport.
               (should (string-match-p "after-00" content))
               (should (string-match-p "after-04" content)))))
+      (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
+;; Tests: scrollback rows are not rerendered (dirty-row reuse)
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-scrollback-not-rebuilt-on-shrink ()
+  "Scrollback rows survive a vertical-only viewport shrink without rerendering.
+A column-only or full resize erases and rebuilds the buffer, but shrinking
+only the row count must leave existing scrollback lines untouched."
+  (let ((buf (generate-new-buffer " *ghostel-test-sb-shrink*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 80 1000))
+                 (inhibit-read-only t))
+            ;; 8 rows into a 5-row terminal → lines 0-2 scroll into scrollback.
+            (dotimes (i 8)
+              (ghostel--write-input term (format "row-%02d\r\n" i)))
+            (ghostel--redraw term t)
+            ;; Stamp every line with the sentinel after the initial full render.
+            (ghostel-test--mark-all-lines-clean)
+            ;; Shrink rows only — columns are unchanged so the buffer is not erased.
+            (ghostel--set-size term 3 80)
+            (ghostel--redraw term)
+            ;; The 3 original scrollback lines must not have been rebuilt.
+            (should (ghostel-test--line-clean-p 0))
+            (should (ghostel-test--line-clean-p 1))
+            (should (ghostel-test--line-clean-p 2))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-scrollback-not-rebuilt-on-expand ()
+  "Scrollback rows above the new active area survive a vertical viewport expand.
+Expanding the row count pulls some scrollback rows back into the viewport,
+but rows that remain in scrollback must not be rerendered."
+  (let ((buf (generate-new-buffer " *ghostel-test-sb-expand*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 80 1000))
+                 (inhibit-read-only t))
+            ;; 20 rows into a 5-row terminal → 15 scrollback rows in the buffer.
+            (dotimes (i 20)
+              (ghostel--write-input term (format "row-%02d\r\n" i)))
+            (ghostel--redraw term t)
+            (ghostel-test--mark-all-lines-clean)
+            ;; Expand to 8 rows.  The resize render re-renders the last 8 lines,
+            ;; so lines 0-11 stay in scrollback and must remain untouched.
+            (ghostel--set-size term 8 80)
+            (ghostel--redraw term)
+            (dotimes (i 12)
+              (should (ghostel-test--line-clean-p i)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-content-preserved-across-vertical-resizes ()
+  "Buffer content survives expand then shrink without loss or duplication.
+Expands from the initial size (staying within the available scrollback so
+no rows are pulled back) then shrinks below the original size.  No
+assumption is made about which lines are rebuilt; the full buffer text
+must be identical after each resize."
+  (let ((buf (generate-new-buffer " *ghostel-test-resize-roundtrip*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 80 1000))
+                 (inhibit-read-only t))
+            ;; Write 20 rows into a 5-row terminal → 15 rows in scrollback.
+            (dotimes (i 20)
+              (ghostel--write-input term (format "row-%02d\r\n" i)))
+            (ghostel--redraw term t)
+            (let ((baseline (buffer-substring-no-properties (point-min) (point-max))))
+              ;; Expand to 8 rows — within the 15-row scrollback, so no
+              ;; rows are exhausted from libghostty's scrollback cap.
+              (ghostel--set-size term 8 80)
+              (ghostel--redraw term)
+              (should (equal baseline (buffer-substring-no-properties (point-min) (point-max))))
+              ;; Shrink to 3 rows — smaller than the original 5.
+              (ghostel--set-size term 3 80)
+              (ghostel--redraw term)
+              (should (equal baseline (buffer-substring-no-properties (point-min) (point-max)))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-shrink-line-count-and-content ()
+  "After a vertical shrink the buffer contracts to the new viewport row count.
+With no scrollback the content fits entirely within the smaller viewport, so
+the buffer must have exactly as many lines as the new row count — no phantom
+rows left over from the previous larger size.  The first line must contain
+the written content; all remaining lines must be empty."
+  (let ((buf (generate-new-buffer " *ghostel-test-shrink-lines*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 80 1000))
+                 (inhibit-read-only t))
+            (ghostel--write-input term "hello\r\n")
+            (ghostel--redraw term t)
+            (ghostel--set-size term 3 80)
+            (ghostel--redraw term)
+            (should (= 3 (count-lines (point-min) (point-max))))
+            (goto-char (point-min))
+            (should (equal "hello"
+                           (buffer-substring-no-properties
+                            (line-beginning-position) (line-end-position))))
+            (dotimes (_ 2)
+              (forward-line 1)
+              (should (equal ""
+                             (buffer-substring-no-properties
+                              (line-beginning-position) (line-end-position)))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-scrollback-not-rebuilt-on-new-row ()
+  "Adding a row to a full viewport does not recreate existing scrollback rows.
+When a new row pushes the top viewport row into scrollback, the rows
+already in scrollback must remain untouched."
+  (let ((buf (generate-new-buffer " *ghostel-test-sb-newrow*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 80 1000))
+                 (inhibit-read-only t))
+            ;; 8 rows → lines 0-2 are scrollback after the initial render.
+            (dotimes (i 8)
+              (ghostel--write-input term (format "first-%02d\r\n" i)))
+            (ghostel--redraw term t)
+            (ghostel-test--mark-all-lines-clean)
+            ;; One more row scrolls through the viewport.
+            (ghostel--write-input term "extra\r\n")
+            (ghostel--redraw term)
+            ;; The 3 pre-existing scrollback rows must not have been rebuilt.
+            (should (ghostel-test--line-clean-p 0))
+            (should (ghostel-test--line-clean-p 1))
+            (should (ghostel-test--line-clean-p 2))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-partial-redraw-only-dirty-row-rebuilt ()
+  "Modifying one active row rebuilds only that row; unchanged rows are preserved.
+The incremental dirty-row path calls `delete-region' + re-insert for dirty rows
+and `forward-line' for clean ones.  Only the dirty row loses the sentinel."
+  (let ((buf (generate-new-buffer " *ghostel-test-partial-dirty*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 80 1000))
+                 (inhibit-read-only t))
+            ;; Fill the viewport and park the cursor on row 2 before the
+            ;; initial draw.  This avoids dirtying row 4 on the second
+            ;; render: a cursor move from row 4 → row 2 would dirty both
+            ;; rows, breaking the single-dirty-row assertion below.
+            (ghostel--write-input term "row-0\r\nrow-1\r\nrow-2\r\nrow-3\r\nrow-4\e[3;1H")
+            (ghostel--redraw term t)
+            (ghostel-test--mark-all-lines-clean)
+            ;; Cursor is already on row 2; overwrite it in place.
+            (ghostel--write-input term "modified")
+            (ghostel--redraw term)
+            ;; Row 2 was dirty and must have been rebuilt (sentinel gone).
+            (should-not (ghostel-test--line-clean-p 2))
+            ;; The remaining rows were clean and must not have been rebuilt.
+            (should (ghostel-test--line-clean-p 0))
+            (should (ghostel-test--line-clean-p 1))
+            (should (ghostel-test--line-clean-p 3))
+            (should (ghostel-test--line-clean-p 4))))
       (kill-buffer buf))))
 
 ;; -----------------------------------------------------------------------
@@ -3414,7 +3591,7 @@ compile buffer that flashes open and disappears."
           (setq-local ghostel--process proc
                       ghostel-compile--command "sleep 5"
                       ghostel-compile--start-time (current-time)
-                                ghostel-compile--scan-marker (copy-marker (point-max)))
+                      ghostel-compile--scan-marker (copy-marker (point-max)))
           ;; Finalize with a real process attached: must NOT kill the
           ;; buffer AND must NOT insert the default sentinel's
           ;; "Process NAME killed: N" line into it.
@@ -3583,7 +3760,7 @@ scrolled below the window."
                  (lambda (&rest _) (setq jumped t))))
         (setq ghostel-compile--command "make"
               ghostel-compile--start-time (current-time)
-                ghostel-compile--scan-marker (copy-marker (point-max)))
+              ghostel-compile--scan-marker (copy-marker (point-max)))
         (insert "/tmp/x.c:1:1: error: boom\n")
         (ghostel-compile--finalize buf 1 (current-time))
         (should jumped)))))                                    ; first-error called

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -2202,27 +2202,6 @@ first real focus event."
       (set-window-configuration saved-window-config)
       (ghostel-test--cleanup-focus-buffer buf))))
 
-(ert-deftest ghostel-test-focus-minibuffer ()
-  "Activating the minibuffer triggers focus-out on the ghostel buffer."
-  (let* ((events nil)
-         (focus-fn (lambda () t))
-         (buf (ghostel-test--make-focus-buffer " *ghostel-focus-mini*"))
-         (saved-window-config (current-window-configuration)))
-    (unwind-protect
-        (ghostel-test--with-focus-stub events focus-fn
-          (delete-other-windows)
-          (switch-to-buffer buf)
-          (ghostel--focus-change)
-          (should (equal (car events) (cons buf t)))
-          ;; Simulate minibuffer activation by selecting the minibuffer window.
-          (let ((mb-win (minibuffer-window)))
-            (select-window mb-win)
-            (setq events nil)
-            (ghostel--focus-change)
-            (should (equal (car events) (cons buf nil)))))
-      (set-window-configuration saved-window-config)
-      (ghostel-test--cleanup-focus-buffer buf))))
-
 ;; -----------------------------------------------------------------------
 ;; Test: incremental (partial) redraw
 ;; -----------------------------------------------------------------------
@@ -7758,177 +7737,6 @@ It must also raise `read-process-output-max'.  Same reason as
             (should (null result))
             (should-not set-size-called)))))))
 
-(ert-deftest ghostel-test-resize-minibuffer-crop ()
-  "Minibuffer-induced height shrink on primary screen is cropped (nil)."
-  (with-temp-buffer
-    (let ((ghostel--term 'fake)
-          (ghostel--term-rows 40)
-          (ghostel--term-cols 120)
-          (set-size-called nil))
-      (let ((cur-buf (current-buffer)))
-        (cl-letf (((symbol-function 'ghostel--set-size)
-                   (lambda (_term _h _w) (setq set-size-called t)))
-                  ((symbol-function 'ghostel--delayed-redraw) #'ignore)
-                  ((symbol-function 'ghostel--alt-screen-p) (lambda (_t) nil))
-                  ((symbol-function 'minibuffer-depth) (lambda () 1))
-                  ((symbol-function 'process-buffer)
-                   (lambda (_proc) cur-buf))
-                  ((default-value 'window-adjust-process-window-size-function)
-                   (lambda (_proc _wins) '(120 . 25))))
-          (let ((result (ghostel--window-adjust-process-window-size
-                         'fake-proc '(fake-win))))
-            (should (null result))
-            (should-not set-size-called)))))))
-
-(ert-deftest ghostel-test-resize-minibuffer-alt-screen-commits ()
-  "Alt-screen apps (htop/vim) skip the crop path and resize normally."
-  (with-temp-buffer
-    (let ((ghostel--term 'fake)
-          (ghostel--term-rows 40)
-          (ghostel--term-cols 120)
-          (set-size-args nil))
-      (let ((cur-buf (current-buffer)))
-        (cl-letf (((symbol-function 'ghostel--set-size)
-                   (lambda (_term h w &rest _) (setq set-size-args (list h w))))
-                  ((symbol-function 'ghostel--delayed-redraw) #'ignore)
-                  ((symbol-function 'ghostel--alt-screen-p) (lambda (_t) t))
-                  ((symbol-function 'minibuffer-depth) (lambda () 1))
-                  ((symbol-function 'process-buffer)
-                   (lambda (_proc) cur-buf))
-                  ((default-value 'window-adjust-process-window-size-function)
-                   (lambda (_proc _wins) '(120 . 25))))
-          (let ((result (ghostel--window-adjust-process-window-size
-                         'fake-proc '(fake-win))))
-            (should (equal '(120 . 25) result))
-            (should (equal '(25 120) set-size-args))
-            (should (eql ghostel--term-rows 25))))))))
-
-(ert-deftest ghostel-test-resize-minibuffer-width-only-shrink-commits ()
-  "Width-only shrink with minibuffer open skips the crop and resizes."
-  (with-temp-buffer
-    (let ((ghostel--term 'fake)
-          (ghostel--term-rows 40)
-          (ghostel--term-cols 120)
-          (set-size-args nil))
-      (let ((cur-buf (current-buffer)))
-        (cl-letf (((symbol-function 'ghostel--set-size)
-                   (lambda (_term h w &rest _) (setq set-size-args (list h w))))
-                  ((symbol-function 'ghostel--delayed-redraw) #'ignore)
-                  ((symbol-function 'ghostel--alt-screen-p) (lambda (_t) nil))
-                  ((symbol-function 'minibuffer-depth) (lambda () 1))
-                  ((symbol-function 'process-buffer)
-                   (lambda (_proc) cur-buf))
-                  ;; width 100 < 120, height unchanged.
-                  ((default-value 'window-adjust-process-window-size-function)
-                   (lambda (_proc _wins) '(100 . 40))))
-          (let ((result (ghostel--window-adjust-process-window-size
-                         'fake-proc '(fake-win))))
-            (should (equal '(100 . 40) result))
-            (should (equal '(40 100) set-size-args))))))))
-
-(ert-deftest ghostel-test-commit-cropped-size-on-focus ()
-  "Focus return to a cropped ghostel window commits size and SIGWINCH."
-  (with-temp-buffer
-    (let ((ghostel--term 'fake)
-          (ghostel--process 'fake-proc)
-          (ghostel--term-rows 40)
-          (ghostel--term-cols 120)
-          (ghostel--force-next-redraw nil)
-          (set-size-args nil)
-          (swsize-args nil)
-          (redraw-called nil))
-      ;; Pass a real `(selected-window)' rather than a fake symbol so
-      ;; `with-selected-window' works without stubbing implementation
-      ;; internals (which differ across the supported Emacs versions).
-      (cl-letf (((symbol-function 'ghostel--set-size)
-                 (lambda (_term h w &rest _) (setq set-size-args (list h w))))
-                ((symbol-function 'ghostel--delayed-redraw)
-                 (lambda (_buf) (setq redraw-called t)))
-                ((symbol-function 'process-live-p) (lambda (_p) t))
-                ((symbol-function 'set-process-window-size)
-                 (lambda (_p h w) (setq swsize-args (list h w))))
-                ;; Regression guard for #192: if the function ever
-                ;; reverts to `window-body-height' instead of
-                ;; `window-screen-lines', the assertions below fail
-                ;; because 99 ≠ 25.
-                ((symbol-function 'window-body-height) (lambda (&rest _) 99))
-                ((symbol-function 'window-screen-lines) (lambda () 25.0))
-                ((symbol-function 'window-max-chars-per-line) (lambda (&rest _) 120))
-                ((symbol-function 'minibuffer-depth) (lambda () 1)))
-        (ghostel--commit-cropped-size (selected-window))
-        (should (equal '(25 120) set-size-args))
-        (should (equal '(25 120) swsize-args))
-        (should (eql ghostel--term-rows 25))
-        (should (eql ghostel--term-cols 120))
-        (should ghostel--force-next-redraw)
-        (should redraw-called)))))
-
-(ert-deftest ghostel-test-commit-cropped-size-noop-outside-minibuffer ()
-  "Focus change outside the minibuffer does not resize."
-  (with-temp-buffer
-    (let ((ghostel--term 'fake)
-          (ghostel--process 'fake-proc)
-          (ghostel--term-rows 40)
-          (ghostel--term-cols 120)
-          (set-size-called nil)
-          (swsize-called nil))
-      (cl-letf (((symbol-function 'ghostel--set-size)
-                 (lambda (_term _h _w) (setq set-size-called t)))
-                ((symbol-function 'ghostel--delayed-redraw) #'ignore)
-                ((symbol-function 'set-process-window-size)
-                 (lambda (_p _h _w) (setq swsize-called t)))
-                ((symbol-function 'minibuffer-depth) (lambda () 0)))
-        (ghostel--commit-cropped-size 'test-win)
-        (should-not set-size-called)
-        (should-not swsize-called)))))
-
-(ert-deftest ghostel-test-commit-cropped-size-noop-on-deselect ()
-  "Hook firing on WINDOW deselection does not resize."
-  (with-temp-buffer
-    (let ((ghostel--term 'fake)
-          (ghostel--process 'fake-proc)
-          (ghostel--term-rows 40)
-          (ghostel--term-cols 120)
-          (set-size-called nil)
-          (swsize-called nil))
-      (cl-letf (((symbol-function 'ghostel--set-size)
-                 (lambda (_term _h _w) (setq set-size-called t)))
-                ((symbol-function 'ghostel--delayed-redraw) #'ignore)
-                ((symbol-function 'process-live-p) (lambda (_p) t))
-                ((symbol-function 'set-process-window-size)
-                 (lambda (_p _h _w) (setq swsize-called t)))
-                ((symbol-function 'window-live-p) (lambda (_w) t))
-                ((symbol-function 'window-frame) (lambda (_w) 'test-frame))
-                ;; Selected window is *not* our window — we're being deselected.
-                ((symbol-function 'frame-selected-window)
-                 (lambda (_f) 'other-win))
-                ((symbol-function 'minibuffer-depth) (lambda () 1)))
-        (ghostel--commit-cropped-size 'test-win)
-        (should-not set-size-called)
-        (should-not swsize-called)))))
-
-(ert-deftest ghostel-test-commit-cropped-size-noop-when-matched ()
-  "If the window already matches the committed size, do nothing."
-  (with-temp-buffer
-    (let ((ghostel--term 'fake)
-          (ghostel--process 'fake-proc)
-          (ghostel--term-rows 40)
-          (ghostel--term-cols 120)
-          (set-size-called nil)
-          (swsize-called nil))
-      (cl-letf (((symbol-function 'ghostel--set-size)
-                 (lambda (_term _h _w) (setq set-size-called t)))
-                ((symbol-function 'ghostel--delayed-redraw) #'ignore)
-                ((symbol-function 'process-live-p) (lambda (_p) t))
-                ((symbol-function 'set-process-window-size)
-                 (lambda (_p _h _w) (setq swsize-called t)))
-                ((symbol-function 'window-screen-lines) (lambda () 40.0))
-                ((symbol-function 'window-max-chars-per-line) (lambda (&rest _) 120))
-                ((symbol-function 'minibuffer-depth) (lambda () 1)))
-        (ghostel--commit-cropped-size (selected-window))
-        (should-not set-size-called)
-        (should-not swsize-called)))))
-
 ;;; SIGWINCH delivery tests — verify the PTY actually sends the signal
 
 ;; Uses ghostel-test--wait-for defined at the top of this file.
@@ -8768,7 +8576,6 @@ slip past the unit tests."
     ghostel-test-focus-two-ghostel-buffers
     ghostel-test-focus-frame-blur
     ghostel-test-focus-skips-state-update-when-1004-off
-    ghostel-test-focus-minibuffer
     ghostel-test-raw-key-sequences
     ghostel-test-modifier-number
     ghostel-test-send-event
@@ -8881,13 +8688,6 @@ slip past the unit tests."
     ghostel-test-resize-window-adjust
     ghostel-test-resize-nil-size
     ghostel-test-resize-noop-same-dims
-    ghostel-test-resize-minibuffer-crop
-    ghostel-test-resize-minibuffer-alt-screen-commits
-    ghostel-test-resize-minibuffer-width-only-shrink-commits
-    ghostel-test-commit-cropped-size-on-focus
-    ghostel-test-commit-cropped-size-noop-outside-minibuffer
-    ghostel-test-commit-cropped-size-noop-on-deselect
-    ghostel-test-commit-cropped-size-noop-when-matched
     ghostel-test-sigwinch-reaches-shell-basic
     ghostel-test-sigwinch-reaches-shell-ghostel-style
     ghostel-test-sigwinch-reaches-child-process


### PR DESCRIPTION
## Summary

- **Only rebuild on column size changes** — vertical-only resizes (row count up or down) no longer erase and rebuild the scrollback buffer. Only column changes (which invalidate line wrapping) trigger a full rebuild. Resizes are now deferred via `pending_resize` and committed at redraw time so the redrawer sees the full pre-resize active area before committing.
- **Remove minibuffer hacks** — the `ghostel--commit-cropped-size` / crop-deferral logic that tried to hide resize events while the minibuffer was open is no longer needed now that resize commits are deferred; removed.
- **Tests** — 7 new ERT tests covering scrollback survival across shrinks, expands, roundtrip resize sequences, and incremental dirty-row reuse.

## Key changes

- `terminal.zig`: `cols`/`rows` → `size: ViewportSize`; new `pending_resize` field; `cell_width_px`/`cell_height_px` stored on terminal; `resize()` no longer calls `ghostty_terminal_resize` directly.
- `render.zig`: `commitResize()` called at redraw time; rebuild condition is `cols_changed` (not `rebuild_pending`); `rows_in_buffer` replaces `scrollback_in_buffer` (tracks total rows in buffer, not just scrollback rows); `renderToEnd()` extracted.
- `ghostel.el`: `ghostel--commit-cropped-size` and minibuffer crop path removed; `ghostel--set-size-with-cell-dims` wrapper keeps resize call sites consistent.

## Test plan

- [x] `make test` passes (ERT suite including new tests)
- [x] Resize a ghostel buffer vertically — scrollback content is preserved without flicker
- [x] Resize a ghostel buffer horizontally — scrollback is rebuilt (expected)
- [x] Open minibuffer while ghostel is visible — no resize artifact on close