### PR TITLE
Re-assert stty echo for remote spawns to fix #224

### DIFF
--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -423,11 +423,13 @@ same as in any compilation buffer."
             (compilation--update-in-progress-mode-line))
           (ghostel-compile--finalize buffer exit (current-time)))))))
 
-(defconst ghostel-compile--stty-flags "erase '^?' iutf8 -ixon -echo"
+(defconst ghostel-compile--stty-flags
+  (concat ghostel--default-stty " -echo")
   "`stty' flags for the compile PTY.
-Matches `ghostel--spawn-pty's flags for non-shell programs, with
-`echo' off so we don't render an echoed copy of the command (which
-users already see in the header).")
+Layers `-echo' on top of `ghostel--default-stty' so we don't render
+an echoed copy of the command (which users already see in the
+header).  `sane' in the baseline turns echo on; the trailing
+`-echo' overrides it.")
 
 (defun ghostel-compile--spawn (command buffer height width)
   "Spawn COMMAND in BUFFER via a PTY sized HEIGHT rows by WIDTH columns.

--- a/lisp/ghostel-debug.el
+++ b/lisp/ghostel-debug.el
@@ -56,16 +56,23 @@ Populated by `ghostel-debug-ghostel'.  A plist with:
   :command          — the ((\"/bin/sh\" \"-c\" \"<wrapper>\")) list
                       that was passed to `make-process'
   :process-environment — copy taken just before `make-process'
-  :filter-bytes     — first `:filter-cap' bytes of PTY output
-  :filter-cap       — soft cap (bytes) for :filter-bytes
-  :filter-truncated — non-nil if more PTY output arrived after the cap
-  :send-keys        — first `:send-cap' (TIMESTAMP . STRING) sends
+  :filter-events    — list of (TIMESTAMP . CHUNK) PTY-output events,
+                      chronological, capped at `:filter-cap' total bytes
+  :filter-cap       — soft cap (total bytes) for :filter-events
+  :filter-bytes     — running total of bytes appended to :filter-events
+  :filter-truncated — non-nil once cap reached and chunks dropped
+  :send-keys        — list of (TIMESTAMP . STRING) sends, capped at `:send-cap'
   :send-cap         — soft cap (count) for :send-keys
   :send-truncated   — non-nil if more sends arrived after the cap
-Read by `ghostel-debug-info'.")
+Read by `ghostel-debug-info'.  Filter events and sends share a
+single chronological timeline in the report so `sent X, received
+no echo for Ns' is visible at a glance.")
 
-(defconst ghostel-debug--filter-cap 4096
-  "Soft cap (bytes) on `ghostel-debug--spawn-capture' :filter-bytes.")
+(defconst ghostel-debug--filter-cap (* 16 1024)
+  "Soft cap (total bytes) on `ghostel-debug--spawn-capture' :filter-events.
+Sized to comfortably cover an initial prompt plus a handful of
+input/echo round-trips so post-spawn behavior (not just the prompt)
+is visible in the timeline.")
 
 (defconst ghostel-debug--send-cap 64
   "Soft cap (entries) on `ghostel-debug--spawn-capture' :send-keys.")
@@ -850,31 +857,16 @@ and the report should still render usefully on those Emacsen."
                          (length (tramp-compute-multi-hops vec)))
                      (error nil)))))
     (insert (format "Multi-hop length:    %s\n" (or hops "(unknown)"))))
