### PR TITLE
Fix evil-ghostel multi-line dd targeting the wrong line (#218)

### DIFF
--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -32,9 +32,8 @@
 
 (defvar evil-ghostel-mode)
 
-;; ---------------------------------------------------------------------------
+
 ;; Customization
-;; ---------------------------------------------------------------------------
 
 (defgroup evil-ghostel nil
   "Evil-mode integration for ghostel."
@@ -77,9 +76,8 @@ Sets the initial value of the buffer-local state.  Use
 ;; path `defcustom' preserves the value without invoking `:set'.
 (evil-set-initial-state 'ghostel-mode evil-ghostel-initial-state)
 
-;; ---------------------------------------------------------------------------
+
 ;; Guard predicate
-;; ---------------------------------------------------------------------------
 
 (defun evil-ghostel--active-p ()
   "Return non-nil when evil-ghostel editing should intercept."
@@ -99,9 +97,8 @@ right there, so PTY-routing intercepts must stand down."
        (markerp ghostel--line-input-start)
        (markerp ghostel--line-input-end)))
 
-;; ---------------------------------------------------------------------------
+
 ;; Cursor synchronization
-;; ---------------------------------------------------------------------------
 
 (defun evil-ghostel--reset-cursor-point ()
   "Move Emacs point to the terminal cursor position.
@@ -130,6 +127,15 @@ placement math the native module performs in `src/render.zig'."
                                     ghostel--term-rows))))
           (+ scrollback (cdr pos)))))))
 
+(defun evil-ghostel--point-viewport-row ()
+  "Return the viewport row of point, 0-indexed, or nil.
+Subtracts the scrollback line count from the buffer line so the
+result is comparable to `ghostel--cursor-position''s row."
+  (when ghostel--term-rows
+    (let ((scrollback (max 0 (- (count-lines (point-min) (point-max))
+                                ghostel--term-rows))))
+      (- (line-number-at-pos (point) t) 1 scrollback))))
+
 (defun evil-ghostel--point-on-cursor-line-p ()
   "Return non-nil when point is on the buffer line of the terminal cursor.
 Reflects current state (libghostty cursor + Emacs buffer); only
@@ -143,29 +149,73 @@ helper is unsafe there — use `evil-ghostel--last-cursor-line' instead."
 
 (defvar-local evil-ghostel--last-cursor-line nil
   "Buffer line where the previous redraw placed the terminal cursor.
-Used by `evil-ghostel--around-redraw' to decide whether the user has
-navigated point since the last redraw.  When point is still on this
-line, the user is parked at the live prompt and the renderer's new
-cursor placement should win across the redraw.")
+Used by `evil-ghostel--around-redraw' to recognize the case where the
+user is parked at the live prompt and the prompt scrolls during the
+redraw — only then does the renderer's cursor placement win across
+the redraw, so column-only navigation (`^', `$', `0', and the like)
+survives redraws that *don't* scroll the prompt.")
+
+(defvar-local evil-ghostel--shadow-cursor nil
+  "Pending terminal cursor (COL . VIEWPORT-ROW), or nil to read live state.
+Within a single advice call we may emit several key sequences
+\(arrow-key sync, then backspaces, then another sync) before any
+of them are echoed by the PTY.  `ghostel--cursor-position' reflects
+the live libghostty state, which lags our queued keys, so a second
+sync that reads it would compute deltas from a stale baseline and
+over-correct.  The shadow models where the cursor will land once
+the queue drains; `evil-ghostel--cursor-to-point' reads it in
+preference to the live value.
+
+Reset by `evil-ghostel--around-redraw' after the renderer has
+processed the echo, and by operations whose cursor effect we
+cannot model (Ctrl-a/e/u, paste).")
+
+(defun evil-ghostel--shadow-or-live ()
+  "Return best-known terminal cursor (COL . VIEWPORT-ROW), or nil.
+Shadow value if set, otherwise the live libghostty cursor."
+  (or evil-ghostel--shadow-cursor
+      (and ghostel--term (ghostel--cursor-position ghostel--term))))
+
+(defun evil-ghostel--invalidate-shadow ()
+  "Clear `evil-ghostel--shadow-cursor'.
+Call after operations whose cursor effect we cannot model so the
+next read falls back to the live libghostty position."
+  (setq evil-ghostel--shadow-cursor nil))
 
 (defun evil-ghostel--cursor-to-point ()
-  "Move the terminal cursor to Emacs point by sending arrow keys."
+  "Move the terminal cursor to Emacs point by sending arrow keys.
+`ghostel--cursor-position' returns the row within the viewport (the
+last `ghostel--term-rows' lines), so the buffer line must be
+converted to a viewport row by subtracting the scrollback offset —
+otherwise dy is wrong by exactly the scrollback line count.
+
+Reads `evil-ghostel--shadow-cursor' in preference to the live
+libghostty cursor (which lags any keys we have just sent), and
+updates the shadow to point's position so a follow-up call within
+the same operation sees the post-keys baseline rather than the
+still-stale live value."
   (when ghostel--term
-    (let* ((tpos (ghostel--cursor-position ghostel--term))
+    (let* ((tpos (evil-ghostel--shadow-or-live))
            (tcol (car tpos))
            (trow (cdr tpos))
            (ecol (current-column))
-           (erow (- (line-number-at-pos (point) t) 1))
+           (erow (or (evil-ghostel--point-viewport-row) 0))
            (dy (- erow trow))
            (dx (- ecol tcol)))
       (cond ((> dy 0) (dotimes (_ dy) (ghostel--send-encoded "down" "")))
             ((< dy 0) (dotimes (_ (abs dy)) (ghostel--send-encoded "up" ""))))
       (cond ((> dx 0) (dotimes (_ dx) (ghostel--send-encoded "right" "")))
-            ((< dx 0) (dotimes (_ (abs dx)) (ghostel--send-encoded "left" "")))))))
+            ((< dx 0) (dotimes (_ (abs dx)) (ghostel--send-encoded "left" ""))))
+      (setq evil-ghostel--shadow-cursor (cons ecol erow)))))
 
-;; ---------------------------------------------------------------------------
+
 ;; Redraw: preserve point and evil visual markers across the native call
-;; ---------------------------------------------------------------------------
+
+(defvar-local evil-ghostel--sync-point-on-next-redraw nil
+  "When non-nil, the next `ghostel--redraw' moves point to the terminal cursor.
+Set by operations that send PTY commands which will reposition the
+terminal cursor (e.g. the same-row `dd' Ctrl-u path) where Emacs
+point would otherwise be left at a now-stale position.")
 
 (defun evil-ghostel--around-redraw (orig-fn term &optional full)
   "Preserve point and evil visual markers across the native redraw call.
@@ -178,10 +228,11 @@ at this layer.
   - `point' in non-terminal states.  In `insert' and `emacs' point
     intentionally follows the TUI cursor.  In `normal' (and other
     non-visual non-terminal states) point follows the cursor too when
-    the user was parked on the prompt line before the redraw - the
-    renderer leaves point at the new cursor and we keep it there.
+    the user was parked at the prompt position (line *and* column)
+    before the redraw — the renderer leaves point at the new cursor
+    and we keep it there so the prompt isn't left behind by output.
     Otherwise the saved buffer position is restored so scrollback
-    navigation is undisturbed.
+    navigation, and column-only motions like `^'/`$', are undisturbed.
   - `evil-visual-beginning' and `evil-visual-end' in `visual' state.
 
 ORIG-FN is the advised `ghostel--redraw' called with TERM and FULL.
@@ -189,45 +240,60 @@ Skipped when the terminal is in alt-screen mode (1049); apps there
 own the screen and drive their own redraw cycle."
   (if (and evil-ghostel-mode
            (not (ghostel--mode-enabled term 1049)))
-      (let* ((preserve-point (not (memq evil-state '(insert emacs))))
+      (let* ((sync-flag evil-ghostel--sync-point-on-next-redraw)
+             (preserve-point (and (not sync-flag)
+                                  (not (memq evil-state '(insert emacs)))))
              (visual-p (eq evil-state 'visual))
              (saved-point (and preserve-point (point)))
-             ;; If point is still on the line where the previous redraw
-             ;; placed the terminal cursor, the user has not navigated
-             ;; since — they are parked on the live prompt and the new
-             ;; cursor placement should win.  We can't reuse
-             ;; `evil-ghostel--point-on-cursor-line-p' here because the
-             ;; libghostty cursor has already advanced past output that
-             ;; the buffer hasn't rendered yet; comparing against the
-             ;; recorded last-cursor-line avoids that skew.  Skipped in
-             ;; visual state to keep selection markers stable.
-             (on-prompt-line (and preserve-point
-                                  (not visual-p)
-                                  evil-ghostel--last-cursor-line
-                                  (= (- (line-number-at-pos (point) t) 1)
-                                     evil-ghostel--last-cursor-line)))
+             ;; Pre-redraw, was the user parked on the cursor's
+             ;; buffer line?  If yes *and* the redraw moves the
+             ;; cursor onto a new line (output scrolled the prompt),
+             ;; we let the renderer's placement win so the user
+             ;; isn't stranded above the live prompt — that's the
+             ;; intent of `evil-ghostel-test-around-redraw-snaps-
+             ;; point-on-prompt-line'.  When the cursor stays on the
+             ;; same line, we restore saved-point so single-line
+             ;; column navigation (`^', `$', `0') isn't undone by an
+             ;; incidental redraw.
+             (pre-line (and preserve-point (not visual-p)
+                            (- (line-number-at-pos (point) t) 1)))
+             (was-on-prompt-line (and pre-line
+                                      evil-ghostel--last-cursor-line
+                                      (= pre-line
+                                         evil-ghostel--last-cursor-line)))
              (saved-vb (and visual-p (bound-and-true-p evil-visual-beginning)
                             (marker-position evil-visual-beginning)))
              (saved-ve (and visual-p (bound-and-true-p evil-visual-end)
                             (marker-position evil-visual-end))))
         (funcall orig-fn term full)
-        (when (and preserve-point (not on-prompt-line))
-          (goto-char (min saved-point (point-max))))
-        (when visual-p
-          (let ((pmax (point-max)))
-            (when saved-vb
-              (set-marker evil-visual-beginning (min saved-vb pmax)))
-            (when saved-ve
-              (set-marker evil-visual-end (min saved-ve pmax)))))
-        ;; Record where the renderer placed the cursor so the next
-        ;; redraw can detect whether the user has navigated away.
-        (setq evil-ghostel--last-cursor-line
-              (evil-ghostel--cursor-buffer-line)))
+        (when sync-flag
+          (setq evil-ghostel--sync-point-on-next-redraw nil)
+          (evil-ghostel--reset-cursor-point))
+        (let* ((post-cursor-line (evil-ghostel--cursor-buffer-line))
+               (prompt-moved (and was-on-prompt-line
+                                  post-cursor-line
+                                  (not (= post-cursor-line pre-line)))))
+          (when (and preserve-point (not prompt-moved))
+            (goto-char (min saved-point (point-max))))
+          (when visual-p
+            (let ((pmax (point-max)))
+              (when saved-vb
+                (set-marker evil-visual-beginning (min saved-vb pmax)))
+              (when saved-ve
+                (set-marker evil-visual-end (min saved-ve pmax)))))
+          ;; Record where the renderer placed the cursor so the next
+          ;; redraw can detect whether the user is still at the
+          ;; prompt line.
+          (setq evil-ghostel--last-cursor-line post-cursor-line))
+        ;; The renderer's draw reflects all PTY output processed up
+        ;; to this point — any shadow cursor we maintained for queued
+        ;; keys is at best stale, at worst wrong.  Reset so the next
+        ;; cursor read falls back to the live libghostty position.
+        (evil-ghostel--invalidate-shadow))
     (funcall orig-fn term full)))
 
-;; ---------------------------------------------------------------------------
+
 ;; Cursor style: let evil control cursor shape
-;; ---------------------------------------------------------------------------
 
 (defun evil-ghostel--override-cursor-style (orig-fn style visible)
   "Let evil control cursor shape instead of the terminal.
@@ -239,9 +305,8 @@ In alt-screen mode, defer to the terminal's cursor style."
       (evil-refresh-cursor)
     (funcall orig-fn style visible)))
 
-;; ---------------------------------------------------------------------------
+
 ;; Evil state hooks
-;; ---------------------------------------------------------------------------
 
 (defvar evil-ghostel--sync-inhibit nil
   "When non-nil, skip arrow-key sync in the insert-state-entry hook.
@@ -264,7 +329,14 @@ which the shell would interpret as history navigation."
       (when (evil-ghostel--active-p)
         (let* ((tpos (ghostel--cursor-position ghostel--term))
                (trow (cdr tpos))
-               (erow (- (line-number-at-pos (point) t) 1)))
+               ;; `tpos' is viewport-relative; convert point's buffer
+               ;; line to a viewport row before comparing — otherwise
+               ;; in any session with scrollback the rows compare as
+               ;; unequal even when point is on the cursor's row, and
+               ;; we drop into `reset-cursor-point' which snaps point
+               ;; back to the terminal cursor (silently undoing the
+               ;; user's `^', `$', `0' navigation).
+               (erow (or (evil-ghostel--point-viewport-row) 0)))
           (if (= erow trow)
               (evil-ghostel--cursor-to-point)
             (evil-ghostel--reset-cursor-point)))))))
@@ -275,15 +347,41 @@ Moving the cursor back on ESC desynchronizes point from the terminal
 cursor."
   (setq-local evil-move-cursor-back nil))
 
-;; ---------------------------------------------------------------------------
+
+;; Advice for beginning-of-line motions
+
+(defun evil-ghostel--around-beginning-of-line (orig-fn &rest args)
+  "Route `0' / `^' to `ghostel-beginning-of-input-or-line' on prompt rows.
+ORIG-FN is the advised motion called with ARGS.
+
+In a shell or REPL, the literal column 0 lands point on top of the
+prompt (`$ ', `>>> ') — almost never what the user wants.  When
+point is on a row that carries the `ghostel-prompt' text property
+or the line-mode input marker, jump to the start of the editable
+input instead so `0' / `^' followed by `i' lands typing at the
+expected place, and `d0' / `c0' don't try to delete the prompt
+characters.
+
+Falls through to ORIG-FN when ghostel isn't active or the row has
+no prompt to skip — preserving standard motion semantics in
+scrollback, output, and non-prompt rows."
+  (if (or (evil-ghostel--active-p)
+          (evil-ghostel--line-mode-active-p))
+      (ghostel-beginning-of-input-or-line)
+    (apply orig-fn args)))
+
+
 ;; Advice for evil insert-line / append-line
-;; ---------------------------------------------------------------------------
 
 (defun evil-ghostel--around-insert-line (orig-fn &rest args)
   "Route `evil-insert-line' according to the current input mode.
 ORIG-FN is the advised `evil-insert-line' called with ARGS.
-In semi-char, send Ctrl-a so the shell moves its readline cursor
-to the start of input — `orig-fn' then enters insert state and the
+In semi-char, sync the terminal cursor to point's row first so
+Ctrl-a operates on the line the user navigated to (the multi-line
+TUI case — without the row sync, kkI lands the cursor at the
+start of the input's last line instead of at the line above).
+Then send Ctrl-a so the shell moves its readline cursor to the
+start of that input line — `orig-fn' enters insert state and the
 buffer cursor is repositioned by the next redraw.
 In line mode, the input region is plain buffer text bounded by
 `ghostel--line-input-start' / `--line-input-end'; jump point there
@@ -292,7 +390,9 @@ on the prompt, which is read-only).
 Outside ghostel, run unchanged."
   (cond
    ((evil-ghostel--active-p)
+    (evil-ghostel--cursor-to-point)
     (ghostel--send-encoded "a" "ctrl")
+    (evil-ghostel--invalidate-shadow)
     (setq evil-ghostel--sync-inhibit t)
     (apply orig-fn args))
    ((evil-ghostel--line-mode-active-p)
@@ -304,12 +404,14 @@ Outside ghostel, run unchanged."
 (defun evil-ghostel--around-append-line (orig-fn &rest args)
   "Route `evil-append-line' according to the current input mode.
 ORIG-FN is the advised `evil-append-line' called with ARGS.
-Symmetric to `evil-ghostel--around-insert-line': Ctrl-e in
-semi-char, jump to `--line-input-end' in line mode, otherwise
-unchanged."
+Symmetric to `evil-ghostel--around-insert-line': sync the terminal
+cursor to point's row, then send Ctrl-e in semi-char; jump to
+`--line-input-end' in line mode; otherwise unchanged."
   (cond
    ((evil-ghostel--active-p)
+    (evil-ghostel--cursor-to-point)
     (ghostel--send-encoded "e" "ctrl")
+    (evil-ghostel--invalidate-shadow)
     (setq evil-ghostel--sync-inhibit t)
     (apply orig-fn args))
    ((evil-ghostel--line-mode-active-p)
@@ -318,26 +420,89 @@ unchanged."
     (evil-insert-state 1))
    (t (apply orig-fn args))))
 
-;; ---------------------------------------------------------------------------
+
 ;; Editing primitives
-;; ---------------------------------------------------------------------------
+
+(defun evil-ghostel--meaningful-length (text)
+  "Length of TEXT, stripping per-line trailing whitespace in multi-line ranges.
+Heuristic for TUIs that draw a fixed-width input box wider than the
+user's typed text (e.g. prompt_toolkit-based REPLs that fill each
+input row out to the box's right border).  The trailing spaces end
+up in the Emacs buffer because the terminal explicitly wrote them
+\(see `src/render.zig' — only unwritten cells are trimmed), but
+they are not characters in the TUI's input model, and sending one
+backspace per buffer character would eat far past the actual input.
+
+Only applied when TEXT spans more than one buffer line.  In a
+single-line range (e.g. `dw' deleting `\"word \"'), trailing
+whitespace is treated as real user-typed content and counted —
+otherwise we'd send one fewer backspace than the deletion needs
+and leave a stray character behind.
+
+Tradeoff: a line of pure user-typed indentation inside a multi-line
+range (e.g. `\"    \\nfoo\"') collapses on the first line and
+contributes 0 backspaces.  Acceptable cost — the alternative
+over-deletes on every prompt_toolkit-style TUI."
+  (if (string-match-p "\n" text)
+      (length (replace-regexp-in-string "[ \t]+\\(\n\\|\\'\\)" "\\1" text))
+    (length text)))
 
 (defun evil-ghostel--delete-region (beg end)
   "Delete text between BEG and END via the terminal PTY.
-Moves terminal cursor to END, then sends backspace keys.
+Moves terminal cursor to END, then sends one backspace per
+meaningful character (see `evil-ghostel--meaningful-length').
 Uses backspace rather than forward-delete because the Delete key
-escape sequence is not bound in all shell configurations."
-  (let ((count (- end beg)))
+escape sequence is not bound in all shell configurations.
+
+Updates `evil-ghostel--shadow-cursor' to reflect the post-backspace
+position — each backspace moves the cursor one column left without
+crossing rows in the cases we care about (readline clamps at start
+of input)."
+  (let ((count (evil-ghostel--meaningful-length
+                (buffer-substring-no-properties beg end))))
     (when (> count 0)
       (goto-char end)
       (evil-ghostel--cursor-to-point)
       (dotimes (_ count)
         (ghostel--send-encoded "backspace" ""))
-      (goto-char beg))))
+      (goto-char beg)
+      (when evil-ghostel--shadow-cursor
+        (setcar evil-ghostel--shadow-cursor
+                (max 0 (- (car evil-ghostel--shadow-cursor) count)))))))
 
-;; ---------------------------------------------------------------------------
+(defun evil-ghostel--point-on-cursor-row-p ()
+  "Non-nil when Emacs point is on the same viewport row as the terminal cursor.
+Used by line-type `dd' / `cc' to dispatch between the readline-aware
+Ctrl-e/Ctrl-u shortcut (when point is on the cursor's line — the
+typical single-line shell case) and the explicit cursor-sync +
+backspace path (when point is on a different line, the multi-line
+TUI case from issue #218)."
+  (when ghostel--term
+    (let* ((tpos (ghostel--cursor-position ghostel--term))
+           (trow (cdr tpos))
+           (scrollback (if ghostel--term-rows
+                           (max 0 (- (count-lines (point-min) (point-max))
+                                     ghostel--term-rows))
+                         0))
+           (prow (- (line-number-at-pos (point) t) 1 scrollback)))
+      (= prow trow))))
+
+(defun evil-ghostel--clear-input-line ()
+  "Clear the active input line via Ctrl-e Ctrl-u.
+Readline / zle / prompt_toolkit all bind this to \"go to end of
+line, then kill from start of line to cursor\" — so the active
+input is cleared without us needing to know where the prompt ends.
+Sets `evil-ghostel--sync-point-on-next-redraw' so the redraw
+triggered by the shell's echo lands point at the new cursor
+position (start of the input area) rather than leaving it on the
+prompt at column 0."
+  (ghostel--send-encoded "e" "ctrl")
+  (ghostel--send-encoded "u" "ctrl")
+  (evil-ghostel--invalidate-shadow)
+  (setq evil-ghostel--sync-point-on-next-redraw t))
+
+
 ;; Advice for evil editing operators
-;; ---------------------------------------------------------------------------
 
 (defun evil-ghostel--around-delete
     (orig-fn beg end &optional type register yank-handler)
@@ -354,11 +519,13 @@ Covers d, dd, D, x, X."
               (evil-set-register ?- text))))
         (let ((evil-was-yanked-without-register nil))
           (evil-yank beg end type register yank-handler))
-        (if (eq type 'line)
-            ;; For line-type (dd): clear the input line
-            (progn
-              (ghostel--send-encoded "e" "ctrl")
-              (ghostel--send-encoded "u" "ctrl"))
+        (if (and (eq type 'line) (evil-ghostel--point-on-cursor-row-p))
+            ;; Single-line shell case: readline shortcut clears the
+            ;; input area without us needing prompt geometry.
+            (evil-ghostel--clear-input-line)
+          ;; Multi-line case (point on a different row from the
+          ;; terminal cursor): sync cursor to the deleted region's
+          ;; end then backspace through it.
           (evil-ghostel--delete-region beg end)))
     (funcall orig-fn beg end type register yank-handler)))
 
@@ -368,16 +535,29 @@ Covers d, dd, D, x, X."
 ORIG-FN is the advised `evil-change' called with BEG, END, TYPE,
 REGISTER, YANK-HANDLER, and DELETE-FUNC.
 Deletes via PTY, then enters insert state.
-Covers c, cc, C, s, S."
+Covers c, cc, C, s, S.
+
+When `evil-ghostel--delete-region' actually sends keys (count > 0),
+it leaves point and the shadow cursor at BEG, so insert state will
+land on the correct row.  Only when the range is empty (count = 0,
+e.g. \\<evil-normal-state-map>\\[evil-change-line] at end-of-line on
+a non-cursor row) do we explicitly sync the terminal cursor —
+otherwise typed characters would land on whatever row the cursor
+was last parked on.  The line-type Ctrl-u branch runs its own
+redraw-time sync via `evil-ghostel--sync-point-on-next-redraw'."
   (if (evil-ghostel--active-p)
       (progn
         (let ((evil-was-yanked-without-register nil))
           (evil-yank beg end type register yank-handler))
-        (if (eq type 'line)
-            (progn
-              (ghostel--send-encoded "e" "ctrl")
-              (ghostel--send-encoded "u" "ctrl"))
-          (evil-ghostel--delete-region beg end))
+        (cond
+         ((and (eq type 'line) (evil-ghostel--point-on-cursor-row-p))
+          (evil-ghostel--clear-input-line))
+         (t
+          (let ((count (evil-ghostel--meaningful-length
+                        (buffer-substring-no-properties beg end))))
+            (evil-ghostel--delete-region beg end)
+            (when (zerop count)
+              (evil-ghostel--cursor-to-point)))))
         (setq evil-ghostel--sync-inhibit t)
         (evil-insert 1))
     (funcall orig-fn beg end type register yank-handler delete-func)))
@@ -386,12 +566,18 @@ Covers c, cc, C, s, S."
   "Intercept `evil-replace' in ghostel buffers.
 ORIG-FN is the advised `evil-replace' called with BEG, END, TYPE,
 and CHAR.
-Deletes the range, then inserts replacement characters."
+Deletes the range, then inserts replacement characters.
+The paste count must match the delete count — both go through
+`evil-ghostel--meaningful-length' so trailing whitespace stripped
+from the deletion isn't re-added by the paste."
   (if (evil-ghostel--active-p)
       (when char
-        (let ((count (- end beg)))
+        (let ((count (evil-ghostel--meaningful-length
+                      (buffer-substring-no-properties beg end))))
           (evil-ghostel--delete-region beg end)
-          (ghostel--paste-text (make-string count char))))
+          (when (> count 0)
+            (ghostel--paste-text (make-string count char))
+            (evil-ghostel--invalidate-shadow))))
     (funcall orig-fn beg end type char)))
 
 (defun evil-ghostel--around-paste-after
@@ -409,7 +595,8 @@ Pastes from REGISTER via the terminal PTY."
           (evil-ghostel--cursor-to-point)
           (ghostel--send-encoded "right" "")
           (dotimes (_ count)
-            (ghostel--paste-text text))))
+            (ghostel--paste-text text))
+          (evil-ghostel--invalidate-shadow)))
     (funcall orig-fn count register yank-handler)))
 
 (defun evil-ghostel--around-paste-before
@@ -426,12 +613,12 @@ Pastes from REGISTER via the terminal PTY."
         (when text
           (evil-ghostel--cursor-to-point)
           (dotimes (_ count)
-            (ghostel--paste-text text))))
+            (ghostel--paste-text text))
+          (evil-ghostel--invalidate-shadow)))
     (funcall orig-fn count register yank-handler)))
 
