### PR TITLE
ghostel-compile: read-only by default, C-u for interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,11 +826,12 @@ tool gets confused by the unfamiliar `TERM`, set
 
 Commands:
 
-| Command                      | Description                                              |
-|------------------------------|----------------------------------------------------------|
-| `M-x ghostel-compile`        | Prompt for a command and run it (uses `compile-command`) |
-| `M-x ghostel-recompile`      | Re-run the last command in its original directory        |
-| `M-x ghostel-compile-global-mode` | Route *all* `compile`-style calls through ghostel (opt-in) |
+| Command                       | Description                                                                |
+|-------------------------------|----------------------------------------------------------------------------|
+| `M-x ghostel-compile`         | Run a command in a read-only ghostel buffer (uses `compile-command`)       |
+| `C-u M-x ghostel-compile`     | Prompt for the command and run it in an *interactive* (writable) buffer    |
+| `M-x ghostel-recompile`       | Re-run the last command in its original directory (preserves launch mode)  |
+| `M-x ghostel-compile-global-mode` | Route *all* `compile`-style calls through ghostel (opt-in)             |
 
 What a run looks like — the buffer text matches `M-x compile`:
 
@@ -845,6 +846,20 @@ make -j4 test
 Compilation finished at Wed Apr 15 08:30:19, duration 8.20 s
 ```
 
+By default the buffer is **read-only and navigable from the start** —
+just like a `M-x compile` buffer.  `g` reruns, `n`/`p` walk errors
+(parsed once the run finishes), `RET` jumps to the source.
+Keystrokes do *not* reach the running process, so the
+"compile-mode" UX (read coloured output, kill with `C-c C-c`) is
+available even mid-run.
+
+Pass a prefix arg (`C-u M-x ghostel-compile`, mirroring
+`C-u M-x compile`) to launch in **interactive** mode instead — the
+buffer stays writable for the duration of the run, so programs like
+`htop`, `less`, test runners that prompt for input, or anything that
+wants live keystrokes work.  `ghostel-recompile` (`g`) preserves
+whichever mode the buffer was launched in.
+
 When the command finishes, the live process and ghostel renderer are
 torn down and the buffer's major mode is switched to
 `ghostel-compile-view-mode` (derived from `compilation-mode`).  The
@@ -853,9 +868,38 @@ coloured error / line-number faces; the buffer never returns to an
 interactive ghostel terminal — a recompile discards it and starts
 fresh in the original directory.  `mode-line-process` shows
 `:run` while the command is running and `:exit [N]` afterwards, using
-the same faces `M-x compile` uses.
+the same faces `M-x compile` uses.  In an interactive run the marker
+reads `:run/i` instead of `:run` so you can see at a glance that the
+buffer accepts keystrokes.
 
-Keybindings (in `ghostel-compile-view-mode`):
+#### Live mode switching
+
+Sometimes a command turns out to need input — a `read -p`, a `git
+push` password prompt, a test runner asking `y/n`, or you'd like
+to attach to `htop` mid-run.  Two keys switch the buffer's state
+without restarting the process:
+
+| Key                   | Action                                          |
+|-----------------------|-------------------------------------------------|
+| `C-c C-j`             | Switch to interactive (writable terminal)       |
+| `C-c C-e` / `C-c C-t` | Switch back to read-only / compile-mode-style   |
+
+(`C-c C-t` mirrors `ghostel-mode`'s key for entering copy-mode —
+the read-only/navigable state in a regular ghostel terminal — so
+the same muscle memory works in compile buffers.)
+
+Both keys are bound by `ghostel-compile-toggle-mode`, a small
+buffer-local minor mode auto-enabled in compile buffers (so the
+keys don't show up in regular `M-x ghostel` terminals).  They work
+in either run state — the minor-mode keymap takes precedence, so
+your keystrokes are intercepted before they reach the PTY.
+
+Subsequent recompiles preserve whichever state you last switched
+to.  After the run finishes the keys remain bound; calling them
+on a finished buffer is a no-op with a "recompile with `g`
+instead" message.
+
+#### Keybindings (in `ghostel-compile-view-mode`, also active during a read-only run)
 
 | Key             | Action                                                  |
 |-----------------|---------------------------------------------------------|
@@ -864,6 +908,8 @@ Keybindings (in `ghostel-compile-view-mode`):
 | `RET` / `mouse-2` | Jump to the source of the error under point           |
 | `M-g n` / `M-g p` | Standard `next-error` / `previous-error`              |
 | `C-c C-c`       | `compile-goto-error` (same as RET)                      |
+| `C-c C-k`       | `kill-compilation` — interrupt the running process      |
+| `C-c C-j` / `C-c C-e` / `C-c C-t` | Switch to interactive / read-only (see above) |
 
 These standard `compile` options are honoured:
 
@@ -872,7 +918,10 @@ These standard `compile` options are honoured:
   written back, and the history list is `compile-history`, so recent
   commands round-trip between the two commands.
 - **`compilation-read-command`** — when nil, `ghostel-compile` runs
-  `compile-command` silently; pass a prefix arg to force the prompt.
+  `compile-command` silently; pass any prefix arg to force the
+  prompt.  The universal prefix (`C-u`) additionally switches the
+  buffer into interactive (writable) mode, mirroring
+  `C-u M-x compile`.
 - **`compilation-ask-about-save`** — modified buffers are offered for
   saving before launching.
 - **`compilation-auto-jump-to-first-error`** — jumps to the first error
@@ -898,10 +947,21 @@ buffer automatically.
 (ghostel-compile-global-mode 1)
 ```
 
-`grep-mode` falls through to the stock `compilation-start`
-implementation by default, because its output parsing and
-window-management conventions don't fit a live TTY.  Extend
-`ghostel-compile-global-mode-excluded-modes` to opt other modes out.
+How calls are routed:
+
+- Plain `M-x compile` (or any caller passing `MODE=nil`,
+  `compilation-mode`, or a `compilation-mode` subclass) → **read-only**
+  ghostel buffer (the compile-style default).  A subclass is
+  honoured: its error-regexp, font-lock keywords, and keymap take
+  effect when the buffer is finalized.
+- `C-u M-x compile` (i.e. `compilation-start COMMAND t`, the comint
+  variant) → **interactive** ghostel buffer instead of stock
+  `comint-mode`.  You still get a real TTY for the command, just
+  with the writable behaviour the caller asked for.
+- `grep-mode` falls through to the stock `compilation-start`
+  implementation, because its output parsing and window-management
+  conventions don't fit a live TTY.  Extend
+  `ghostel-compile-global-mode-excluded-modes` to opt other modes out.
 
 Ghostel-specific customisation:
 

