### PR TITLE
Auto-enter copy mode on mouse-1 click when no app tracks the mouse

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1437,14 +1437,14 @@ Input modes (`ghostel-semi-char-mode-map', `ghostel-char-mode-map',
   "C-c C-j"          #'ghostel-semi-char-mode
   "C-c M-d"          #'ghostel-char-mode
   "C-c C-l"          #'ghostel-line-mode
-  ;; Mouse click events (for terminal mouse tracking)
-  "<down-mouse-1>"   #'ghostel--mouse-press
-  "<mouse-1>"        #'ghostel--mouse-release
+  ;; Mouse click events
+  "<down-mouse-1>"   #'ghostel-mouse-press-or-copy-mode
+  "<mouse-1>"        #'ghostel-mouse-release-or-set-point
+  "<drag-mouse-1>"   #'ghostel-mouse-drag-or-set-region
   "<down-mouse-2>"   #'ghostel--mouse-press
   "<mouse-2>"        #'ghostel--mouse-release
   "<down-mouse-3>"   #'ghostel--mouse-press
   "<mouse-3>"        #'ghostel--mouse-release
-  "<drag-mouse-1>"   #'ghostel--mouse-drag
   "<drag-mouse-2>"   #'ghostel--mouse-drag
   "<drag-mouse-3>"   #'ghostel--mouse-drag
   ;; Drag and drop
@@ -2137,6 +2137,58 @@ Return non-nil if the event was forwarded (mouse tracking is active)."
                             (ghostel--mouse-button-number event)
                             row col
                             (ghostel--mouse-mods event)))))
