### PR TITLE
Match ghostty's OSC 133 marker layout for bash/zsh/fish

### DIFF
--- a/etc/shell/ghostel.bash
+++ b/etc/shell/ghostel.bash
@@ -21,24 +21,41 @@ builtin command stty echo 2>/dev/null
 
 # Report working directory to the terminal via OSC 7
 __ghostel_osc7() {
-    printf '\e]7;file://%s%s\e\\' "$HOSTNAME" "$PWD"
+    printf '\e]7;file://%s%s\a' "$HOSTNAME" "$PWD"
 }
 
 # --- Semantic prompt markers (OSC 133) ---
+#
+# Marker layout mirrors ghostty's bash integration:
+#   - 133;A emitted via printf at end of PROMPT_COMMAND (once per
+#     cycle, with redraw=last;cl=line;aid=$BASHPID).
+#   - PS1 wrapped with 133;P;k=i (initial-prompt) at start and 133;B
+#     (input boundary) at end.
+#   - PS1 newlines (the bash `\n' escape) get 133;P;k=s injected.
+#   - PS2 wrapped with 133;P;k=s at start and 133;B at end.
+#
+# Why not embed 133;A inline in PS1?  133;A has fresh-line behavior
+# (CR+LF when cursor is not at column 0).  bash readline redraws PS1
+# on every keystroke that changes display state — embedding 133;A
+# would CR+LF on every redraw, eating the prompt.  133;P is the
+# side-effect-free equivalent.
+#
+# `\[ \]' mark the OSC sequence as zero-width for readline's line-wrap
+# math; `\a' is BEL — used everywhere here because `${var//pat/repl}'
+# eats backslashes in the replacement, which would break ST (`\e\\').
 
 # Emit "command finished" (D) for the previous command.
 # D is skipped on the very first prompt (no previous command).
 __ghostel_prompt_start() {
     if [[ -n "$__ghostel_prompt_shown" ]]; then
-        printf '\e]133;D;%s\e\\' "$__ghostel_last_status"
+        printf '\e]133;D;%s\a' "$__ghostel_last_status"
     fi
     __ghostel_prompt_shown=1
 }
 
 # Emit "command output start" (C) via the DEBUG trap, and restore the
 # unmarked PS1/PS2 so the user's command (and any other DEBUG-trap