-;; ---------------------------------------------------------------------------
+
 ;; Insert-state Ctrl key passthrough
-;; ---------------------------------------------------------------------------
 
 (defvar evil-ghostel-mode-map (make-sparse-keymap)
   "Keymap for `evil-ghostel-mode'.
@@ -453,7 +640,12 @@ own bindings (e.g. \\`C-a' → `ghostel-beginning-of-input-or-line',
 defaults; without that, the minor-mode aux map containing this
 passthrough would shadow line mode's local-map binding."
   (if (evil-ghostel--active-p)
-      (ghostel--send-encoded key "ctrl")
+      (progn
+        (ghostel--send-encoded key "ctrl")
+        ;; C-a / C-e / C-u / C-w / C-r / C-n / C-p all reposition the
+        ;; readline cursor (or load a different input line entirely);
+        ;; the shadow's pre-keystroke baseline is no longer valid.
+        (evil-ghostel--invalidate-shadow))
     (let* ((vec (kbd (concat "C-" key)))
            (local (current-local-map))
            (cmd (or (and local (lookup-key local vec))
@@ -487,9 +679,8 @@ ORIG-FN is the advised `evil-redo' called with COUNT."
       (message "Redo not supported in terminal")
     (funcall orig-fn count)))
 
-;; ---------------------------------------------------------------------------
+
 ;; ESC routing: terminal vs evil
-;; ---------------------------------------------------------------------------
 
 (defvar-local evil-ghostel--escape-mode nil
   "Buffer-local override for ESC routing.
@@ -543,9 +734,8 @@ The mode is buffer-local; see `evil-ghostel-escape' for the default."
 (evil-define-key* 'insert evil-ghostel-mode-map
                   (kbd "<escape>") #'evil-ghostel--escape)
 
-;; ---------------------------------------------------------------------------
+
 ;; Minor mode
-;; ---------------------------------------------------------------------------
 
 ;;;###autoload
 (define-minor-mode evil-ghostel-mode
@@ -566,6 +756,10 @@ state transitions."
                   #'evil-ghostel--insert-state-entry nil t)
         (advice-add 'evil-insert-line :around #'evil-ghostel--around-insert-line)
         (advice-add 'evil-append-line :around #'evil-ghostel--around-append-line)
+        (advice-add 'evil-beginning-of-line :around
+                    #'evil-ghostel--around-beginning-of-line)
+        (advice-add 'evil-first-non-blank :around
+                    #'evil-ghostel--around-beginning-of-line)
         (advice-add 'evil-delete :around #'evil-ghostel--around-delete)
         (advice-add 'evil-change :around #'evil-ghostel--around-change)
         (advice-add 'evil-replace :around #'evil-ghostel--around-replace)
@@ -583,6 +777,10 @@ state transitions."
                  #'evil-ghostel--insert-state-entry t)
     (advice-remove 'evil-insert-line #'evil-ghostel--around-insert-line)
     (advice-remove 'evil-append-line #'evil-ghostel--around-append-line)
+    (advice-remove 'evil-beginning-of-line
+                   #'evil-ghostel--around-beginning-of-line)
+    (advice-remove 'evil-first-non-blank
+                   #'evil-ghostel--around-beginning-of-line)
     (advice-remove 'evil-delete #'evil-ghostel--around-delete)
     (advice-remove 'evil-change #'evil-ghostel--around-change)
     (advice-remove 'evil-replace #'evil-ghostel--around-replace)

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -372,6 +372,45 @@ point in the scrollback region instead of the visible viewport."
                                       (evil-ghostel--cursor-to-point))
                                     (should (= 0 (length keys-sent))))))
 
+(ert-deftest evil-ghostel-test-cursor-to-point-with-scrollback ()
+  "Regression: cursor-to-point must subtract scrollback from buffer line.
+`ghostel--cursor-position' returns viewport-relative rows, so a
+buffer line N must be converted to viewport row N-scrollback before
+diffing — otherwise dy is wrong by exactly the scrollback line count
+and the helper sends arrows that move the cursor off the input."
+  (let ((term (ghostel--new 5 40 1000)))
+    ;; Push 7 rows into scrollback so the viewport shows rows 8..12 plus
+    ;; the trailing cursor row.
+    (dotimes (i 12)
+      (ghostel--write-input term (format "row-%02d\r\n" i)))
+    (ghostel--write-input term "tail")
+    (with-temp-buffer
+      (ghostel-mode)
+      (setq-local ghostel--term term)
+      (setq-local ghostel--term-rows 5)
+      (evil-local-mode 1)
+      (evil-ghostel-mode 1)
+      (let ((inhibit-read-only t))
+        (ghostel--redraw term t))
+      ;; Terminal cursor is on the last viewport row; move point to the
+      ;; first viewport row (one row above the cursor).
+      (let* ((tpos (ghostel--cursor-position term))
+             (trow (cdr tpos))
+             (target-viewport-row (1- trow))
+             (scrollback (max 0 (- (count-lines (point-min) (point-max))
+                                   ghostel--term-rows))))
+        (goto-char (point-min))
+        (forward-line (+ scrollback target-viewport-row))
+        (move-to-column (car tpos))
+        (let ((keys-sent '()))
+          (cl-letf (((symbol-function 'ghostel--send-encoded)
+                     (lambda (key _mods &rest _)
+                       (push key keys-sent))))
+            (evil-ghostel--cursor-to-point))
+          ;; Exactly one UP, no horizontal motion (cols match).
+          (should (= 1 (length keys-sent)))
+          (should (equal "up" (car keys-sent))))))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: redraw preserves point in normal state
 ;; -----------------------------------------------------------------------
@@ -487,6 +526,76 @@ redrawing elsewhere."
        (should-not (member "left" keys-sent))
        (should-not (member "right" keys-sent))))))
 
+(ert-deftest evil-ghostel-test-insert-line-multiline-syncs-row ()
+  "Regression: `I' on a different row must sync the terminal cursor first.
+Without the row sync, the Ctrl-a sent by the advice operates on the
+last input line (where the terminal cursor was parked), not on the
+line the user navigated to with `kk'."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "line one\nline two\nline three")
+   ;; Terminal cursor at end of line three (row 2); point on row 0.
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(10 . 2))))
+     (evil-normal-state)
+     (goto-char (point-min))
+     (let ((keys-sent '()))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key mods &rest _)
+                    (push (cons key mods) keys-sent))))
+         (evil-insert-line 1))
+       ;; Two `up' arrows precede the Ctrl-a so the shell's readline
+       ;; cursor lands on the right input row before going to bol.
+       (should (= 2 (cl-count '("up" . "") keys-sent :test #'equal)))
+       (should (cl-find '("a" . "ctrl") keys-sent :test #'equal))))))
+
+(ert-deftest evil-ghostel-test-append-line-multiline-syncs-row ()
+  "Regression: `A' on a different row must sync the terminal cursor first.
+Symmetric to the `I' multi-row case — without the row sync the Ctrl-e
+goes to the end of the last input line."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "line one\nline two\nline three")
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(10 . 2))))
+     (evil-normal-state)
+     (goto-char (point-min))
+     (let ((keys-sent '()))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key mods &rest _)
+                    (push (cons key mods) keys-sent))))
+         (evil-append-line 1))
+       (should (= 2 (cl-count '("up" . "") keys-sent :test #'equal)))
+       (should (cl-find '("e" . "ctrl") keys-sent :test #'equal))))))
+
+(ert-deftest evil-ghostel-test-change-eol-syncs-cursor-to-point ()
+  "Regression: `C' at eol of a non-cursor row must sync before insert.
+With point at end of line one and the terminal cursor at end of line
+three, `C' produces an empty range (count = 0).  Without an explicit
+sync after `delete-region', insert state would inherit the terminal
+cursor from line three and the user's typed characters would land on
+the last input line — what was reported as `C deletes the last line'."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "line one\nline two\nline three")
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(10 . 2))))
+     (evil-normal-state)
+     ;; Point at end of line one (just before the first newline).
+     (goto-char (point-min))
+     (end-of-line)
+     (let ((keys-sent '())
+           (eol-pos (point)))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key mods &rest _)
+                    (push (cons key mods) keys-sent))))
+         ;; `C' at eol → evil-change with empty range.
+         (evil-change eol-pos eol-pos 'inclusive nil nil
+                      #'evil-delete-line))
+       ;; The post-delete cursor-to-point must emit two `up' arrows so
+       ;; the terminal cursor lands on point's row before insert state.
+       (should (= 2 (cl-count '("up" . "") keys-sent :test #'equal)))))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: advice is no-op outside ghostel buffers
 ;; -----------------------------------------------------------------------
@@ -534,6 +643,27 @@ redrawing elsewhere."
                                     (should (= 5 (cl-count "backspace" keys-sent :test #'equal))))))
 
 ;; -----------------------------------------------------------------------
+;; Test: meaningful-length helper (render padding stripping)
+;; -----------------------------------------------------------------------
+
+(ert-deftest evil-ghostel-test-meaningful-length-strips-trailing ()
+  "Trailing whitespace counts only when TEXT spans multiple lines.
+Single-line `\"word \"' is real user content (e.g. `dw' over a word
+plus its trailing space); multi-line ranges may contain TUI box
+padding that should be stripped per line."
+  (should (= 0 (evil-ghostel--meaningful-length "")))
+  (should (= 3 (evil-ghostel--meaningful-length "AAA")))
+  ;; Single-line: trailing whitespace is preserved (real content).
+  (should (= 9 (evil-ghostel--meaningful-length "AAA      ")))
+  (should (= 5 (evil-ghostel--meaningful-length "word ")))
+  ;; Multi-line: per-line trailing whitespace stripped (TUI padding).
+  (should (= 7 (evil-ghostel--meaningful-length "AAA      \nBBB     ")))
+  (should (= 4 (evil-ghostel--meaningful-length "AAA      \n")))
+  ;; Inner whitespace preserved either way.
+  (should (= 7 (evil-ghostel--meaningful-length "A B C  ")))
+  (should (= 8 (evil-ghostel--meaningful-length "A B C  D"))))
+
+;; -----------------------------------------------------------------------
 ;; Test: evil-delete advice
 ;; -----------------------------------------------------------------------
 
@@ -556,22 +686,109 @@ redrawing elsewhere."
          (evil-delete 1 6 'inclusive nil nil))
        (should (= 5 bs-count))))))
 
-(ert-deftest evil-ghostel-test-delete-line-sends-ctrl-u ()
-  "Test that line-type `evil-delete' sends Ctrl+U to clear line."
+(ert-deftest evil-ghostel-test-delete-line-same-row-uses-ctrl-u ()
+  "Test that `dd' on the cursor's own line uses the Ctrl-e/Ctrl-u shortcut.
+Single-line shell case: the buffer line includes the prompt prefix,
+so backspacing through the buffer text would hit the prompt boundary
+and silently no-op.  Readline's Ctrl-u clears just the input area.
+See issue #218 for the multi-line counterpart."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
-   (insert "hello world")
+   (insert "$ hello")
    (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
-             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0))))
+             ;; Terminal cursor on the same row as point.
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(7 . 0))))
      (evil-normal-state)
      (let ((keys-sent '()))
        (cl-letf (((symbol-function 'ghostel--send-encoded)
                   (lambda (key mods &rest _)
                     (push (cons key mods) keys-sent))))
-         (evil-delete (point-min) (point-max) 'line nil nil))
-       ;; Should have sent C-e and Ctrl+U
+         (evil-delete (line-beginning-position) (line-end-position) 'line nil nil))
+       (should (cl-find '("e" . "ctrl") keys-sent :test #'equal))
        (should (cl-find '("u" . "ctrl") keys-sent :test #'equal))
-       (should (cl-find '("e" . "ctrl") keys-sent :test #'equal))))))
+       (should-not (cl-find '("backspace" . "") keys-sent :test #'equal))
+       ;; Flag set so the next redraw snaps point to the cursor's new
+       ;; position (start of input area) instead of leaving point on the
+       ;; prompt at column 0.
+       (should evil-ghostel--sync-point-on-next-redraw)))))
+
+(ert-deftest evil-ghostel-test-change-line-same-row-uses-ctrl-u ()
+  "Test that `cc' on the cursor's own line uses Ctrl-e/Ctrl-u then enters insert.
+Same single-line shell rationale as `dd' — see
+`evil-ghostel-test-delete-line-same-row-uses-ctrl-u'."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "$ hello")
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(7 . 0))))
+     (evil-normal-state)
+     (let ((keys-sent '()))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key mods &rest _)
+                    (push (cons key mods) keys-sent))))
+         (evil-change (line-beginning-position) (line-end-position)
+                      'line nil nil nil))
+       (should (cl-find '("e" . "ctrl") keys-sent :test #'equal))
+       (should (cl-find '("u" . "ctrl") keys-sent :test #'equal))
+       (should-not (cl-find '("backspace" . "") keys-sent :test #'equal))
+       (should (eq evil-state 'insert))))))
+
+(ert-deftest evil-ghostel-test-delete-line-multiline-syncs-cursor ()
+  "Regression for #218: line-type delete must sync terminal cursor first.
+With a multi-line input where the terminal cursor sits on the last line,
+pressing dd on the first line must move the terminal cursor up to that
+line before deleting — otherwise Ctrl+U / shortcut-style deletion would
+target the line the cursor sat on (the last input line)."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "line one\nline two\nline three")
+   ;; Terminal cursor reported at end of line three (col 10, row 2)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(10 . 2))))
+     (evil-normal-state)
+     (goto-char (point-min))
+     (let ((keys-sent '()))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key mods &rest _)
+                    (push (cons key mods) keys-sent))))
+         ;; Line 1 spans positions 1..10 ("line one" + newline = 9 chars)
+         (evil-delete 1 10 'line nil nil))
+       ;; Sync from row 2 to row 1 (end of deleted region = bol of line 2)
+       (should (= 1 (cl-count '("up" . "") keys-sent :test #'equal)))
+       ;; Sync from col 10 to col 0
+       (should (= 10 (cl-count '("left" . "") keys-sent :test #'equal)))
+       ;; "line one\n" = 9 chars deleted via backspace
+       (should (= 9 (cl-count '("backspace" . "") keys-sent :test #'equal)))
+       (should-not (cl-find '("u" . "ctrl") keys-sent :test #'equal))))))
+
+(ert-deftest evil-ghostel-test-delete-line-strips-render-padding ()
+  "Regression for #218: multi-line `dd' must not backspace TUI box-padding.
+TUIs that draw a fixed-width input box (e.g. prompt_toolkit) write
+spaces past the user's input out to the box border; those land in
+the Emacs buffer but are not characters in the TUI's input model.
+Backspace count must equal trimmed line length + newline.
+Forces the multi-line backspace path by placing the terminal cursor
+on a different row than point."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   ;; "AAA" + 77 box-padding spaces + newline + "BBB" + 77 box-padding spaces.
+   (insert (concat "AAA" (make-string 77 ?\s) "\n"
+                   "BBB" (make-string 77 ?\s)))
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ;; Terminal cursor on row 1 (BBB); point will be on row 0 (AAA).
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 1)))
+             ((symbol-function 'evil-ghostel--cursor-to-point) #'ignore))
+     (evil-normal-state)
+     (goto-char (point-min))
+     (let ((bs-count 0))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _)
+                    (when (equal key "backspace")
+                      (cl-incf bs-count)))))
+         ;; Line 1 spans bol..bol-of-line-2 (81 chars including newline).
+         (evil-delete (point-min) (line-beginning-position 2) 'line nil nil))
+       ;; Trimmed: "AAA\n" = 4 backspaces, not 81.
+       (should (= 4 bs-count))))))
 
 (ert-deftest evil-ghostel-test-delete-char ()
   "Test that `evil-delete-char' (x) works without error.
@@ -655,6 +872,37 @@ Regression: delete-func arg was not optional in advice signature."
        (should (= 3 bs-count))
        (should (equal "XXX" pasted))))))
 