+
+(defun ghostel--mouse-tracking-active-p ()
+  "Non-nil if libghostty has any DEC mouse-tracking mode set.
+Checks modes 1000 (normal), 1002 (button-event), and 1003
+\(any-event) - the modes a running program enables when it wants
+to consume mouse input."
+  (and ghostel--term
+       (or (ghostel--mode-enabled ghostel--term 1000)
+           (ghostel--mode-enabled ghostel--term 1002)
+           (ghostel--mode-enabled ghostel--term 1003))))
+
+(defun ghostel-mouse-press-or-copy-mode (event)
+  "Forward EVENT to the terminal, or hand off to `mouse-drag-region'.
+When a DEC mouse-tracking mode (1000/1002/1003) is enabled, behaves
+like `ghostel--mouse-press' and forwards the press to the running
+program.  Otherwise hands EVENT off to `mouse-drag-region' so Emacs's
+standard click-to-set-point and drag-to-select work; if the buffer is
+in semi-char mode (where typing normally goes to the terminal) it
+also switches to `ghostel-copy-mode' first so the buffer is frozen
+and read-only for the duration of the selection."
+  (interactive "e")
+  (select-window (posn-window (event-start event)))
+  (cond
+   ((ghostel--mouse-tracking-active-p)
+    (ghostel--mouse-press event))
+   ((eq ghostel--input-mode 'semi-char)
+    (ghostel-copy-mode)
+    (mouse-drag-region event))
+   (t
+    (mouse-drag-region event))))
+
+(defun ghostel-mouse-release-or-set-point (event)
+  "Forward EVENT to the terminal, or hand off to `mouse-set-point'.
+Companion to `ghostel-mouse-press-or-copy-mode' for the left-button
+release event.  With tracking off, defers to Emacs's standard
+click handler so the release of a non-drag click sets point normally."
+  (interactive "e")
+  (if (ghostel--mouse-tracking-active-p)
+      (ghostel--mouse-release event)
+    (mouse-set-point event)))
+
+(defun ghostel-mouse-drag-or-set-region (event)
+  "Forward EVENT to the terminal, or hand off to `mouse-set-region'.
+Companion to `ghostel-mouse-press-or-copy-mode' for the left-button
+drag event.  With tracking off, defers to Emacs's standard drag
+handler so the selection survives release; without this,
+`mouse-drag-track's exit hook deactivates the mark and our
+intercept keeps `mouse-set-region' from re-establishing the region."
+  (interactive "e")
+  (if (ghostel--mouse-tracking-active-p)
+      (ghostel--mouse-drag event)
+    (mouse-set-region event)))
 
 
 ;;; Input modes — state helpers

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -8527,6 +8527,185 @@ redraw and produce visible flicker, so point is left alone."
         (kill-local-variable 'ghostel--scroll-intercept-active)
         (kill-local-variable 'pre-command-hook)))))
 
+(ert-deftest ghostel-test-mouse-1-press-no-tracking-semi-char ()
+  "Left-press in semi-char with no tracking enters copy mode and drags.
+Hands EVENT off to `mouse-drag-region' after switching to copy mode so
+Emacs's standard click-set-point and drag-to-select work, with the
+buffer frozen for selection."
+  (let ((fake-event `(down-mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (copy-mode-called nil)
+        (drag-region-arg nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t)))
+                ((symbol-function 'mouse-drag-region)
+                 (lambda (event) (setq drag-region-arg event)))
+                ((symbol-function 'select-window) (lambda (_w) nil)))
+        (ghostel-mouse-press-or-copy-mode fake-event))
+      (should copy-mode-called)
+      (should (equal fake-event drag-region-arg)))))
+
+(ert-deftest ghostel-test-mouse-1-press-no-tracking-copy-mode ()
+  "Left-press in copy mode hands off without re-toggling copy mode.
+Calling `ghostel-copy-mode' while already in copy mode would exit it,
+so the function must skip the toggle and go straight to drag-region."
+  (let ((fake-event `(down-mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (copy-mode-called nil)
+        (drag-region-arg nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'copy)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t)))
+                ((symbol-function 'mouse-drag-region)
+                 (lambda (event) (setq drag-region-arg event)))
+                ((symbol-function 'select-window) (lambda (_w) nil)))
+        (ghostel-mouse-press-or-copy-mode fake-event))
+      (should-not copy-mode-called)
+      (should (equal fake-event drag-region-arg)))))
+
+(ert-deftest ghostel-test-mouse-1-press-no-tracking-line-mode ()
+  "Left-press in line mode hands off to `mouse-drag-region' as-is.
+Line mode keeps its own buffer state; we should not switch to copy
+mode or otherwise interfere."
+  (let ((fake-event `(down-mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (copy-mode-called nil)
+        (drag-region-arg nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'line)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t)))
+                ((symbol-function 'mouse-drag-region)
+                 (lambda (event) (setq drag-region-arg event)))
+                ((symbol-function 'select-window) (lambda (_w) nil)))
+        (ghostel-mouse-press-or-copy-mode fake-event))
+      (should-not copy-mode-called)
+      (should (equal fake-event drag-region-arg)))))
+
+(ert-deftest ghostel-test-mouse-1-release-no-tracking-sets-point ()
+  "Release with no tracking hands off to `mouse-set-point'."
+  (let ((fake-event `(mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (set-point-arg nil)
+        (mouse-event-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-point)
+                 (lambda (event) (setq set-point-arg event)))
+                ((symbol-function 'ghostel--mouse-event)
+                 (lambda (&rest _) (setq mouse-event-called t) t)))
+        (ghostel-mouse-release-or-set-point fake-event))
+      (should (equal fake-event set-point-arg))
+      (should-not mouse-event-called))))
+
+(ert-deftest ghostel-test-mouse-1-release-tracking-forwards ()
+  "Release with active tracking forwards via `ghostel--mouse-release'."
+  (let ((fake-event `(mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (set-point-called nil)
+        (mouse-event-args nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--process 'fake)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term mode) (eq mode 1000)))
+                ((symbol-function 'mouse-set-point)
+                 (lambda (_e) (setq set-point-called t)))
+                ((symbol-function 'ghostel--mouse-event)
+                 (lambda (_term action button row col mods)
+                   (setq mouse-event-args (list action button row col mods))
+                   t))
+                ((symbol-function 'process-live-p) (lambda (_p) t)))
+        (ghostel-mouse-release-or-set-point fake-event))
+      (should-not set-point-called)
+      (should (equal 1 (nth 0 mouse-event-args))))))   ; action = release
+
+(ert-deftest ghostel-test-mouse-1-drag-no-tracking-sets-region ()
+  "Drag-end with no tracking hands off to `mouse-set-region'.
+This is the bug guard: without it, `mouse-drag-track's exit hook
+deactivates the mark, our intercept blocks `mouse-set-region', and
+the user-visible region disappears on release."
+  (let ((fake-event `(drag-mouse-1
+                      (,(selected-window) 1 (5 . 2) 0)
+                      (,(selected-window) 7 (10 . 4) 0)))
+        (set-region-arg nil)
+        (mouse-event-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-region)
+                 (lambda (event) (setq set-region-arg event)))
+                ((symbol-function 'ghostel--mouse-event)
+                 (lambda (&rest _) (setq mouse-event-called t) t)))
+        (ghostel-mouse-drag-or-set-region fake-event))
+      (should (equal fake-event set-region-arg))
+      (should-not mouse-event-called))))
+
+(ert-deftest ghostel-test-mouse-1-drag-tracking-forwards ()
+  "Drag-end with active tracking forwards via `ghostel--mouse-drag'."
+  (let ((fake-event `(drag-mouse-1
+                      (,(selected-window) 1 (5 . 2) 0)
+                      (,(selected-window) 7 (10 . 4) 0)))
+        (set-region-called nil)
+        (mouse-event-args nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--process 'fake)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term mode) (eq mode 1000)))
+                ((symbol-function 'mouse-set-region)
+                 (lambda (_e) (setq set-region-called t)))
+                ((symbol-function 'ghostel--mouse-event)
+                 (lambda (_term action button row col mods)
+                   (setq mouse-event-args (list action button row col mods))
+                   t))
+                ((symbol-function 'process-live-p) (lambda (_p) t)))
+        (ghostel-mouse-drag-or-set-region fake-event))
+      (should-not set-region-called)
+      (should (equal 2 (nth 0 mouse-event-args))))))   ; action = motion
+
+(ert-deftest ghostel-test-mouse-1-press-tracking-forwards-to-terminal ()
+  "Left-press with active mouse-tracking forwards to libghostty.
+Never enters copy mode and never hands off to `mouse-drag-region'."
+  (let ((fake-event `(down-mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (copy-mode-called nil)
+        (drag-region-called nil)
+        (mouse-event-args nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--process 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 ;; Pretend DEC mode 1000 (normal mouse) is enabled.
+                 (lambda (_term mode) (eq mode 1000)))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t)))
+                ((symbol-function 'mouse-drag-region)
+                 (lambda (_e) (setq drag-region-called t)))
+                ((symbol-function 'ghostel--mouse-event)
+                 (lambda (_term action button row col mods)
+                   (setq mouse-event-args (list action button row col mods))
+                   t))
+                ((symbol-function 'process-live-p) (lambda (_p) t))
+                ((symbol-function 'select-window) (lambda (_w) nil)))
+        (ghostel-mouse-press-or-copy-mode fake-event))
+      (should-not copy-mode-called)
+      (should-not drag-region-called)
+      (should (equal 0 (nth 0 mouse-event-args)))   ; action = press
+      (should (equal 1 (nth 1 mouse-event-args)))   ; button 1 = mouse-1
+      (should (equal 5 (nth 2 mouse-event-args)))   ; row
+      (should (equal 10 (nth 3 mouse-event-args)))))) ; col
+
 (ert-deftest ghostel-test-scroll-intercept-unselected-window ()
   "Wheel events on an unselected ghostel window must not loop.
 


### PR DESCRIPTION
## Summary
- Left-clicking in a ghostel buffer used to be a no-op when no app had a DEC mouse-tracking mode (1000/1002/1003) enabled — `<down-mouse-1>`, `<mouse-1>`, and `<drag-mouse-1>` all routed to the libghostty encoder, which produces no bytes when no tracking is on, blocking Emacs's default `mouse-drag-region` / `mouse-set-point` / `mouse-set-region` from ever running.
- New wrappers `ghostel-mouse-press-or-copy-mode`, `ghostel-mouse-release-or-set-point`, and `ghostel-mouse-drag-or-set-region` forward only when a tracking mode is active. Otherwise they hand off to the standard Emacs handlers, so click-set-point and drag-to-select work in any input mode.
- From semi-char (where typing is forwarded to the terminal) the press wrapper switches to copy mode first so the buffer is frozen and read-only for the duration of the selection. Already-read-only modes (copy/emacs/line) hand off directly without toggling.
- Char mode and the middle/right-button bindings keep their existing unconditional forwarding so TUIs that consume mouse input still work.

## Why three wrappers
`mouse-drag-track`'s `set-transient-map` exit hook calls `(deactivate-mark) (pop-mark)` after release; standard Emacs relies on `<drag-mouse-1>` then firing `mouse-set-region` to re-establish the region. Wrapping only `<down-mouse-1>` would let the user drag-select while holding the button but lose the region the moment they released.

## Test plan
- [x] `make -j4 all` passes (build, lint, checkdoc, 316 elisp+native tests, Zig tests)
- [x] Live: drag-select in semi-char enters `:Copy` and the region stays after release
- [x] Live: drag-select while already in copy / emacs / line modes
- [x] Live: tmux with `set -g mouse on` and htop still receive forwarded clicks