### PR TITLE
Dispatch OSC 51;E elisp synchronously from the process filter

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2992,14 +2992,18 @@ the redraw is performed immediately to minimize typing latency."
       (when ghostel--term
         ;; Accumulate output for batched write-input at redraw time.
         (push output ghostel--pending-output)
-        ;; Respond to OSC 4/10/11 color queries immediately: programs like
-        ;; `duf' read stdin with a tight timeout and give up if the reply
-        ;; waits for the redraw timer.  Flushing runs the extractor in the
-        ;; native module, which writes the reply back through the PTY
-        ;; before this filter returns.
-        (when (string-match-p
-               "\e\\]\\(?:4;[0-9]+;\\?\\|10;\\?\\|11;\\?\\)" output)
-          (ghostel--flush-pending-output))
+        ;; Respond to OSC 51;E or OSC 4/10/11 color queries immediately:
+        ;; programs like `duf' read stdin with a tight timeout and give up if
+        ;; the reply waits for the redraw timer.
+        ;; Flushing runs the extractor in the native module, which writes the reply
+        ;; back through the PTY before this filter returns.
+        ;; Carry a 16-byte tail so an introducer split across reads still matches.
+        (let* ((prev (cadr ghostel--pending-output))
+               (carry (and prev (substring prev (max 0 (- (length prev) 16))))))
+          (when (string-match-p
+                 "\e\\]\\(?:4;[0-9]+;\\?\\|10;\\?\\|11;\\?\\|51;E\\)"
+                 (if carry (concat carry output) output))
+            (ghostel--flush-pending-output)))
         ;; Immediate redraw for interactive echo: small output arriving
         ;; within `ghostel-immediate-redraw-interval' of last keystroke.
         (if (and (> ghostel-immediate-redraw-threshold 0)

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1880,6 +1880,50 @@ the reply waits for the redraw timer."
             (should ghostel--pending-output)))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-osc51-eval-filter-flush ()
+  "The process filter must dispatch OSC 51;E synchronously.
+Callers like `b4 prep --edit-cover' delete temp files shortly
+after sending the OSC; a delayed dispatch (via the redraw timer)
+loses the race with `tempfile.TemporaryDirectory' cleanup, so
+`find-file' opens a file whose parent directory is already gone."
+  (let ((buf (generate-new-buffer " *ghostel-osc51-flush*"))
+        (fake-proc (make-symbol "fake-proc"))
+        (dispatched nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (setq ghostel--term (ghostel--new 25 80 1000))
+          (setq ghostel--process fake-proc)
+          (let ((ghostel-eval-cmds
+                 `(("noop" ,(lambda (&rest args)
+                              (setq dispatched (cons 'noop args)))))))
+            (cl-letf (((symbol-function 'process-buffer) (lambda (_) buf))
+                      ((symbol-function 'process-live-p) (lambda (_) t))
+                      ((symbol-function 'ghostel--invalidate) #'ignore))
+              ;; OSC 51;E must run before `ghostel--filter' returns.
+              (ghostel--filter fake-proc "\e]51;Enoop \"hi\"\e\\")
+              (should (equal '(noop "hi") dispatched))
+              (should (equal nil ghostel--pending-output))
+
+              ;; OSC 51;A (directory tracking, not elisp eval) must NOT
+              ;; trigger the sync flush — it's harmless to defer.
+              (setq dispatched nil)
+              (ghostel--filter fake-proc "\e]51;A/tmp\e\\")
+              (should (equal nil dispatched))
+              (should ghostel--pending-output)
+
+              ;; The OSC introducer can straddle a filter-call boundary
+              ;; (slow producers, SSH, tiny TCP segments).  The first
+              ;; chunk alone doesn't match — but the second chunk plus
+              ;; the carryover tail of the first must trigger dispatch.
+              (setq dispatched nil
+                    ghostel--pending-output nil)
+              (ghostel--filter fake-proc "prefix\e]51;")
+              (should (equal nil dispatched))
+              (ghostel--filter fake-proc "Enoop \"split\"\e\\")
+              (should (equal '(noop "split") dispatched))
+              (should (equal nil ghostel--pending-output)))))
+      (kill-buffer buf))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: focus events gated by mode 1004
 ;; -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- OSC 51;E callbacks (the whitelisted elisp dispatch behind `ghostel-eval-cmds`) were piggy-backing on the redraw-timer flush of `ghostel--pending-output`, so `find-file` and friends ran tens of ms after the writer had already moved on.
- Callers like `b4 prep --edit-cover` write the OSC inside a `with tempfile.TemporaryDirectory(...)` block and then continue immediately. The temp directory was being cleaned up before the deferred dispatch ran, surfacing as `ghostel: error calling find-file: Setting current directory: No such file or directory, /tmp/b4-editorXXXX/`.
- Extend the existing immediate-flush regex in `ghostel--filter` (already used for OSC 4/10/11 color queries) to also cover OSC 51;E. This matches vterm, which runs OSC 51;E elisp synchronously inside `term_redraw` on the process-filter stack. OSC 51;A (directory tracking) intentionally stays deferred since it has no such race.

Fixes #209.

## Test plan

- [x] `make -j4 all` (zig + elisp + native + lint) passes
- [x] `make test-evil` passes
- [x] New regression test `ghostel-test-osc51-eval-filter-flush` covers both the positive case (51;E flushes synchronously) and the negative case (51;A stays pending)
- [ ] Manual smoke test against the issue's python reproducer (and/or `b4 prep --edit-cover`)