-# observers) doesn't see our markers.  Mirror of the restore-on-precmd
-# logic in `__ghostel_wrapped_prompt_command'.
+# observers) doesn't see our markers.
 # Guard: skip when running inside PROMPT_COMMAND itself.
 __ghostel_in_prompt_command=0
 __ghostel_preexec() {
@@ -47,36 +64,16 @@ __ghostel_preexec() {
         PS1=$__ghostel_saved_ps1
         PS2=$__ghostel_saved_ps2
     fi
-    printf '\e]133;C\e\\'
+    printf '\e]133;C\a'
 }
 
-# Wrap PS1/PS2 with 133;A at the start and 133;B at the end.  We inject
-# 133;A after every line break in PS1 too: bash 5.x readline redraws
-# only the last visual line of the prompt (CR + reprint, no preceding
-# 133;A).  Without a 133;A on every line, the redrawn cells fall outside
-# the PROMPT scope and become INPUT-tagged.  We inject after both
-# literal newlines and the bash `\n' PS1 escape.
-#
-# `\[ \]' mark the OSC sequence as zero-width for readline's line-wrap
-# math; `\a' is BEL — a valid OSC terminator.  We use BEL rather than
-# ST (ESC \) because `${var//pat/repl}' eats backslashes in the
-# replacement, which would break a multi-line ST-terminated marker.
-#
-# Re-wrap from PROMPT_COMMAND each cycle: `.bashrc' or a prompt theme
+# Wrap PS1/PS2 with the inline markers and emit 133;A separately.
+# Re-wrap each PROMPT_COMMAND cycle: a prompt theme or `.bashrc'
 # loaded after this file commonly reassigns PS1, stripping our wrap.
-# Each cycle:
-#   1. Restore the unmarked PS1/PS2 if nobody touched them since our
-#      last wrap — keeps user PROMPT_COMMAND additions and themes that
-#      pattern-match $PS1 from seeing markers.
-#   2. Run the user's captured PROMPT_COMMAND (may rewrite $PS1).
-#   3. Re-wrap.  Skip if PS1 already has our marker (defensive).
 __ghostel_wrapped_prompt_command() {
-    # Capture $? FIRST.  A bare assignment such as
-    # `__ghostel_in_prompt_command=1' on its own line counts as a
-    # successful command and resets $? to 0 in bash, so any later
-    # `$?' read here would always see 0 and we'd report `:exit [0]'
-    # for every command.  `local' with `=$?' evaluates `$?' before
-    # invoking the local builtin, preserving the real exit status.
+    # Capture $? FIRST.  A bare assignment counts as a successful
+    # command and resets $? to 0; `local' with `=$?' evaluates `$?'
+    # before invoking the local builtin, preserving the exit status.
     local __ghostel_status=$?
     __ghostel_in_prompt_command=1
     __ghostel_last_status=$__ghostel_status
@@ -91,21 +88,31 @@ __ghostel_wrapped_prompt_command() {
 
     eval "${__ghostel_original_prompt_command:-}"
 
-    local __ghostel_marker='\[\e]133;A\a\]'
-    if [[ "$PS1" != *"$__ghostel_marker"* ]]; then
+    local __ghostel_p_initial='\[\e]133;P;k=i\a\]'
+    if [[ "$PS1" != *"$__ghostel_p_initial"* ]]; then
         __ghostel_saved_ps1=$PS1
         __ghostel_saved_ps2=$PS2
-        local __ghostel_ps1_a='\[\e]133;A\a\]'
-        local __ghostel_ps1_b='\[\e]133;B\a\]'
-        PS1="${PS1//$'\n'/$'\n'${__ghostel_ps1_a}}"
-        PS1="${PS1//\\n/\\n${__ghostel_ps1_a}}"
-        PS1="${__ghostel_ps1_a}${PS1}${__ghostel_ps1_b}"
-        # PS2 (continuation): wrap with the same A/B markers so multi-line
-        # input still has a known prompt-prefix → input boundary.
-        PS2="${__ghostel_ps1_a}${PS2}${__ghostel_ps1_b}"
+        local __ghostel_p_secondary='\[\e]133;P;k=s\a\]'
+        local __ghostel_b='\[\e]133;B\a\]'
+        PS1="${__ghostel_p_initial}${PS1}${__ghostel_b}"
+        # Inject 133;P;k=s after the bash `\n' PS1 escape so each
+        # continuation row of a multiline prompt is tagged.  Skip
+        # literal newlines ($'\n') — they may live inside $(...)
+        # command substitutions where escape sequences would break
+        # syntax.
+        if [[ "$PS1" == *"\n"* ]]; then
+            PS1="${PS1//\\n/\\n${__ghostel_p_secondary}}"
+        fi
+        # PS2 (continuation): k=s + B.
+        PS2="${__ghostel_p_secondary}${PS2}${__ghostel_b}"
         __ghostel_marked_ps1=$PS1
         __ghostel_marked_ps2=$PS2
     fi
+
+    # Emit 133;A once per cycle (with cl=line for click-events and
+    # redraw=last so libghostty knows the prompt-redraw boundary).
+    # `aid=$BASHPID' tags this prompt with the current shell PID.
+    printf '\e]133;A;redraw=last;cl=line;aid=%s\a' "$BASHPID"
 
     __ghostel_in_prompt_command=0
 }

--- a/etc/shell/ghostel.fish
+++ b/etc/shell/ghostel.fish
@@ -16,61 +16,63 @@ functions -q __ghostel_osc7; and return
 
 # Report working directory to the terminal via OSC 7
 function __ghostel_osc7 --on-event fish_prompt
-    printf '\e]7;file://%s%s\e\\' (hostname) "$PWD"
+    printf '\e]7;file://%s%s\a' (hostname) "$PWD"
 end
 
 # --- Semantic prompt markers (OSC 133) ---
+#
+# Mirrors ghostty's fish integration:
+#   - 133;A on `fish_prompt' (start of prompt).
+#   - 133;C on `fish_preexec' (start of command output).
+#   - 133;D on `fish_postexec' (end of command).
+#
+# Note: ghostty does NOT emit 133;B in fish — fish has no "after
+# fish_prompt" event, and ghostty does without it.  Cells from 133;A
+# to 133;C carry the `prompt' semantic state in libghostty, which the
+# link-skip logic treats the same as `input' for skip purposes.
 
-set -g __ghostel_prompt_shown 0
-
-function __ghostel_postexec --on-event fish_postexec
-    set -g __ghostel_last_status $status
+# Detect fish version for the 133;A `click_events' parameter (fish
+# 4.1+ supports it).
+set -l __ghostel_fish_major 0
+set -l __ghostel_fish_minor 0
+if set -q version[1]
+    set -l __ghostel_v (string match -r '(\d+)\.(\d+)' -- $version[1])
+    if set -q __ghostel_v[2]; and test -n "$__ghostel_v[2]"
+        set __ghostel_fish_major "$__ghostel_v[2]"
+    end
+    if set -q __ghostel_v[3]; and test -n "$__ghostel_v[3]"
+        set __ghostel_fish_minor "$__ghostel_v[3]"
+    end
+end
+set -g __ghostel_prompt_start_mark "\e]133;A\a"
+if test "$__ghostel_fish_major" -gt 4; or test "$__ghostel_fish_major" -eq 4 -a "$__ghostel_fish_minor" -ge 1
+    set -g __ghostel_prompt_start_mark "\e]133;A;click_events=1\a"
 end
 
+set -g __ghostel_prompt_state ""
+
 # Emit "command finished" (D) for the previous command, then "prompt
-# start" (A) for the new prompt.  Both fire from a fish_prompt event
-# handler so they're independent of the fish_prompt function body —
-# survives mid-session `function fish_prompt' redefinitions that would
-# otherwise drop our wrap.
-function __ghostel_prompt_start --on-event fish_prompt
-    if test "$__ghostel_prompt_shown" = 1
-        printf '\e]133;D;%s\e\\' "$__ghostel_last_status"
+# start" (A) for the new prompt.
+function __ghostel_mark_prompt_start --on-event fish_prompt --on-event fish_posterror
+    # If we never got the fish_postexec event (e.g. fish_posterror
+    # without postexec), close the prior section now.
+    if test "$__ghostel_prompt_state" != "prompt-start"
+        printf '\e]133;D\a'
     end
-    set -g __ghostel_prompt_shown 1
-    printf '\e]133;A\e\\'
+    set -g __ghostel_prompt_state prompt-start
+    printf "$__ghostel_prompt_start_mark"
 end
 
 # Emit "command output start" (C) before command runs.
-function __ghostel_preexec --on-event fish_preexec
-    printf '\e]133;C\e\\'
+function __ghostel_mark_output_start --on-event fish_preexec
+    set -g __ghostel_prompt_state pre-exec
+    printf '\e]133;C\a'
 end
 
-# Wrap fish_prompt to emit 133;B (input boundary) at the end of every
-# prompt render.  Fish has no "after fish_prompt" event, so we wrap the
-# function itself.
-#
-# Deferred to fire-time via `--on-event fish_prompt' so themes/plugins
-# loaded after ghostel.fish (later in config.fish or in conf.d/) have
-# already defined fish_prompt before we wrap it.  Re-checks each fire
-# and re-wraps if our wrap was removed (e.g. user redefined fish_prompt
-# mid-session).  One-prompt warmup is the trade-off: if a theme's own
-# `--on-event fish_prompt' handler runs after ours and redefines
-# fish_prompt, this fire is unwrapped but the next is wrapped.
-function __ghostel_ensure_fish_prompt_wrap --on-event fish_prompt
-    functions -q fish_prompt; or return
-    # Skip if already wrapped — detect via a sentinel comment in the
-    # wrapped body.  Cheaper and more robust than comparing function
-    # bodies, since fish preserves comments in `functions <name>' output.
-    if functions fish_prompt | string match -q '*__ghostel_wrapped*'
-        return
-    end
-    functions -e __ghostel_orig_fish_prompt 2>/dev/null
-    functions -c fish_prompt __ghostel_orig_fish_prompt
-    function fish_prompt
-        # __ghostel_wrapped — sentinel for the idempotency check above.
-        __ghostel_orig_fish_prompt
-        printf '\e]133;B\e\\'
-    end
+# Emit "command finished" (D) with exit status after command runs.
+function __ghostel_mark_output_end --on-event fish_postexec
+    set -g __ghostel_prompt_state post-exec
+    printf '\e]133;D;%s\a' $status
 end
 
 # Outbound `ssh' wrapper.  See etc/ghostel.bash for the full design

--- a/etc/shell/ghostel.zsh
+++ b/etc/shell/ghostel.zsh
@@ -20,97 +20,133 @@
 # Report working directory to the terminal via OSC 7
 __ghostel_osc7() {
     builtin emulate -L zsh -o no_warn_create_global -o no_aliases
-    builtin printf '\e]7;file://%s%s\e\\' "$HOST" "$PWD"
+    builtin printf '\e]7;file://%s%s\a' "$HOST" "$PWD"
 }
 
 # --- Semantic prompt markers (OSC 133) ---
+#
+# Marker layout mirrors ghostty's zsh integration:
+#   - mark1 = `%{\e]133;A;cl=line\a%}'  — primary prompt start
+#   - mark2 = `%{\e]133;P;k=s\a%}'      — continuation (multi-line, PS2)
+#   - markB = `%{\e]133;B\a%}'          — input boundary
+# `%{...%}' marks the OSC sequence as zero-width to zsh's prompt
+# expansion.  BEL terminates the OSC.
 
-# Capture $? from the just-finished command.  Must run before any other
-# precmd that resets $?, hence prepended at the head of `precmd_functions'.
 __ghostel_save_status() {
-    # Capture $? FIRST: `emulate -L' below resets it to 0.
-    # `$status' is a read-only zsh special parameter (synonym for $?), so
-    # use a different name for the local copy.
     builtin local cmd_status=$?
     builtin emulate -L zsh -o no_warn_create_global -o no_aliases
     __ghostel_last_status=$cmd_status
 }
 
-# Emit "command finished" (D) for the previous command.
-# 133;A and 133;B are embedded in PROMPT itself (see `__ghostel_ensure_prompt_wrap'
-# below) so they fire in lockstep with prompt rendering, including
-# readline-style redraws — emitting them from precmd here would only
-# fire once and leave any subsequent redraw outside the PROMPT scope.
+# Emit "command finished" (D) for the previous command.  Marks A/B/P
+# are embedded in PROMPT itself by `__ghostel_ensure_prompt_wrap' so
+# they fire in lockstep with prompt rendering (including
+# `zle reset-prompt', SIGWINCH, etc).
 __ghostel_prompt_start() {
     builtin emulate -L zsh -o no_warn_create_global -o no_aliases
     if [[ -n "$__ghostel_prompt_shown" ]]; then
-        builtin printf '\e]133;D;%s\e\\' "$__ghostel_last_status"
+        builtin printf '\e]133;D;%s\a' "$__ghostel_last_status"
     fi
     __ghostel_prompt_shown=1
 }
 
-# Restore the unmarked PROMPT (mirror of the restore-on-precmd logic in
-# `__ghostel_ensure_prompt_wrap') and emit "command output start" (C).
-# Restoring before later preexec hooks run keeps themes that pattern-match
-# `$PROMPT' (e.g. Pure) from seeing our OSC sequences.
+# Restore the unmarked PROMPT/PROMPT2 if nothing else has modified them
+# since our precmd added marks.  This ensures other preexec hooks see
+# a clean PROMPT without our marks; if PROMPT was modified (e.g. by an
+# async theme update), leave it alone.  Then emit "command output
+# start" (C).
 __ghostel_preexec() {
     builtin emulate -L zsh -o no_warn_create_global -o no_aliases
     if [[ -n ${__ghostel_marked_prompt+x} && "$PROMPT" == "$__ghostel_marked_prompt" ]]; then
         PROMPT=$__ghostel_saved_prompt
+        PROMPT2=$__ghostel_saved_prompt2
     fi
-    builtin printf '\e]133;C\e\\'
+    builtin printf '\e]133;C\a'
 }
 
-# Wrap PROMPT with 133;A at the start and 133;B at the end so they fire
-# in lockstep with prompt rendering, including any redraws. %{ %} mark
-# the OSC sequence as zero-width for line-wrap. $'...' is ANSI-C quoting:
-# \e is ESC, \\ is a single backslash — so \e\\ is ESC \ (ST).
-#
-# Re-wrap from precmd: a `.zshrc' or prompt theme loaded after this file
-# (oh-my-zsh, powerlevel10k, starship, prompt_*) commonly reassigns
-# PROMPT and strips our wrap.  Each cycle:
-#   1. If $PROMPT matches our last marked snapshot, nobody touched it —
-#      restore to the saved unmarked version before re-marking.  Avoids
-#      exposing markers to other hooks (themes like Pure pattern-match
-#      $PROMPT to strip/rebuild and break if they see our markers).
-#   2. Otherwise treat $PROMPT as a new clean baseline (theme rebuild,
-#      async update).  Skip wrapping if it already contains our marker
-#      (defensive: theme copied a marked PROMPT somewhere).
-#   3. Reposition to the end of `precmd_functions' so we run after any
-#      precmd added later (themes that rebuild PROMPT each prompt, e.g.
-#      p10k's `_p9k_precmd').  One-prompt warmup is the trade-off.
+# Wrap PROMPT/PROMPT2 with semantic prompt markers.  Mirrors ghostty's
+# `_ghostty_precmd' wrap logic: only wrap when we're already last in
+# `precmd_functions' (so our marks aren't immediately overwritten by a
+# later hook).  Otherwise self-reorder for next cycle and emit mark1
+# directly via printf as a one-shot fallback.
 __ghostel_ensure_prompt_wrap() {
     builtin emulate -L zsh -o no_warn_create_global -o no_aliases
-    if [[ -n ${__ghostel_marked_prompt+x} && "$PROMPT" == "$__ghostel_marked_prompt" ]]; then
-        PROMPT=$__ghostel_saved_prompt
-    fi
-    if [[ "$PROMPT" != *$'%{\e]133;A'* ]]; then
-        __ghostel_saved_prompt=$PROMPT
-        # If $PROMPT ends with an unpaired `%', appending our `%{...%}'
-        # markers turns the user's `%' + our `%{' into a single `%{'
-        # prompt escape, swallowing the marker.  Double the trailing `%'
-        # to make it a literal percent.
-        [[ $PROMPT == *[^%]% || $PROMPT == % ]] && PROMPT=$PROMPT%
-        PROMPT=$'%{\e]133;A\e\\%}'"$PROMPT"$'%{\e]133;B\e\\%}'
-        __ghostel_marked_prompt=$PROMPT
-    fi
-    if [[ ${precmd_functions[-1]} != __ghostel_ensure_prompt_wrap ]]; then
-        precmd_functions=(${precmd_functions:#__ghostel_ensure_prompt_wrap})
-        precmd_functions+=(__ghostel_ensure_prompt_wrap)
+
+    builtin local mark1=$'%{\e]133;A;cl=line\a%}'
+    if [[ -o prompt_percent ]]; then
+        builtin typeset -g precmd_functions
+        if [[ ${precmd_functions[-1]} == __ghostel_ensure_prompt_wrap ]]; then
+            # Restore PROMPT/PROMPT2 to their pre-mark state if nothing
+            # else has modified them since we last added marks.  Avoids
+            # exposing PROMPT with our marks to other hooks (themes
+            # like Pure pattern-match $PROMPT to strip/rebuild and
+            # break if they see our markers).  If PROMPT was modified
+            # (theme, async update), keep the modified version.
+            builtin local ps1_changed=0
+            if [[ -n ${__ghostel_saved_prompt+x} ]]; then
+                if [[ $PROMPT == $__ghostel_marked_prompt ]]; then
+                    PROMPT=$__ghostel_saved_prompt
+                    PROMPT2=$__ghostel_saved_prompt2
+                elif [[ $PROMPT != $__ghostel_saved_prompt ]]; then
+                    ps1_changed=1
+                fi
+            fi
+
+            # Save the clean PROMPT/PROMPT2 before adding marks.
+            __ghostel_saved_prompt=$PROMPT
+            __ghostel_saved_prompt2=$PROMPT2
+
+            builtin local mark2=$'%{\e]133;P;k=s\a%}'
+            builtin local markB=$'%{\e]133;B\a%}'
+
+            # Trailing bare `%' would combine with `{' in markB to form
+            # a `%{' prompt escape and swallow the marker.  Double it.
+            [[ $PROMPT == *[^%]% || $PROMPT == % ]] && PROMPT=$PROMPT%
+            PROMPT=${mark1}${PROMPT}${markB}
+
+            # Multiline prompt: inject mark2 (k=s) after each newline so
+            # libghostty distinguishes primary vs continuation rows.
+            # Skip if PROMPT changed in this cycle — injecting marks
+            # into newlines breaks pattern matching in themes that
+            # strip/rebuild the prompt (e.g. Pure).
+            if (( ! ps1_changed )) && [[ $PROMPT == *$'\n'* ]]; then
+                PROMPT=${PROMPT//$'\n'/$'\n'${mark2}}
+            fi
+
+            [[ $PROMPT2 == *[^%]% || $PROMPT2 == % ]] && PROMPT2=$PROMPT2%
+            PROMPT2=${mark2}${PROMPT2}${markB}
+
+            __ghostel_marked_prompt=$PROMPT
+        else
+            # Not last in precmd_functions — a later hook will overwrite
+            # PROMPT after we wrap it.  Move ourselves to the end for
+            # next cycle, and emit mark1 once via printf so the upcoming
+            # prompt is still tagged.  `$mark1[3,-3]' strips the leading
+            # `%{' and trailing `%}' to print just the OSC bytes.
+            precmd_functions=(${precmd_functions:#__ghostel_ensure_prompt_wrap} __ghostel_ensure_prompt_wrap)
+            if ! builtin zle; then
+                builtin printf '%s' $mark1[3,-3]
+            fi
+        fi
+    elif ! builtin zle; then
+        # Without prompt_percent we cannot patch PROMPT.  Emit mark1
+        # directly when not invoked from zle.
+        builtin printf '%s' $mark1[3,-3]
     fi
 }
 
-# ZLE line-init fallback: if $PROMPT lost its markers between precmd and
-# this redraw (e.g. an async theme update via `zle -F' reassigned
-# $PROMPT then triggered `zle reset-prompt' without re-firing precmd),
-# emit 133;A + 133;B directly so libghostty still tags the input span —
-# the link-skip logic in the renderer relies on `ghostel-input' cells.
-# Side-effect: this can create duplicate `ghostel--prompt-positions'
-# entries during heavy async updates; navigation steps may be no-ops on
-# those cycles.  Acceptable trade-off vs. the link-skip false positive.
+# ZLE line-init fallback: emit prompt markers directly if PROMPT lost
+# them between precmd and this redraw (e.g. another plugin regenerated
+# PROMPT after our precmd ran).  Use 133;P, NOT 133;A: the fallback
+# fires from `zle-line-init' AFTER the prompt has been drawn, so the
+# cursor is past column 0 — libghostty CR+LFs on 133;A when cursor !=
+# col 0, pushing the input cursor onto a blank line below the prompt
+# char.  133;P is the side-effect-free prompt-start marker.  Also
+# emit 133;B to mark the input area.
 __ghostel_zle_line_init_hook() {
+    builtin emulate -L zsh -o no_warn_create_global -o no_aliases
     [[ "$PROMPT" != *$'%{\e]133;A'* ]] && \
-        printf '\e]133;A\e\\\e]133;B\e\\'
+        builtin printf '\e]133;P;k=i\a\e]133;B\a'
 }
 
 # One-shot installer: registered as a precmd, runs once on the first

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2608,14 +2608,16 @@ Two distinct artifacts both surface here:
 
 (defun ghostel--osc133-marker (type param)
   "Handle an OSC 133 semantic prompt marker from the Zig module.
-TYPE is a single character string: A, B, C, or D.
+TYPE is a single character string: A, B, C, D, or P.
 PARAM is the exit status string for type D, or nil.
 Note: the `ghostel-prompt' text property is applied by the native
 render loop (which queries libghostty's per-row semantic state),
 not here.  This handler only tracks prompt positions and exit status."
   (pcase type
-    ("A"
-     ;; Prompt start — record line number.
+    ((or "A" "P")
+     ;; Prompt start — record line number.  P is the explicit
+     ;; prompt-start marker (no fresh-line side effect); both mark
+     ;; a navigable prompt position.
      (push (cons (count-lines (point-min) (point-max)) nil)
            ghostel--prompt-positions))
     ("C"

--- a/src/module.zig
+++ b/src/module.zig
@@ -370,11 +370,14 @@ fn dispatchPostWriteOscs(env: emacs.Env, term: *Terminal, data: []const u8) void
                     env.makeString(b64),
                 );
             },
-            // OSC 133: semantic prompt markers (A/B/C/D).
+            // OSC 133: semantic prompt markers (A/B/C/D/P).  P is
+            // "explicit prompt start" — same as A for navigation but
+            // without libghostty's fresh-line side effect, used by the
+            // zsh `zle-line-init' fallback when PROMPT-wrap was lost.
             133 => {
                 if (osc.payload.len == 0) continue;
                 const marker_type = osc.payload[0];
-                if (marker_type != 'A' and marker_type != 'B' and marker_type != 'C' and marker_type != 'D') continue;
+                if (marker_type != 'A' and marker_type != 'B' and marker_type != 'C' and marker_type != 'D' and marker_type != 'P') continue;
                 const has_param = osc.payload.len > 1 and osc.payload[1] == ';';
                 const param_data = if (has_param) osc.payload[2..] else &[_]u8{};
                 const type_str: [1]u8 = .{marker_type};

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -3129,7 +3129,20 @@ native URI lookup when Emacs invokes it for tooltip display or clicking."
       (setq markers nil)
       (ghostel--write-input term "hello\e]133;A\e\\world\e]133;B\e\\")
       (should (assoc "A" markers))                         ; 133;A in mixed stream
-      (should (assoc "B" markers)))))                      ; 133;B in mixed stream
+      (should (assoc "B" markers))                         ; 133;B in mixed stream
+
+      ;; 133;P (explicit prompt start, no fresh-line side effect) — used
+      ;; by the zsh `zle-line-init' fallback and forwarded to elisp the
+      ;; same way as A so prompt navigation keeps working when the
+      ;; PROMPT-wrap was clobbered by a theme.
+      (setq markers nil)
+      (ghostel--write-input term "\e]133;P\e\\")
+      (should (assoc "P" markers))                         ; 133;P bare detected
+      (setq markers nil)
+      (ghostel--write-input term "\e]133;P;k=i\e\\")
+      (let ((p-entry (assoc "P" markers)))
+        (should p-entry)                                   ; 133;P with k=i detected
+        (should (equal "k=i" (cdr p-entry)))))))           ; param payload preserved
 
 ;; -----------------------------------------------------------------------
 ;; Test: OSC 133 prompt text properties
@@ -3196,6 +3209,205 @@ scanner skips them."
               (should (null (get-text-property
                              (point-min) 'ghostel-input))))))
       (kill-buffer buf))))
+
+;; -----------------------------------------------------------------------
+;; Test: zsh `zle-line-init' fallback uses 133;P (no fresh-line)
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-zsh-line-init-fallback-no-fresh-line ()
+  "Use 133;P (not 133;A) in the `zle-line-init' fallback emit.
+When ghostel's PROMPT-wrap is bypassed (e.g. a theme like
+powerlevel10k overrides PROMPT after our precmd), the
+`zle-line-init' fallback in `etc/shell/ghostel.zsh' fires
+post-prompt-draw to emit OSC 133 markers directly.  It must use
+133;P, NOT 133;A — libghostty's fresh-line behavior on 133;A would
+CR+LF the cursor onto a blank row below the prompt char (#230).
+
+The test sources ghostel.zsh in a real zsh subprocess, removes the
+PROMPT-wrap function from `precmd_functions' to simulate the wrap
+being overwritten, sets a multi-line PROMPT, and verifies the
+cursor lands at the end of the prompt char rather than one row
+below it."
+  (skip-unless (executable-find "zsh"))
+  (let* ((root (or (ghostel--resource-root)
+                   (file-name-directory (locate-library "ghostel"))))
+         (shell-zsh (expand-file-name "etc/shell/ghostel.zsh" root)))
+    (skip-unless (file-exists-p shell-zsh))
+    (let ((buf (generate-new-buffer " *ghostel-test-line-init-fallback*")))
+      (unwind-protect
+          (with-current-buffer buf
+            (ghostel-mode)
+            (setq ghostel--term (ghostel--new 8 80 200))
+            (let* ((process-environment
+                    (append (list "TERM=xterm-ghostty"
+                                  "INSIDE_EMACS=ghostel"
+                                  "COLUMNS=80" "LINES=8")
+                            process-environment))
+                   (proc (make-process
+                          :name "ghostel-test-line-init-fallback"
+                          :buffer buf
+                          :command '("/bin/zsh" "-fi")
+                          :connection-type 'pty
+                          :filter #'ghostel--filter)))
+              (setq ghostel--process proc)
+              (set-process-coding-system proc 'binary 'binary)
+              (set-process-window-size proc 8 80)
+              (set-process-query-on-exit-flag proc nil)
+              (unwind-protect
+                  (progn
+                    ;; Wait for the initial default prompt to land.
+                    (ghostel-test--wait-for
+                     proc (lambda () ghostel--pending-output) 10)
+                    ;; Source ghostel.zsh (registers precmd hooks + the
+                    ;; zle-line-init widget).  Then strip the wrap function
+                    ;; from `precmd_functions' so PROMPT is left untouched
+                    ;; — this exercises the fallback path the same way
+                    ;; powerlevel10k's `_p9k_precmd' override does in the
+                    ;; wild.  Set a multi-line PROMPT so the regression is
+                    ;; visible: cursor must land beside `final-> ', not on
+                    ;; the row below it.
+                    (process-send-string
+                     proc
+                     (concat
+                      "source " shell-zsh "\n"
+                      "precmd_functions=(${precmd_functions:#__ghostel_ensure_prompt_wrap})\n"
+                      "PROMPT=$'top-line\\nfinal-> '\n"
+                      "\n"))
+                    ;; Wait for the multi-line prompt to render.
+                    (ghostel-test--wait-for
+                     proc
+                     (lambda ()
+                       (cl-some (lambda (s) (string-match-p "final-> " s))
+                                ghostel--pending-output))
+                     15)
+                    ;; Give zle a beat to enter line-init and emit the OSC.
+                    (sleep-for 0.2)
+                    (ghostel--flush-pending-output)
+                    (let ((inhibit-read-only t))
+                      (ghostel--redraw ghostel--term t))
+                    (let* ((pos (ghostel--cursor-position ghostel--term))
+                           (col (car pos))
+                           (row (cdr pos)))
+                      ;; Cursor sits right after `final-> ' (8 chars).
+                      (should (= 8 col))
+                      ;; ...and on the same row as `final-> ', not below it.
+                      (save-excursion
+                        (goto-char (point-min))
+                        (forward-line row)
+                        (should
+                         (string-prefix-p
+                          "final-> "
+                          (buffer-substring-no-properties
+                           (line-beginning-position)
+                           (line-end-position)))))))
+                (delete-process proc))))
+        (kill-buffer buf)))))
+
+;; -----------------------------------------------------------------------
+;; Test: prompt cells get tagged even when a theme overrides PROMPT
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-zsh-prompt-cells-tagged-with-self-reorder-theme ()
+  "Tag prompt cells when a self-reordering theme overrides PROMPT.
+Prompt themes that re-assert their position at the END of
+`precmd_functions' on every run (powerlevel10k's `_p9k_precmd',
+and similar) win the snapshot-iteration race and overwrite PROMPT
+after `__ghostel_ensure_prompt_wrap' has wrapped it.  Net: rendered
+PROMPT lacks our inline markers each cycle.
+
+Mirroring ghostty's zsh integration, when our wrap detects it isn't
+last in `precmd_functions' it self-reorders for next cycle AND
+emits 133;A via `printf' once per cycle as a fallback.  That printf
+fires BEFORE the theme overwrites PROMPT and BEFORE zsh draws it,
+so libghostty's cursor enters `.prompt' state before any prompt
+cell is written — and prompt cells get `ghostel-prompt' tagged even
+though our PROMPT wrap didn't stick.
+
+This test registers a fake-p10k precmd that self-reorders to end
+and overrides PROMPT each cycle, runs a few prompt cycles, and
+checks that the most recent prompt's `top-line' row carries the
+`ghostel-prompt' text property."
+  (skip-unless (executable-find "zsh"))
+  (let* ((root (or (ghostel--resource-root)
+                   (file-name-directory (locate-library "ghostel"))))
+         (shell-zsh (expand-file-name "etc/shell/ghostel.zsh" root)))
+    (skip-unless (file-exists-p shell-zsh))
+    (let ((buf (generate-new-buffer " *ghostel-test-rearrange*")))
+      (unwind-protect
+          (with-current-buffer buf
+            (ghostel-mode)
+            (setq ghostel--term (ghostel--new 8 80 200))
+            (let* ((process-environment
+                    (append (list "TERM=xterm-ghostty"
+                                  "INSIDE_EMACS=ghostel"
+                                  "COLUMNS=80" "LINES=8")
+                            process-environment))
+                   (proc (make-process
+                          :name "ghostel-test-rearrange"
+                          :buffer buf
+                          :command '("/bin/zsh" "-fi")
+                          :connection-type 'pty
+                          :filter #'ghostel--filter)))
+              (setq ghostel--process proc)
+              (set-process-coding-system proc 'binary 'binary)
+              (set-process-window-size proc 8 80)
+              (set-process-query-on-exit-flag proc nil)
+              (unwind-protect
+                  (progn
+                    (ghostel-test--wait-for
+                     proc (lambda () ghostel--pending-output) 10)
+                    ;; Source ghostel.zsh + register a fake p10k that
+                    ;; both overrides PROMPT AND self-reorders to end
+                    ;; each cycle (this is what `_p9k_precmd' does).
+                    ;; Then trigger several cycles and probe PROMPT.
+                    (process-send-string
+                     proc
+                     (concat
+                      "source " shell-zsh "\n"
+                      "fake_theme() {\n"
+                      "  PROMPT=$'top-line\\nfinal-> '\n"
+                      "  precmd_functions=(${precmd_functions:#fake_theme})\n"
+                      "  precmd_functions+=(fake_theme)\n"
+                      "}\n"
+                      "precmd_functions+=(fake_theme)\n"
+                      ;; Trigger several prompt cycles so the rearrange
+                      ;; settles.  Cycle 1 has the bug; cycle 2+ should
+                      ;; have the wrap inline in PROMPT.
+                      "true\n"
+                      "true\n"
+                      "true\n"
+                      ;; Print a sentinel after the last prompt cycle
+                      ;; so the test can find a stable anchor in the
+                      ;; rendered buffer to look back from.
+                      "print -r -- 'PROBE_DONE'\n"))
+                    (ghostel-test--wait-for
+                     proc
+                     (lambda ()
+                       (cl-some (lambda (s)
+                                  (string-match-p "PROBE_DONE" s))
+                                ghostel--pending-output))
+                     15)
+                    (sleep-for 0.2)
+                    (ghostel--flush-pending-output)
+                    (let ((inhibit-read-only t))
+                      (ghostel--redraw ghostel--term t))
+                    ;; After the rearrange settles, the WRAP fires INLINE
+                    ;; with PROMPT expansion (cycle 2+) — so 133;A fires
+                    ;; before the prompt content is drawn.  libghostty
+                    ;; sets `.prompt' semantic on subsequent cells, and
+                    ;; the renderer maps that to `ghostel-prompt' text
+                    ;; property.  The most recent prompt's `top-line'
+                    ;; row must carry that property.
+                    ;;
+                    ;; Without the rearrange the fallback fires AFTER
+                    ;; the prompt is drawn, so prompt cells are written
+                    ;; before the marker — they DON'T get tagged.
+                    (save-excursion
+                      (goto-char (point-max))
+                      (should (search-backward "top-line" nil t))
+                      (should (get-text-property (point) 'ghostel-prompt))))
+                (delete-process proc))))
+        (kill-buffer buf)))))
 
 (ert-deftest ghostel-test-osc133-prompt-stops-at-input ()
   "`ghostel-prompt' must end where `ghostel-input' begins on the row.


### PR DESCRIPTION
## Summary

- Closes #230. Cursor was landing on a blank row below the prompt char under powerlevel10k's multi-line prompt because the `zle-line-init` fallback emitted raw 133;A from a context where the cursor had already moved past column 0 — and libghostty CR+LFs on 133;A in that state ("fresh-line" behavior). Ghostty's own integration uses 133;P (no fresh-line) for that exact reason.
- Realigns all three shells to match ghostty's marker emission. Most other ghostel-specific code (OSC 51 elisp eval, SSH terminfo wrapper) is untouched.

## Per-shell changes

**zsh** (`etc/shell/ghostel.zsh`)
- `mark1=$'%{\\e]133;A;cl=line\\a%}'`, `mark2=$'%{\\e]133;P;k=s\\a%}'` (multi-line + PS2), `markB=$'%{\\e]133;B\\a%}'` — all BEL-terminated.
- Wrap PROMPT2; inject mark2 after each newline in PROMPT.
- `[[ -o prompt_percent ]]` guard.
- Conditional wrap: only patch PROMPT when last in `precmd_functions`; otherwise self-reorder + `printf` mark1 once as fallback.
- `zle-line-init` fallback emits `133;P;k=i\a 133;B\a`.

**bash** (`etc/shell/ghostel.bash`)
- Inline marker in PS1 is now `133;P;k=i` (was 133;A). Readline redraws PS1 on every keystroke; embedding 133;A would fresh-line on every redraw.
- Newline injection: `133;P;k=s`. PS2 wrap: `133;P;k=s` + `133;B`.
- Emit `133;A;redraw=last;cl=line;aid=$BASHPID` once per cycle via `printf` at end of `__ghostel_wrapped_prompt_command` — fresh-line fires only at prompt-cycle start.

**fish** (`etc/shell/ghostel.fish`)
- Drop the `fish_prompt` wrap. Ghostty does not emit 133;B in fish (no "after fish_prompt" event); cells from 133;A→133;C are tagged `.prompt` in libghostty which is equivalent to `.input` for the link-skip logic.
- `__ghostel_mark_prompt_start` (on fish_prompt + fish_posterror), `__ghostel_mark_output_start` (on fish_preexec), `__ghostel_mark_output_end` (on fish_postexec).
- Detect fish 4.1+ for `click_events=1` parameter on 133;A.

**zig + elisp**
- `src/module.zig` OSC 133 dispatcher accepts `P` alongside A/B/C/D.
- `ghostel--osc133-marker` treats `P` the same as `A` for `ghostel--prompt-positions`.

OSC terminator switched to BEL (`\a`) everywhere — was ESC `\` on the zsh side. Both are valid; ghostty uses BEL consistently.

## Test plan
- [x] `make -j4 all test-evil` (220 elisp + 50 evil + zig + lint) — all green.
- [x] `make test-native` (117 native, including 2 new e2e zsh tests) — all green.
- [x] New `ghostel-test-zsh-line-init-fallback-no-fresh-line` spawns zsh, forces the fallback path, asserts cursor lands at col 8 (beside `final-> `) instead of col 0 of the next row. Verified to fail without the fix.
- [x] New `ghostel-test-zsh-prompt-cells-tagged-with-self-reorder-theme` spawns zsh, registers a self-reordering fake-theme that overrides PROMPT each cycle (mimicking `_p9k_precmd`), asserts `top-line` row carries `ghostel-prompt`.
- [ ] **Live verification on a real powerlevel10k session** — needs to be done by you; I don't have that setup locally. Should confirm cursor lands beside `❯ ` instead of below it.