### PR TITLE
Set TERM via on-remote infocmp probe, not env propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- No-echo on remote shells launched from a TRAMP `default-directory`
+  (`ghostel-tramp-shell-integration nil`).  The previous fix
+  rebound `tramp-terminal-type`, which only takes effect on the
+  generic `tramp-handle-make-process` path; the ssh-method path
+  (`tramp-sh-handle-make-process`) ignores it.  In addition, when
+  the local default-toplevel `process-environment` already has
+  `TERM=xterm-ghostty` (e.g. Emacs launched from ghostty),
+  `tramp-local-environment-variable-p` strips ghostel's pushed
+  TERM as "ambient", and the remote shell inherits TERM=dumb from
+  TRAMP's connection shell — disabling readline/ZLE/fish line
+  editing.
+
+  The per-spawn `/bin/sh -c` wrapper now sets TERM itself on the
+  remote, after probing for `xterm-ghostty` terminfo via
+  `infocmp`.  Single path covers auto-integration (TERMINFO
+  pushed), manual install (system or `~/.terminfo`), and the
+  bare case (fall back to `xterm-256color` so echo works).  The
+  bogus local TERMINFO path is no longer pushed to the remote.
+  Closes [#224](https://github.com/dakra/ghostel/issues/224)
+  again.
+
+### Added
+- Manual remote-integration setups can now drop the bundled
+  `xterm-ghostty` terminfo at `~/.local/share/ghostel/terminfo/`
+  alongside the shell scripts (`scp -r etc/terminfo/{x,78}` from
+  the local package).  TRAMP-spawned remote shells detect it and
+  prepend the directory to `TERMINFO_DIRS` automatically — no
+  `tic`, no touching `~/.terminfo`.  README "Option 2: Manual
+  setup" updated with the one-shot install recipe.
+
 ## [0.22.0] — 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -305,15 +305,26 @@ the terminal exits).  You can also enable it for specific shells only:
 
 Copy the integration scripts from ghostel's `etc/shell/` directory to
 each remote host (e.g. `~/.local/share/ghostel/`) and source them from
-your shell configuration.  From a local shell:
+your shell configuration.  Optionally co-locate the bundled
+`xterm-ghostty` terminfo there too — the wrapper that launches a
+TRAMP-spawned remote shell prepends
+`~/.local/share/ghostel/terminfo` to the terminfo search path, so
+ghostty-aware apps (Claude Code, neovim, tmux, …) get their fast
+paths without needing `tic` or `~/.terminfo` (see "Manual install
+\(no auto-machinery)" below for that alternative).  From a local
+shell:
 
 ```bash
-ssh REMOTE 'mkdir -p ~/.local/share/ghostel'
+ssh REMOTE 'mkdir -p ~/.local/share/ghostel/terminfo'
 scp "$EMACS_GHOSTEL_PATH"/etc/shell/ghostel.{bash,zsh,fish} REMOTE:.local/share/ghostel/
+scp -r "$EMACS_GHOSTEL_PATH"/etc/terminfo/{x,78} REMOTE:.local/share/ghostel/terminfo/
 ```
 
 (`$EMACS_GHOSTEL_PATH` is set inside ghostel buffers; outside, substitute
-the install path of the ghostel package.)
+the install path of the ghostel package.  The terminfo `scp` is
+optional — without it, TRAMP-spawned remote shells fall back to
+`TERM=xterm-256color`, which still has working echo and basic
+colors but no ghostty-specific fast paths.)
 
 Then add the appropriate gate to the remote shell config:
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -140,13 +140,19 @@ Also honored via `dir-locals.el' for per-project overrides.
 
 TRAMP caveats:
 - Entries with `=' are propagated to the remote shell.
-- TERM is always reset by TRAMP to `tramp-terminal-type' (see
-  `tramp-handle-make-process'); overrides in `ghostel-environment'
-  do not win remotely.  Ghostel rebinds `tramp-terminal-type' for
-  its own remote spawns (to `xterm-256color', or `xterm-ghostty'
-  when the bundled terminfo is pushed via shell integration), so
-  remote shells get a real terminal type and readline/ZLE keep
-  echoing keystrokes.
+- TERM/TERMINFO/TERM_PROGRAM/TERM_PROGRAM_VERSION/COLORTERM here
+  are ignored for remote spawns and overridden unconditionally by
+  the per-spawn `/bin/sh -c' wrapper after `infocmp'-probing the
+  remote for `xterm-ghostty' terminfo.  TRAMP's
+  `tramp-local-environment-variable-p' filter strips env entries
+  that match the local default top-level `process-environment',
+  so pushing TERM via env was unreliable; the wrapper exports
+  these from inside the remote shell instead, where the filter
+  doesn't reach.  Customize `ghostel-term' (locally, or per-host
+  via dir-locals or `connection-local-set-profile-variables') to
+  change what gets advertised; on a customized branch the wrapper
+  exports `TERM=$ghostel-term' only — no `TERM_PROGRAM*' ghostty
+  advertisement.  Every other entry in this list still propagates.
 - INSIDE_EMACS is rewritten by TRAMP via `tramp-inside-emacs',
   which appends `,tramp:VER' to whatever value is in scope.  For
   ghostel that means the remote shell sees `ghostel,tramp:VER'
@@ -3462,27 +3468,54 @@ to restore the terminfo/ directory, or customize `ghostel-term' to silence."
         (append env (list "GHOSTEL_SSH_INSTALL_TERMINFO=1"))
       env)))
 