--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -22,6 +22,13 @@
 ;; header, a "Compilation finished at ..., duration ..." footer, and
 ;; the same `mode-line-process' run/exit faces.
 ;;
+;; By default the buffer is read-only and behaves like a
+;; `compilation-mode' buffer from the start: `g' reruns, `n'/`p'
+;; walk errors, RET jumps to the source.  Pass a prefix arg
+;; (\\[universal-argument] \\[ghostel-compile]) to launch the buffer
+;; in interactive mode instead - keystrokes reach the running
+;; process so programs like `htop', `less', or test prompts work.
+;;
 ;; When the command finishes, the renderer is torn down and the
 ;; buffer's major mode is switched to `ghostel-compile-view-mode'
 ;; (derived from `compilation-mode').  At that point the buffer is a
@@ -29,12 +36,17 @@
 ;; and `next-error' navigation.  It will not return to an interactive
 ;; ghostel terminal — a recompile (`g', `M-x ghostel-recompile')
 ;; discards it and starts fresh in the original `default-directory'.
+;; When invoked from inside the compile buffer, recompile preserves
+;; the launch mode (read-only vs interactive); when invoked from an
+;; unrelated buffer it falls back to the global default (read-only).
 ;;
 ;; Enable `ghostel-compile-global-mode' to route *all* `compile',
 ;; `recompile', `project-compile', ... calls through ghostel.  It
 ;; advises `compilation-start' so every caller benefits without any
-;; further configuration.  `grep-mode' (and comint mode) falls through
-;; to the stock implementation.
+;; further configuration.  `compilation-start' callers asking for
+;; `MODE=t' (the comint variant — \\[universal-argument] \\[compile])
+;; are routed to a writable ghostel terminal instead of comint.
+;; `grep-mode' falls through to the stock implementation.
 ;;
 ;; Standard `compile' options honoured:
 ;;   `compile-command' / `compile-history' (shared with \\[compile])
@@ -136,6 +148,14 @@ survive into the `ghostel-compile-view-mode' buffer after finalize.
 Nil means finalize falls back to the global
 `ghostel-compile-finished-major-mode'.")
 
+(defvar-local ghostel-compile--interactive nil
+  "Non-nil if this run was launched in interactive (writable) mode.
+Nil means the buffer is read-only and navigable like
+`compilation-mode' from the start; non-nil means the buffer behaves
+like an interactive ghostel terminal during the run (keystrokes are
+forwarded to the PTY).  `ghostel-recompile' reads this flag from the
+source buffer so a recompile preserves the launch mode.")
+
 (defvar ghostel-compile-view-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map compilation-mode-map)
@@ -160,16 +180,24 @@ in another window.  `g' runs `ghostel-recompile' instead of
   "Major mode for a finished `ghostel-compile' buffer.
 
 A regular, read-only Emacs buffer.  `g' re-runs the command via
-`ghostel-recompile', `n'/`p' walk errors in the buffer (without
-opening files), RET jumps to the source.  The live process and
-ghostel rendering have been torn down; the buffer will not return
-to a ghostel terminal."
+`ghostel-recompile', `n'/`p' walk errors in the buffer (without opening
+files), RET jumps to the source.  The live process and ghostel rendering
+have been torn down; the buffer will not return to a ghostel terminal.
+
+`ghostel-compile-view-mode-map' is also installed as the buffer's
+local map *during* a read-only run (before the run finishes), so
+the same keys work while the command is still executing."
   :group 'ghostel-compile
   ;; Make sure our keymap actually parents `compilation-mode-map' even
   ;; if it was created earlier — `define-derived-mode' won't reset an
   ;; already-set parent.
   (set-keymap-parent ghostel-compile-view-mode-map compilation-mode-map)
   (setq-local next-error-function #'compilation-next-error-function)
+  ;; Re-enable the live toggle minor mode so `C-c C-j' / `C-c C-e'
+  ;; remain bound on the finished buffer (they error with a clean
+  ;; "No live process" message — better UX than the keys silently
+  ;; disappearing post-finalize).
+  (ghostel-compile-toggle-mode 1)
   ;; Make sure point lands at the top after a successful recompile (and
   ;; that future input doesn't inherit ghostel's terminal-style behaviour).
   (setq-local window-point-insertion-type nil)
@@ -223,10 +251,15 @@ Plain text, matching the `M-x compile' footer format."
             status-word ts (ghostel-compile--format-duration duration))))
 
 (defun ghostel-compile--set-mode-line-running ()
-  "Set `mode-line-process' to the running indicator."
-  (setq mode-line-process
-        (list '(:propertize ":run" face compilation-mode-line-run)
-              'compilation-mode-line-errors))
+  "Set `mode-line-process' to the running indicator.
+Reads `ghostel-compile--interactive' so the indicator reflects the
+*current* run state — `:run' for read-only, `:run/i' for
+interactive.  The toggle commands call this to refresh the marker
+when the user switches state mid-run."
+  (let ((label (if ghostel-compile--interactive ":run/i" ":run")))
+    (setq mode-line-process
+          (list (list :propertize label 'face 'compilation-mode-line-run)
+                'compilation-mode-line-errors)))
   (force-mode-line-update))
 
 (defun ghostel-compile--set-mode-line-exit (exit)
@@ -344,6 +377,10 @@ same as in any compilation buffer."
           (let* ((saved-command command)
                  (saved-start-time start-time)
                  (saved-directory directory)
+                 (saved-interactive ghostel-compile--interactive)
+                 (saved-compilation-arguments
+                  (and (local-variable-p 'compilation-arguments)
+                       compilation-arguments))
                  (target-mode (or ghostel-compile--view-mode-override
                                   ghostel-compile-finished-major-mode)))
             (when target-mode
@@ -352,7 +389,12 @@ same as in any compilation buffer."
                         ghostel-compile--directory saved-directory
                         ghostel-compile--start-time saved-start-time
                         ghostel-compile--last-exit exit
+                        ghostel-compile--interactive saved-interactive
                         ghostel-compile--finalized t)
+            ;; Preserve `compilation-arguments' so `revert-buffer' on
+            ;; the finished buffer still reproduces the same run.
+            (when saved-compilation-arguments
+              (setq-local compilation-arguments saved-compilation-arguments))
             ;; Pin the buffer's `default-directory' to the directory the
             ;; user invoked `ghostel-compile' from, so it doesn't drift if
             ;; the command happened to `cd' elsewhere during the run.
@@ -499,7 +541,7 @@ local machine happens to have)."
 
 ;;; Buffer management
 
-(defun ghostel-compile--prepare-buffer (name dir)
+(defun ghostel-compile--prepare-buffer (name dir &optional interactive)
   "Return the ghostel buffer named NAME, reset for a fresh run from DIR.
 If a buffer with NAME already exists, the run is prepared in place
 — the buffer is erased and the terminal rebuilt, but the buffer
@@ -512,7 +554,19 @@ before killing it, unless `compilation-always-kill' is non-nil or
 the process has its query-on-exit flag cleared.
 
 Creates the terminal directly — no interactive shell is spawned —
-so there is no remote-integration round-trip on TRAMP buffers."
+so there is no remote-integration round-trip on TRAMP buffers.
+
+When INTERACTIVE is non-nil the buffer keeps the regular
+`ghostel-mode' keymap so keystrokes reach the running process —
+the same UX a user gets from \\[universal-argument]
+\\[ghostel-compile] or from `compilation-start' under
+`ghostel-compile-global-mode' with `MODE=t'.  When INTERACTIVE is
+nil (the default) the buffer is made read-only and the local map is
+set to `ghostel-compile-view-mode-map' so it behaves like a
+`compilation-mode' buffer.  Either way the major mode stays
+`ghostel-mode' during the run so the renderer, redraw timer, and
+resize hooks
+\(all gated on `derived-mode-p \\='ghostel-mode\\=') keep working."
   (let ((existing (get-buffer name)))
     (when existing
       (with-current-buffer existing
@@ -567,6 +621,22 @@ so there is no remote-integration round-trip on TRAMP buffers."
       ;; also fired, but also made state-reset implicit; make it
       ;; explicit here so this helper doesn't have two code paths.
       (ghostel-mode)
+      ;; Wire up `next-error' so `\\[next-error]' / `M-g n' work as soon
+      ;; as errors land, including in the interactive variant.
+      (setq-local next-error-function #'compilation-next-error-function)
+
+      ;; In read-only (compile-style) mode, swap the local keymap to the
+      ;; compile-style one and lock the buffer.  Major mode stays `ghostel-mode'
+      ;; so the renderer/timer/resize hooks (which all gate on `derived-mode-p
+      ;; \\='ghostel-mode\\=') keep working; only input handling changes.
+      (unless interactive
+        (use-local-map ghostel-compile-view-mode-map)
+        (setq buffer-read-only t))
+      ;; Enable the live toggle (`C-c C-j' / `C-c C-e') in compile
+      ;; buffers, regardless of which run mode they're in.  The
+      ;; minor-mode keymap takes precedence over the major-mode map
+      ;; and the buffer-local map, so the keys work in both states.
+      (ghostel-compile-toggle-mode 1)
       (let ((inhibit-read-only t))
         (erase-buffer))
       (setq ghostel--pending-output nil)
@@ -592,7 +662,9 @@ so there is no remote-integration round-trip on TRAMP buffers."
 
 ;;; Entry points
 
-(defun ghostel-compile--start (command buffer-name dir &optional finished-mode)
+(defun ghostel-compile--start (command buffer-name dir
+                                       &optional finished-mode interactive
+                                       compilation-args)
   "Run COMMAND in BUFFER-NAME from DIR and return the buffer.
 Creates or resets the buffer, spawns COMMAND via `shell-file-name',
 and displays the buffer.  Used by both `ghostel-compile' and the
@@ -602,26 +674,47 @@ FINISHED-MODE, when non-nil, is the major mode to switch the
 buffer into after finalize (overriding
 `ghostel-compile-finished-major-mode').  The advice uses this to
 honour custom compile-mode subclasses the caller passed to
-`compilation-start'."
+`compilation-start'.
+
+INTERACTIVE, when non-nil, runs COMMAND in a writable ghostel terminal.
+
+COMPILATION-ARGS, when non-nil, is the list `(COMMAND MODE
+NAME-FUNCTION HIGHLIGHT-REGEXP)' that gets stored as
+`compilation-arguments' on the buffer so `\\[revert-buffer]' (and
+any other code that walks `compilation-arguments') re-runs via
+`compilation-start' with the original mode/name-function preserved."
   (unless (and command (not (string-blank-p command)))
     (user-error "Empty compile command"))
   (save-some-buffers (not compilation-ask-about-save)
                      compilation-save-buffers-predicate)
-  (let* ((buffer (ghostel-compile--prepare-buffer buffer-name dir))
+  (let* ((buffer (ghostel-compile--prepare-buffer buffer-name dir interactive))
          (outwin (display-buffer buffer '(nil (allow-no-window . t))))
          (start-time (current-time)))
     (with-current-buffer buffer
-      ;; During the run the buffer stays plain `ghostel-mode' so
-      ;; keystrokes reach the process for interactive programs like
-      ;; `htop', `less', or read prompts.  Compile-mode semantics
-      ;; (`g', `n'/`p', error nav) kick in at finalize when the
+      ;; The buffer's major mode stays `ghostel-mode' during the run
+      ;; (so the renderer/timer/resize hooks keep firing).  When
+      ;; INTERACTIVE is non-nil, keystrokes reach the process for
+      ;; programs like `htop', `less', or read prompts; otherwise the
+      ;; buffer is read-only with `compilation-mode'-style keys via
+      ;; `ghostel-compile-view-mode-map' (see `--prepare-buffer').
+      ;; Compile-mode error parsing kicks in at finalize when the
       ;; buffer is switched to `ghostel-compile-view-mode'.
       (setq ghostel-compile--command command
             ghostel-compile--directory dir
             ghostel-compile--start-time start-time
             ghostel-compile--last-exit nil
             ghostel-compile--finalized nil
-            ghostel-compile--view-mode-override finished-mode)
+            ghostel-compile--view-mode-override finished-mode
+            ghostel-compile--interactive interactive)
+      ;; Make `revert-buffer' (and third-party code that walks
+      ;; `compilation-arguments') restart the run via `compilation-start'.
+      ;; Direct callers don't pass a tuple — synthesize one that records
+      ;; the launch mode in the MODE slot so a revert routes through the
+      ;; advice and lands back on the same variant.
+      (setq-local compilation-arguments
+                  (or compilation-args
+                      (list command (and interactive t) nil nil)))
+      (setq-local revert-buffer-function #'compilation-revert-buffer)
       ;; `prepare-buffer' sized the VT from the selected window (no
       ;; display-buffer had happened yet).  `display-buffer' above may
       ;; have placed the buffer in a smaller window — reconcile the VT
@@ -683,7 +776,7 @@ honour custom compile-mode subclasses the caller passed to
     buffer))
 
 ;;;###autoload
-(defun ghostel-compile (command)
+(defun ghostel-compile (command &optional interactive)
   "Run COMMAND in a ghostel terminal with compilation integration.
 
 Like \\[compile], but uses a ghostel buffer so programs that require
@@ -698,6 +791,15 @@ scripts work exactly as in \\[shell-command].  No shell-integration
 setup is required — the process sentinel reports the real exit
 status.
 
+If optional second arg INTERACTIVE is non-nil the buffer is a
+writable ghostel terminal during the run.
+Otherwise (the default) the buffer is read-only and behaves like a
+`compilation-mode' buffer with `g' reruns, `n'/`p' walk errors, etc.
+
+Interactively, prompts for the command if option
+`compilation-read-command' is non-nil, otherwise uses
+`compile-command'.  With prefix arg, always prompts.
+
 Output always scrolls as it arrives (equivalent to
 `compilation-scroll-output' being non-nil).  `compilation-ask-about-save'
 and `compilation-auto-jump-to-first-error' are honoured.  The command
@@ -711,10 +813,12 @@ and `compile-history'."
                               (if (equal (car compile-history) default)
                                   '(compile-history . 1)
                                 'compile-history))
-        default))))
+        default))
+    (consp current-prefix-arg)))
   (unless (equal command (eval compile-command t))
     (setq compile-command command))
-  (ghostel-compile--start command ghostel-compile-buffer-name default-directory))
+  (ghostel-compile--start command ghostel-compile-buffer-name
+                          default-directory nil interactive))
 
 (defun ghostel-recompile (&optional edit-command)
   "Re-run the last `ghostel-compile' command in its original directory.
@@ -727,7 +831,11 @@ local `ghostel-compile--command'), re-runs into THAT buffer — the
 window showing it stays put.  This matches `M-x recompile' in a
 `*compilation*' buffer.  Otherwise falls back to
 `ghostel-compile-buffer-name', and ultimately to `compile-command'
-with the current `default-directory' when no prior run exists."
+with the current `default-directory' when no prior run exists.
+
+The launch mode (read-only vs interactive) is preserved from the
+source buffer's `ghostel-compile--interactive' flag, so a buffer
+launched with \\[universal-argument] reruns interactively."
   (interactive "P")
   (let* ((source (cond
                   ((local-variable-p 'ghostel-compile--command)
@@ -741,7 +849,10 @@ with the current `default-directory' when no prior run exists."
                   default-directory))
          (name (if (buffer-live-p source)
                    (buffer-name source)
-                 ghostel-compile-buffer-name)))
+                 ghostel-compile-buffer-name))
+         (launched-interactive (and (buffer-live-p source)
+                                    (buffer-local-value
+                                     'ghostel-compile--interactive source))))
     (unless (and cmd (not (string-blank-p cmd)))
       (user-error "No previous `ghostel-compile' command to re-run"))
     (when edit-command
@@ -752,7 +863,102 @@ with the current `default-directory' when no prior run exists."
                    'compile-history)))
       (unless (equal cmd (eval compile-command t))
         (setq compile-command cmd)))
-    (ghostel-compile--start cmd name dir)))
+    (ghostel-compile--start cmd name dir nil launched-interactive)))
+
+
+;;; Live toggle: switch between read-only (compile-style) and interactive
+
+(defun ghostel-compile--assert-live-run ()
+  "Signal a `user-error' unless the current buffer has a live compile run.
+Both toggle commands need a live process: switching is meaningful
+only while the command is still running.  Post-finalize there is
+nothing to send keystrokes to, and a non-compile buffer has no
+`ghostel-compile--command' to begin with."
+  (unless (and (derived-mode-p 'ghostel-mode)
+               (local-variable-p 'ghostel-compile--command))
+    (user-error "Not in a `ghostel-compile' buffer"))
+  (unless (and (boundp 'ghostel--process) (process-live-p ghostel--process))
+    (user-error "No live process - recompile with `g' instead")))
+
+(defun ghostel-compile-switch-to-interactive ()
+  "Switch the current `ghostel-compile' run to interactive mode.
+The buffer becomes writable and `ghostel-mode's keymap is
+restored, so keystrokes reach the running process — useful when
+the command turned out to need input (a `read -p', a `git push'
+password prompt, an `htop'-style program).  No-op if the buffer is
+already interactive.
+
+Bound to \\[ghostel-compile-switch-to-interactive] in
+`ghostel-compile-toggle-mode' (active in compile buffers)."
+  (interactive)
+  (ghostel-compile--assert-live-run)
+  (if ghostel-compile--interactive
+      (message "ghostel-compile: already interactive")
+    (setq ghostel-compile--interactive t)
+    (use-local-map ghostel-mode-map)
+    (setq buffer-read-only nil)
+    ;; Place point at the VT cursor so the user's first keystroke
+    ;; lands at the prompt, not at wherever they happened to be
+    ;; navigating in the read-only buffer.
+    (when ghostel--term
+      (let ((rc (ghostel--cursor-position ghostel--term)))
+        (goto-char (point-min))
+        (forward-line (cdr rc))
+        (move-to-column (car rc))))
+    (ghostel-compile--set-mode-line-running)
+    (when ghostel-compile-debug
+      (message "ghostel-compile: switched to interactive"))))
+
+(defun ghostel-compile-switch-to-readonly ()
+  "Switch the current `ghostel-compile' run to read-only/compile-mode-style.
+Restores `ghostel-compile-view-mode-map' as the local map and
+locks the buffer, so `g' reruns, `n'/`p' walk errors, RET jumps —
+the normal `compilation-mode' UX — even while the command keeps
+running.  Subsequent recompiles will preserve this state.  No-op
+if the buffer is already read-only.
+
+Bound to \\[ghostel-compile-switch-to-readonly] in
+`ghostel-compile-toggle-mode' (active in compile buffers)."
+  (interactive)
+  (ghostel-compile--assert-live-run)
+  (if (not ghostel-compile--interactive)
+      (message "ghostel-compile: already read-only")
+    (setq ghostel-compile--interactive nil)
+    (use-local-map ghostel-compile-view-mode-map)
+    (setq buffer-read-only t)
+    (ghostel-compile--set-mode-line-running)
+    (when ghostel-compile-debug
+      (message "ghostel-compile: switched to read-only"))))
+
+(defvar ghostel-compile-toggle-mode-map
+  (let ((m (make-sparse-keymap)))
+    (define-key m (kbd "C-c C-j") #'ghostel-compile-switch-to-interactive)
+    (define-key m (kbd "C-c C-e") #'ghostel-compile-switch-to-readonly)
+    ;; Mirror `ghostel-mode's `C-c C-t' (= enter copy-mode, the
+    ;; navigable freeze).  Compile-mode read-only state is the
+    ;; closest analogue, so binding it to the same key carries the
+    ;; muscle memory across.
+    (define-key m (kbd "C-c C-t") #'ghostel-compile-switch-to-readonly)
+    m)
+  "Keymap for `ghostel-compile-toggle-mode'.
+\\<ghostel-compile-toggle-mode-map>\\[ghostel-compile-switch-to-interactive] switches to interactive
+\(writable terminal); \\[ghostel-compile-switch-to-readonly] switches
+back to read-only/compile-mode-style.  The latter is also bound to
+the same key `ghostel-mode' uses for entering copy-mode, so muscle
+memory carries across.  The minor-mode keymap takes precedence over
+both `ghostel-mode-map' and the buffer-local
+`ghostel-compile-view-mode-map', so the keys work regardless of
+which run state the buffer is in.")
+
+(define-minor-mode ghostel-compile-toggle-mode
+  "Minor mode providing live mode-switching for `ghostel-compile' buffers.
+Auto-enabled in `ghostel-compile' buffers (both during the run and
+post-finalize).  Off elsewhere — regular `ghostel' terminals don't
+get these bindings.
+
+\\{ghostel-compile-toggle-mode-map}"
+  :lighter nil
+  :keymap ghostel-compile-toggle-mode-map)
 
 
 ;;; ghostel-compile-global-mode — opt-in: advise compilation-start
@@ -771,21 +977,42 @@ opt a specific caller out."
 Falls back to ORIG-FN (with COMMAND, MODE, NAME-FUNCTION,
 HIGHLIGHT-REGEXP, CONTINUE unchanged) when:
 
-- MODE is t — `compilation-start' asks for a comint buffer, which
-  we don't emulate.
 - MODE is in `ghostel-compile-global-mode-excluded-modes' — e.g.
   `grep-mode' by default.
 - CONTINUE is non-nil — the caller wants to append to an existing
   compilation buffer; each `ghostel-compile' run replaces its
   buffer from scratch, so we can't honour that.
 
-Otherwise routes COMMAND through `ghostel-compile--start', honouring
-NAME-FUNCTION for the buffer name and HIGHLIGHT-REGEXP for error
-highlighting."
-  (if (or (eq mode t)
-          continue
-          (memq mode ghostel-compile-global-mode-excluded-modes))
-      (funcall orig-fn command mode name-function highlight-regexp continue)
+Otherwise routes COMMAND through `ghostel-compile--start':
+
+- MODE is nil or `compilation-mode' - read-only ghostel buffer
+- MODE is t - `compilation-start's request for an interactive
+  comint buffer.  We honour the *interactive* part by spawning a
+  writable ghostel terminal (so programs that want a TTY still
+  work) instead of falling through to `comint-mode'.
+- MODE is a `compilation-mode' subclass — read-only ghostel
+  buffer; finalize switches to that subclass so its error-regexp,
+  font-lock keywords, and keymap are honoured.
+
+NAME-FUNCTION drives the buffer name and HIGHLIGHT-REGEXP the
+error highlighting in all cases."
+  (cond
+   ((or continue (memq mode ghostel-compile-global-mode-excluded-modes))
+    (funcall orig-fn command mode name-function highlight-regexp continue))
+   ((eq mode t)
+    ;; Mirror stock `compilation-start': name-of-mode is "compilation"
+    ;; when MODE is t.  Spawn a writable ghostel terminal — same UX
+    ;; the legacy `ghostel-compile' had, so callers asking for an
+    ;; interactive buffer still get one (just rendered by ghostel).
+    (let* ((buf-name (compilation-buffer-name "compilation" t name-function))
+           (buffer (ghostel-compile--start
+                    command buf-name default-directory nil t
+                    (list command mode name-function highlight-regexp))))
+      (when highlight-regexp
+        (with-current-buffer buffer
+          (setq-local compilation-highlight-regexp highlight-regexp)))
+      buffer))
+   (t
     (let* ((actual-mode (or mode 'compilation-mode))
            (name-of-mode
             (replace-regexp-in-string "-mode\\'" ""
@@ -801,13 +1028,14 @@ highlighting."
            ;; from `compilation-mode' and adds our own keybindings.
            (finished-mode (unless (eq actual-mode 'compilation-mode)
                             actual-mode))
-           (buffer (ghostel-compile--start command buf-name
-                                           default-directory
-                                           finished-mode)))
+           (buffer (ghostel-compile--start
+                    command buf-name default-directory
+                    finished-mode nil
+                    (list command mode name-function highlight-regexp))))
       (when highlight-regexp
         (with-current-buffer buffer
           (setq-local compilation-highlight-regexp highlight-regexp)))
-      buffer)))
+      buffer))))
 
 ;;;###autoload
 (define-minor-mode ghostel-compile-global-mode
@@ -818,6 +1046,18 @@ When enabled, advises `compilation-start' so that \\[compile],
 goes through `compilation-start' runs in a ghostel terminal —
 giving you a real TTY for progress bars, colours, and curses tools
 without having to switch commands.
+
+The default routing is read-only: a plain \\[compile] (or any caller
+passing `MODE=nil' / `MODE=compilation-mode') yields a read-only buffer
+that behaves like a `compilation-mode' buffer.  Callers asking for the
+comint variant \(\\[universal-argument] \\[compile], i.e. `MODE=t') are
+routed to a writable ghostel terminal - interactive throughout the run,
+so programs like `htop' or test prompts work - instead of falling
+through to `comint-mode'.  Note: this means `compilation-shell-minor-mode'
+is *not* enabled in the interactive variant - its keymap would shadow
+`ghostel-mode's input handlers and break key forwarding to the PTY.
+Custom `compilation-mode' subclasses yield a read-only buffer that
+finalizes into the subclass.
 
 Modes in `ghostel-compile-global-mode-excluded-modes' (by default,
 `grep-mode') still use the stock implementation, since their output

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -4077,7 +4077,8 @@ be what `--start' receives."
           (setq ghostel-compile--command "make"
                 ghostel-compile--directory "/some/project/")
           (cl-letf (((symbol-function 'ghostel-compile--start)
-                     (lambda (_cmd _name dir) (setq dir-at-call dir))))
+                     (lambda (_cmd _name dir &optional _fm _i)
+                       (setq dir-at-call dir))))
             ;; Recompile from a buffer whose default-directory is somewhere else.
             (let ((default-directory "/elsewhere/"))
               (ghostel-recompile))
@@ -4101,7 +4102,8 @@ displaced by a new one."
           (setq ghostel-compile--command "make"
                 ghostel-compile--directory "/proj/")
           (cl-letf (((symbol-function 'ghostel-compile--start)
-                     (lambda (_cmd name _dir) (setq name-at-call name))))
+                     (lambda (_cmd name _dir &optional _fm _i)
+                       (setq name-at-call name))))
             (ghostel-recompile))
           ;; Buffer-name of the CURRENT buffer, not `ghostel-compile-buffer-name'.
           (should (equal "*some-specific-name*" name-at-call)))
@@ -4121,7 +4123,8 @@ edited version, matching the behaviour of \\[recompile]."
           (let ((cmd-at-call nil)
                 (prompt-default nil))
             (cl-letf (((symbol-function 'ghostel-compile--start)
-                       (lambda (cmd _name _dir) (setq cmd-at-call cmd)))
+                       (lambda (cmd _name _dir &optional _fm _i)
+                         (setq cmd-at-call cmd)))
                       ((symbol-function 'read-shell-command)
                        (lambda (_prompt default &rest _)
                          (setq prompt-default default)
@@ -4133,7 +4136,8 @@ edited version, matching the behaviour of \\[recompile]."
             ;; Without the prefix: no prompt, runs the last cmd verbatim.
             (setq cmd-at-call nil prompt-default nil)
             (cl-letf (((symbol-function 'ghostel-compile--start)
-                       (lambda (cmd _name _dir) (setq cmd-at-call cmd)))
+                       (lambda (cmd _name _dir &optional _fm _i)
+                         (setq cmd-at-call cmd)))
                       ((symbol-function 'read-shell-command)
                        (lambda (&rest _) (setq prompt-default t) "never")))
               (ghostel-recompile)
@@ -4297,18 +4301,23 @@ Specifically, it must not change the selected window or mutate its
     (should-not ghostel-called)))                              ; ours did not
 
 (ert-deftest ghostel-test-compile-global-mode-routes-to-ghostel-start ()
-  "For supported modes, the advice routes COMMAND through `ghostel-compile--start'."
+  "For supported modes, the advice routes COMMAND through `ghostel-compile--start'.
+The default route — MODE nil or `compilation-mode' — must use the
+read-only variant (interactive=nil)."
   (let ((captured nil))
     (cl-letf (((symbol-function 'ghostel-compile--start)
-               (lambda (cmd name dir &optional _finished-mode)
-                 (setq captured (list cmd name dir))
+               (lambda (cmd name dir &optional _finished-mode interactive
+                            &rest _)
+                 (setq captured (list cmd name dir interactive))
                  (generate-new-buffer " *ghostel-test-advice*"))))
       (ghostel-compile--compilation-start-advice
        (lambda (&rest _) (error "Stock path should not run"))
        "make test" nil nil nil nil))
     (should (equal "make test" (nth 0 captured)))              ; command preserved
     ;; Default buffer name for `compilation-mode' is "*compilation*".
-    (should (string-match-p "compilation" (nth 1 captured)))))
+    (should (string-match-p "compilation" (nth 1 captured)))
+    ;; Read-only by default — no prefix, no MODE=t.
+    (should-not (nth 3 captured))))
 
 (ert-deftest ghostel-test-compile-global-mode-threads-subclass-mode ()
   "A custom compile-mode subclass passed as MODE is forwarded to finalize.
@@ -4318,22 +4327,28 @@ The advice must pass a non-`compilation-mode' MODE through to
 subclass (with its error-regexp, font-lock keywords, etc.) is the
 major mode the buffer ends up in after finalize — and *not*
 override with the default `ghostel-compile-view-mode'."
-  (let ((captured-finished nil))
+  (let ((captured-finished nil)
+        (captured-interactive 'unset))
     (cl-letf (((symbol-function 'ghostel-compile--start)
-               (lambda (_cmd _name _dir &optional finished-mode)
-                 (setq captured-finished finished-mode)
+               (lambda (_cmd _name _dir &optional finished-mode interactive
+                             &rest _)
+                 (setq captured-finished finished-mode
+                       captured-interactive interactive)
                  nil)))
-      ;; Custom mode → threaded through.
+      ;; Custom mode → threaded through; still read-only (interactive=nil).
       (ghostel-compile--compilation-start-advice
        (lambda (&rest _) (error "Stock path should not run"))
        "make" 'my-custom-compile-mode nil nil nil)
       (should (eq 'my-custom-compile-mode captured-finished))
+      (should-not captured-interactive)
       ;; Plain `compilation-mode' → nil (default view-mode kicks in).
-      (setq captured-finished :unchanged)
+      (setq captured-finished :unchanged
+            captured-interactive 'unset)
       (ghostel-compile--compilation-start-advice
        (lambda (&rest _) (error "Stock path should not run"))
        "make" 'compilation-mode nil nil nil)
-      (should-not captured-finished))))
+      (should-not captured-finished)
+      (should-not captured-interactive))))
 
 (ert-deftest ghostel-test-compile-global-mode-falls-through-on-continue ()
   "Non-nil CONTINUE must fall through: `--start' recreates the buffer."
@@ -4347,15 +4362,26 @@ override with the default `ghostel-compile-view-mode'."
     (should orig-called)
     (should-not ghostel-called)))
 
-(ert-deftest ghostel-test-compile-global-mode-falls-through-on-comint ()
-  "MODE=t (comint) must fall through."
-  (let ((orig-called nil))
+(ert-deftest ghostel-test-compile-global-mode-routes-mode-t-to-interactive ()
+  "MODE=t routes to a writable ghostel terminal, not stock comint.
+This is the user-facing target for `\\[universal-argument] \\[compile]':
+the caller is asking for an interactive buffer, and we honour that
+by spawning a ghostel terminal (so a real TTY is still available)
+instead of falling through to `comint-mode'."
+  (let ((captured-interactive 'unset)
+        (captured-name nil))
     (cl-letf (((symbol-function 'ghostel-compile--start)
-               (lambda (&rest _) (error "Should not run"))))
+               (lambda (_cmd name _dir &optional _fm interactive &rest _)
+                 (setq captured-interactive interactive
+                       captured-name name)
+                 (generate-new-buffer " *ghostel-test-mode-t*"))))
       (ghostel-compile--compilation-start-advice
-       (lambda (&rest _) (setq orig-called t) nil)
+       (lambda (&rest _) (error "Stock comint path should not run"))
        "make" t nil nil nil))
-    (should orig-called)))
+    (should (eq t captured-interactive))                         ; interactive variant
+    ;; Stock `compilation-start' uses "compilation" as name-of-mode for MODE=t;
+    ;; we mirror that for buffer-name parity.
+    (should (string-match-p "compilation" captured-name))))
 
 (ert-deftest ghostel-test-compile-global-mode-excluded-custom-mode ()
   "A custom mode added to `ghostel-compile-global-mode-excluded-modes' falls through."
@@ -4368,18 +4394,465 @@ override with the default `ghostel-compile-view-mode'."
        "whatever" 'my-fake-grep-mode nil nil nil))
     (should orig-called)))
 
+(ert-deftest ghostel-test-compile-interactive-form-no-prefix ()
+  "`M-x ghostel-compile' with no prefix arg → INTERACTIVE=nil (read-only run)."
+  (let ((captured-interactive 'unset)
+        (compile-command "make")
+        (compilation-read-command nil)
+        (current-prefix-arg nil))
+    (cl-letf (((symbol-function 'ghostel-compile--start)
+               (lambda (_cmd _name _dir &optional _fm interactive)
+                 (setq captured-interactive interactive)))
+              ((symbol-function 'save-some-buffers) (lambda (&rest _) nil)))
+      (call-interactively #'ghostel-compile)
+      (should-not captured-interactive))))
+
+(ert-deftest ghostel-test-compile-interactive-form-c-u ()
+  "\\[universal-argument] \\[ghostel-compile] → INTERACTIVE=t (writable terminal)."
+  (let ((captured-interactive 'unset)
+        (compile-command "make")
+        (current-prefix-arg '(4)))                               ; C-u
+    (cl-letf (((symbol-function 'ghostel-compile--start)
+               (lambda (_cmd _name _dir &optional _fm interactive)
+                 (setq captured-interactive interactive)))
+              ((symbol-function 'read-shell-command)
+               (lambda (_p default &rest _) default))           ; auto-accept
+              ((symbol-function 'save-some-buffers) (lambda (&rest _) nil)))
+      (call-interactively #'ghostel-compile)
+      (should (eq t captured-interactive)))))
+
+(ert-deftest ghostel-test-compile-interactive-form-numeric-prefix ()
+  "Numeric prefix prompts but does NOT switch to interactive mode.
+Mirrors stock \\[compile] where the `consp' check on
+`current-prefix-arg' is the gate for the interactive (comint)
+variant — a numeric prefix like `C-3' is `consp'-false."
+  (let ((captured-interactive 'unset)
+        (prompted nil)
+        (compile-command "make")
+        (current-prefix-arg 3))                                   ; numeric prefix
+    (cl-letf (((symbol-function 'ghostel-compile--start)
+               (lambda (_cmd _name _dir &optional _fm interactive)
+                 (setq captured-interactive interactive)))
+              ((symbol-function 'read-shell-command)
+               (lambda (_p default &rest _) (setq prompted t) default))
+              ((symbol-function 'save-some-buffers) (lambda (&rest _) nil)))
+      (call-interactively #'ghostel-compile)
+      (should prompted)                                           ; prompt happened
+      (should-not captured-interactive))))                        ; still read-only
+
+(ert-deftest ghostel-test-compile-recompile-preserves-interactive-mode ()
+  "`ghostel-recompile' must reuse the launch mode of the source buffer.
+A buffer launched with INTERACTIVE=t reruns interactively; one
+launched read-only reruns read-only."
+  (let ((captured-interactive 'unset)
+        (inhibit-message t))
+    (cl-letf (((symbol-function 'ghostel-compile--start)
+               (lambda (_cmd _name _dir &optional _fm interactive)
+                 (setq captured-interactive interactive))))
+      ;; Source buffer launched interactively.
+      (let ((buf (generate-new-buffer " *ghostel-test-recompile-int*")))
+        (unwind-protect
+            (with-current-buffer buf
+              (ghostel-mode)
+              (setq ghostel-compile--command "make"
+                    ghostel-compile--directory "/tmp/"
+                    ghostel-compile--interactive t)
+              (ghostel-recompile)
+              (should (eq t captured-interactive)))
+          (kill-buffer buf)))
+      ;; Source buffer launched read-only.
+      (setq captured-interactive 'unset)
+      (let ((buf (generate-new-buffer " *ghostel-test-recompile-ro*")))
+        (unwind-protect
+            (with-current-buffer buf
+              (ghostel-mode)
+              (setq ghostel-compile--command "make"
+                    ghostel-compile--directory "/tmp/"
+                    ghostel-compile--interactive nil)
+              (ghostel-recompile)
+              (should-not captured-interactive))
+          (kill-buffer buf))))))
+
+(ert-deftest ghostel-test-compile-readonly-buffer-during-run ()
+  "Default (read-only) run: buffer is locked, compile keys are bound.
+
+The buffer is in `ghostel-mode' (so the renderer keeps working) but
+`buffer-read-only' is set and the local map is the compile-style
+`ghostel-compile-view-mode-map' — `g' reruns, `n'/`p' walk errors,
+attempts to mutate the buffer signal `buffer-read-only'."
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf-name "*ghostel-test-readonly-compile*")
+         (inhibit-message t)
+         (save-some-buffers-default-predicate (lambda () nil))
+         (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil))
+        (kill-buffer buf-name)))
+    (unwind-protect
+        ;; INTERACTIVE arg omitted → defaults to nil (read-only).
+        (let ((buf (ghostel-compile--start "sleep 30" buf-name
+                                           default-directory)))
+          (with-current-buffer buf
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () (eq 'run (process-status ghostel--process))))
+            ;; Major mode is still ghostel-mode (renderer prerequisite).
+            (should (eq major-mode 'ghostel-mode))
+            ;; Buffer is read-only.
+            (should buffer-read-only)
+            ;; Local map is the compile-style one.
+            (should (eq (current-local-map) ghostel-compile-view-mode-map))
+            ;; `g' is bound to ghostel-recompile (not to ghostel's
+            ;; self-insert), `n'/`p' walk errors.
+            (should (eq (key-binding "g") #'ghostel-recompile))
+            (should (eq (key-binding "n") #'compilation-next-error))
+            (should (eq (key-binding "p") #'compilation-previous-error))
+            ;; Plain letters do NOT route to the process — `a' is not
+            ;; bound to ghostel's self-insert in the compile keymap,
+            ;; so a keystroke wouldn't make it to the PTY.
+            (should-not (eq (key-binding "a") #'ghostel--self-insert))
+            ;; A mutation attempt is rejected with `buffer-read-only'.
+            (should-error (barf-if-buffer-read-only)
+                          :type 'buffer-read-only)
+            ;; Kill the sleep process so the test doesn't leak.
+            (let ((p ghostel--process))
+              (when (process-live-p p)
+                (set-process-sentinel p #'ignore)
+                (set-process-filter p #'ignore)
+                (setq compilation-in-progress
+                      (delq p compilation-in-progress))
+                (delete-process p)))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil))
+          (kill-buffer buf-name))))))
+
+(ert-deftest ghostel-test-compile-finalize-preserves-interactive-mode ()
+  "Finalize must carry `ghostel-compile--interactive' across the mode switch.
+The variable is buffer-local and `funcall target-mode' wipes
+locals, so finalize has to save and restore it — otherwise
+`ghostel-recompile' from the finished buffer would lose the launch
+mode."
+  (ghostel-test--with-compile-buffer buf
+    (setq ghostel-compile--command "make"
+          ghostel-compile--start-time (current-time)
+          ghostel-compile--scan-marker (copy-marker (point-max))
+          ghostel-compile--directory "/tmp/"
+          ghostel-compile--interactive t)
+    (ghostel-compile--finalize buf 0 (current-time))
+    (should (eq t ghostel-compile--interactive)))
+  (ghostel-test--with-compile-buffer buf
+    (setq ghostel-compile--command "make"
+          ghostel-compile--start-time (current-time)
+          ghostel-compile--scan-marker (copy-marker (point-max))
+          ghostel-compile--directory "/tmp/"
+          ghostel-compile--interactive nil)
+    (ghostel-compile--finalize buf 0 (current-time))
+    (should-not ghostel-compile--interactive)))
+
+(ert-deftest ghostel-test-compile-recompile-after-finalize-preserves-mode ()
+  "End-to-end: finalize → `g' must recompile in the launched mode.
+The earlier per-step tests cover the variable across each
+transition; this one chains them — finalize the buffer (which
+performs `funcall target-mode' under the hood, the operation that
+wipes buffer-locals), then call `ghostel-recompile' and assert the
+INTERACTIVE arg `--start' receives matches the original launch."
+  (let ((captured-interactive 'unset)
+        (inhibit-message t))
+    ;; Finalized buffer originally launched read-only.
+    (ghostel-test--with-compile-buffer buf
+      (setq ghostel-compile--command "make"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--scan-marker (copy-marker (point-max))
+            ghostel-compile--directory "/tmp/"
+            ghostel-compile--interactive nil)
+      (ghostel-compile--finalize buf 0 (current-time))
+      ;; Buffer is now in `ghostel-compile-view-mode' — `funcall target-mode'
+      ;; just ran.  Press `g' from inside it.
+      (cl-letf (((symbol-function 'ghostel-compile--start)
+                 (lambda (_cmd _name _dir &optional _fm interactive &rest _)
+                   (setq captured-interactive interactive))))
+        (ghostel-recompile))
+      (should-not captured-interactive))
+    ;; And originally launched interactively.
+    (setq captured-interactive 'unset)
+    (ghostel-test--with-compile-buffer buf
+      (setq ghostel-compile--command "htop"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--scan-marker (copy-marker (point-max))
+            ghostel-compile--directory "/tmp/"
+            ghostel-compile--interactive t)
+      (ghostel-compile--finalize buf 0 (current-time))
+      (cl-letf (((symbol-function 'ghostel-compile--start)
+                 (lambda (_cmd _name _dir &optional _fm interactive &rest _)
+                   (setq captured-interactive interactive))))
+        (ghostel-recompile))
+      (should (eq t captured-interactive)))))
+
+(ert-deftest ghostel-test-compile-sets-compilation-arguments ()
+  "`--start' must populate `compilation-arguments' for `revert-buffer'.
+Direct callers (no tuple passed) get the launch mode in the MODE
+slot so a revert routes through the global-mode advice and lands
+on the same variant.  The advice passes its own tuple verbatim, so
+custom MODE / NAME-FUNCTION / HIGHLIGHT-REGEXP survive a revert."
+  ;; Direct call without a tuple → synthesized default.
+  (let ((buf-name "*ghostel-test-compargs-direct*")
+        (inhibit-message t)
+        (save-some-buffers-default-predicate (lambda () nil))
+        (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name)))
+    (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+              ((symbol-function 'ghostel--new) (lambda (&rest _) 'fake))
+              ((symbol-function 'ghostel--apply-palette) #'ignore)
+              ((symbol-function 'ghostel--set-size) #'ignore)
+              ((symbol-function 'ghostel--cursor-position)
+               (lambda (_) (cons 0 0)))
+              ((symbol-function 'ghostel-compile--render-header-live)
+               #'ignore)
+              ((symbol-function 'ghostel-compile--spawn)
+               (lambda (_cmd buf _h _w)
+                 (let ((p (start-process "ghostel-test-args" buf
+                                         "sleep" "100")))
+                   (set-process-sentinel p #'ignore)
+                   (set-process-query-on-exit-flag p nil)
+                   (with-current-buffer buf (setq ghostel--process p))
+                   p))))
+      (unwind-protect
+          (let ((buf (ghostel-compile--start "make" buf-name "/tmp/" nil nil)))
+            (with-current-buffer buf
+              ;; Default tuple records nil in MODE (read-only run).
+              (should (equal '("make" nil nil nil) compilation-arguments))
+              (should (eq #'compilation-revert-buffer revert-buffer-function))
+              (let ((p ghostel--process))
+                (when (process-live-p p)
+                  (setq compilation-in-progress
+                        (delq p compilation-in-progress))
+                  (delete-process p)))))
+        (when (get-buffer buf-name)
+          (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name))))))
+  ;; Caller-supplied tuple wins.
+  (let ((buf-name "*ghostel-test-compargs-tuple*")
+        (inhibit-message t)
+        (save-some-buffers-default-predicate (lambda () nil))
+        (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name)))
+    (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+              ((symbol-function 'ghostel--new) (lambda (&rest _) 'fake))
+              ((symbol-function 'ghostel--apply-palette) #'ignore)
+              ((symbol-function 'ghostel--set-size) #'ignore)
+              ((symbol-function 'ghostel--cursor-position)
+               (lambda (_) (cons 0 0)))
+              ((symbol-function 'ghostel-compile--render-header-live)
+               #'ignore)
+              ((symbol-function 'ghostel-compile--spawn)
+               (lambda (_cmd buf _h _w)
+                 (let ((p (start-process "ghostel-test-args2" buf
+                                         "sleep" "100")))
+                   (set-process-sentinel p #'ignore)
+                   (set-process-query-on-exit-flag p nil)
+                   (with-current-buffer buf (setq ghostel--process p))
+                   p))))
+      (unwind-protect
+          (let* ((tuple '("make" my-mode my-namer "rgxp"))
+                 (buf (ghostel-compile--start "make" buf-name "/tmp/"
+                                              nil nil tuple)))
+            (with-current-buffer buf
+              (should (equal tuple compilation-arguments))
+              (let ((p ghostel--process))
+                (when (process-live-p p)
+                  (setq compilation-in-progress
+                        (delq p compilation-in-progress))
+                  (delete-process p)))))
+        (when (get-buffer buf-name)
+          (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name)))))))
+
+(ert-deftest ghostel-test-compile-toggle-mode-keymap-bindings ()
+  "`ghostel-compile-toggle-mode-map' binds the switch commands.
+`switch-to-readonly' has two bindings — the second mirrors
+`ghostel-mode's copy-mode key, since both are navigable/frozen
+states."
+  (should (eq #'ghostel-compile-switch-to-interactive
+              (lookup-key ghostel-compile-toggle-mode-map (kbd "C-c C-j"))))
+  (should (eq #'ghostel-compile-switch-to-readonly
+              (lookup-key ghostel-compile-toggle-mode-map (kbd "C-c C-e"))))
+  (should (eq #'ghostel-compile-switch-to-readonly
+              (lookup-key ghostel-compile-toggle-mode-map (kbd "C-c C-t")))))
+
+(ert-deftest ghostel-test-compile-switch-errors-without-process ()
+  "Both switch commands error in a buffer without a live process.
+Post-finalize the keys remain bound but the commands refuse to act
+— the user is told to recompile with `g' instead."
+  (let ((buf (generate-new-buffer " *ghostel-test-switch-no-proc*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel-compile--command "make"
+                ghostel--process nil)
+          (should-error (ghostel-compile-switch-to-interactive)
+                        :type 'user-error)
+          (should-error (ghostel-compile-switch-to-readonly)
+                        :type 'user-error))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-compile-switch-errors-in-non-compile-buffer ()
+  "Both switch commands error in a `ghostel-mode' buffer with no compile state."
+  (let ((buf (generate-new-buffer " *ghostel-test-switch-non-compile*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          ;; No `ghostel-compile--command' — not a compile buffer.
+          (should-error (ghostel-compile-switch-to-interactive)
+                        :type 'user-error)
+          (should-error (ghostel-compile-switch-to-readonly)
+                        :type 'user-error))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-compile-mode-line-running-reflects-interactive ()
+  "`--set-mode-line-running' shows `:run' read-only / `:run/i' interactive."
+  (with-temp-buffer
+    (let ((ghostel-compile--interactive nil))
+      (ghostel-compile--set-mode-line-running)
+      (should (equal ":run" (cadr (car mode-line-process)))))
+    (let ((ghostel-compile--interactive t))
+      (ghostel-compile--set-mode-line-running)
+      (should (equal ":run/i" (cadr (car mode-line-process)))))))
+
+(ert-deftest ghostel-test-compile-switch-flips-state ()
+  "End-to-end: spawn a long sleep read-only, switch to interactive and back.
+
+After `\\[ghostel-compile-switch-to-interactive]' the buffer must
+become writable, the local map must drop the compile-style one for
+`ghostel-mode-map', and `mode-line-process' must show `:run/i'.
+After `\\[ghostel-compile-switch-to-readonly]' the buffer must lock
+back, install `ghostel-compile-view-mode-map', and the mode-line
+must read `:run' again."
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf-name "*ghostel-test-toggle-flip*")
+         (inhibit-message t)
+         (save-some-buffers-default-predicate (lambda () nil))
+         (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name)))
+    (unwind-protect
+        ;; Default (read-only) launch.
+        (let ((buf (ghostel-compile--start "sleep 30" buf-name
+                                           default-directory)))
+          (with-current-buffer buf
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () (eq 'run (process-status ghostel--process))))
+            ;; Initial state: read-only.
+            (should (eq (current-local-map) ghostel-compile-view-mode-map))
+            (should buffer-read-only)
+            (should-not ghostel-compile--interactive)
+            (should (equal ":run" (cadr (car mode-line-process))))
+            ;; Switch to interactive.
+            (ghostel-compile-switch-to-interactive)
+            (should ghostel-compile--interactive)
+            (should-not buffer-read-only)
+            (should (eq (current-local-map) ghostel-mode-map))
+            (should (equal ":run/i" (cadr (car mode-line-process))))
+            ;; No-op when already interactive.
+            (ghostel-compile-switch-to-interactive)
+            (should ghostel-compile--interactive)        ; unchanged
+            ;; Switch back to read-only.
+            (ghostel-compile-switch-to-readonly)
+            (should-not ghostel-compile--interactive)
+            (should buffer-read-only)
+            (should (eq (current-local-map) ghostel-compile-view-mode-map))
+            (should (equal ":run" (cadr (car mode-line-process))))
+            ;; No-op when already read-only.
+            (ghostel-compile-switch-to-readonly)
+            (should-not ghostel-compile--interactive)    ; unchanged
+            ;; Cleanup.
+            (let ((p ghostel--process))
+              (when (process-live-p p)
+                (set-process-sentinel p #'ignore)
+                (set-process-filter p #'ignore)
+                (setq compilation-in-progress
+                      (delq p compilation-in-progress))
+                (delete-process p)))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name))))))
+
+(ert-deftest ghostel-test-compile-toggle-mode-active-during-run ()
+  "`ghostel-compile-toggle-mode' is auto-enabled in compile buffers.
+The minor-mode keymap takes precedence over the local map and the
+major-mode map, so `\\[ghostel-compile-switch-to-interactive]' /
+`\\[ghostel-compile-switch-to-readonly]' work in both run states."
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf-name "*ghostel-test-toggle-mode-active*")
+         (inhibit-message t)
+         (save-some-buffers-default-predicate (lambda () nil))
+         (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name)))
+    (unwind-protect
+        (let ((buf (ghostel-compile--start "sleep 30" buf-name
+                                           default-directory)))
+          (with-current-buffer buf
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () (eq 'run (process-status ghostel--process))))
+            ;; Read-only state: minor-mode binding wins over view-mode-map.
+            (should ghostel-compile-toggle-mode)
+            (should (eq (key-binding (kbd "C-c C-j"))
+                        #'ghostel-compile-switch-to-interactive))
+            (should (eq (key-binding (kbd "C-c C-e"))
+                        #'ghostel-compile-switch-to-readonly))
+            ;; Switch and re-check: keys still bound (minor-mode wins
+            ;; over `ghostel-mode-map' too).
+            (ghostel-compile-switch-to-interactive)
+            (should ghostel-compile-toggle-mode)
+            (should (eq (key-binding (kbd "C-c C-j"))
+                        #'ghostel-compile-switch-to-interactive))
+            (should (eq (key-binding (kbd "C-c C-e"))
+                        #'ghostel-compile-switch-to-readonly))
+            ;; Cleanup.
+            (let ((p ghostel--process))
+              (when (process-live-p p)
+                (set-process-sentinel p #'ignore)
+                (set-process-filter p #'ignore)
+                (setq compilation-in-progress
+                      (delq p compilation-in-progress))
+                (delete-process p)))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name))))))
+
+(ert-deftest ghostel-test-compile-toggle-mode-active-post-finalize ()
+  "After finalize, the toggle mode survives into `ghostel-compile-view-mode'.
+The keys remain bound; the commands error gracefully because there
+is no live process."
+  (ghostel-test--with-compile-buffer buf
+    (setq ghostel-compile--command "make"
+          ghostel-compile--start-time (current-time)
+          ghostel-compile--scan-marker (copy-marker (point-max))
+          ghostel-compile--directory "/tmp/")
+    (ghostel-compile--finalize buf 0 (current-time))
+    ;; View-mode is now the major mode; the toggle minor mode must be on.
+    (should ghostel-compile-toggle-mode)
+    (should (eq (key-binding (kbd "C-c C-j"))
+                #'ghostel-compile-switch-to-interactive))
+    ;; And the command rejects the call because there's no process.
+    (should-error (ghostel-compile-switch-to-interactive)
+                  :type 'user-error)))
+
 (ert-deftest ghostel-test-compile-allows-interactive-input-during-run ()
-  "Regression: during a run the buffer must be interactive.
+  "Regression: when launched interactively, the buffer must accept input.
 
-`ghostel-compile--start' must not enable `compilation-minor-mode'
-on the live buffer — that minor mode's keymap shadows
-`ghostel-mode's self-insert, so letters like `q', `a', `g' would
-stop reaching the process (breaking `htop', `less', read prompts
-etc.).  And `--spawn' must set `ghostel--process' so
-`ghostel--self-insert' has a process to send keystrokes to.
+When `ghostel-compile--start' is called with INTERACTIVE non-nil
+\(via \\[universal-argument] \\[ghostel-compile], or
+`compilation-start' with MODE=t under `ghostel-compile-global-mode'),
+the live buffer must remain writable: `compilation-minor-mode' must
+not be enabled on it, and the local map must keep `ghostel-mode's
+self-insert so letters like `q', `a', `g' reach the process (this
+is what makes `htop', `less', read prompts etc. work).  And
+`--spawn' must set `ghostel--process' so `ghostel--self-insert' has
+a process to send keystrokes to.
 
-Run a long-lived `cat', verify both conditions, then send bytes
-through the process to confirm they land in the buffer."
+Run a long-lived `cat' interactively, verify both conditions, then
+send bytes through the process to confirm they land in the buffer."
   (skip-unless (file-executable-p "/bin/sh"))
   (let* ((buf-name "*ghostel-test-interactive-compile*")
          (inhibit-message t)
@@ -4389,7 +4862,8 @@ through the process to confirm they land in the buffer."
       (let ((kill-buffer-query-functions nil))
         (kill-buffer buf-name)))
     (unwind-protect
-        (let ((buf (ghostel-compile--start "cat" buf-name default-directory)))
+        (let ((buf (ghostel-compile--start "cat" buf-name
+                                           default-directory nil t))) ; interactive=t
           (with-current-buffer buf
             ;; Wait for the process to be alive.
             (ghostel-test--wait-for
@@ -4399,6 +4873,8 @@ through the process to confirm they land in the buffer."
             ;; minor mode stealing keys.
             (should (eq major-mode 'ghostel-mode))
             (should-not (bound-and-true-p compilation-minor-mode))
+            ;; Buffer is writable in interactive mode.
+            (should-not buffer-read-only)
             ;; Plain letters route through ghostel-mode's self-insert,
             ;; not through compilation-mode's navigation commands.
             (should (eq (key-binding "q") #'ghostel--self-insert))
@@ -9854,8 +10330,19 @@ slip past the unit tests."
     ghostel-test-compile-global-mode-routes-to-ghostel-start
     ghostel-test-compile-global-mode-threads-subclass-mode
     ghostel-test-compile-global-mode-falls-through-on-continue
-    ghostel-test-compile-global-mode-falls-through-on-comint
+    ghostel-test-compile-global-mode-routes-mode-t-to-interactive
     ghostel-test-compile-global-mode-excluded-custom-mode
+    ghostel-test-compile-interactive-form-no-prefix
+    ghostel-test-compile-interactive-form-c-u
+    ghostel-test-compile-interactive-form-numeric-prefix
+    ghostel-test-compile-recompile-preserves-interactive-mode
+    ghostel-test-compile-finalize-preserves-interactive-mode
+    ghostel-test-compile-recompile-after-finalize-preserves-mode
+    ghostel-test-compile-toggle-mode-keymap-bindings
+    ghostel-test-compile-switch-errors-without-process
+    ghostel-test-compile-switch-errors-in-non-compile-buffer
+    ghostel-test-compile-mode-line-running-reflects-interactive
+    ghostel-test-compile-toggle-mode-active-post-finalize
     ghostel-test-compile-reconciles-vt-size-to-outwin
     ghostel-test-compile-reconciles-skips-when-no-outwin
     ghostel-test-viewport-start-skips-trailing-newline


### PR DESCRIPTION
## Summary

Aligns `ghostel-compile` with `M-x compile`'s read-only / `C-u` interactive distinction.

- `M-x ghostel-compile` (no prefix) → **read-only** ghostel buffer.  `g` reruns, `n`/`p` walk errors, RET jumps, `C-c C-c` jumps, `C-c C-k` interrupts — all from the start of the run, not just after it finishes.
- `C-u M-x ghostel-compile` → **interactive** ghostel buffer (the previous default).  Keystrokes reach the PTY so `htop`, `less`, test prompts work.
- Under `ghostel-compile-global-mode`, `compilation-start CMD` (no MODE) goes through the read-only path; `compilation-start CMD t` (the comint variant — what `C-u M-x compile` triggers) is now routed to a writable ghostel terminal instead of falling through to stock `comint-mode`.
- `ghostel-recompile` (`g`) preserves the launch mode of the source buffer.

## Implementation

The major mode stays `ghostel-mode` during the run because the renderer, redraw timer, filter, and resize hooks all gate on `(derived-mode-p 'ghostel-mode)`.  For the read-only path, `--prepare-buffer` swaps `(use-local-map ghostel-compile-view-mode-map)` (which already inherits from `compilation-mode-map` and rebinds `g`/`n`/`p`) and sets `buffer-read-only`.  Every render write path already binds `inhibit-read-only`, so the renderer keeps updating fine.

A new buffer-local `ghostel-compile--interactive` flag tracks the launch mode and is restored across the finalize mode-switch so `ghostel-recompile` reads it correctly after the buffer transitions to `ghostel-compile-view-mode`.

## Test plan

- [x] `make -j4 all` clean (235 elisp + 118 native + 52 zig tests, lint OK)
- [x] Six new elisp tests cover prefix-arg parsing (`nil` / `C-u` / numeric), recompile mode preservation, finalize mode preservation, and the global-mode advice routing for `MODE=t`
- [x] One native test verifies the read-only buffer rejects mutation with `buffer-read-only`, has `ghostel-compile-view-mode-map` as its local map, and binds `g` to `ghostel-recompile`
- [x] Live verification in a running daemon for all four scenarios:
  - `M-x ghostel-compile` → read-only ✓
  - `(ghostel-compile … t)` → writable ✓
  - `compilation-start CMD` (global) → read-only ✓
  - `compilation-start CMD t` (global) → writable (no fall-through to comint) ✓
- [x] README updated (commands table, behavior section, global-mode routing description)

## Out of scope

- Live error parsing during the read-only run — kept at parse-at-finalize for now.
- `ghostel-compile-finished-major-mode` semantics unchanged: both variants still finalize into `ghostel-compile-view-mode` (or whatever subclass the caller passed).