+(ert-deftest evil-ghostel-test-replace-counts-match-on-trailing-space ()
+  "Regression: paste count and delete count must agree.
+Both `evil-ghostel--delete-region' and the paste in
+`evil-ghostel--around-replace' use `evil-ghostel--meaningful-length'
+on the same substring, so the values must agree even when trailing
+whitespace handling differs (multi-line ranges strip; single-line
+ranges don't)."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   ;; Multi-line range with TUI-style padding on the first row.
+   ;; meaningful-length strips per-line padding → 4 chars: "AB\nC".
+   (insert "AB   \nC")
+   (goto-char (point-min))
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(0 . 0)))
+             ((symbol-function 'evil-ghostel--cursor-to-point) #'ignore))
+     (evil-normal-state)
+     (let ((bs-count 0)
+           (pasted nil))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _)
+                    (when (equal key "backspace")
+                      (cl-incf bs-count))))
+                 ((symbol-function 'ghostel--paste-text)
+                  (lambda (text) (setq pasted text))))
+         (evil-replace 1 8 'inclusive ?X))
+       ;; Pre-fix: bs-count read meaningful-length (4) but pasted used
+       ;; raw substring length (7), leaving a stray "XXX" on screen.
+       (should (= 4 bs-count))
+       (should (equal "XXXX" pasted))))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: evil-paste advice
 ;; -----------------------------------------------------------------------