-  ;; The TERM-stripping diagnostic that drove the second #224 fix.
-  ;; If `(getenv "TERM")' equals an entry in the default-toplevel
-  ;; `process-environment', `tramp-local-environment-variable-p'
-  ;; treats it as ambient and strips ghostel's push, leaving the
-  ;; remote shell with `tramp-terminal-type' (= "dumb" by default).
-  (let* ((cur-term (getenv "TERM"))
-         (top-env (default-toplevel-value 'process-environment))
-         (top-term-entry (cl-find-if
-                          (lambda (e)
-                            (and (stringp e)
-                                 (string-prefix-p "TERM=" e)))
-                          top-env))
-         (top-term (and top-term-entry
-                        (substring top-term-entry 5)))
-         (would-strip (and cur-term top-term
-                           (string= cur-term top-term))))
-    (insert (format "TERM (current):      %s\n"
-                    (or cur-term "(unset)")))
-    (insert (format "TERM (toplevel):     %s\n"
-                    (or top-term "(unset)")))
-    (insert (format "TRAMP would strip pushed TERM: %s\n"
-                    (cond (would-strip
-                           "YES — current matches toplevel; ghostel's push\n                                would be filtered as ambient")
-                          ((null cur-term) "n/a (TERM unset)")
-                          (t "no"))))))
+  ;; TERM in the *connection shell* — what TRAMP exports for
+  ;; `process-file' calls and (without our preamble) what the
+  ;; spawned shell would inherit.  Ghostel's spawned shell does
+  ;; NOT see this directly: the on-remote `/bin/sh -c' preamble
+  ;; in `ghostel--remote-term-preamble' overrides TERM via
+  ;; `infocmp xterm-ghostty' before exec'ing the shell.  See the
+  ;; Spawn capture's wrapper command for the actual TERM the
+  ;; spawned shell ends up with.
+  (insert (format "TERM (connection shell): %s\n"
+                  (or (getenv "TERM") "(unset)"))))
 
 (defun ghostel-debug--insert-spawn-capture (cap)
   "Render the spawn capture plist CAP into the current buffer.
@@ -943,43 +935,64 @@ delta is what ghostel + TRAMP actually contributed."
         (insert "  Missing vs current (current has these, spawn didn't):\n")
         (dolist (e (sort (copy-sequence removed) #'string<))
           (insert (format "    - %s\n" e)))))))
-  ;; First N bytes of PTY output.  Did bash even start?  Send a
-  ;; prompt?  Echo back garbage?  This is the second-most useful
-  ;; signal after the wrapper script.
-  (let ((bytes (plist-get cap :filter-bytes))
-        (cap-size (plist-get cap :filter-cap))
-        (truncated (plist-get cap :filter-truncated)))
-    (insert (format "\nFirst PTY output (cap=%d bytes, %d captured%s):\n"
-                    cap-size (length bytes)
-                    (if truncated ", more arrived (truncated)" "")))
+  ;; Unified RECV/SEND timeline.  Interleaving PTY output and
+  ;; keystrokes by timestamp makes echo gaps obvious — a SEND "l"
+  ;; followed only by another SEND (no RECV "l" between) is the
+  ;; #224 signature.  Keeping them as separate sections (the previous
+  ;; layout) hid that pattern.
+  (ghostel-debug--insert-spawn-timeline cap))
+
+(defun ghostel-debug--insert-spawn-timeline (cap)
+  "Render CAP's interleaved RECV/SEND timeline into the current buffer.
+CAP is the spawn-capture plist (see `ghostel-debug--spawn-capture').
+Long chunks are truncated for display; the full bytes remain in
+the plist."
+  (let* ((t0 (plist-get cap :time))
+         (recv-cap (plist-get cap :filter-cap))
+         (recv-bytes (plist-get cap :filter-bytes))
+         (recv-events (plist-get cap :filter-events))
+         (recv-truncated (plist-get cap :filter-truncated))
+         (send-cap (plist-get cap :send-cap))
+         (sends (plist-get cap :send-keys))
+         (send-truncated (plist-get cap :send-truncated))
+         (events
+          (sort (append
+                 (mapcar (lambda (e)
+                           (list (car e) :recv (cdr e)))
+                         recv-events)
+                 (mapcar (lambda (s)
+                           (list (car s) :send (cdr s))) sends))
+                (lambda (a b) (time-less-p (car a) (car b))))))
+    (insert (format
+             "\nTimeline (RECV cap=%d bytes/%d captured%s; SEND cap=%d/%d captured%s):\n"
+             recv-cap (or recv-bytes 0)
+             (if recv-truncated ", more dropped" "")
+             send-cap (length sends)
+             (if send-truncated ", more dropped" "")))
     (cond
-     ((zerop (length bytes))
-      (insert "  (nothing — shell never wrote to its PTY)\n"))
+     ((null events)
+      (insert "  (no PTY output, no sends — shell never wrote and Emacs never typed)\n"))
      (t
       (let ((print-escape-control-characters t)
-            (print-escape-newlines t))
-        (insert (format "  %s\n" (prin1-to-string bytes)))))))
-  ;; First N keystrokes.  Confirms whether anything left Emacs at all.
-  (let ((keys (plist-get cap :send-keys))
-        (cap-size (plist-get cap :send-cap))
-        (truncated (plist-get cap :send-truncated))
-        (t0 (plist-get cap :time)))
-    (insert (format "\nFirst sends (cap=%d, %d captured%s):\n"
-                    cap-size (length keys)
-                    (if truncated ", more sent (truncated)" "")))
-    (cond
-     ((null keys)
-      (insert "  (no `ghostel--send-string' calls during capture)\n"))
-     (t
-      (let ((print-escape-control-characters t)
-            (print-escape-newlines t))
-        (cl-loop for (ts . s) in keys
-                 for i from 1
-                 do (insert
-                     (format "  %2d. +%6.3fs  %s\n"
-                             i
-                             (float-time (time-subtract ts t0))
-                             (prin1-to-string s)))))))))
+            (print-escape-newlines t)
+            (display-cap 240))
+        (dolist (ev events)
+          (let* ((ts (nth 0 ev))
+                 (kind (nth 1 ev))
+                 (data (nth 2 ev))
+                 (label (if (eq kind :send) "SEND" "RECV"))
+                 (truncated (> (length data) display-cap))
+                 (shown (if truncated
+                            (substring data 0 display-cap)
+                          data)))
+            (insert (format "  +%7.3fs  %s  %s%s\n"
+                            (float-time (time-subtract ts t0))
+                            label
+                            (prin1-to-string shown)
+                            (if truncated
+                                (format " (… +%d bytes)"
+                                        (- (length data) display-cap))
+                              ""))))))))))
 
 (defun ghostel-debug--insert-remote-probes (ghostel-buf)
   "Run live probes against the remote of GHOSTEL-BUF and insert results.
@@ -1124,8 +1137,9 @@ into `ghostel-debug--spawn-capture'.  Self-removing — fires at most once."
                   :process-environment spawn-env
                   :command (and (processp proc)
                                 (process-command proc))
-                  :filter-bytes ""
+                  :filter-events nil
                   :filter-cap ghostel-debug--filter-cap
+                  :filter-bytes 0
                   :filter-truncated nil
                   :send-keys nil
                   :send-cap ghostel-debug--send-cap
@@ -1140,15 +1154,18 @@ into `ghostel-debug--spawn-capture'.  Self-removing — fires at most once."
       proc)))
 
 (defun ghostel-debug--capture-filter (proc output)
-  "Append OUTPUT to the capture's :filter-bytes for PROC's buffer.
-Bounded by `:filter-cap'; sets `:filter-truncated' once exceeded."
+  "Append OUTPUT to the capture's :filter-events for PROC's buffer.
+Each call appends a (TIMESTAMP . CHUNK) event so the post-mortem
+report can interleave PTY output with sends on a single timeline.
+Bounded by `:filter-cap' total bytes; sets `:filter-truncated' once
+the cap is hit and further chunks are dropped."
   (when (and (stringp output)
              (buffer-live-p (process-buffer proc)))
     (with-current-buffer (process-buffer proc)
       (when ghostel-debug--spawn-capture
         (let* ((cap (plist-get ghostel-debug--spawn-capture :filter-cap))
-               (cur (plist-get ghostel-debug--spawn-capture :filter-bytes))
-               (room (- cap (length cur))))
+               (total (plist-get ghostel-debug--spawn-capture :filter-bytes))
+               (room (- cap total)))
           (cond
            ((<= room 0)
             (unless (plist-get ghostel-debug--spawn-capture
@@ -1158,10 +1175,16 @@ Bounded by `:filter-cap'; sets `:filter-truncated' once exceeded."
                                :filter-truncated t))))
            (t
             (let* ((take (min room (length output)))
-                   (fits (substring output 0 take)))
+                   (fits (substring output 0 take))
+                   (events (plist-get ghostel-debug--spawn-capture
+                                      :filter-events)))
+              (setq ghostel-debug--spawn-capture
+                    (plist-put ghostel-debug--spawn-capture :filter-events
+                               (append events
+                                       (list (cons (current-time) fits)))))
               (setq ghostel-debug--spawn-capture
                     (plist-put ghostel-debug--spawn-capture :filter-bytes
-                               (concat cur fits)))
+                               (+ total take)))
               (when (> (length output) take)
                 (setq ghostel-debug--spawn-capture
                       (plist-put ghostel-debug--spawn-capture

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3304,6 +3304,23 @@ caller sees one combined :env / :temp-dirs / :temp-files."
           (setq out (plist-put out key (append b e))))))
     out))
 
+(defconst ghostel--default-stty "-nl sane iutf8 -ixon erase '^?'"
+  "Baseline stty flags applied before exec'ing the spawned program.
+`sane' resets line discipline to known-good defaults — including
+echo, canonical mode, and signal handling - which defends against
+upstreams that leave the PTY in an unexpected state by the time the
+spawned shell starts (TRAMP env stripping, custom remote /etc/bashrc, old
+bash readline init order).  The explicit flags layer on top of `sane':
+- `iutf8': kernel UTF-8 awareness so backspace erases multi-byte
+  characters correctly.  `sane' may clear it on some implementations,
+  so set it explicitly afterwards.
+- `-ixon': disable XON/XOFF flow control so the XON/XOFF characters
+  pass through to the application instead of being swallowed by the
+  PTY line discipline.
+- `erase ^?': Emacs PTYs leave VERASE undefined, but shells like
+  fish check VERASE at startup to decide whether the DEL byte
+  means backspace.")
+
 (defun ghostel--setup-remote-integration (shell-type)
   "Set up shell integration on the remote host for SHELL-TYPE.
 Reads the local integration script, writes it (with any necessary
@@ -3345,7 +3362,7 @@ Returns nil on failure."
                                           "fi\n"
                                           integration))
              (list :env nil :args (list "--rcfile" path)
-                   :stty "erase '^?' iutf8 -ixon echo" :temp-files (list temp))))
+                   :stty ghostel--default-stty :temp-files (list temp))))
           ;; Zsh: ZDOTDIR replaces .zshenv search, so we restore it,
           ;; source the user's .zshenv, then load integration.
           ('zsh
@@ -3374,7 +3391,7 @@ Returns nil on failure."
                                           "    'builtin' 'unset' '_ghostel_file'\n"
                                           "}\n"))
              (list :env (list (format "ZDOTDIR=%s" remote-dir))
-                   :args nil :stty "erase '^?' iutf8 -ixon"
+                   :args nil :stty ghostel--default-stty
                    :temp-dirs (list temp-dir))))
           ;; Fish: -C runs after config, so just source the script.
           ('fish
@@ -3385,7 +3402,7 @@ Returns nil on failure."
              (list :env nil
                    :args (list "-C" (format "source %s"
                                             (shell-quote-argument path)))
-                   :stty "erase '^?' iutf8 -ixon" :temp-files (list temp)))))))
+                   :stty ghostel--default-stty :temp-files (list temp)))))))
         (if tinfo
             (ghostel--merge-integration-plists base tinfo)
           base))
