### PR TITLE
Survive theme PROMPT/PS1/fish_prompt overrides in shell integration

### DIFF
--- a/etc/shell/ghostel.bash
+++ b/etc/shell/ghostel.bash
@@ -28,11 +28,6 @@ __ghostel_osc7() {
 
 # Emit "command finished" (D) for the previous command.
 # D is skipped on the very first prompt (no previous command).
-# 133;A and 133;B are embedded in PS1 itself (see below) so they fire
-# in lockstep with prompt rendering, including readline redraws (bash 5.x
-# redraws the prompt after bracketed-paste-mode setup; if 133;A came from
-# PROMPT_COMMAND it would only fire once, leaving the redrawn prompt
-# cells outside the PROMPT scope).
 __ghostel_prompt_start() {
     if [[ -n "$__ghostel_prompt_shown" ]]; then
         printf '\e]133;D;%s\e\\' "$__ghostel_last_status"
@@ -40,14 +35,41 @@ __ghostel_prompt_start() {
     __ghostel_prompt_shown=1
 }
 
-# Emit "command output start" (C) via the DEBUG trap.
+# Emit "command output start" (C) via the DEBUG trap, and restore the
+# unmarked PS1/PS2 so the user's command (and any other DEBUG-trap
+# observers) doesn't see our markers.  Mirror of the restore-on-precmd
+# logic in `__ghostel_wrapped_prompt_command'.
 # Guard: skip when running inside PROMPT_COMMAND itself.
 __ghostel_in_prompt_command=0
 __ghostel_preexec() {
     [[ "$__ghostel_in_prompt_command" = 1 ]] && return
+    if [[ -n "${__ghostel_marked_ps1+x}" && "$PS1" == "$__ghostel_marked_ps1" ]]; then
+        PS1=$__ghostel_saved_ps1
+        PS2=$__ghostel_saved_ps2
+    fi
     printf '\e]133;C\e\\'
 }
 
+# Wrap PS1/PS2 with 133;A at the start and 133;B at the end.  We inject
+# 133;A after every line break in PS1 too: bash 5.x readline redraws
+# only the last visual line of the prompt (CR + reprint, no preceding
+# 133;A).  Without a 133;A on every line, the redrawn cells fall outside
+# the PROMPT scope and become INPUT-tagged.  We inject after both
+# literal newlines and the bash `\n' PS1 escape.
+#
+# `\[ \]' mark the OSC sequence as zero-width for readline's line-wrap
+# math; `\a' is BEL — a valid OSC terminator.  We use BEL rather than
+# ST (ESC \) because `${var//pat/repl}' eats backslashes in the
+# replacement, which would break a multi-line ST-terminated marker.
+#
+# Re-wrap from PROMPT_COMMAND each cycle: `.bashrc' or a prompt theme
+# loaded after this file commonly reassigns PS1, stripping our wrap.
+# Each cycle:
+#   1. Restore the unmarked PS1/PS2 if nobody touched them since our
+#      last wrap — keeps user PROMPT_COMMAND additions and themes that
+#      pattern-match $PS1 from seeing markers.
+#   2. Run the user's captured PROMPT_COMMAND (may rewrite $PS1).
+#   3. Re-wrap.  Skip if PS1 already has our marker (defensive).
 __ghostel_wrapped_prompt_command() {
     # Capture $? FIRST.  A bare assignment such as
     # `__ghostel_in_prompt_command=1' on its own line counts as a
@@ -58,33 +80,39 @@ __ghostel_wrapped_prompt_command() {
     local __ghostel_status=$?
     __ghostel_in_prompt_command=1
     __ghostel_last_status=$__ghostel_status
+
+    if [[ -n "${__ghostel_marked_ps1+x}" && "$PS1" == "$__ghostel_marked_ps1" ]]; then
+        PS1=$__ghostel_saved_ps1
+        PS2=$__ghostel_saved_ps2
+    fi
+
     __ghostel_prompt_start
     __ghostel_osc7
+
     eval "${__ghostel_original_prompt_command:-}"
+
+    local __ghostel_marker='\[\e]133;A\a\]'
+    if [[ "$PS1" != *"$__ghostel_marker"* ]]; then
+        __ghostel_saved_ps1=$PS1
+        __ghostel_saved_ps2=$PS2
+        local __ghostel_ps1_a='\[\e]133;A\a\]'
+        local __ghostel_ps1_b='\[\e]133;B\a\]'
+        PS1="${PS1//$'\n'/$'\n'${__ghostel_ps1_a}}"
+        PS1="${PS1//\\n/\\n${__ghostel_ps1_a}}"
+        PS1="${__ghostel_ps1_a}${PS1}${__ghostel_ps1_b}"
+        # PS2 (continuation): wrap with the same A/B markers so multi-line
+        # input still has a known prompt-prefix → input boundary.
+        PS2="${__ghostel_ps1_a}${PS2}${__ghostel_ps1_b}"
+        __ghostel_marked_ps1=$PS1
+        __ghostel_marked_ps2=$PS2
+    fi
+
     __ghostel_in_prompt_command=0
 }
 
 # Preserve any existing PROMPT_COMMAND.
 __ghostel_original_prompt_command="${PROMPT_COMMAND:+$PROMPT_COMMAND}"
 PROMPT_COMMAND="__ghostel_wrapped_prompt_command"
-
-# Wrap PS1 with 133;A at the start and 133;B at the end. For multi-line
-# prompts we ALSO inject 133;A after every line break in PS1: bash 5.x
-# readline redraws only the last visual line of the prompt (CR + reprint,
-# no preceding 133;A). Without a 133;A on every line, the redrawn cells
-# fall outside the PROMPT scope and become INPUT-tagged.
-# We inject after both literal newlines and the bash `\n' PS1 escape
-# (which expands to a newline at prompt-render time).
-# \[ \] mark the OSC sequence as zero-width for readline's line-wrap math;
-# \a is BEL — a valid OSC terminator. We use BEL rather than ST (ESC \)
-# because `${var//pat/repl}' eats backslashes in the replacement, which
-# would break a multi-line ST-terminated marker.
-__ghostel_ps1_a='\[\e]133;A\a\]'
-__ghostel_ps1_b='\[\e]133;B\a\]'
-PS1="${PS1//$'\n'/$'\n'${__ghostel_ps1_a}}"
-PS1="${PS1//\\n/\\n${__ghostel_ps1_a}}"
-PS1="${__ghostel_ps1_a}${PS1}${__ghostel_ps1_b}"
-unset __ghostel_ps1_a __ghostel_ps1_b
 
 trap '__ghostel_preexec' DEBUG
 

--- a/etc/shell/ghostel.fish
+++ b/etc/shell/ghostel.fish
@@ -27,16 +27,17 @@ function __ghostel_postexec --on-event fish_postexec
     set -g __ghostel_last_status $status
 end
 
-# Emit "command finished" (D) for the previous command.
-# 133;A and 133;B are emitted by wrapping fish_prompt below so they fire
-# in lockstep with prompt rendering, including any redraws — emitting from
-# `--on-event fish_prompt` handlers (which fire only once per prompt cycle
-# and only before fish_prompt) would leave redraws outside the PROMPT scope.
+# Emit "command finished" (D) for the previous command, then "prompt
+# start" (A) for the new prompt.  Both fire from a fish_prompt event
+# handler so they're independent of the fish_prompt function body —
+# survives mid-session `function fish_prompt' redefinitions that would
+# otherwise drop our wrap.
 function __ghostel_prompt_start --on-event fish_prompt
     if test "$__ghostel_prompt_shown" = 1
         printf '\e]133;D;%s\e\\' "$__ghostel_last_status"
     end
     set -g __ghostel_prompt_shown 1
+    printf '\e]133;A\e\\'
 end
 
 # Emit "command output start" (C) before command runs.
@@ -44,13 +45,29 @@ function __ghostel_preexec --on-event fish_preexec
     printf '\e]133;C\e\\'
 end
 
-# Wrap fish_prompt with 133;A at the start and 133;B at the end so they
-# fire in lockstep with prompt rendering. If the user redefines fish_prompt
-# later, they're responsible for re-sourcing this file.
-if functions -q fish_prompt; and not functions -q __ghostel_orig_fish_prompt
+# Wrap fish_prompt to emit 133;B (input boundary) at the end of every
+# prompt render.  Fish has no "after fish_prompt" event, so we wrap the
+# function itself.
+#
+# Deferred to fire-time via `--on-event fish_prompt' so themes/plugins
+# loaded after ghostel.fish (later in config.fish or in conf.d/) have
+# already defined fish_prompt before we wrap it.  Re-checks each fire
+# and re-wraps if our wrap was removed (e.g. user redefined fish_prompt
+# mid-session).  One-prompt warmup is the trade-off: if a theme's own
+# `--on-event fish_prompt' handler runs after ours and redefines
+# fish_prompt, this fire is unwrapped but the next is wrapped.
+function __ghostel_ensure_fish_prompt_wrap --on-event fish_prompt
+    functions -q fish_prompt; or return
+    # Skip if already wrapped — detect via a sentinel comment in the
+    # wrapped body.  Cheaper and more robust than comparing function
+    # bodies, since fish preserves comments in `functions <name>' output.
+    if functions fish_prompt | string match -q '*__ghostel_wrapped*'
+        return
+    end
+    functions -e __ghostel_orig_fish_prompt 2>/dev/null
     functions -c fish_prompt __ghostel_orig_fish_prompt
     function fish_prompt
-        printf '\e]133;A\e\\'
+        # __ghostel_wrapped — sentinel for the idempotency check above.
         __ghostel_orig_fish_prompt
         printf '\e]133;B\e\\'
     end

--- a/etc/shell/ghostel.zsh
+++ b/etc/shell/ghostel.zsh
@@ -19,40 +19,144 @@
 
 # Report working directory to the terminal via OSC 7
 __ghostel_osc7() {
-    printf '\e]7;file://%s%s\e\\' "$HOST" "$PWD"
+    builtin emulate -L zsh -o no_warn_create_global -o no_aliases
+    builtin printf '\e]7;file://%s%s\e\\' "$HOST" "$PWD"
 }
 
 # --- Semantic prompt markers (OSC 133) ---
 
+# Capture $? from the just-finished command.  Must run before any other
+# precmd that resets $?, hence prepended at the head of `precmd_functions'.
 __ghostel_save_status() {
-    __ghostel_last_status="$?"
+    # Capture $? FIRST: `emulate -L' below resets it to 0.
+    # `$status' is a read-only zsh special parameter (synonym for $?), so
+    # use a different name for the local copy.
+    builtin local cmd_status=$?
+    builtin emulate -L zsh -o no_warn_create_global -o no_aliases
+    __ghostel_last_status=$cmd_status
 }
 
 # Emit "command finished" (D) for the previous command.
-# 133;A and 133;B are embedded in PROMPT itself (see below) so they fire
-# in lockstep with prompt rendering, including readline-style redraws —
-# emitting from precmd would only fire once and leave any subsequent
-# redraw outside the PROMPT scope.
+# 133;A and 133;B are embedded in PROMPT itself (see `__ghostel_ensure_prompt_wrap'
+# below) so they fire in lockstep with prompt rendering, including
+# readline-style redraws — emitting them from precmd here would only
+# fire once and leave any subsequent redraw outside the PROMPT scope.
 __ghostel_prompt_start() {
+    builtin emulate -L zsh -o no_warn_create_global -o no_aliases
     if [[ -n "$__ghostel_prompt_shown" ]]; then
-        printf '\e]133;D;%s\e\\' "$__ghostel_last_status"
+        builtin printf '\e]133;D;%s\e\\' "$__ghostel_last_status"
     fi
     __ghostel_prompt_shown=1
 }
 
-# Emit "command output start" (C).
+# Restore the unmarked PROMPT (mirror of the restore-on-precmd logic in
+# `__ghostel_ensure_prompt_wrap') and emit "command output start" (C).
+# Restoring before later preexec hooks run keeps themes that pattern-match
+# `$PROMPT' (e.g. Pure) from seeing our OSC sequences.
 __ghostel_preexec() {
-    printf '\e]133;C\e\\'
+    builtin emulate -L zsh -o no_warn_create_global -o no_aliases
+    if [[ -n ${__ghostel_marked_prompt+x} && "$PROMPT" == "$__ghostel_marked_prompt" ]]; then
+        PROMPT=$__ghostel_saved_prompt
+    fi
+    builtin printf '\e]133;C\e\\'
 }
-
-precmd_functions=(__ghostel_save_status __ghostel_prompt_start __ghostel_osc7 "${precmd_functions[@]}")
-preexec_functions=(__ghostel_preexec "${preexec_functions[@]}")
 
 # Wrap PROMPT with 133;A at the start and 133;B at the end so they fire
 # in lockstep with prompt rendering, including any redraws. %{ %} mark
 # the OSC sequence as zero-width for line-wrap. $'...' is ANSI-C quoting:
 # \e is ESC, \\ is a single backslash — so \e\\ is ESC \ (ST).
-PROMPT=$'%{\e]133;A\e\\%}'"${PROMPT}"$'%{\e]133;B\e\\%}'
+#
+# Re-wrap from precmd: a `.zshrc' or prompt theme loaded after this file
+# (oh-my-zsh, powerlevel10k, starship, prompt_*) commonly reassigns
+# PROMPT and strips our wrap.  Each cycle:
+#   1. If $PROMPT matches our last marked snapshot, nobody touched it —
+#      restore to the saved unmarked version before re-marking.  Avoids
+#      exposing markers to other hooks (themes like Pure pattern-match
+#      $PROMPT to strip/rebuild and break if they see our markers).
+#   2. Otherwise treat $PROMPT as a new clean baseline (theme rebuild,
+#      async update).  Skip wrapping if it already contains our marker
+#      (defensive: theme copied a marked PROMPT somewhere).
+#   3. Reposition to the end of `precmd_functions' so we run after any
+#      precmd added later (themes that rebuild PROMPT each prompt, e.g.
+#      p10k's `_p9k_precmd').  One-prompt warmup is the trade-off.
+__ghostel_ensure_prompt_wrap() {
+    builtin emulate -L zsh -o no_warn_create_global -o no_aliases
+    if [[ -n ${__ghostel_marked_prompt+x} && "$PROMPT" == "$__ghostel_marked_prompt" ]]; then
+        PROMPT=$__ghostel_saved_prompt
+    fi
+    if [[ "$PROMPT" != *$'%{\e]133;A'* ]]; then
+        __ghostel_saved_prompt=$PROMPT
+        # If $PROMPT ends with an unpaired `%', appending our `%{...%}'
+        # markers turns the user's `%' + our `%{' into a single `%{'
+        # prompt escape, swallowing the marker.  Double the trailing `%'
+        # to make it a literal percent.
+        [[ $PROMPT == *[^%]% || $PROMPT == % ]] && PROMPT=$PROMPT%
+        PROMPT=$'%{\e]133;A\e\\%}'"$PROMPT"$'%{\e]133;B\e\\%}'
+        __ghostel_marked_prompt=$PROMPT
+    fi
+    if [[ ${precmd_functions[-1]} != __ghostel_ensure_prompt_wrap ]]; then
+        precmd_functions=(${precmd_functions:#__ghostel_ensure_prompt_wrap})
+        precmd_functions+=(__ghostel_ensure_prompt_wrap)
+    fi
+}
+
+# ZLE line-init fallback: if $PROMPT lost its markers between precmd and
+# this redraw (e.g. an async theme update via `zle -F' reassigned
+# $PROMPT then triggered `zle reset-prompt' without re-firing precmd),
+# emit 133;A + 133;B directly so libghostty still tags the input span —
+# the link-skip logic in the renderer relies on `ghostel-input' cells.
+# Side-effect: this can create duplicate `ghostel--prompt-positions'
+# entries during heavy async updates; navigation steps may be no-ops on
+# those cycles.  Acceptable trade-off vs. the link-skip false positive.
+__ghostel_zle_line_init_hook() {
+    [[ "$PROMPT" != *$'%{\e]133;A'* ]] && \
+        printf '\e]133;A\e\\\e]133;B\e\\'
+}
+
+# One-shot installer: registered as a precmd, runs once on the first
+# prompt fire (after `.zshrc' has finished and any user/theme
+# `zle-line-init' widget is in place).  Chains our hook to whatever
+# existing widget is registered, then removes itself from precmd_functions.
+#
+# Mirrors ghostty's zsh integration:
+#   - If the widget is already managed by `add-zle-hook-widget'
+#     (oh-my-zsh, prezto and others wrap zle-line-init this way),
+#     register through that framework instead of overwriting — blindly
+#     rebinding the widget detaches the framework's dispatcher chain.
+#   - Otherwise, save any existing widget under a leading-dot name (works
+#     around zsh-syntax-highlighting bugs) and append a tail invocation
+#     of the original to our hook function's body so it still runs after
+#     us.  `flag' picks `-N' vs. `-Nw' — the former preserves $WIDGET
+#     for user-defined widgets, the latter is needed for builtins.
+__ghostel_install_zle_hook() {
+    builtin emulate -L zsh -o no_warn_create_global -o no_aliases
+    builtin local hook=line-init
+    builtin local func=__ghostel_zle_line_init_hook
+    builtin local widget=zle-$hook
+    builtin local orig_widget flag
+    if [[ ${widgets[$widget]} == user:azhw:* ]] && \
+           (( $+functions[add-zle-hook-widget] )); then
+        add-zle-hook-widget $hook $func
+    else
+        if (( $+widgets[$widget] )); then
+            orig_widget=._ghostel_orig_$widget
+            builtin zle -A $widget $orig_widget
+            if [[ ${widgets[$widget]} == user:* ]]; then
+                flag=
+            else
+                flag=w
+            fi
+            functions[$func]+="
+                builtin zle $orig_widget -N$flag -- \"\$@\""
+        fi
+        builtin zle -N $widget $func
+    fi
+    precmd_functions=(${precmd_functions:#__ghostel_install_zle_hook})
+}
+
+precmd_functions=(__ghostel_save_status __ghostel_prompt_start __ghostel_osc7 "${precmd_functions[@]}")
+precmd_functions+=(__ghostel_ensure_prompt_wrap __ghostel_install_zle_hook)
+preexec_functions=(__ghostel_preexec "${preexec_functions[@]}")
 
 # Outbound `ssh' wrapper.  See etc/ghostel.bash for the full design
 # notes — this is the zsh port of the same install-and-cache logic.


### PR DESCRIPTION
## Summary

- Re-wrap `PROMPT` / `PS1` / `fish_prompt` from precmd / `PROMPT_COMMAND` / `--on-event fish_prompt` instead of once at source time, so themes loaded after ghostel's bootstrap can't strip the OSC 133;A/B markers.
- Mirror ghostty's own shell-integration patterns (`add-zle-hook-widget` detection, defensive `emulate -L`, save/restore of clean prompt, leading-dot orig widget) to match their robustness.
- Without these markers the renderer never tagged user-typed cells `ghostel-input`, so the file-path link detector linkified them and the link keymap's RET binding shadowed the normal terminal RET in tty Emacs — pressing RET on `cd some/path` opened the link instead of running the command.

Closes #199.

## What changed per shell

**zsh** (`etc/shell/ghostel.zsh`):
- Wrap `\$PROMPT` from a precmd hook that self-repositions to the end of `precmd_functions` so themes that rebuild `\$PROMPT` in their own precmd (p10k, agnoster, ...) still run before us. One-prompt warmup the first time.
- Save/restore unmarked `\$PROMPT` around the wrap (in precmd and preexec) so themes that pattern-match `\$PROMPT` (e.g. Pure) and other hooks see a clean baseline.
- Double a trailing unpaired `%` in `\$PROMPT` before wrapping (otherwise `%` + `%{B}` collapses into a single prompt escape that swallows the marker).
- ZLE line-init fallback emits 133;A+133;B if `\$PROMPT` lost its markers between precmd and the redraw (async theme updates via `zle -F`). Installer detects `add-zle-hook-widget`-managed widgets and registers through the framework instead of overwriting — overwriting detaches the framework's dispatcher chain on oh-my-zsh / prezto.
- `builtin emulate -L zsh -o no_warn_create_global -o no_aliases` in every precmd/preexec/installer so users with non-default shell options don't break us.

**bash** (`etc/shell/ghostel.bash`):
- PS1 wrap moved from source-time into `__ghostel_wrapped_prompt_command` so `.bashrc`-time re-assigns and theme `PROMPT_COMMAND` entries are caught each cycle.
- Save/restore PS1+PS2 in `__ghostel_wrapped_prompt_command` and the DEBUG-trap preexec.
- PS2 (continuation) wrapped too.

**fish** (`etc/shell/ghostel.fish`):
- 133;A emission moved out of the `fish_prompt` wrap into the `--on-event fish_prompt` handler so it survives any mid-session `function fish_prompt` redefinition.
- The `fish_prompt` wrap (still required for 133;B since fish has no after-prompt event) is deferred to fire-time via `--on-event fish_prompt` so themes/plugins loaded after ghostel.fish in `config.fish` or `conf.d/` are wrapped, not overridden. Re-checks each fire; idempotency detected via a sentinel comment that fish preserves in `functions <name>` output.

## Known limitations (matching ghostty)

- bash: if a user **appends** to `PROMPT_COMMAND` *after* sourcing ghostel.bash and that addition reassigns PS1, our wrap is lost on every cycle. Same race ghostty's bash integration has.
- fish: a theme `--on-event fish_prompt` handler that's registered *after* ghostel and redefines `fish_prompt` causes a one-prompt warmup before our handler self-repositions on the next fire.
- zsh ZLE line-init fallback emits 133;A+133;B (not ghostty's 133;P) because `module.zig` accepts only A/B/C/D — minor side-effect of duplicate `ghostel--prompt-positions` entries on heavy async-update themes.

## Test plan

- [x] zsh: hostile `.zshrc` that overrides `PROMPT` after sourcing → wrap re-applies
- [x] zsh: theme rebuilds `PROMPT` in its own precmd → fire 1 unwrapped (warmup), fire 2+ wrapped, hook self-repositions to last
- [x] zsh: idempotency — 5 fires → exactly 1 `133;A` in `\$PROMPT`
- [x] zsh: trailing-`%` in `PROMPT='%~ \$%'` → correctly doubled
- [x] zsh: lifecycle — precmd→wrapped(31), preexec→clean(5), precmd→wrapped(31)
- [x] zsh: ZLE installer with no existing widget, with plain user widget (chains via leading-dot orig + appended tail call), `add-zle-hook-widget` path mirrors ghostty's
- [x] zsh: `setopt warn_create_global` produces no warnings from our functions
- [x] bash: PROMPT_COMMAND lifecycle — wrap, idempotent re-wrap, preexec restore
- [x] bash: theme `PROMPT_COMMAND` set before source → still wraps after eval'ing user PC
- [x] fish: theme defines `fish_prompt` *after* sourcing ghostel.fish → wrap installed on first prompt event
- [x] fish: idempotency — 5 fires → exactly 1 reference to `__ghostel_orig_fish_prompt` in `fish_prompt` body
- [x] fish: mid-session `function fish_prompt` redefine → wrap removed, re-installed on next prompt event
- [x] `make -j4 all` (218 elisp + native + Zig + lint) and `make test-evil` (50) all pass