-(defun ghostel--remote-tramp-terminal-type (extra-env)
-  "Return TERM value to bind `tramp-terminal-type' to for a remote spawn.
-TRAMP's `make-process' handler resets TERM to `tramp-terminal-type'
-\(default \"dumb\") regardless of the caller's `process-environment'.
+(defun ghostel--remote-term-preamble ()
+  "Return a `/bin/sh' snippet that sets TERM for a remote spawn wrapper.
+Designed to run *on the remote*, inside the per-spawn `/bin/sh -c'
+wrapper, so the choice happens after TRAMP env propagation.  This
+sidesteps `tramp-local-environment-variable-p', which strips
+`TERM=' entries that match the local default top-level
+`process-environment' — leaving the remote shell to inherit
+TERM=dumb from TRAMP's connection shell, and disabling
+readline/ZLE/fish line editing on the remote (issue #224).
 
-When EXTRA-ENV contains a `TERMINFO=' entry - meaning
-`ghostel--setup-remote-integration' has pushed the bundled
-xterm-ghostty terminfo to the remote - advertise `xterm-ghostty'.
-Otherwise fall back to `xterm-256color' (a universally available
-terminfo entry) when `ghostel-term' is `xterm-ghostty', or honor a
-non-default `ghostel-term' verbatim."
-  (let ((terminfo-pushed
-         (seq-some (lambda (e)
-                     (and (stringp e) (string-prefix-p "TERMINFO=" e)))
-                   extra-env)))
-    (cond
-     ((and terminfo-pushed (equal ghostel-term "xterm-ghostty"))
-      "xterm-ghostty")
-     ((equal ghostel-term "xterm-ghostty")
-      "xterm-256color")
-     (t ghostel-term))))
+When `ghostel-term' is the default \"xterm-ghostty\", the snippet:
+1. Prepends ~/.local/share/ghostel/terminfo to TERMINFO_DIRS when
+   that directory holds the bundled entry.  This lets manual
+   setups co-locate terminfo with the shell-integration scripts
+   (see README, \"Option 2: Manual setup\") in one place — no
+   `tic', no touching ~/.terminfo.
+2. Probes via `infocmp xterm-ghostty'.  The probe honors all of
+   ncurses' standard lookup paths (the prepended dir, $TERMINFO,
+   ~/.terminfo, $TERMINFO_DIRS, and the compiled defaults), so
+   it succeeds whenever the entry is reachable any way — bundled,
+   system-installed, or pushed via `ghostel-tramp-shell-integration'.
+   On success, advertise ghostty; on failure, fall back to
+   \"xterm-256color\" (universally available) so echo keeps working.
+
+When `ghostel-term' was customized to anything else, honor it
+verbatim.  `COLORTERM=truecolor' is exported unconditionally."
+  (cond
+   ((equal ghostel-term "xterm-ghostty")
+    (concat
+     ;; Pick up a co-located bundle if the user dropped one alongside
+     ;; the shell integration scripts.  Tilde expands in assignment
+     ;; context per POSIX; ${TERMINFO_DIRS:+:$TERMINFO_DIRS} preserves
+     ;; any prior search list.
+     "if [ -e ~/.local/share/ghostel/terminfo/x/xterm-ghostty ] "
+     "|| [ -e ~/.local/share/ghostel/terminfo/78/xterm-ghostty ]; "
+     "then export TERMINFO_DIRS=~/.local/share/ghostel/terminfo"
+     "${TERMINFO_DIRS:+:$TERMINFO_DIRS}; "
+     "fi; "
+     "TERM=xterm-256color; "
+     "if infocmp xterm-ghostty >/dev/null 2>&1; then "
+     "TERM=xterm-ghostty; "
+     "TERM_PROGRAM=ghostty; TERM_PROGRAM_VERSION=1.3.2; "
+     "export TERM_PROGRAM TERM_PROGRAM_VERSION; "
+     "fi; "
+     "COLORTERM=truecolor; export TERM COLORTERM; "))
+   (t
+    (concat "TERM=" (shell-quote-argument ghostel-term)
+            "; COLORTERM=truecolor; export TERM COLORTERM; "))))
 
 (defun ghostel--spawn-pty (program program-args height width stty-flags
                                    extra-env &optional remote-p)
@@ -3515,19 +3548,28 @@ matches the PTY window size, and stores the process in
   ;; the wrapper so only the target program remains.
   (let* ((shell-command
           (list "/bin/sh" "-c"
-                (concat "stty " stty-flags
-                        (format " rows %d columns %d" height width)
-                        " 2>/dev/null; "
-                        "printf '\\033[H\\033[2J'; exec "
-                        (shell-quote-argument program)
-                        (and program-args
-                             (concat " "
-                                     (mapconcat #'shell-quote-argument
-                                                program-args " "))))))
+                (concat
+                 ;; Remote spawns: pick TERM via an on-remote probe
+                 (and remote-p (ghostel--remote-term-preamble))
+                 "stty " stty-flags
+                 (format " rows %d columns %d" height width)
+                 " 2>/dev/null; "
+                 "printf '\\033[H\\033[2J'; exec "
+                 (shell-quote-argument program)
+                 (and program-args
+                      (concat " "
+                              (mapconcat #'shell-quote-argument
+                                         program-args " "))))))
          (process-environment
           (append
            ghostel-environment
-           (cons "INSIDE_EMACS=ghostel" (ghostel--terminal-env))
+           (cons "INSIDE_EMACS=ghostel"
+                 ;; The remote wrapper sets TERM/TERMINFO/COLORTERM/
+                 ;; TERM_PROGRAM* itself; keeping the local entries
+                 ;; here would also push the local TERMINFO path,
+                 ;; which is meaningless on the remote and (per
+                 ;; terminfo(5)) makes ncurses ignore system entries.
+                 (if remote-p '() (ghostel--terminal-env)))
            extra-env
            process-environment))
          ;; Large TUI redraws (Claude Code, pi on resize) can emit
@@ -3539,14 +3581,7 @@ matches the PTY window size, and stores the process in
          ;; consume a full redraw frame.  Both are captured at
          ;; `make-process' time, so they must be let-bound here.
          (process-adaptive-read-buffering nil)
-         (read-process-output-max (max read-process-output-max (* 1024 1024)))
-         ;; TRAMP's `make-process' handler resets TERM to
-         ;; `tramp-terminal-type' (defaults to "dumb") regardless of
-         ;; what we put in `process-environment'.
-         (tramp-terminal-type (if remote-p
-                                  (ghostel--remote-tramp-terminal-type
-                                   extra-env)
-                                tramp-terminal-type)))
+         (read-process-output-max (max read-process-output-max (* 1024 1024))))
     ;; Pre-spawn hook: runs while `process-environment' is dynamically
     ;; bound to the about-to-be-spawned env, so hook functions can
     ;; `setenv' to inject/override entries that the child inherits.

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -7670,88 +7670,137 @@ setting it to nil forces off."
                                         captured-env)))
                 (when (process-live-p proc) (delete-process proc))))))))))
 
