### PR TITLE
Detect password prompts and answer via read-passwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Password prompt detection.  When `sudo`, `ssh`, `gpg`, `passwd`,
+  etc. ask for a password ghostel pops up `read-passwd` and sends
+  the answer through the PTY — the keystrokes never flow through
+  Emacs's normal key pipeline, so the password does not land in
+  `view-lossage`, the recent-keys ring, or any keyboard-macro
+  recording.  Detection mirrors libghostty's heuristic (the slave
+  tty is in canonical mode with echo off) via a tiny `tcgetattr`
+  Zig binding, with a regex fallback on the cursor row when the
+  local tty's echo state can't be observed (remote ssh, programs
+  that don't toggle echo).  Mode-line shows ` 🔒Password` while a
+  prompt is open, the wire copy of the password is `clear-string`'d
+  immediately after the send, and wrong-password retries auto-detect
+  via cursor movement.  Customize `ghostel-password-prompt-functions`
+  — a chain of `(ROW) -> string-or-nil` sources tried in order — to
+  plug in `auth-source` (or Keepass / pass / etc); the
+  defcustom docstring includes a TRAMP-aware
+  `auth-source-pick-first-password` example.  PR
+  [#241](https://github.com/dakra/ghostel/pull/241).
+
 ## [0.22.1] — 2026-05-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -346,6 +346,12 @@ history in **any** mode that has a read-only buffer (Emacs or copy).
 - Focus events gated by DEC mode 1004
 - Drag-and-drop (file paths and text)
 
+### Password prompt detection
+- When `sudo`, `ssh`, `gpg`, `passwd`, etc. ask for a password, ghostel pops up `read-passwd` and sends the answer through the PTY — keystrokes never flow through Emacs's normal key pipeline, so the password does **not** land in `view-lossage`, the recent-keys ring, or any keyboard-macro recording.
+- Detection mirrors libghostty's heuristic — the slave tty is in canonical mode with echo off — via a tiny `tcgetattr` Zig binding, with a regex fallback on the cursor row for cases where the local tty's echo state can't be observed (remote ssh, programs that don't toggle echo).
+- Mode-line shows ` 🔒Password` while a prompt is open. Wrong-password retries auto-detect (cursor moves to the new prompt row). The wire copy of the password is `clear-string`'d immediately after the send so it doesn't sit in the heap.
+- Extensible via `ghostel-password-prompt-functions` — a chain of `(ROW) -> string-or-nil` sources tried in order. Default reads with `read-passwd`; users prepend their own (auth-source / Keepass / pass / etc) and the default acts as the fallback. The defcustom docstring includes a TRAMP-aware `auth-source-pick-first-password` example.
+
 ### Shell Integration
 - Automatic injection for bash, zsh, and fish — no shell RC edits needed
 - **OSC 7** — directory tracking (`default-directory` follows the shell's cwd, TRAMP-aware for remote hosts)
@@ -1214,37 +1220,38 @@ powering Neovim's built-in terminal.
 
 ### Feature comparison
 
-| Feature                       | ghostel   | vterm   |
-|-------------------------------|-----------|---------|
-| True color (24-bit)           | Yes       | Yes     |
-| OSC 4/10/11 color queries     | Yes       | No      |
-| Bold / italic / faint         | Yes       | Yes     |
-| Underline styles (5 types)    | Yes       | No      |
-| Underline color               | Yes       | No      |
-| Strikethrough                 | Yes       | Yes     |
-| Cursor styles                 | 4 types   | 3 types |
-| OSC 8 hyperlinks              | Yes       | No      |
-| Plain-text URL/file detection | Yes       | No      |
-| OSC 9 / 777 notifications     | Yes       | No      |
-| OSC 9;4 progress reports      | Yes       | No      |
-| Kitty graphics protocol       | Yes       | No      |
-| Kitty keyboard protocol       | Yes       | No      |
-| Mouse passthrough (SGR)       | Yes       | No      |
-| Bracketed paste               | Yes       | Yes     |
-| Alternate screen              | Yes       | Yes     |
-| Shell integration auto-inject | Yes       | No      |
-| Prompt navigation (OSC 133)   | Yes       | Yes     |
-| Elisp eval from shell         | Yes       | Yes     |
-| TRAMP remote terminals        | Yes       | Yes     |
-| OSC 52 clipboard              | Yes       | Yes     |
-| Copy mode                     | Yes       | Yes     |
-| Char mode (runtime toggle)    | Yes       | No      |
-| Line mode (local editing)     | Yes       | No      |
-| Emacs mode (read-only, live)  | Yes       | No      |
-| Drag-and-drop                 | Yes       | No      |
-| Auto module download          | Yes       | No      |
-| Scrollback default            | ~5,000    | 1,000   |
-| PTY throughput (plain ASCII)  | 81 MB/s   | 34 MB/s |
+| Feature                       | ghostel  | vterm    |
+|-------------------------------|----------|----------|
+| True color (24-bit)           | ✅       | ✅       |
+| OSC 4/10/11 color queries     | ✅       | ❌       |
+| Bold / italic / faint         | ✅       | ✅       |
+| Underline styles (5 types)    | ✅       | ❌       |
+| Underline color               | ✅       | ❌       |
+| Strikethrough                 | ✅       | ✅       |
+| Cursor styles                 | 4 types  | 3 types  |
+| OSC 8 hyperlinks              | ✅       | ❌       |
+| Plain-text URL/file detection | ✅       | ❌       |
+| OSC 9 / 777 notifications     | ✅       | ❌       |
+| OSC 9;4 progress reports      | ✅       | ❌       |
+| Kitty graphics protocol       | ✅       | ❌       |
+| Kitty keyboard protocol       | ✅       | ❌       |
+| Mouse passthrough (SGR)       | ✅       | ❌       |
+| Bracketed paste               | ✅       | ✅       |
+| Alternate screen              | ✅       | ✅       |
+| Shell integration auto-inject | ✅       | ❌       |
+| Prompt navigation (OSC 133)   | ✅       | ✅       |
+| Elisp eval from shell         | ✅       | ✅       |
+| TRAMP remote terminals        | ✅       | ✅       |
+| OSC 52 clipboard              | ✅       | ✅       |
+| Copy mode                     | ✅       | ✅       |
+| Char mode (runtime toggle)    | ✅       | ❌       |
+| Line mode (local editing)     | ✅       | ❌       |
+| Emacs mode (read-only, live)  | ✅       | ❌       |
+| Drag-and-drop                 | ✅       | ❌       |
+| Password prompt detection     | ✅       | ❌       |
+| Auto module download          | ✅       | ❌       |
+| Scrollback default            | ~5,000   | 1,000    |
+| PTY throughput (plain ASCII)  | 81 MB/s  | 34 MB/s  |
 | Default redraw rate           | ~30 fps   | ~10 fps |
 
 ### Key differences
@@ -1288,6 +1295,16 @@ defaults to ~30 fps redraw; vterm defaults to ~10 fps.
 bash, zsh, and fish — no shell RC changes needed.  vterm requires manually
 sourcing scripts in your shell configuration.  Both support Elisp eval from
 the shell and TRAMP-aware remote directory tracking.
+
+**Password prompts.**  Ghostel detects when the foreground program is reading
+a password (`sudo`, `ssh`, `gpg`, …) and prompts via `read-passwd`, sending
+the answer down the PTY without routing keystrokes through Emacs's normal
+key pipeline.  vterm has no such interception: each character of your
+password is a regular keypress, so it ends up in `view-lossage`, the
+recent-keys ring, and anything else that observes the key pipeline (e.g.
+keyboard macros being recorded).  Ghostel's hook also lets you plug in
+`auth-source` to satisfy known prompts without typing — see
+[Password prompt detection](#password-prompt-detection) above.
 
 **Performance.**  In PTY throughput benchmarks (1 MB streamed through `cat`,
 both backends configured with ~1,000 lines of scrollback), ghostel is

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -423,6 +423,52 @@ Disabled by default for security: a malicious escape sequence in
 command output could silently overwrite your clipboard."
   :type 'boolean)
 
+(defcustom ghostel-password-prompt-regex
+  "[Pp]ass\\(?:word\\|phrase\\)[^:]*:[ \t]*\\'"
+  "Regex matched against the cursor row to detect a password prompt.
+Fallback for when `ghostel--pty-password-input-p' returns nil —
+typically remote ssh sessions, or programs that don't flip echo off.
+The default covers `Password:', `[sudo] password for X:', and
+`Enter passphrase for key …:'."
+  :type 'regexp)
+
+(defcustom ghostel-password-prompt-functions
+  '(ghostel--default-password-source)
+  "Sources tried in order to obtain a password when one is needed.
+Each function is called with one argument — ROW, the trimmed text
+of the cursor's row at the moment the prompt was detected, or
+nil when the row text isn't available.  Called inside the ghostel
+buffer when `ghostel--password-mode-p' transitions from nil to t.
+Should return a string (the password) or nil to defer to the next
+function.  The first non-nil return wins; ghostel sends that
+string + carriage return to the subprocess and clears the wire
+copy.  Beware: returning an empty string \"\" is treated as a
+hit (sudo will see it as a wrong password and re-prompt) — guard
+your sources to return nil on miss; never default a miss to \"\".
+
+The default `ghostel--default-password-source' reads with
+`read-passwd' and so always returns (unless the user
+`keyboard-quit's, which propagates).
+
+To plug in `auth-source' (or keepass, pass, etc) prepend a function that
+returns the looked-up secret on hit, nil on miss; the default acts as
+the fallback.  `default-directory' carries the TRAMP remote host when
+ghostel was spawned through TRAMP, so the same handler works for `sudo'
+on the local box and on a remote one:
+
+  (defun my-ghostel-auth-source (row)
+    (let* ((user (and row
+                      (string-match
+                       \"\\\\[sudo\\\\] .+ for \\\\([^:]+\\\\):\" row)
+                      (match-string 1 row)))
+           (host (or (file-remote-p default-directory \\='host)
+                     (system-name))))
+      (and user
+           (auth-source-pick-first-password :host host :user user))))
+
+  (add-hook \\='ghostel-password-prompt-functions #\\='my-ghostel-auth-source)"
+  :type 'hook)
+
 (defcustom ghostel-notification-function #'ghostel-default-notify
   "Function called for OSC 9 / OSC 777 desktop notifications.
 Called with two string arguments: TITLE and BODY.  Title is empty
@@ -768,6 +814,7 @@ or when the `bash-completion' package is not installed."
 (declare-function ghostel--set-size "ghostel-module" (term rows cols &optional cell-w cell-h))
 (declare-function ghostel--write-input "ghostel-module")
 (declare-function ghostel--native-uri-at "ghostel-module")
+(declare-function ghostel--pty-password-input-p "ghostel-module" (path))
 
 (declare-function spinner-create "spinner")
 (declare-function spinner-start "spinner")
@@ -2111,6 +2158,9 @@ has gone off and a prompt is locatable.  Cleared when the user
 manually switches input modes so a later alt-screen exit does not
 surprise them by force-resuming line mode.")
 
+(defvar ghostel--password-mode-p)         ; forward decls; defined below.
+(defvar ghostel--password-handled-cursor) ;
+
 (defvar-local ghostel--mode-line-tag nil
   "Current input-mode label rendered in `mode-line-process'.
 String like \":Char\" / \":Line\" / \":Copy\" / \":Emacs\", or
@@ -2142,7 +2192,9 @@ OSC 9;4 packet, and same-value packets must not fire FMLU."
                       (list ghostel--mode-line-tag
                             (and ghostel--spinner-active
                                  'spinner--mode-line-construct)
-                            ghostel--mode-line-progress)))
+                            ghostel--mode-line-progress
+                            (and ghostel--password-mode-p
+                                 (propertize " 🔒Password" 'face 'warning)))))
          (new-val (pcase parts
                     ('() nil)
                     (`(,only) only)
@@ -3996,6 +4048,157 @@ prompts while output continues streaming in."
   (ghostel--navigate-previous-prompt n))
 
 
+;;; Password prompt detection
+
+;; Mirrors libghostty's heuristic (canonical mode + echo off, see
+;; ghostty/src/termio/Exec.zig) so password input from sudo/ssh/gpg/etc is read
+;; through `read-passwd' instead of streamed through Emacs's key handling (where
+;; it would land in `view-lossage' and the recent-keys ring).  Falls back to a
+;; regex match on the cursor row for cases where the local tty's echo state
+;; can't be observed — remote ssh sessions, programs that don't toggle echo.
+
+(defvar-local ghostel--password-mode-p nil
+  "Non-nil while a password prompt is currently active.
+Set by `ghostel--detect-password-prompt' on the rising edge and
+cleared by the handler when the password is submitted (or
+aborted).  Used to render the mode-line indicator and to keep
+the rising-edge detector from running its hook twice for one
+prompt.")
+
+(defvar-local ghostel--password-handled-cursor nil
+  "Cursor (COL . ROW) where the most recent password handler returned.
+Detection is suppressed while the cursor still sits on this row.
+This bridges the race window between the user submitting a
+password and the foreground program restoring echo (sudo, ssh,
+gpg are all canonical+!echo for tens of milliseconds after they
+read), which would otherwise look like a fresh rising edge.
+Cleared automatically when the falling edge is observed (echo
+restored) or when the cursor moves to a different row — both
+naturally re-arm the detector for follow-on prompts (a second
+`sudo' in a script, a wrong-password retry that prints `Sorry,
+try again.' on a new row).")
+
+(defun ghostel--cursor-row-text ()
+  "Return the text of the row containing the terminal cursor, or nil.
+The text is taken from the buffer (post-redraw), without text
+properties, with trailing whitespace trimmed.  Returns nil for
+the empty row so callers can pass the result through `or' to a
+default."
+  (when ghostel--term
+    (let ((pos (ignore-errors (ghostel--cursor-position ghostel--term)))
+          (vp-start (ghostel--viewport-start)))
+      (when (and pos vp-start)
+        (save-excursion
+          (goto-char vp-start)
+          (forward-line (cdr pos))
+          (let ((line (string-trim-right
+                       (buffer-substring-no-properties
+                        (line-beginning-position) (line-end-position)))))
+            (and (not (string-empty-p line)) line)))))))
+
+(defun ghostel--password-prompt-detected-p ()
+  "Return non-nil if the foreground program looks like it's reading a password.
+Tries the libghostty heuristic first (canonical mode + echo off via
+`ghostel--pty-password-input-p'), then falls back to matching the
+cursor row against `ghostel-password-prompt-regex'."
+  (or (and (processp ghostel--process)
+           (process-live-p ghostel--process)
+           (when-let* ((tty (process-tty-name ghostel--process)))
+             (ghostel--pty-password-input-p tty)))
+      (when-let* ((row (ghostel--cursor-row-text)))
+        (string-match-p ghostel-password-prompt-regex row))))
+
+(defun ghostel--detect-password-prompt ()
+  "Update `ghostel--password-mode-p' and run hook on rising edge.
+Called from `ghostel--delayed-redraw' once the buffer reflects
+the latest output.  Suppresses re-fires while the cursor is
+still on the row where the previous handler returned (see
+`ghostel--password-handled-cursor')."
+  (let ((now (ghostel--password-prompt-detected-p))
+        (cursor (and ghostel--term
+                     (ignore-errors (ghostel--cursor-position ghostel--term)))))
+    (cond
+     ;; Echo back on — clear all state so a future prompt re-arms.
+     ((not now)
+      (when (or ghostel--password-mode-p ghostel--password-handled-cursor)
+        (setq ghostel--password-mode-p nil
+              ghostel--password-handled-cursor nil)
+        (ghostel--mode-line-refresh)))
+     ;; Already showing the indicator (handler is in flight).
+     (ghostel--password-mode-p nil)
+     ;; Just-handled prompt — wait for the cursor to move off the row.
+     ((and ghostel--password-handled-cursor
+           cursor
+           (equal cursor ghostel--password-handled-cursor))
+      nil)
+     ;; Rising edge: a fresh prompt or a retry on a new row.
+     (t
+      (setq ghostel--password-mode-p t
+            ghostel--password-handled-cursor nil)
+      (ghostel--mode-line-refresh)
+      ;; Defer so the prompt minibuffer doesn't open from inside the
+      ;; process filter — opening it there blocks further PTY output
+      ;; until the user submits.
+      (let ((buf (current-buffer)))
+        (run-at-time
+         0 nil
+         (lambda ()
+           (when (buffer-live-p buf)
+             (with-current-buffer buf
+               (when ghostel--password-mode-p
+                 (ghostel--prompt-password)))))))))))
+
+(defun ghostel--default-password-source (row)
+  "Default password source: prompt with `read-passwd'.
+ROW is the cursor row text (used as the prompt label); falls back
+to \"Password:\" when nil.  Always returns a string (or signals
+quit on `keyboard-quit'), so this source - at the tail of
+`ghostel-password-prompt-functions' - acts as the fallback once
+any prepended sources have returned nil."
+  (read-passwd (concat (or row "Password:") " ")))
+
+(defun ghostel--prompt-password ()
+  "Run `ghostel-password-prompt-functions' until one returns a password.
+The cursor row text is captured once and passed to each source,
+so handlers that match against the prompt don't each pay for a
+separate buffer scan.  Sends the result + carriage return to the
+subprocess, clears the string, and arms the post-submission
+suppression so the detector doesn't re-fire while the foreground
+program restores echo.  State cleanup runs even when a source
+signals quit (`keyboard-quit' during `read-passwd'), so the
+indicator and suppression always reach a sane state."
+  (let ((pwd nil)
+        (row (ghostel--cursor-row-text)))
+    (unwind-protect
+        (setq pwd (run-hook-with-args-until-success
+                   'ghostel-password-prompt-functions
+                   row))
+      ;; The (concat pwd "\r") wire copy is freshly allocated and owned by us,
+      ;; so `clear-string' it after the send.  Nested `unwind-protect' so the
+      ;; wire is cleared even if `process-send-string' errors (e.g. process died
+      ;; between `process-live-p' and the send).
+      ;;
+      ;; Deliberately do NOT clear PWD itself: an `auth-source' backend that
+      ;; returns the secret as a string may share that string with the
+      ;; auth-source cache (the :secret in the cached plist).  Clearing it would
+      ;; zero the cache in place and break later lookups.  The default
+      ;; `ghostel--default-password-source' uses `read-passwd' which returns a new
+      ;; string; that one lives until GC.  Sources whose backend hands out shared
+      ;; strings should `copy-sequence' before returning if they want clearing.
+      (when pwd
+        (let ((wire (concat pwd "\r")))
+          (unwind-protect
+              (when (and (processp ghostel--process)
+                         (process-live-p ghostel--process))
+                (process-send-string ghostel--process wire))
+            (clear-string wire))))
+      (setq ghostel--password-handled-cursor
+            (and ghostel--term
+                 (ignore-errors (ghostel--cursor-position ghostel--term))))
+      (setq ghostel--password-mode-p nil)
+      (ghostel--mode-line-refresh))))
+
+
 ;;; Callbacks from native module
 
 (defun ghostel--osc51-eval (str)
@@ -5398,7 +5601,8 @@ new output arrives."
               ;; update the alt-screen-prev cache for the next cycle.
               (ghostel--line-mode-post-redraw)))
           (setq ghostel--snap-requested nil)
-          (setq ghostel--windows-needing-snap nil))))))
+          (setq ghostel--windows-needing-snap nil))
+        (ghostel--detect-password-prompt)))))
 
 
 (defun ghostel-force-redraw ()

--- a/src/module.zig
+++ b/src/module.zig
@@ -11,6 +11,7 @@ const render = @import("render.zig");
 const input = @import("input.zig");
 const kitty_graphics = @import("kitty_graphics.zig");
 const sys = @import("sys.zig");
+const pty = @import("pty.zig");
 
 const c = emacs.c;
 
@@ -53,6 +54,7 @@ export fn emacs_module_init(runtime: *c.struct_emacs_runtime) callconv(.c) c_int
     env.bindFunction("ghostel--enable-vt-log", 0, 0, &fnEnableVtLog, "Enable libghostty internal log routing to *ghostel-debug*.\n\n(ghostel--enable-vt-log)");
     env.bindFunction("ghostel--disable-vt-log", 0, 0, &fnDisableVtLog, "Disable libghostty internal log routing.\n\n(ghostel--disable-vt-log)");
     env.bindFunction("ghostel--native-uri-at", 3, 3, &fnUriAt, "Get URI at ROW-from-bottom and COL.\n\n(ghostel--native-uri-at TERM ROW COL)");
+    env.bindFunction("ghostel--pty-password-input-p", 1, 1, &fnPtyPasswordInputP, "Return t if the tty at PATH is in canonical mode with echo off.\n\nThis mirrors libghostty's password-input heuristic.  Returns nil when the path can't be opened or isn't a tty.\n\n(ghostel--pty-password-input-p PATH)");
 
     emacs.initSymbols(env);
 
@@ -716,6 +718,14 @@ fn fnGetTitle(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*an
         return env.nil();
     };
     return if (title) |t| env.makeString(t) else env.nil();
+}
+
+/// (ghostel--pty-password-input-p PATH)
+fn fnPtyPasswordInputP(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*anyopaque) callconv(.c) c.emacs_value {
+    const env = emacs.Env.init(raw_env.?);
+    var stack_buf: [1024]u8 = undefined;
+    const path = env.extractString(args[0], &stack_buf) orelse return env.nil();
+    return if (pty.isPasswordMode(path)) env.t() else env.nil();
 }
 
 /// (ghostel--get-pwd TERM)

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -1,0 +1,32 @@
+/// PTY introspection helpers.
+///
+/// Mirrors libghostty's password-input heuristic (canonical mode + echo
+/// off) from `src/termio/Exec.zig` so embedders that don't go through
+/// the full `Surface` apprt — like ghostel — can detect the same
+/// signal.  The check is purely a read of the slave's termios; it does
+/// not change the device's state and is safe to run frequently.
+const std = @import("std");
+
+/// Returns true if the tty at PATH is in canonical mode with echo
+/// disabled — the heuristic libghostty uses to decide that the
+/// foreground program is reading a password (`stty -echo` is what
+/// `getpass(3)`, `sudo`, `ssh`, `gpg`, etc. all do).  Returns false
+/// when the path can't be opened or stat'd as a tty; callers treat
+/// that as "unknown, try the regex fallback".
+///
+/// `O_NOCTTY` keeps the open from making this fd our controlling tty,
+/// and `O_NONBLOCK` keeps it from blocking on a tty that hasn't seen
+/// DCD.  Neither flag affects what `tcgetattr` reads.  `RDONLY` is
+/// sufficient — we never write to the slave; reducing the mode means
+/// a stray write through this fd can't garble the child's input.
+pub fn isPasswordMode(path: []const u8) bool {
+    const fd = std.posix.open(path, .{
+        .ACCMODE = .RDONLY,
+        .NOCTTY = true,
+        .NONBLOCK = true,
+    }, 0) catch return false;
+    defer std.posix.close(fd);
+
+    const tio = std.posix.tcgetattr(fd) catch return false;
+    return tio.lflag.ICANON and !tio.lflag.ECHO;
+}

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -3769,6 +3769,274 @@ narrow input after the wide char keeps growing the region."
       (kill-buffer buf))))
 
 ;; -----------------------------------------------------------------------
+;; Test: password prompt detection
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-pty-password-input-p-detects-stty-no-echo ()
+  "Report t when a child's tty has ECHO off and ICANON on.
+This is the libghostty heuristic (canonical && !echo) replicated in
+the Zig binding.  Spawn a shell that does `stty -echo' and poll
+until the change takes effect."
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf (generate-new-buffer " *ghostel-test-pwd-stty*"))
+         (proc (start-process "ghostel-test-pwd-stty" buf
+                              "/bin/sh" "-c" "stty -echo; sleep 30")))
+    (set-process-query-on-exit-flag proc nil)
+    (unwind-protect
+        (let ((tty (process-tty-name proc)))
+          (should tty)
+          (ghostel-test--wait-for
+           proc (lambda () (ghostel--pty-password-input-p tty)) 5)
+          (should (ghostel--pty-password-input-p tty)))
+      (when (process-live-p proc) (kill-process proc))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-pty-password-input-p-default-is-nil ()
+  "Cooked-mode tty (canonical + echo) returns nil from the heuristic.
+Emacs's default pty starts with echo OFF (Emacs handles echo itself),
+so `stty sane' is required to mimic a normal shell prompt — which is
+exactly what `ghostel--spawn-pty' does at startup."
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf (generate-new-buffer " *ghostel-test-pwd-cooked*"))
+         (proc (start-process "ghostel-test-pwd-cooked" buf
+                              "/bin/sh" "-c" "stty sane; sleep 30")))
+    (set-process-query-on-exit-flag proc nil)
+    (unwind-protect
+        (let ((tty (process-tty-name proc)))
+          (should tty)
+          ;; Wait for stty sane to take effect.
+          (ghostel-test--wait-for
+           proc (lambda () (not (ghostel--pty-password-input-p tty))) 5)
+          (should-not (ghostel--pty-password-input-p tty)))
+      (when (process-live-p proc) (kill-process proc))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-pty-password-input-p-non-tty-returns-nil ()
+  "Non-tty / nonexistent paths return nil rather than erroring."
+  (should-not (ghostel--pty-password-input-p "/dev/null"))
+  (should-not (ghostel--pty-password-input-p
+               "/tmp/ghostel-test-does-not-exist-7c4af2")))
+
+(ert-deftest ghostel-test-password-detect-regex-fallback ()
+  "When the libghostty heuristic returns nil, the regex fallback fires.
+Feeds a `[sudo] password for ...:' prompt into the terminal, asserts
+`ghostel--password-prompt-detected-p' returns t with the heuristic
+stubbed to nil."
+  (let ((buf (generate-new-buffer " *ghostel-test-pwd-regex*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term (ghostel--new 5 80 1000))
+          (setq ghostel--term-rows 5)
+          (ghostel--write-input ghostel--term "[sudo] password for alice: ")
+          (let ((inhibit-read-only t))
+            (ghostel--redraw ghostel--term t))
+          (cl-letf (((symbol-function 'ghostel--pty-password-input-p)
+                     (lambda (_path) nil)))
+            (should (ghostel--password-prompt-detected-p))))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-password-detect-regex-no-false-positive ()
+  "Cursor row that doesn't match any regex returns nil from the fallback."
+  (let ((buf (generate-new-buffer " *ghostel-test-pwd-no-match*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term (ghostel--new 5 80 1000))
+          (setq ghostel--term-rows 5)
+          (ghostel--write-input ghostel--term "$ ls -la")
+          (let ((inhibit-read-only t))
+            (ghostel--redraw ghostel--term t))
+          (cl-letf (((symbol-function 'ghostel--pty-password-input-p)
+                     (lambda (_path) nil)))
+            (should-not (ghostel--password-prompt-detected-p))))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-prompt-password-sends-via-subprocess ()
+  "Send the source's return value to the subprocess with a CR.
+Plain RET on a tty produces CR, so we send the password followed
+by CR and clear state.  Regression check: must NOT send via
+`ghostel--write-input' (the local VT parser) — that path echoes
+the password into the terminal buffer and never
+reaches the real subprocess."
+  (let ((buf (generate-new-buffer " *ghostel-test-pwd-dispatch*"))
+        (sent nil)
+        (vt-input nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term (ghostel--new 5 80 1000))
+          (setq ghostel--term-rows 5)
+          (setq ghostel--process 'fake-proc)
+          (setq ghostel--password-mode-p t)
+          (let ((ghostel-password-prompt-functions
+                 (list (lambda (_row) "hunter2"))))
+            (cl-letf (((symbol-function 'processp) (lambda (_p) t))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string)
+                       (lambda (_proc data) (push (copy-sequence data) sent)))
+                      ((symbol-function 'ghostel--write-input)
+                       (lambda (_term data) (push data vt-input))))
+              (ghostel--prompt-password)))
+          (should (equal sent '("hunter2\r")))
+          (should-not vt-input)
+          (should-not ghostel--password-mode-p))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-prompt-password-clears-wire-copy ()
+  "Clear the freshly allocated wire copy after the send.
+The password+CR string is `clear-string'd so the secret doesn't sit
+in the heap until the next GC.  Captures the actual reference — not
+a copy — and asserts every byte is zero after
+`ghostel--prompt-password' returns."
+  (let ((buf (generate-new-buffer " *ghostel-test-pwd-clear*"))
+        (wire-ref nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term (ghostel--new 5 80 1000))
+          (setq ghostel--term-rows 5)
+          (setq ghostel--process 'fake-proc)
+          (setq ghostel--password-mode-p t)
+          (let ((ghostel-password-prompt-functions
+                 (list (lambda (_row) "hunter2"))))
+            (cl-letf (((symbol-function 'processp) (lambda (_p) t))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string)
+                       (lambda (_proc data) (setq wire-ref data))))
+              (ghostel--prompt-password)))
+          (should wire-ref)
+          (should (= 8 (length wire-ref)))               ; "hunter2\r" length
+          (should (cl-every #'zerop (string-to-list wire-ref))))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-prompt-password-tries-sources-in-order ()
+  "First source returning non-nil wins; later sources don't run.
+Sources returning nil are skipped so a chain like \"auth-source first,
+read-passwd as fallback\" works without each handler reimplementing
+the fallback logic."
+  (let ((buf (generate-new-buffer " *ghostel-test-pwd-chain*"))
+        (sent nil)
+        (chain nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term (ghostel--new 5 80 1000))
+          (setq ghostel--term-rows 5)
+          (setq ghostel--process 'fake-proc)
+          (setq ghostel--password-mode-p t)
+          (let ((ghostel-password-prompt-functions
+                 (list (lambda (_row) (push 'first chain) nil)
+                       (lambda (_row) (push 'second chain) "from-second")
+                       (lambda (_row) (push 'third chain) "should-not-run"))))
+            (cl-letf (((symbol-function 'processp) (lambda (_p) t))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string)
+                       (lambda (_proc data) (push (copy-sequence data) sent))))
+              (ghostel--prompt-password)))
+          (should (equal sent '("from-second\r")))
+          (should (equal chain '(second first))))  ; reversed push order
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-prompt-password-resets-state-on-quit ()
+  "Reset state when all sources return nil or a source quits.
+The indicator clears and the cursor-suppression arms — same as
+a successful submission."
+  (let ((buf (generate-new-buffer " *ghostel-test-pwd-quit*"))
+        (sent nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term (ghostel--new 5 80 1000))
+          (setq ghostel--term-rows 5)
+          (setq ghostel--process 'fake-proc)
+          (setq ghostel--password-mode-p t)
+          (let ((ghostel-password-prompt-functions
+                 (list (lambda (_row) nil) (lambda (_row) nil))))
+            (cl-letf (((symbol-function 'process-send-string)
+                       (lambda (_proc data) (push (copy-sequence data) sent))))
+              (ghostel--prompt-password)))
+          (should-not sent)
+          (should-not ghostel--password-mode-p)
+          (should ghostel--password-handled-cursor))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-detect-password-prompt-fires-once-per-edge ()
+  "Hook fires on rising edge only; falling edge clears state."
+  (let* ((buf (generate-new-buffer " *ghostel-test-pwd-edge*"))
+         (calls 0)
+         (now nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term (ghostel--new 5 80 1000))
+          (setq ghostel--term-rows 5)
+          (let ((ghostel-password-prompt-functions
+                 (list (lambda (_row) (cl-incf calls) nil))))
+            (cl-letf (((symbol-function 'ghostel--password-prompt-detected-p)
+                       (lambda () now)))
+              (setq now t)
+              (ghostel--detect-password-prompt)
+              (should ghostel--password-mode-p)
+              (sleep-for 0.05)
+              (should (= 1 calls))
+              ;; Re-detect while indicator already on → no extra fire.
+              (ghostel--detect-password-prompt)
+              (sleep-for 0.05)
+              (should (= 1 calls))
+              ;; Falling edge clears state.
+              (setq now nil)
+              (ghostel--detect-password-prompt)
+              (should-not ghostel--password-mode-p)
+              (sleep-for 0.05)
+              (should (= 1 calls)))))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-detect-suppresses-while-on-handled-row ()
+  "Suppress re-fire while the cursor stays on the just-handled row.
+Regression: sudo (and friends) hold the tty in canonical+!echo for
+tens of milliseconds after read() returns; the next PTY chunk would
+otherwise look like a fresh rising edge and pop a second
+`read-passwd' minibuffer."
+  (let* ((buf (generate-new-buffer " *ghostel-test-pwd-suppress*"))
+         (calls 0))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel--term (ghostel--new 5 80 1000))
+          (setq ghostel--term-rows 5)
+          (let ((ghostel-password-prompt-functions
+                 (list (lambda (_row) (cl-incf calls) nil))))
+            (cl-letf (((symbol-function 'ghostel--password-prompt-detected-p)
+                       (lambda () t))
+                      ((symbol-function 'ghostel--cursor-position)
+                       (lambda (_term) '(0 . 2))))
+              ;; Initial rising edge fires once.
+              (ghostel--detect-password-prompt)
+              (sleep-for 0.05)
+              (should (= 1 calls))
+              ;; Simulate the handler returning on the same row.
+              (setq ghostel--password-mode-p nil
+                    ghostel--password-handled-cursor '(0 . 2))
+              ;; Detector ticks while echo is still off and cursor unchanged
+              ;; → must NOT fire again.
+              (ghostel--detect-password-prompt)
+              (ghostel--detect-password-prompt)
+              (sleep-for 0.05)
+              (should (= 1 calls))
+              (should-not ghostel--password-mode-p))
+            ;; Cursor moves to a new row (sudo's `Sorry, try again.' or
+            ;; the next program's prompt).  Detector must re-fire.
+            (cl-letf (((symbol-function 'ghostel--password-prompt-detected-p)
+                       (lambda () t))
+                      ((symbol-function 'ghostel--cursor-position)
+                       (lambda (_term) '(0 . 4))))
+              (ghostel--detect-password-prompt)
+              (sleep-for 0.05)
+              (should (= 2 calls)))))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+;; -----------------------------------------------------------------------
 ;; Test: ghostel-command-finish-functions hook
 ;; -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Detects password prompts (`sudo`, `ssh`, `gpg`, `passwd`, …) and answers them via `read-passwd` instead of streaming through Emacs's key pipeline (where they'd land in `view-lossage` and the recent-keys ring).
- New Zig binding `ghostel--pty-password-input-p` mirrors libghostty's `canonical && !echo` heuristic from `ghostty/src/termio/Exec.zig`. Regex fallback on the cursor row covers remote ssh / programs that don't toggle echo.
- `ghostel-password-prompt-functions` is a chain of `(ROW) -> string-or-nil` sources, tried via `run-hook-with-args-until-success`. Default reads with `read-passwd`; users prepend their own (auth-source, 1Password, pass, …) and the default acts as the fallback. Docstring includes a TRAMP-aware `auth-source-pick-first-password` example.
- The freshly allocated `(concat pwd "\r")` wire copy is `clear-string`'d after sending so the password doesn't sit in the heap until the next GC. The source's return value is deliberately not cleared (could be a shared auth-source cache entry).
- `ghostty_feature_requests/06-password-input-setter.md` drafts an upstream proposal to add a setter for libghostty's `password_input` flag — currently the public C-API has only a getter, so libghostty-vt embedders can't round-trip through it.

## Test plan

- [x] `make -j4 all` clean: build + lint + 60 elisp + 137 native + 316 evil tests, no unexpected failures
- [x] Live `sudo -K; sudo true` in a ghostel buffer — `read-passwd` minibuffer pops up, password accepted on first try, mode-line shows ` 🔒Password` while open, `view-lossage` does not contain the password
- [x] Wrong-password retry re-prompts automatically (cursor moves to "Sorry, try again." row, suppression auto-clears)
- [x] No double-prompt after submission (regression test `ghostel-test-detect-suppresses-while-on-handled-row`)
- [x] Wire copy is zeroed after send (regression test `ghostel-test-prompt-password-clears-wire-copy`)
- [x] Hook chain semantics: first non-nil source wins (`ghostel-test-prompt-password-tries-sources-in-order`)
- [x] auth-source extension example (manual smoke test on a real `~/.authinfo.gpg` entry — recommended before merging)