@@ -3539,21 +3556,12 @@ Installs `ghostel--filter' and `ghostel--sentinel', sets binary I/O,
 matches the PTY window size, and stores the process in
 `ghostel--process'.  Returns the process."
   ;; Wrap the program in /bin/sh -c so we can configure the PTY
-  ;; before the program reads its terminal attributes:
-  ;;  - erase '^?': Emacs PTYs leave VERASE undefined, but
-  ;;    shells like fish check VERASE at startup to decide
-  ;;    whether \x7f means backspace.
-  ;;  - iutf8: kernel-level UTF-8 awareness so backspace
-  ;;    correctly erases multi-byte characters.
-  ;;  - -ixon: disable XON/XOFF flow control so C-q and C-s
-  ;;    pass through to the application instead of being
-  ;;    swallowed by the PTY line discipline.
-  ;;  - echo (bash-only): readline buffers its own echo, so
-  ;;    we need PTY-level echo early in startup.  Old bash
-  ;;    versions (notably macOS /bin/bash 3.2) may initialize
-  ;;    readline before ENV-sourced integration runs.
-  ;; The clear-screen hides the stty output.  exec replaces
-  ;; the wrapper so only the target program remains.
+  ;; before the program reads its terminal attributes.  See
+  ;; `ghostel--default-stty' for the default flag set and rationale;
+  ;; STTY-FLAGS is whatever the caller picked (typically that default
+  ;; or a remote-integration variant).  The clear-screen hides the
+  ;; stty output.  exec replaces the wrapper so only the target
+  ;; program remains.
   (let* ((shell-command
           (list "/bin/sh" "-c"
                 (concat
@@ -3691,12 +3699,9 @@ on the remote host."
                       ((and (eq shell-type 'bash) integration-env)
                        (list "--posix"))
                       (t nil)))
-         (stty-flags (cond
-                      (remote-integration
-                       (plist-get remote-integration :stty))
-                      ((eq shell-type 'bash)
-                       "erase '^?' iutf8 -ixon echo")
-                      (t "erase '^?' iutf8 -ixon")))
+         (stty-flags (if remote-integration
+                         (plist-get remote-integration :stty)
+                       ghostel--default-stty))
          (extra-env (append
                      (unless remote-p
                        (list (format "EMACS_GHOSTEL_PATH=%s" ghostel-dir)))
@@ -4348,7 +4353,7 @@ Signals `user-error' if BUFFER already has a live ghostel process."
         (ghostel--set-size-with-cell-dims ghostel--term height width)
         (ghostel--apply-palette ghostel--term)
         (ghostel--spawn-pty program args height width
-                            "erase '^?' iutf8 -ixon echo" nil remote-p)))))
+                            ghostel--default-stty nil remote-p)))))
 
 ;;;###autoload
 (defun ghostel-project (&optional arg)

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -8282,7 +8282,8 @@ nil so the fallback warning fires."
 (ert-deftest ghostel-test-start-process-local-bash-integration-keeps-early-echo ()
   "Local bash integration must keep `stty echo' in the wrapper.
 Old bash versions can initialize readline before the ENV-injected
-integration script runs, so input echo must be enabled before exec."
+integration script runs, so input echo must be enabled before exec.
+`sane' in `ghostel--default-stty' is what guarantees echo here."
   (let ((captured-env nil)
         (orig-make-process (symbol-function #'make-process)))
     (cl-letf (((symbol-function #'make-process)
@@ -8300,7 +8301,10 @@ integration script runs, so input echo must be enabled before exec."
           (unwind-protect
               (let ((cmd (process-command proc)))
                 (should (equal '("/bin/sh" "-c") (seq-take cmd 2)))
-                (should (string-match-p "stty .* -ixon echo\\b" (nth 2 cmd)))
+                (should (string-match-p
+                         (concat "stty " (regexp-quote ghostel--default-stty))
+                         (nth 2 cmd)))
+                (should (string-match-p "\\bsane\\b" (nth 2 cmd)))
                 (should (string-match-p "exec /bin/bash --posix" (nth 2 cmd)))
                 (should (member "GHOSTEL_BASH_INJECT=1" captured-env))
                 (should (seq-some (lambda (s) (string-prefix-p "ENV=" s))
@@ -8639,7 +8643,7 @@ while :; do sleep 0.1; done'\n")
           (should (equal (nth 1 captured) '("/etc/hosts")))
           (should (numberp (nth 2 captured)))
           (should (numberp (nth 3 captured)))
-          (should (equal (nth 4 captured) "erase '^?' iutf8 -ixon echo"))
+          (should (equal (nth 4 captured) ghostel--default-stty))
           (should (null (nth 5 captured)))
           ;; Local default-directory — no TRAMP — so remote-p must be nil.
           (should (null (nth 6 captured))))
@@ -8870,10 +8874,8 @@ silently misbehave for #224-class bugs) belong in the standard report."
                 (should (string-match-p "direct-async (effective):" content))
                 (should (string-match-p "Would dispatch direct-async:" content))
                 (should (string-match-p "Multi-hop length:" content))
-                (should (string-match-p "TERM (current):" content))
-                (should (string-match-p "TERM (toplevel):" content))
                 (should (string-match-p
-                         "TRAMP would strip pushed TERM:" content))))))
+                         "TERM (connection shell):" content))))))
       (when (get-buffer "*ghostel-debug*")
         (kill-buffer "*ghostel-debug*")))))
 
@@ -8922,30 +8924,36 @@ sections all materialize."
     (unwind-protect
         (save-window-excursion
           (ghostel-test--with-compile-buffer buf
-            (setq-local ghostel-debug--spawn-capture
-                        (list :time (current-time)
-                              :default-directory "/ssh:host.example.com:/tmp/"
-                              :remote-p t
-                              :program "/bin/bash"
-                              :program-args nil
-                              :height 24 :width 80
-                              :stty-flags "erase '^?' iutf8 -ixon"
-                              :extra-env nil
-                              :process-environment
-                              '("INSIDE_EMACS=ghostel"
-                                "TERM=xterm-ghostty"
-                                "PATH=/usr/bin")
-                              :command
-                              '("/bin/sh" "-c"
-                                "TERM=xterm-256color; if infocmp xterm-ghostty >/dev/null 2>&1; then TERM=xterm-ghostty; fi; export TERM; exec /bin/bash")
-                              :filter-bytes "\e]0;hostname\007$ "
-                              :filter-cap 4096
-                              :filter-truncated nil
-                              :send-keys
-                              (list (cons (current-time) "l")
-                                    (cons (current-time) "s"))
-                              :send-cap 64
-                              :send-truncated nil))
+            (let* ((t0 (current-time))
+                   (t1 (time-add t0 0.010))
+                   (t2 (time-add t0 0.500))
+                   (t3 (time-add t0 0.700)))
+              (setq-local ghostel-debug--spawn-capture
+                          (list :time t0
+                                :default-directory "/ssh:host.example.com:/tmp/"
+                                :remote-p t
+                                :program "/bin/bash"
+                                :program-args nil
+                                :height 24 :width 80
+                                :stty-flags ghostel--default-stty
+                                :extra-env nil
+                                :process-environment
+                                '("INSIDE_EMACS=ghostel"
+                                  "TERM=xterm-ghostty"
+                                  "PATH=/usr/bin")
+                                :command
+                                '("/bin/sh" "-c"
+                                  "TERM=xterm-256color; if infocmp xterm-ghostty >/dev/null 2>&1; then TERM=xterm-ghostty; fi; export TERM; exec /bin/bash")
+                                :filter-events
+                                (list (cons t1 "\e]0;hostname\007$ "))
+                                :filter-cap 16384
+                                :filter-bytes (length "\e]0;hostname\007$ ")
+                                :filter-truncated nil
+                                :send-keys
+                                (list (cons t2 "l")
+                                      (cons t3 "s"))
+                                :send-cap 64
+                                :send-truncated nil)))
             (ghostel-debug-info)
             (with-current-buffer "*ghostel-debug*"
               (let ((content (buffer-string)))
@@ -8961,46 +8969,59 @@ sections all materialize."
                 ;; Env delta header.
                 (should (string-match-p "process-environment at spawn"
                                         content))
-                ;; First PTY output preview.
-                (should (string-match-p "First PTY output" content))
-                ;; First sends preview.
-                (should (string-match-p "First sends" content))
-                (should (string-match-p "\"l\"" content))))))
+                ;; Unified RECV/SEND timeline.
+                (should (string-match-p "^Timeline (RECV cap=" content))
+                (should (string-match-p "RECV  \"" content))
+                (should (string-match-p "SEND  \"l\"" content))
+                (should (string-match-p "SEND  \"s\"" content))))))
       (when (get-buffer "*ghostel-debug*")
         (kill-buffer "*ghostel-debug*")))))
 
 (ert-deftest ghostel-test-debug-capture-filter-bounded ()
-  "`ghostel-debug--capture-filter' caps :filter-bytes and flags truncation.
-Keeps the first :filter-cap bytes verbatim, sets :filter-truncated once
-overflow occurs, and stops growing afterwards (so steady-state shell
-output doesn't accumulate unboundedly)."
+  "`ghostel-debug--capture-filter' records timestamped events and caps total bytes.
+Each call appends a (TS . CHUNK) event up to :filter-cap total bytes.
+Once the cap is hit, :filter-truncated is set and further chunks are
+dropped (so steady-state shell output doesn't accumulate unboundedly)."
   (ghostel-test--with-compile-buffer buf
     (setq-local ghostel-debug--spawn-capture
-                (list :filter-bytes ""
+                (list :filter-events nil
                       :filter-cap 16
+                      :filter-bytes 0
                       :filter-truncated nil))
     (let ((proc (make-pipe-process :name "ghostel-test-capture"
                                    :buffer buf :noquery t)))
       (unwind-protect
-          (progn
+          (cl-flet ((events-bytes ()
+                      (mapconcat #'cdr
+                                 (plist-get ghostel-debug--spawn-capture
+                                            :filter-events)
+                                 "")))
             (ghostel-debug--capture-filter proc "0123456789")
-            (should (equal (plist-get ghostel-debug--spawn-capture
-                                      :filter-bytes)
-                           "0123456789"))
+            (should (= 1 (length (plist-get ghostel-debug--spawn-capture
+                                            :filter-events))))
+            (should (equal (events-bytes) "0123456789"))
+            (should (= 10 (plist-get ghostel-debug--spawn-capture
+                                     :filter-bytes)))
             (should-not (plist-get ghostel-debug--spawn-capture
                                    :filter-truncated))
-            ;; This chunk overflows the 16-byte cap (10 + 10 = 20).
+            ;; This chunk overflows the 16-byte cap (10 + 10 = 20):
+            ;; the first 6 bytes fit, the rest is dropped and the
+            ;; truncated flag flips on.
             (ghostel-debug--capture-filter proc "ABCDEFGHIJ")
-            (should (equal (plist-get ghostel-debug--spawn-capture
-                                      :filter-bytes)
-                           "0123456789ABCDEF"))
+            (should (= 2 (length (plist-get ghostel-debug--spawn-capture
+                                            :filter-events))))
+            (should (equal (events-bytes) "0123456789ABCDEF"))
+            (should (= 16 (plist-get ghostel-debug--spawn-capture
+                                     :filter-bytes)))
             (should (plist-get ghostel-debug--spawn-capture
                                :filter-truncated))
-            ;; Further chunks no-op against the cap.
+            ;; Further chunks no-op against the cap — no new event,
+            ;; total bytes unchanged.
             (ghostel-debug--capture-filter proc "more")
-            (should (equal (plist-get ghostel-debug--spawn-capture
-                                      :filter-bytes)
-                           "0123456789ABCDEF")))
+            (should (= 2 (length (plist-get ghostel-debug--spawn-capture
+                                            :filter-events))))
+            (should (= 16 (plist-get ghostel-debug--spawn-capture
+                                     :filter-bytes))))
         (delete-process proc)))))
 
 (ert-deftest ghostel-test-debug-capture-send-bounded ()


### PR DESCRIPTION
## Summary

- Collapse `stty-flags` so remote spawns without `ghostel-tramp-shell-integration` also re-assert `echo`. Local bash already did this defensively; the remote-without-integration branch omitted it, leaving silent input on hosts where some upstream (TRAMP env stripping, custom remote `/etc/bashrc`, old bash readline init order) had cleared the PTY's echo bit before the spawned shell took over.
- Replace debug-info's "First PTY output" + "First sends" sections with a unified RECV/SEND timeline. `ghostel-debug--capture-filter` now records each chunk as a `(timestamp . chunk)` event, cap bumped from 4 KB to 16 KB so post-prompt activity survives. The `SEND "l"` followed by another `SEND` with no `RECV "l"` between is the #224 signature — the old layout hid it.
- Drop the misleading "TRAMP would strip pushed TERM" diagnostic; ghostel sets TERM via the on-remote `/bin/sh -c` preamble, not `process-environment`, so the strip-check no longer applies.

Refs #224.

## Test plan

- [x] `make -j4 all` — 228/228 elisp tests pass; byte-compile, checkdoc, package-lint, docquotes clean
- [x] @jvillasante retries on his ssh host (`ghostel-debug-ghostel`, type a few keys, `C-u M-x ghostel-debug-info`) and confirms input is now echoed