-(ert-deftest ghostel-test-remote-tramp-terminal-type-helper ()
-  "`ghostel--remote-tramp-terminal-type' picks a TERM that restores echo.
-TRAMP's `make-process' handler resets TERM to `tramp-terminal-type'
-\(default \"dumb\"); leaving that unchanged disables readline/ZLE/fish
-line editing on the remote, which manifests as no visual feedback
-while typing (issue #224).  The helper must:
-- advertise `xterm-ghostty' only when bundled terminfo was pushed
-  to the remote via shell integration (TERMINFO=... in extra-env);
-- otherwise fall back to `xterm-256color' (universally available)
-  when the local TERM is `xterm-ghostty';
-- honor a user-customized non-default `ghostel-term' verbatim."
-  (let ((ghostel-term "xterm-ghostty"))
-    ;; No TERMINFO push → safe fallback.
-    (should (equal (ghostel--remote-tramp-terminal-type nil)
-                   "xterm-256color"))
-    (should (equal (ghostel--remote-tramp-terminal-type
-                    '("FOO=bar" "BAZ=qux"))
-                   "xterm-256color"))
-    ;; TERMINFO push → advertise xterm-ghostty.
-    (should (equal (ghostel--remote-tramp-terminal-type
-                    '("TERMINFO=/tmp/ghostel-XYZ"))
-                   "xterm-ghostty"))
-    (should (equal (ghostel--remote-tramp-terminal-type
-                    '("FOO=bar" "TERMINFO=/tmp/ghostel-XYZ"))
-                   "xterm-ghostty")))
-  ;; Non-default `ghostel-term' wins as-is — user opted into a
-  ;; specific TERM and we don't second-guess them.
-  (let ((ghostel-term "xterm-256color"))
-    (should (equal (ghostel--remote-tramp-terminal-type nil)
-                   "xterm-256color"))
-    (should (equal (ghostel--remote-tramp-terminal-type
-                    '("TERMINFO=/tmp/ghostel-XYZ"))
-                   "xterm-256color")))
-  (let ((ghostel-term "screen-256color"))
-    (should (equal (ghostel--remote-tramp-terminal-type nil)
-                   "screen-256color"))))
+(ert-deftest ghostel-test-remote-term-preamble ()
+  "`ghostel--remote-term-preamble' embeds an `infocmp' probe.
+The probe runs *on the remote* (inside the per-spawn wrapper), so
+TERM is decided after env propagation — sidestepping
+`tramp-local-environment-variable-p', which would otherwise strip
+`TERM=' entries that match the local default top-level
+`process-environment' and leave the remote shell to inherit
+TERM=dumb (issue #224).
 
-(ert-deftest ghostel-test-spawn-pty-rebinds-tramp-terminal-type ()
-  "`ghostel--spawn-pty' must rebind `tramp-terminal-type' when REMOTE-P.
-TRAMP's `make-process' handler reads `tramp-terminal-type' inside
-the call and uses it as the remote TERM.  Without this rebinding,
-remote spawns get TERM=dumb and the user sees no echo (issue #224).
+A single probe path covers every case: auto-integration (TERMINFO=
+already in env, points at the pushed terminfo dir),
+manually-installed (system, `~/.terminfo', or co-located with the
+shell-integration scripts under `~/.local/share/ghostel/terminfo'),
+and absent (fall back to `xterm-256color' so echo works)."
+  (let* ((ghostel-term "xterm-ghostty")
+         (preamble (ghostel--remote-term-preamble)))
+    ;; Default value for the case infocmp fails.
+    (should (string-match-p "\\bTERM=xterm-256color;" preamble))
+    ;; Probe and conditional upgrade.
+    (should (string-match-p "infocmp xterm-ghostty" preamble))
+    (should (string-match-p "\\bTERM=xterm-ghostty;" preamble))
+    (should (string-match-p "TERM_PROGRAM=ghostty;" preamble))
+    (should (string-match-p "TERM_PROGRAM_VERSION=" preamble))
+    ;; Co-located bundle gets prepended to TERMINFO_DIRS — so a
+    ;; user can `scp` the terminfo dir alongside the shell
+    ;; scripts and the probe finds it without `tic` or
+    ;; ~/.terminfo gymnastics.
+    (should (string-match-p
+             "~/\\.local/share/ghostel/terminfo/x/xterm-ghostty"
+             preamble))
+    (should (string-match-p
+             "~/\\.local/share/ghostel/terminfo/78/xterm-ghostty"
+             preamble))
+    (should (string-match-p
+             (regexp-quote
+              "TERMINFO_DIRS=~/.local/share/ghostel/terminfo")
+             preamble))
+    ;; Existing TERMINFO_DIRS must be preserved (prepend, not
+    ;; replace) so a system-configured search list still works.
+    (should (string-match-p (regexp-quote "${TERMINFO_DIRS:+:$TERMINFO_DIRS}")
+                            preamble))
+    ;; Order is load-bearing: the TERMINFO_DIRS prepend must run
+    ;; BEFORE the `infocmp' probe, otherwise ncurses won't find the
+    ;; co-located bundle and the probe falls back to xterm-256color.
+    (should (< (string-match (regexp-quote
+                              "TERMINFO_DIRS=~/.local/share/ghostel/terminfo")
+                             preamble)
+               (string-match "infocmp xterm-ghostty" preamble)))
+    ;; Always exported.
+    (should (string-match-p "COLORTERM=truecolor" preamble))
+    (should (string-match-p "export TERM COLORTERM" preamble)))
+  ;; Customized `ghostel-term' is honored verbatim — no probe, no
+  ;; ghostty advertisement, no TERMINFO_DIRS munging.
+  (let* ((ghostel-term "xterm-256color")
+         (preamble (ghostel--remote-term-preamble)))
+    (should-not (string-match-p "infocmp" preamble))
+    (should-not (string-match-p "TERM_PROGRAM=ghostty" preamble))
+    (should-not (string-match-p "TERMINFO_DIRS" preamble))
+    (should (string-match-p "TERM=xterm-256color" preamble))
+    (should (string-match-p "COLORTERM=truecolor" preamble)))
+  (let* ((ghostel-term "screen-256color")
+         (preamble (ghostel--remote-term-preamble)))
+    (should-not (string-match-p "infocmp" preamble))
+    (should (string-match-p "TERM=screen-256color" preamble))))
 
-Locally, `tramp-terminal-type' must be left alone — there's no
-TRAMP layer in the path."
-  (require 'tramp)
-  (let ((seen-tramp-terminal-type nil)
-        (orig-make-process (symbol-function #'make-process)))
-    (cl-letf (((symbol-function #'make-process)
-               (lambda (&rest plist)
-                 (setq seen-tramp-terminal-type tramp-terminal-type)
-                 (apply orig-make-process plist))))
-      (with-temp-buffer
-        (setq-local ghostel--term-rows 25
-                    ghostel--term-cols 80)
-        (let ((tramp-terminal-type "dumb")
-              (ghostel-term "xterm-ghostty")
-              (ghostel-kill-buffer-on-exit nil))
-          ;; Remote spawn without pushed TERMINFO → xterm-256color.
-          (setq seen-tramp-terminal-type nil)
-          (let ((proc (ghostel--spawn-pty
-                       "/bin/sh" nil 25 80 "-ixon" nil t)))
-            (unwind-protect
-                (should (equal seen-tramp-terminal-type
-                               "xterm-256color"))
-              (when (process-live-p proc) (delete-process proc))))
-          ;; Remote spawn with pushed TERMINFO → xterm-ghostty.
-          (setq seen-tramp-terminal-type nil)
-          (let ((proc (ghostel--spawn-pty
-                       "/bin/sh" nil 25 80 "-ixon"
-                       '("TERMINFO=/tmp/ghostel-XYZ") t)))
-            (unwind-protect
-                (should (equal seen-tramp-terminal-type
-                               "xterm-ghostty"))
-              (when (process-live-p proc) (delete-process proc))))
-          ;; Local spawn → leave the binding alone.
-          (setq seen-tramp-terminal-type nil)
-          (let ((proc (ghostel--spawn-pty
-                       "/bin/sh" nil 25 80 "-ixon" nil nil)))
-            (unwind-protect
-                (should (equal seen-tramp-terminal-type "dumb"))
-              (when (process-live-p proc) (delete-process proc)))))))))
+(ert-deftest ghostel-test-spawn-pty-uses-remote-term-preamble ()
+  "`ghostel--spawn-pty' embeds the remote preamble in the wrapper script.
+The preamble runs on the remote, so TERM is set after TRAMP's
+env propagation — sidestepping `tramp-local-environment-variable-p'
+which would otherwise strip `TERM=' entries that match the local
+default toplevel and leave the remote shell with TERM=dumb (#224).
+
+Local spawns must not get the preamble; their TERM still rides in
+`process-environment' via `ghostel--terminal-env'."
+  ;; First cl-letf of `make-process' in a fresh Emacs would trigger
+  ;; native-comp of a subr trampoline; disable to keep the test
+  ;; portable across machines without a working gccjit toolchain.
+  (let ((native-comp-enable-subr-trampolines nil))
+    (with-temp-buffer
+      (setq-local ghostel--term-rows 25 ghostel--term-cols 80
+                  ;; The wrapped `make-process' below still calls the
+                  ;; real one via apply; needs a directory it can chdir
+                  ;; into.  /tmp is the safe default already used by
+                  ;; sibling tests.
+                  default-directory "/tmp/")
+      (let ((ghostel-term "xterm-ghostty")
+            (ghostel-kill-buffer-on-exit nil)
+            (orig-make-process (symbol-function #'make-process)))
+        ;; Remote spawn → preamble in wrapper, TERM/TERMINFO not
+        ;; added by ghostel.  Use a clean `process-environment' so
+        ;; the assertion is about ghostel's contribution, not the
+        ;; test runner's ambient env.
+        (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+               (captured-env nil)
+               (captured-cmd nil))
+          (cl-letf (((symbol-function #'make-process)
+                     (lambda (&rest plist)
+                       (setq captured-env process-environment)
+                       (setq captured-cmd (plist-get plist :command))
+                       (apply orig-make-process plist))))
+            (let ((proc (ghostel--spawn-pty
+                         "/bin/sh" nil 25 80 "-ixon" nil t)))
+              (unwind-protect
+                  (let ((script (nth 2 captured-cmd)))
+                    (should (string-match-p "infocmp xterm-ghostty" script))
+                    (should (string-match-p "export TERM COLORTERM" script))
+                    ;; Ghostel must not push the local TERMINFO path —
+                    ;; it points at a dir the remote can't read and
+                    ;; (per terminfo(5)) suppresses system lookups.
+                    (should-not (seq-some
+                                 (lambda (s) (string-prefix-p "TERMINFO=" s))
+                                 captured-env))
+                    ;; TERM also stays out of env — wrapper handles it.
+                    (should-not (member "TERM=xterm-ghostty" captured-env)))
+                (when (process-live-p proc) (delete-process proc))))))
+        ;; Local spawn → no preamble, env-driven TERM.
+        (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+               (captured-env nil)
+               (captured-cmd nil))
+          (cl-letf (((symbol-function #'make-process)
+                     (lambda (&rest plist)
+                       (setq captured-env process-environment)
+                       (setq captured-cmd (plist-get plist :command))
+                       (apply orig-make-process plist))))
+            (let ((proc (ghostel--spawn-pty
+                         "/bin/sh" nil 25 80 "-ixon" nil nil)))
+              (unwind-protect
+                  (let ((script (nth 2 captured-cmd)))
+                    (should-not (string-match-p "infocmp" script))
+                    (should (member "TERM=xterm-ghostty" captured-env)))
+                (when (process-live-p proc) (delete-process proc))))))))))
 
 (ert-deftest ghostel-test-tramp-inside-emacs-preserves-ghostel-prefix ()
   "TRAMP rewrites INSIDE_EMACS but must preserve the user-set prefix.
@@ -9031,8 +9080,8 @@ slip past the unit tests."
     ghostel-test-get-shell-local
     ghostel-test-fish-auto-inject-loads-integration
     ghostel-test-tramp-inside-emacs-preserves-ghostel-prefix
-    ghostel-test-remote-tramp-terminal-type-helper
-    ghostel-test-spawn-pty-rebinds-tramp-terminal-type
+    ghostel-test-remote-term-preamble
+    ghostel-test-spawn-pty-uses-remote-term-preamble
     ghostel-test-resize-window-adjust
     ghostel-test-resize-nil-size
     ghostel-test-resize-noop-same-dims


### PR DESCRIPTION
## Summary

Fixes #224 (again). The previous fix (6a6101a) rebound `tramp-terminal-type`, but that variable is only consulted by `tramp-handle-make-process` (the generic handler). The ssh-method path most users hit (`tramp-sh-handle-make-process`) ignores it entirely. Plus, when the local default-toplevel `process-environment` already had `TERM=xterm-ghostty` (e.g. Emacs launched from ghostty), `tramp-local-environment-variable-p` stripped ghostel's pushed TERM as "ambient" — and the remote shell inherited `TERM=dumb` from TRAMP's connection shell, disabling readline/ZLE/fish line editing.

The new approach moves the TERM decision into the per-spawn `/bin/sh -c` wrapper so the *remote* shell decides after env propagation:

- Probe via `infocmp xterm-ghostty`. On hit, advertise ghostty (`TERM`/`TERM_PROGRAM`/`TERM_PROGRAM_VERSION`); on miss, fall back to `xterm-256color` so echo works.
- When `~/.local/share/ghostel/terminfo` holds the bundled entry, prepend it to `TERMINFO_DIRS` *before* the probe — manual setups can co-locate terminfo with the shell scripts (no `tic`, no `~/.terminfo`).
- The local on-disk TERMINFO path is no longer pushed to the remote (it pointed at a directory the remote couldn't read and per terminfo(5) was suppressing system lookups).
- `tramp-terminal-type` let-binding from 6a6101a is removed.

README "Option 2: Manual setup" updated with the one-shot install recipe (shell scripts + co-located terminfo in one mkdir + scp burst).

## Test plan

- [x] `make -j4 all` green (219/219 elisp, 47/47 native, lint, build)
- [x] Wrapper-script POSIX portability (dash, bash, zsh, ksh)
- [x] TRAMP-quoting roundtrip verified — backslash-escaped tildes survive the connection-shell strip step, inner `/bin/sh -c` sees literal `~/...` and expands correctly
- [x] Convention-path detection verified end-to-end via `HOME` override + `tramp-shell-quote-argument` simulation
- [x] New `ghostel-test-remote-term-preamble` and `ghostel-test-spawn-pty-uses-remote-term-preamble` cover the wrapper shape, the env-doesn't-leak-TERM-or-TERMINFO contract, and the load-bearing order (TERMINFO_DIRS prepend BEFORE the `infocmp` probe)
- [x] Live verification on a real TRAMP `/ssh:` session (manual, since TRAMP isn't covered by the automated test suite)

## Behavioral matrix

| Setup | Before | After |
|---|---|---|
| No integration, nothing on remote | TERM=dumb → no echo | TERM=xterm-256color → echo works |
| `ghostel-tramp-shell-integration t` | works | unchanged (TERMINFO env reaches the probe) |
| Manual install via `~/.terminfo` | broken (bogus local TERMINFO suppressed lookup) | works (probe finds it) |
| Manual install via co-located `~/.local/share/ghostel/terminfo` | n/a | works (newly supported) |