### PR TITLE
Add ghostel-spinner-progress for animated indeterminate progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `ghostel-spinner-progress`, a built-in handler for
+  `ghostel-progress-function` that animates `mode-line-process` via
+  [spinner.el](https://github.com/Malabarba/spinner.el) during
+  indeterminate progress (e.g. while Claude Code is working) and
+  shows percentage text for determinate states.  spinner.el is a
+  soft dependency: when it is on the `load-path` at ghostel load
+  time, `ghostel-progress-function` defaults to this handler;
+  otherwise the existing `ghostel-default-progress` text indicator
+  is used.  New `ghostel-spinner-type` defcustom (default
+  `progress-bar`) selects the spinner style.
+
 ### Fixed
 - Claude Code's progress reports now update `mode-line-process` in
   ghostel buffers.  Claude Code gates OSC 9;4 progress emission on

--- a/README.md
+++ b/README.md
@@ -603,37 +603,29 @@ AI agents like Claude Code, and other long-running commands emit it to
 report completion percentage.  Ghostel dispatches these to
 `ghostel-progress-function` with `(STATE PROGRESS)` where STATE is one of
 `remove`, `set`, `error`, `indeterminate`, `pause` and PROGRESS is an
-integer 0-100 or nil.  The default handler, `ghostel-default-progress`,
-updates `mode-line-process` in the terminal buffer:
+integer 0-100 or nil.
 
-- `[42%]` — running at 42% done
-- `[...]` — indeterminate progress
-- `[err 73%]` — error (shown in the `error` face)
-- `[paused 25%]` — paused
-- (cleared) — removed
+Two built-in handlers are available:
 
-#### Example: spinner.el in the mode line
+- `ghostel-default-progress` — plain text in `mode-line-process`:
+  `[42%]`, `[...]`, `[err 73%]`, `[paused 25%]`, or cleared on
+  `remove`.  Zero dependencies.
+- `ghostel-spinner-progress` — animates `mode-line-process` via
+  [spinner.el](https://github.com/Malabarba/spinner.el) during
+  `indeterminate` (e.g. while Claude Code is working) and falls back
+  to the same text indicator for the other states.
 
-For a fancier visual indicator during indeterminate progress, swap
-`ghostel-progress-function` for a handler backed by
-[spinner.el](https://github.com/Malabarba/spinner.el):
+`ghostel-progress-function` defaults to `ghostel-spinner-progress` when
+spinner.el is on the `load-path` at ghostel load time, otherwise to
+`ghostel-default-progress`.  Pin a specific handler explicitly:
 
 ```elisp
-(require 'spinner)
-(defvar-local my/ghostel-spinner nil)
-(defun my/ghostel-progress (state progress)
-  (pcase state
-    ((or 'set 'indeterminate)
-     (unless my/ghostel-spinner
-       (setq my/ghostel-spinner (spinner-create 'progress-bar t))
-       (spinner-start my/ghostel-spinner))
-     (when (eq state 'set)
-       (setq mode-line-process (format " [%d%%]" (or progress 0)))))
-    ((or 'remove 'error 'pause)
-     (when my/ghostel-spinner
-       (spinner-stop my/ghostel-spinner)
-       (setq my/ghostel-spinner nil)))))
-(setq ghostel-progress-function #'my/ghostel-progress)
+;; Pin to spinner (errors with a hint if spinner.el isn't installed):
+(setq ghostel-progress-function #'ghostel-spinner-progress)
+;; Or stay on the plain text indicator:
+(setq ghostel-progress-function #'ghostel-default-progress)
+;; Pick a different spinner style — see `spinner-types' in spinner.el:
+(setq ghostel-spinner-type 'horizontal-moving)
 ```
 
 ### Color Palette

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -407,18 +407,35 @@ originating ghostel buffer as `current-buffer', so it may block or
 spawn processes freely without stalling the terminal."
   :type '(choice (const :tag "Disabled" nil) function))
 
-(defcustom ghostel-progress-function #'ghostel-default-progress
+(defcustom ghostel-progress-function
+  (if (locate-library "spinner")
+      #'ghostel-spinner-progress
+    #'ghostel-default-progress)
   "Function called for ConEmu OSC 9;4 progress reports.
 Called with two arguments: STATE (one of the symbols `remove',
 `set', `error', `indeterminate', `pause') and PROGRESS (an integer
 0-100, or nil when not reported).  Set to nil to ignore progress
 reports.
 
+When spinner.el is on the `load-path' at ghostel load time, the
+default is `ghostel-spinner-progress' (which animates the mode
+line during indeterminate progress).  Otherwise it is
+`ghostel-default-progress' (a plain text indicator).
+
 The handler runs synchronously on the VT-parser callpath because
 progress updates are expected to feed the mode line or similar
 cheap UI.  A slow handler here will stall terminal output — defer
 expensive work via `run-at-time' on your own if you need it."
   :type '(choice (const :tag "Disabled" nil) function))
+
+(defcustom ghostel-spinner-type 'progress-bar
+  "Spinner style used by `ghostel-spinner-progress'.
+Passed to `spinner-create' as its first argument; see
+`spinner-types' in spinner.el for the full list (e.g.
+`progress-bar', `horizontal-moving', `vertical-breathing').
+Only consulted when `ghostel-progress-function' is
+`ghostel-spinner-progress'."
+  :type 'symbol)
 
 (defcustom ghostel-enable-url-detection t
   "Automatically detect and linkify URLs in terminal output.
@@ -649,6 +666,10 @@ Bump this only when the Elisp code requires a newer native module
 (declare-function ghostel--set-size "ghostel-module" (term rows cols &optional cell-w cell-h))
 (declare-function ghostel--write-input "ghostel-module")
 (declare-function ghostel--native-uri-at "ghostel-module")
+
+(declare-function spinner-create "spinner")
+(declare-function spinner-start "spinner")
+(declare-function spinner-stop "spinner")
 
 
 ;;; Automatic download and compilation of native module
@@ -2746,6 +2767,52 @@ PROGRESS (an integer 0-100 or nil).  STATE is one of the symbols
       (setq mode-line-process new-val)
       (force-mode-line-update))))
 
+(defvar-local ghostel--spinner-active nil
+  "Non-nil when this buffer has a spinner started by `ghostel-spinner-progress'.
+The spinner object itself lives in spinner.el's buffer-local
+`spinner-current'; this flag is what ghostel inspects to keep
+`ghostel-spinner-progress' idempotent and to give the sentinel
+something to gate teardown on.")
+
+(defun ghostel--spinner-stop ()
+  "Stop this buffer's progress spinner, if any.
+Safe to call when no spinner is running.  Errors from spinner.el
+\(e.g. on a half-torn-down buffer) are swallowed — this is
+teardown.  Does not touch `mode-line-process'."
+  (when ghostel--spinner-active
+    (ignore-errors (spinner-stop))
+    (setq ghostel--spinner-active nil)))
+
+(defun ghostel-spinner-progress (state progress)
+  "Spinner-driven handler for OSC 9;4 ConEmu progress reports.
+Animates `mode-line-process' via spinner.el during indeterminate
+progress; falls back to a static text indicator (matching
+`ghostel-default-progress') for `set', `error', `pause', and `remove'.
+STATE is one of those symbols; PROGRESS is an integer 0-100 or nil.
+
+Requires spinner.el to be available; signals a `user-error' on
+the first call if it is not.  The spinner style is controlled by
+`ghostel-spinner-type'."
+  (unless (require 'spinner nil t)
+    (user-error
+     "Cannot run `ghostel-spinner-progress' without spinner.el — install it \
+from MELPA or set `ghostel-progress-function' to #'ghostel-default-progress"))
+  (if (eq state 'indeterminate)
+      ;; Indeterminate: install spinner.el's mode-line construct.
+      ;; Clear any prior determinate text first so the spinner shows alone,
+      ;; not appended to a stale \" [50%]\".
+      (unless ghostel--spinner-active
+        (setq mode-line-process nil)
+        (spinner-start ghostel-spinner-type)
+        (setq ghostel--spinner-active t))
+    ;; Any other state: stop the spinner and clear the (now-inert)
+    ;; mode-line construct it left behind, then defer to the text indicator.
+    (when ghostel--spinner-active
+      (spinner-stop)
+      (setq mode-line-process nil
+            ghostel--spinner-active nil))
+    (ghostel-default-progress state progress)))
+
 (defun ghostel--handle-notification (title body)
   "Dispatch TITLE and BODY to `ghostel-notification-function'.
 Called synchronously from the native VT parser; the user handler
@@ -3063,6 +3130,7 @@ PROCESS is the shell process, EVENT describes the state change."
           (setq ghostel--plain-link-detection-timer nil
                 ghostel--plain-link-detection-begin nil
                 ghostel--plain-link-detection-end nil))
+        (ghostel--spinner-stop)
         (run-hook-with-args 'ghostel-exit-functions buf event)
         (if ghostel-kill-buffer-on-exit
             (kill-buffer buf)

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1752,6 +1752,89 @@ without the real package installed."
     (ghostel-default-progress 'remove nil)
     (should (null mode-line-process))))
 
+(ert-deftest ghostel-test-spinner-progress-errors-without-spinner ()
+  "`ghostel-spinner-progress' signals a user-error when spinner.el is absent.
+Stubs `require' to refuse loading `spinner' so the test does not depend on
+whether spinner.el is actually installed in the test env."
+  (cl-letf* ((orig-require (symbol-function #'require))
+             ((symbol-function #'require)
+              (lambda (feature &optional filename noerror)
+                (if (eq feature 'spinner)
+                    (if noerror nil
+                      (signal 'file-missing (list "stub-no-spinner")))
+                  (funcall orig-require feature filename noerror)))))
+    (with-temp-buffer
+      (should-error (ghostel-spinner-progress 'indeterminate nil)
+                    :type 'user-error))))
+
+(ert-deftest ghostel-test-spinner-progress-indeterminate-starts-once ()
+  "`ghostel-spinner-progress' starts the spinner once across repeat events.
+Multiple `indeterminate' events during one working phase must not stack
+spinners — claude-code emits transitions repeatedly.  Verifies that
+`spinner-start' is called with the configured TYPE symbol (which is the
+form that installs spinner.el's mode-line construct) and that
+`ghostel--spinner-active' tracks the started/stopped state."
+  (let ((start-calls 0)
+        (start-args nil))
+    (cl-letf (((symbol-function #'require)
+               (lambda (&rest _) t))
+              ((symbol-function #'spinner-start)
+               (lambda (&rest args)
+                 (cl-incf start-calls)
+                 (setq start-args args)))
+              ((symbol-function #'spinner-stop) #'ignore))
+      (with-temp-buffer
+        (ghostel-spinner-progress 'indeterminate nil)
+        (ghostel-spinner-progress 'indeterminate nil)
+        (should (= 1 start-calls))
+        (should (equal (list ghostel-spinner-type) start-args))
+        (should ghostel--spinner-active)))))
+
+(ert-deftest ghostel-test-spinner-progress-set-stops-and-shows-percent ()
+  "On `set', the spinner is stopped and `mode-line-process' is the percent text.
+Without the explicit stop, spinner.el's mode-line construct would
+remain (rendering empty alongside the percentage)."
+  (let ((stop-calls 0))
+    (cl-letf (((symbol-function #'require)
+               (lambda (&rest _) t))
+              ((symbol-function #'spinner-start) #'ignore)
+              ((symbol-function #'spinner-stop)
+               (lambda (&rest _) (cl-incf stop-calls))))
+      (with-temp-buffer
+        (ghostel-spinner-progress 'indeterminate nil)
+        (ghostel-spinner-progress 'set 50)
+        (should (= 1 stop-calls))
+        (should-not ghostel--spinner-active)
+        (should (equal " [50%]" mode-line-process))))))
+
+(ert-deftest ghostel-test-spinner-progress-remove-clears-modeline ()
+  "On `remove', the spinner stops and `mode-line-process' is nil."
+  (cl-letf (((symbol-function #'require)
+             (lambda (&rest _) t))
+            ((symbol-function #'spinner-start) #'ignore)
+            ((symbol-function #'spinner-stop) #'ignore))
+    (with-temp-buffer
+      (ghostel-spinner-progress 'indeterminate nil)
+      (ghostel-spinner-progress 'remove nil)
+      (should-not ghostel--spinner-active)
+      (should (null mode-line-process)))))
+
+(ert-deftest ghostel-test-spinner-stop-helper-clears-state ()
+  "`ghostel--spinner-stop' calls `spinner-stop' and clears the active flag.
+The sentinel relies on this helper to drop a live spinner when the shell
+exits, so a regression here would leak the timer past the buffer's life."
+  (let ((stop-calls 0))
+    (cl-letf (((symbol-function #'spinner-stop)
+               (lambda (&rest _) (cl-incf stop-calls))))
+      (with-temp-buffer
+        (setq ghostel--spinner-active t)
+        (ghostel--spinner-stop)
+        (should (= 1 stop-calls))
+        (should-not ghostel--spinner-active)
+        ;; Idempotent: a second call is a no-op.
+        (ghostel--spinner-stop)
+        (should (= 1 stop-calls))))))
+
 (ert-deftest ghostel-test-osc-partial-does-not-starve-later ()
   "A partial OSC must not cannibalize or starve a following complete OSC.
 Input \"\\e]7;PARTIAL\\e]52;c;aGVsbG8=\\a\" would, under a naive
@@ -8710,6 +8793,11 @@ slip past the unit tests."
     ghostel-test-default-notify-uses-alert
     ghostel-test-default-notify-empty-title-uses-buffer-name
     ghostel-test-default-progress-modeline
+    ghostel-test-spinner-progress-errors-without-spinner
+    ghostel-test-spinner-progress-indeterminate-starts-once
+    ghostel-test-spinner-progress-set-stops-and-shows-percent
+    ghostel-test-spinner-progress-remove-clears-modeline
+    ghostel-test-spinner-stop-helper-clears-state
     ghostel-test-flush-pending-output-preserves-buffer
     ghostel-test-copy-mode-cursor
     ghostel-test-ignore-cursor-change


### PR DESCRIPTION
## Summary

- Adds `ghostel-spinner-progress`, a built-in handler for `ghostel-progress-function` that animates `mode-line-process` via [spinner.el](https://github.com/Malabarba/spinner.el) during indeterminate progress (the only state Claude Code emits) and falls back to the existing text indicator for `set` / `error` / `pause` / `remove`.
- spinner.el is a soft dependency: when on the `load-path` at ghostel load time, `ghostel-progress-function` defaults to the new handler; otherwise it stays on `ghostel-default-progress`. The handler itself defers `(require 'spinner nil t)` to first call and signals `user-error` with an install hint if missing.
- New `ghostel-spinner-type` defcustom (default `progress-bar`) selects the spinner style. Spinner state is buffer-local and torn down by `ghostel--sentinel` alongside the existing redraw / input / link timers, so the timer can't outlive the shell process.

## Why not the README example

The previous README snippet had two latent bugs the built-in avoids:

1. Spinner.el's tick overwrites `mode-line-process` every ~100 ms, so on a `'set` event the percentage display was stomped almost immediately. The built-in stops the spinner on any non-`indeterminate` state before deferring to the text indicator.
2. The spinner timer was never cleaned up on buffer kill. The built-in hooks into the existing sentinel-driven teardown path.

README updated to point at the built-in instead.

## Test plan

- [x] `make -j4 all` clean (build, lint, 224/224 tests pass — 5 new spinner tests under the existing elisp test group, no native dep).
- [x] New unit tests cover: missing-spinner.el error path, idempotent indeterminate, spinner stopped + percentage shown on `'set`, modeline cleared on `'remove`, `ghostel--spinner-stop` helper.
- [ ] Live verification: `M-x ghostel`, run `claude` on a multi-step task, confirm modeline animates during work and clears on completion. (Reviewer please sanity-check on your own setup; reporter saw `[...]` text in the prior fix and asked for animation.)
- [ ] No-spinner.el path: with spinner.el absent from `load-path`, confirm `ghostel-progress-function` defaults to `ghostel-default-progress` and the existing text indicator behavior is preserved.