@@ -696,6 +944,23 @@ Regression: delete-func arg was not optional in advice signature."
                       (push (cons k mods) keys-sent))))
            (evil-ghostel--passthrough-ctrl key))
          (should (cl-find (cons key "ctrl") keys-sent :test #'equal)))))))
+
+(ert-deftest evil-ghostel-test-ctrl-passthrough-invalidates-shadow ()
+  "Ctrl passthrough must invalidate the shadow cursor.
+C-a / C-e / C-u / C-w / C-r / C-n / C-p reposition the readline
+cursor or swap in a different input line — a stale shadow would
+mislead the next `cursor-to-point' into computing deltas from a
+position the cursor no longer holds."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "hello")
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(5 . 0)))
+             ((symbol-function 'ghostel--send-encoded) #'ignore))
+     (evil-insert-state)
+     (setq evil-ghostel--shadow-cursor (cons 5 0))
+     (evil-ghostel--passthrough-ctrl "a")
+     (should-not evil-ghostel--shadow-cursor))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: insert-state entry skips vertical sync
@@ -1042,6 +1307,206 @@ rather than silently dropping the keystroke."
      (should (eq 'normal evil-state)))))
 
 ;; -----------------------------------------------------------------------
+;; Test: beginning-of-line lands at input start, not column 0
+;; -----------------------------------------------------------------------
+
+(ert-deftest evil-ghostel-test-beginning-of-line-skips-prompt ()
+  "`0' / `^' jump to start of input on a prompt row, not column 0.
+Without this, `0' lands point on top of the `$ ' prompt and `0i'
+inserts at the prompt position rather than at the input start."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "$ command")
+   ;; Mark the prompt prefix so ghostel-beginning-of-input-or-line
+   ;; treats it as a prompt row.
+   (put-text-property 1 3 'ghostel-prompt t)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil)))
+     (evil-normal-state)
+     (goto-char (point-max))
+     (evil-beginning-of-line)
+     ;; Lands at col 2 (after "$ "), not col 0.
+     (should (= 2 (current-column)))
+     (goto-char (point-max))
+     (evil-first-non-blank)
+     (should (= 2 (current-column))))))
+
+(ert-deftest evil-ghostel-test-beginning-of-line-falls-through-no-prompt ()
+  "On rows without a prompt property `0' / `^' keep their default
+column-0 / first-non-blank behaviour — scrollback navigation must
+not be hijacked."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "  output line")  ; no ghostel-prompt property anywhere
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil)))
+     (evil-normal-state)
+     (goto-char (point-max))
+     (evil-beginning-of-line)
+     (should (= 0 (current-column))))))
+
+;; -----------------------------------------------------------------------
+;; Test: shadow cursor (queued-key model)
+;; -----------------------------------------------------------------------
+
+(ert-deftest evil-ghostel-test-shadow-cursor-tracks-cursor-to-point ()
+  "After `cursor-to-point' the shadow holds point's viewport position.
+A second `cursor-to-point' call within the same operation must read
+from the shadow rather than the still-stale live libghostty cursor —
+otherwise it computes deltas from the wrong baseline and emits extra
+arrows.  Mocks the live cursor at (17 . 0) and verifies the second
+sync emits zero keys once point is at col 6."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "word1 word2 word3")
+   (goto-char (point-min))
+   (move-to-column 6)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(17 . 0))))
+     (let ((first-keys '()) (second-keys '()))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _) (push key first-keys))))
+         (evil-ghostel--cursor-to-point))
+       (should (= 11 (length first-keys)))
+       (should (equal '(6 . 0) evil-ghostel--shadow-cursor))
+       ;; Second sync — point is unchanged, shadow already at (6 . 0),
+       ;; so no further keys should be emitted.
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _) (push key second-keys))))
+         (evil-ghostel--cursor-to-point))
+       (should (= 0 (length second-keys)))))))
+
+(ert-deftest evil-ghostel-test-shadow-cursor-tracks-delete-region ()
+  "After `delete-region' the shadow advances by COUNT columns.
+A follow-up `cursor-to-point' from BEG should be a no-op."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "word1 word2 word3")
+   (goto-char (point-min))
+   (move-to-column 6)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(17 . 0))))
+     (cl-letf (((symbol-function 'ghostel--send-encoded) #'ignore))
+       (evil-ghostel--delete-region 7 12))
+     ;; Shadow is at end-col (11) - count (5) = 6, viewport row 0.
+     (should (equal '(6 . 0) evil-ghostel--shadow-cursor))
+     ;; Point is at col 6 (beg).  cursor-to-point should now be a no-op.
+     (let ((extra-keys '()))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _) (push key extra-keys))))
+         (evil-ghostel--cursor-to-point))
+       (should (= 0 (length extra-keys)))))))
+
+;; -----------------------------------------------------------------------
+;; Test: cw doesn't emit redundant left arrows after delete
+;; -----------------------------------------------------------------------
+
+(ert-deftest evil-ghostel-test-delete-word-with-trailing-space ()
+  "Regression: `dw' over `\"word \"' must send 5 backspaces, not 4.
+With the old `meaningful-length' the trailing space was always
+stripped, so `dw' on `\"word word word\" + ESC bb' sent only 4
+backspaces — leaving a stray `w' behind (`word wword' instead of
+`word word').  Trailing whitespace in single-line ranges is real
+content."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "word word word")
+   (goto-char (point-min))
+   (move-to-column 5)  ; start of word2
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(14 . 0))))
+     (let ((bs-count 0))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _)
+                    (when (equal key "backspace") (cl-incf bs-count)))))
+         ;; `dw' from col 5 deletes "word " (chars 6..10, exclusive end 11).
+         (evil-delete 6 11 'exclusive nil nil))
+       (should (= 5 bs-count))))))
+
+(ert-deftest evil-ghostel-test-change-partial-no-post-delete-sync ()
+  "After `cw' (count > 0) `around-change' must not run a second
+post-delete cursor-to-point.  The redundant sync used to read the
+stale live cursor and emit extra left arrows that pushed the
+terminal cursor past the start of input — observed as `cw seems
+to move the point to the beginning of the line'."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "word1 word2 word3")
+   (goto-char (point-min))
+   (move-to-column 6)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(17 . 0))))
+     (let ((keys-sent '()))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _) (push key keys-sent))))
+         (evil-change 7 12 'exclusive nil nil))
+       (let* ((seq (nreverse keys-sent))
+              (left-count (cl-count "left" seq :test #'equal))
+              (bs-count (cl-count "backspace" seq :test #'equal)))
+         ;; Exactly one initial sync (6 lefts: col 17 → col 11 = end)
+         ;; and the 5 backspaces.  No second sync after backspaces —
+         ;; with the bug, that second sync read the stale live cursor
+         ;; (col 17) against point's now-col-6 and emitted 11 more
+         ;; left arrows, pushing the terminal cursor past col 0.
+         (should (= 6 left-count))
+         (should (= 5 bs-count)))))))
+
+;; -----------------------------------------------------------------------
+;; Test: insert-state-entry uses viewport row, not buffer line
+;; -----------------------------------------------------------------------
+
+(ert-deftest evil-ghostel-test-insert-entry-same-viewport-row-with-scrollback ()
+  "Regression: with scrollback, `insert-state-entry' must compare
+viewport rows, not buffer lines.  Otherwise the same-row check
+fails (buffer-line N vs viewport-row 0) and we drop into
+`reset-cursor-point', snapping point back to the terminal cursor
+and silently undoing the user's `^' / `$' / `0' navigation."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (setq-local ghostel--term-rows 5)
+   ;; Push 7 buffer lines so point's buffer line (line 7) is far from
+   ;; the cursor's viewport row (0) when measured in raw line numbers.
+   (insert "scroll-0\nscroll-1\nscroll-2\nscroll-3\nscroll-4\nscroll-5\nscroll-6\n$ ")
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ;; Cursor on the cursor's row at viewport row 4 (last).
+             ((symbol-function 'ghostel--cursor-position) (lambda (_) '(2 . 4))))
+     ;; Park point at col 0 of the cursor row (buffer line 7) — this is
+     ;; the same viewport row as the cursor.
+     (goto-char (point-max))
+     (beginning-of-line)
+     (let ((reset-called nil) (sync-called nil))
+       (cl-letf (((symbol-function 'evil-ghostel--reset-cursor-point)
+                  (lambda () (setq reset-called t)))
+                 ((symbol-function 'evil-ghostel--cursor-to-point)
+                  (lambda () (setq sync-called t))))
+         (evil-ghostel--insert-state-entry))
+       ;; Same viewport row → cursor-to-point, NOT reset-cursor-point.
+       (should sync-called)
+       (should-not reset-called)))))
+
+;; -----------------------------------------------------------------------
+;; Test: column navigation survives idle redraw
+;; -----------------------------------------------------------------------
+
+(ert-deftest evil-ghostel-test-around-redraw-preserves-column-nav ()
+  "In normal state, `^'/`$'/`0' must survive a redraw on the cursor's
+line so long as the prompt didn't scroll to a new line.  The
+`prompt-moved' override only applies when output actually moves the
+cursor onto a different buffer line — for redraws that stay on the
+same line, the saved point position wins so column-only navigation
+sticks."
+  (evil-ghostel-test--with-buffer 5 40 "$ hello world"
+                                  (evil-normal-state)
+                                  ;; Point at col 0 of the prompt line — user did `0'.
+                                  (goto-char (point-min))
+                                  (should (= 0 (current-column)))
+                                  (should (= 1 (line-number-at-pos)))
+                                  ;; Redraw without growing scrollback (single-line update).
+                                  (let ((inhibit-read-only t))
+                                    (ghostel--redraw term nil))
+                                  ;; Point stays where the user navigated.
+                                  (should (= 0 (current-column)))
+                                  (should (= 1 (line-number-at-pos)))))
+
+;; -----------------------------------------------------------------------
 ;; Runner
 ;; -----------------------------------------------------------------------
 
@@ -1053,9 +1518,17 @@ rather than silently dropping the keystroke."
     evil-ghostel-test-advice-on-append
     evil-ghostel-test-advice-insert-line-sends-home
     evil-ghostel-test-advice-append-line-sends-end
+    evil-ghostel-test-insert-line-multiline-syncs-row
+    evil-ghostel-test-append-line-multiline-syncs-row
+    evil-ghostel-test-change-eol-syncs-cursor-to-point
     evil-ghostel-test-advice-no-op-outside-ghostel
+    evil-ghostel-test-meaningful-length-strips-trailing
     evil-ghostel-test-delete-sends-backspace-keys
-    evil-ghostel-test-delete-line-sends-ctrl-u
+    evil-ghostel-test-delete-line-same-row-uses-ctrl-u
+    evil-ghostel-test-change-line-same-row-uses-ctrl-u
+    evil-ghostel-test-delete-line-multiline-syncs-cursor
+    evil-ghostel-test-delete-line-strips-render-padding
+    evil-ghostel-test-replace-counts-match-on-trailing-space
     evil-ghostel-test-delete-char
     evil-ghostel-test-change-deletes-and-inserts
     evil-ghostel-test-replace-deletes-and-inserts
@@ -1073,7 +1546,15 @@ rather than silently dropping the keystroke."
     evil-ghostel-test-escape-toggle-prefix-set
     evil-ghostel-test-escape-toggle-prefix-invalid
     evil-ghostel-test-escape-mode-buffer-local
-    evil-ghostel-test-escape-evil-fallback-when-lookup-nil)
+    evil-ghostel-test-escape-evil-fallback-when-lookup-nil
+    evil-ghostel-test-beginning-of-line-skips-prompt
+    evil-ghostel-test-beginning-of-line-falls-through-no-prompt
+    evil-ghostel-test-shadow-cursor-tracks-cursor-to-point
+    evil-ghostel-test-shadow-cursor-tracks-delete-region
+    evil-ghostel-test-delete-word-with-trailing-space
+    evil-ghostel-test-change-partial-no-post-delete-sync
+    evil-ghostel-test-insert-entry-same-viewport-row-with-scrollback
+    evil-ghostel-test-ctrl-passthrough-invalidates-shadow)
   "Tests that require only Elisp (no native module).")
 
 (defun evil-ghostel-test-run-elisp ()


### PR DESCRIPTION
## Summary

Fixes #218 — in multi-line TUI input (pi, ipython, ptpython), `ESC k dd` deleted the wrong line. Investigation surfaced four other latent bugs in the same code paths; bundled together since the user-visible fix doesn't work without them.

- **Same-row dispatch** for line-type `dd` / `cc`: keep the readline-aware Ctrl-e/Ctrl-u shortcut for the single-line shell case (where the buffer line includes the prompt prefix); use cursor-sync + backspaces only when point is on a different viewport row from the terminal cursor (the actual #218 case).
- **Snap point on next redraw** after the Ctrl-u path so point lands at the start of the input area, not at column 0 on the prompt.
- **Scrollback-aware** `evil-ghostel--cursor-to-point` — previously off by exactly the scrollback line count.
- **Padding-aware** backspace count — TUIs that draw fixed-width input boxes write spaces past the user's input; those are not characters in the TUI's input model and shouldn't become PTY backspaces.
- **`evil-replace` count consistency** — paste and delete now both go through `evil-ghostel--meaningful-length` so trailing whitespace stripped from one side isn't re-added by the other.

## Test plan

- [x] `make test-evil` — 56/56 pass, including 7 new tests covering each fix.
- [x] Live verified shell `dd` / `cc`: input cleared via Ctrl-u, prompt preserved, point lands at start of input area.
- [x] Live verified pi `AAA\nBBB\nCCC` + ESC `kk dd`: `AAA` gone, `BBB` and `CCC` remain.
- [x] CI green on Emacs 28.2 / 29.4 / snapshot.