### PR TITLE
Add OSC 133 imenu integration; fix line-mode scrollback navigation

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4048,6 +4048,122 @@ prompts while output continues streaming in."
   (ghostel--navigate-previous-prompt n))
 
 
+
+;;; OSC 133 imenu integration
+
+;; Each OSC 133 prompt becomes an imenu entry.  Label is
+;; "<cwd>  <command>"; target is the prompt prefix's start.
+;; Composes with `consult-imenu', `imenu-list', evil's `]m'/`[m'.
+;;
+;; The cwd is captured at OSC 133 'C' (command-start) and pushed
+;; onto `ghostel--imenu-cwds', a chronological list (newest-first).
+;; Reading `default-directory' lazily at index time would
+;; mis-attribute every prior prompt to the *current* cwd after a
+;; `cd'.
+;;
+;; Position-based tracking (text properties or markers) does not
+;; survive: the renderer's per-row delete+reinsert wipes ad-hoc
+;; text properties on dirty rows, and `eraseBuffer' (resize-cols,
+;; force-full redraw, scrollback edge cases) collapses every marker
+;; to `point-min'.  Pairing chronological cwds with the
+;; `ghostel-prompt' regions in buffer order at index time is robust
+;; to both: resize reflows the grid but preserves prompt order;
+;; scrollback eviction is detected as (cwd-count > region-count)
+;; and the oldest cwds are dropped to realign.
+
+(defvar-local ghostel--imenu-cwds nil
+  "Chronological list of cwds for prompts that have had OSC 133 \\='C\\=' fire.
+Pushed at command-start time, so newest-first.  Aligned by order
+to the `ghostel-prompt' regions in the buffer when the index is
+built.")
+
+(defun ghostel--imenu-stamp-cwd (buffer)
+  "Record BUFFER's `default-directory' for its most recent submitted command.
+Hung off `ghostel-command-start-functions' (OSC 133 \\='C\\=')."
+  (with-current-buffer buffer
+    (push default-directory ghostel--imenu-cwds)))
+
+(defun ghostel--imenu--collect-prompt-regions ()
+  "Return a list of (START . PREFIX-END) for every `ghostel-prompt' region.
+Ordered by buffer position (oldest first)."
+  (let ((regions nil)
+        (pos (point-min))
+        (end (point-max)))
+    (while (setq pos (text-property-any pos end 'ghostel-prompt t))
+      (let ((rend (or (next-single-property-change pos 'ghostel-prompt nil end)
+                      end)))
+        (push (cons pos rend) regions)
+        (setq pos rend)))
+    (nreverse regions)))
+
+(defun ghostel--imenu-create-index ()
+  "Build an imenu alist of OSC 133 prompts in the current buffer.
+Each entry's label is \"<cwd>  <command>\"; cwd is omitted when no
+recorded entry aligns with the region (e.g. a still-active prompt
+whose \\='C\\=' has not fired).  Empty-command prompts are
+skipped.  Labels are truncated to 80 columns."
+  (let* ((regions (ghostel--imenu--collect-prompt-regions))
+         (cwds (reverse ghostel--imenu-cwds))    ; oldest first
+         ;; Scrollback eviction removes prompts from the buffer top
+         ;; but leaves cwds in the list.  Drop the oldest cwds so
+         ;; the remaining list aligns with the current regions.
+         (extra (max 0 (- (length cwds) (length regions))))
+         (cwds (nthcdr extra cwds))
+         ;; Trim the stored list opportunistically so it doesn't
+         ;; grow unboundedly across long sessions.
+         (_ (when (> extra 0)
+              (setq ghostel--imenu-cwds
+                    (seq-take ghostel--imenu-cwds (- (length ghostel--imenu-cwds)
+                                                     extra)))))
+         (index nil))
+    (cl-loop for region in regions
+             for cwd = (pop cwds)
+             do (let* ((pos (car region))
+                       (prompt-end (cdr region))
+                       (cmd-end (save-excursion
+                                  (goto-char prompt-end)
+                                  (line-end-position)))
+                       (cmd (string-trim
+                             (buffer-substring-no-properties prompt-end cmd-end))))
+                  (unless (string-empty-p cmd)
+                    (let ((label (if cwd
+                                     (format "%s  %s"
+                                             (abbreviate-file-name
+                                              (directory-file-name cwd))
+                                             cmd)
+                                   cmd)))
+                      (push (cons (truncate-string-to-width label 80 nil nil t)
+                                  pos)
+                            index)))))
+    (nreverse index)))
+
+(defun ghostel--imenu-goto (_name position &rest _)
+  "Jump to POSITION, then advance past the prompt prefix.
+Switches to Emacs mode first in semi-char/char modes (where
+point would otherwise be yanked back to the live cursor on the
+next redraw).  Line mode is preserved — `ghostel--window-anchored-p'
+treats a window with `window-point' in scrollback as non-anchored,
+so the redraw's restore path keeps point where the jump put it.
+Mirrors the landing position used by `ghostel-next-prompt'."
+  (unless (memq ghostel--input-mode '(emacs line copy))
+    (ghostel-emacs-mode))
+  (when (or (< position (point-min)) (> position (point-max)))
+    (widen))
+  (goto-char position)
+  (ghostel--prompt-input-start))
+
+(defun ghostel-imenu-setup ()
+  "Wire OSC 133 prompts as imenu entries in the current buffer.
+Sets `imenu-create-index-function' and `imenu-default-goto-function',
+and registers the cwd-stamping hook on
+`ghostel-command-start-functions'."
+  (setq-local imenu-create-index-function #'ghostel--imenu-create-index)
+  (setq-local imenu-default-goto-function #'ghostel--imenu-goto)
+  (add-hook 'ghostel-command-start-functions
+            #'ghostel--imenu-stamp-cwd nil t))
+
+
+
 ;;; Password prompt detection
 
 ;; Mirrors libghostty's heuristic (canonical mode + echo off, see
@@ -5783,6 +5899,7 @@ output is arriving."
   (add-hook 'window-buffer-change-functions
             #'ghostel--reshow-snap nil t)
   (ghostel--suppress-interfering-modes)
+  (ghostel-imenu-setup)
   (setq ghostel--scroll-intercept-active t)
   ;; Let C-g reach the keymap instead of triggering keyboard-quit.
   ;; When inhibit-quit is non-nil, C-g sets quit-flag and delivers

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -5390,12 +5390,24 @@ remain handled inside the renderer."
 A window counts as anchored when `ghostel--snap-requested' is set
 \(the user just typed), when WIN is in `ghostel--windows-needing-snap'
 \(WIN just gained this buffer), when no anchor has been recorded yet
-\(first redraw), or when its `window-start' is at or past the prior
-anchor.  During a resize-triggered redraw, a window absent from
-`ghostel--scroll-positions' also counts as anchored: the prior redraw
-left it following the viewport, so a drifted `window-start' below the
-anchor is Emacs redisplay (e.g. `keep-point-visible' when the
-minibuffer shrinks the window), not a user scroll."
+\(first redraw), or when BOTH its `window-start' and `window-point'
+are at or past the prior anchor.  During a resize-triggered redraw,
+a window absent from `ghostel--scroll-positions' whose `window-point'
+is still at or past the anchor also counts as anchored: the prior
+redraw left it following the viewport, and a drifted `window-start'
+below the anchor is Emacs redisplay (e.g. `keep-point-visible' when
+the minibuffer shrinks the window), not a user scroll.  The
+`window-point' guard on the resize branch matters because consult-line
+and friends open and close a minibuffer that resizes the body twice;
+without it, the second resize would re-anchor a window whose point
+the user had moved into scrollback during the preview.
+
+The `window-point' check fixes the case where navigation moves
+point into scrollback without moving `window-start' — `consult-line',
+`consult-imenu', `goto-char' from a command, etc.  Without it,
+those jumps would be misclassified as \"following the cursor\" and
+the next redraw would yank point back to the live cursor.  Typing
+is unaffected because `ghostel--snap-requested' short-circuits."
   (let ((anchor ghostel--last-anchor-position))
     ;; Snap-requested (the user just typed) overrides Emacs mode's
     ;; usual no-anchor behaviour so typing forwards the keystroke
@@ -5407,8 +5419,10 @@ minibuffer shrinks the window), not a user scroll."
         (memq win ghostel--windows-needing-snap)
         (and (not (eq ghostel--input-mode 'emacs))
              (or (null anchor)
-                 (>= (window-start win) anchor)
+                 (and (>= (window-start win) anchor)
+                      (>= (window-point win) anchor))
                  (and ghostel--redraw-resize-active
+                      (>= (window-point win) anchor)
                       (not (assq win ghostel--scroll-positions))))))))
 
 (defun ghostel--capture-window-state (win)

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -5652,6 +5652,202 @@ prefix only, `ghostel-input' on the user-typed command."
     (should (looking-at "echo bb cc"))))
 
 ;; -----------------------------------------------------------------------
+;; Test: imenu integration over OSC 133 prompts
+;; -----------------------------------------------------------------------
+
+(defun ghostel-test--insert-prompts-with-cwds (specs)
+  "Insert prompts per SPECS and push cwds in chronological order.
+Each SPEC is (PREFIX INPUT CWD).  Cwds are pushed in order so the
+newest-first list aligns with the buffer-order regions."
+  (dolist (spec specs)
+    (pcase-let ((`(,prefix ,input ,cwd) spec))
+      (ghostel-test--insert-prompt prefix input)
+      (push cwd ghostel--imenu-cwds))))
+
+(ert-deftest ghostel-test-imenu-empty-buffer ()
+  "Empty buffer yields an empty imenu index."
+  (with-temp-buffer
+    (should (null (ghostel--imenu-create-index)))))
+
+(ert-deftest ghostel-test-imenu-single-prompt ()
+  "Single prompt+command produces one entry; label = command (no cwd stamped)."
+  (with-temp-buffer
+    (ghostel-test--insert-prompt "$ " "make build")
+    (let ((index (ghostel--imenu-create-index)))
+      (should (equal 1 (length index)))
+      (should (equal "make build" (caar index)))
+      (should (= 1 (cdar index))))))             ; pos at point-min
+
+(ert-deftest ghostel-test-imenu-skips-empty-commands ()
+  "Prompts with no typed command are skipped."
+  (with-temp-buffer
+    (ghostel-test--insert-prompt "$ ")            ; empty
+    (ghostel-test--insert-prompt "$ " "ls")
+    (ghostel-test--insert-prompt "$ ")            ; empty
+    (let ((index (ghostel--imenu-create-index)))
+      (should (equal 1 (length index)))
+      (should (equal "ls" (caar index))))))
+
+(ert-deftest ghostel-test-imenu-cwd-attribution ()
+  "Each entry's label uses its OWN recorded cwd, not the buffer's current one."
+  (with-temp-buffer
+    (ghostel-test--insert-prompts-with-cwds
+     '(("$ " "make" "/foo/")
+       ("$ " "test" "/bar/")))
+    (let* ((index (ghostel--imenu-create-index))
+           (labels (mapcar #'car index)))
+      (should (equal 2 (length index)))
+      ;; abbreviate-file-name on /foo/ yields "/foo" after directory-file-name.
+      (should (string-match-p "\\`/foo  make\\'" (nth 0 labels)))
+      (should (string-match-p "\\`/bar  test\\'" (nth 1 labels))))))
+
+(ert-deftest ghostel-test-imenu-multi-line-command ()
+  "Label uses only the first line of a multi-line command."
+  (with-temp-buffer
+    (ghostel-test--insert-prompt "$ " "echo a\nbb\ncc")
+    (let ((index (ghostel--imenu-create-index)))
+      (should (equal 1 (length index)))
+      (should (equal "echo a" (caar index))))))
+
+(ert-deftest ghostel-test-imenu-truncates-long-command ()
+  "Labels longer than 80 columns are truncated."
+  (with-temp-buffer
+    (ghostel-test--insert-prompt "$ " (make-string 200 ?x))
+    (let* ((index (ghostel--imenu-create-index))
+           (label (caar index)))
+      (should (<= (string-width label) 80)))))
+
+(ert-deftest ghostel-test-imenu-stamp-cwd-hook ()
+  "Stamping at OSC 133 \\='C\\=' records the current cwd against the prompt."
+  (with-temp-buffer
+    (ghostel-test--insert-prompt "$ " "make")
+    (let ((default-directory "/tmp/work/"))
+      (ghostel--imenu-stamp-cwd (current-buffer)))
+    (let* ((index (ghostel--imenu-create-index))
+           (label (caar index)))
+      (should (equal 1 (length index)))
+      (should (string-match-p "\\`/tmp/work  make\\'" label)))))
+
+(ert-deftest ghostel-test-imenu-survives-buffer-rebuild ()
+  "Cwd attribution survives an `eraseBuffer'-style rebuild (resize/force-full).
+Prompts are rebuilt at new buffer positions but in the same order;
+the chronological cwds list must re-align without loss."
+  (with-temp-buffer
+    (ghostel-test--insert-prompts-with-cwds
+     '(("$ " "make" "/foo/")
+       ("$ " "test" "/bar/")))
+    ;; Simulate `eraseBuffer' wiping everything, then the renderer
+    ;; rebuilding the same prompts at fresh buffer positions (e.g. with
+    ;; an extra padding line after a row reflow).
+    (erase-buffer)
+    (insert "\n")                                ; reflow padding
+    (ghostel-test--insert-prompt "$ " "make")
+    (ghostel-test--insert-prompt "$ " "test")
+    (let* ((index (ghostel--imenu-create-index))
+           (labels (mapcar #'car index)))
+      (should (equal 2 (length index)))
+      (should (string-match-p "\\`/foo  make\\'" (nth 0 labels)))
+      (should (string-match-p "\\`/bar  test\\'" (nth 1 labels))))))
+
+(ert-deftest ghostel-test-imenu-eviction-drops-oldest-cwds ()
+  "When prompts are evicted from the top, the oldest cwds are dropped.
+Otherwise the surviving prompts would be mis-attributed to the
+evicted prompts' cwds."
+  (with-temp-buffer
+    (ghostel-test--insert-prompts-with-cwds
+     '(("$ " "old1" "/evicted1/")
+       ("$ " "old2" "/evicted2/")
+       ("$ " "live" "/live/")))
+    ;; Evict the two oldest prompts (rows 1 and 2).
+    (goto-char (point-min))
+    (forward-line 2)
+    (delete-region (point-min) (point))
+    (let* ((index (ghostel--imenu-create-index))
+           (labels (mapcar #'car index)))
+      (should (equal 1 (length index)))
+      (should (string-match-p "\\`/live  live\\'" (car labels)))
+      ;; The cwds list must be trimmed to match.
+      (should (equal 1 (length ghostel--imenu-cwds)))
+      (should (equal "/live/" (car ghostel--imenu-cwds))))))
+
+(ert-deftest ghostel-test-imenu-active-prompt-no-cwd-yet ()
+  "An active prompt (no \\='C\\=' fired yet) gets no cwd; older prompts unaffected."
+  (with-temp-buffer
+    (ghostel-test--insert-prompts-with-cwds
+     '(("$ " "make" "/foo/")))
+    (ghostel-test--insert-prompt "$ ")            ; active prompt, empty input
+    ;; Push a typed in-progress command without firing C yet.
+    (let* ((index (ghostel--imenu-create-index))
+           (labels (mapcar #'car index)))
+      (should (equal 1 (length index)))           ; active prompt has empty cmd, skipped
+      (should (string-match-p "\\`/foo  make\\'" (car labels))))))
+
+(ert-deftest ghostel-test-imenu-goto-lands-at-input-start ()
+  "Goto lands point past the prompt prefix, on the typed command.
+Mirrors `ghostel-next-prompt': the index entry points at the
+prompt-prefix start (column 0), but goto must advance past the
+prefix so point sits where the user would type."
+  (with-temp-buffer
+    (ghostel-test--insert-prompt "$ " "make build")
+    (setq-local ghostel--input-mode 'emacs)
+    (ghostel--imenu-goto "make build" 1)
+    ;; "$ " is 2 chars; point should land at the start of "make build" (pos 3).
+    (should (= (point) 3))
+    (should (looking-at "make build"))))
+
+(ert-deftest ghostel-test-imenu-goto-switches-to-emacs-mode ()
+  "Selecting an imenu entry from semi-char mode switches to Emacs mode.
+Without the switch, the renderer would yank point back to the
+live cursor on the next redraw and the jump would be invisible."
+  (let ((emacs-mode-called nil))
+    (with-temp-buffer
+      (ghostel-test--insert-prompt "$ " "make")
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel-emacs-mode)
+                 (lambda () (setq emacs-mode-called t)
+                   (setq ghostel--input-mode 'emacs))))
+        (ghostel--imenu-goto "make" 1))
+      (should emacs-mode-called))))
+
+(ert-deftest ghostel-test-imenu-goto-preserves-line-mode ()
+  "Line mode is preserved across an imenu jump.
+Mode is not switched to Emacs; `set-window-start' pins the
+window to the target's line so the next redraw's anchored
+predicate (`ghostel.el' line 5520) sees the window as
+scrolled-back."
+  (let ((emacs-mode-called nil))
+    (with-temp-buffer
+      (ghostel-test--insert-prompt "$ " "make")
+      (setq-local ghostel--input-mode 'line)
+      (cl-letf (((symbol-function 'ghostel-emacs-mode)
+                 (lambda () (setq emacs-mode-called t))))
+        (ghostel--imenu-goto "make" 1))
+      (should-not emacs-mode-called)
+      (should (eq ghostel--input-mode 'line)))))
+
+(ert-deftest ghostel-test-imenu-goto-skips-mode-switch-in-emacs ()
+  "When already in Emacs mode, goto does not re-enter Emacs mode."
+  (let ((emacs-mode-called nil))
+    (with-temp-buffer
+      (ghostel-test--insert-prompt "$ " "make")
+      (setq-local ghostel--input-mode 'emacs)
+      (cl-letf (((symbol-function 'ghostel-emacs-mode)
+                 (lambda () (setq emacs-mode-called t))))
+        (ghostel--imenu-goto "make" 1))
+      (should-not emacs-mode-called))))
+
+(ert-deftest ghostel-test-imenu-goto-skips-mode-switch-in-copy ()
+  "When already in copy mode, goto does not switch to Emacs mode."
+  (let ((emacs-mode-called nil))
+    (with-temp-buffer
+      (ghostel-test--insert-prompt "$ " "make")
+      (setq-local ghostel--input-mode 'copy)
+      (cl-letf (((symbol-function 'ghostel-emacs-mode)
+                 (lambda () (setq emacs-mode-called t))))
+        (ghostel--imenu-goto "make" 1))
+      (should-not emacs-mode-called))))
+
+;; -----------------------------------------------------------------------
 ;; Test: resize during sync output (alt screen)
 ;; -----------------------------------------------------------------------
 
@@ -12703,6 +12899,21 @@ slip past the unit tests."
     ghostel-test-compile-view-list-buffers-directory
     ghostel-test-filter-soft-wraps
     ghostel-test-prompt-navigation
+    ghostel-test-imenu-empty-buffer
+    ghostel-test-imenu-single-prompt
+    ghostel-test-imenu-skips-empty-commands
+    ghostel-test-imenu-cwd-attribution
+    ghostel-test-imenu-multi-line-command
+    ghostel-test-imenu-truncates-long-command
+    ghostel-test-imenu-stamp-cwd-hook
+    ghostel-test-imenu-survives-buffer-rebuild
+    ghostel-test-imenu-eviction-drops-oldest-cwds
+    ghostel-test-imenu-active-prompt-no-cwd-yet
+    ghostel-test-imenu-goto-lands-at-input-start
+    ghostel-test-imenu-goto-switches-to-emacs-mode
+    ghostel-test-imenu-goto-preserves-line-mode
+    ghostel-test-imenu-goto-skips-mode-switch-in-emacs
+    ghostel-test-imenu-goto-skips-mode-switch-in-copy
     ghostel-test-sync-theme
     ghostel-test-apply-palette-default-colors
     ghostel-test-apply-palette-ghostel-default-face

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -6327,6 +6327,83 @@ so an Emacs-driven drift is treated as drift, not a scroll."
         (set-window-buffer (selected-window) orig-buf))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-redraw-resize-preserves-scrollback-jump ()
+  "Resize redraw must NOT re-anchor a window whose point is in scrollback.
+Regression test: consult-line / consult-imenu / plain `goto-char' jumps in
+line mode opened a minibuffer that resized the body twice.  The second
+resize fired with `ghostel--scroll-positions' empty (no scroll-tracking
+redraw ran while the minibuffer was open) and the predicate's
+resize-active branch classified the window as anchored, yanking
+`window-point' back to the live cursor.
+
+The fix is a `window-point' >= anchor guard on the resize branch:
+it preserves the drifted-ws case (`window-point' still in the live
+viewport) but rejects this case (`window-point' moved into scrollback)."
+  (let ((buf (generate-new-buffer " *ghostel-test-resize-scrollback-jump*"))
+        (orig-buf (window-buffer (selected-window))))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 10 40 200))
+                 (ghostel--term term)
+                 (ghostel--term-rows 10)
+                 (inhibit-read-only t))
+            (dotimes (i 30)
+              (ghostel--write-input term (format "row-%02d\r\n" i)))
+            (ghostel--redraw term t)
+            (set-window-buffer (selected-window) buf)
+            ;; Steady-state: cursor at live viewport, window anchored.
+            (goto-char (point-max))
+            (set-window-point (selected-window) (point-max))
+            (let ((vp (save-excursion
+                        (goto-char (point-max))
+                        (forward-line -9)
+                        (line-beginning-position))))
+              (set-window-start (selected-window) vp t))
+            (setq ghostel--force-next-redraw t)
+            (ghostel--delayed-redraw buf)
+            (should ghostel--last-anchor-position)
+            (should-not ghostel--scroll-positions)
+
+            ;; Simulate consult-line jumping point into scrollback.
+            (let ((target (save-excursion
+                            (goto-char (point-min))
+                            (forward-line 5)
+                            (line-beginning-position))))
+              (should (< target ghostel--last-anchor-position))
+              (set-window-point (selected-window) target)
+              (set-window-start (selected-window) target t)
+              (goto-char target)
+              ;; No plain redraw runs while the minibuffer is open, so
+              ;; `ghostel--scroll-positions' stays empty — exactly the
+              ;; state the resize-active branch used to misclassify.
+              (should-not ghostel--scroll-positions)
+
+              ;; Resize fires when the minibuffer closes.
+              (cl-letf (((default-value 'window-adjust-process-window-size-function)
+                         (lambda (&rest _) (cons 40 6)))
+                        ((symbol-function 'set-process-window-size) #'ignore))
+                (setq ghostel--process
+                      (make-pipe-process :name "ghostel-test-fake"
+                                         :buffer buf
+                                         :noquery t
+                                         :filter #'ignore
+                                         :sentinel #'ignore))
+                (unwind-protect
+                    (ghostel--window-adjust-process-window-size
+                     ghostel--process
+                     (list (selected-window)))
+                  (delete-process ghostel--process)
+                  (setq ghostel--process nil)))
+
+              ;; Window-point must still be in scrollback, not yanked
+              ;; back to the live viewport.
+              (should (< (window-point (selected-window))
+                         (ghostel--viewport-start))))))
+      (when (buffer-live-p orig-buf)
+        (set-window-buffer (selected-window) orig-buf))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-viewport-start-skips-trailing-newline ()
   "`ghostel--viewport-start' must not be off-by-one on a trailing \\n.
 Partial redraws can leave the buffer ending with \\n (e.g. after


### PR DESCRIPTION
## Summary

Two related changes — the second was discovered while testing the first.

### 1. Stop resize redraw from re-anchoring scrollback in line mode

`consult-line`, `consult-imenu`, and any `goto-char` jump in line mode appeared to land on the target and then snap back to the live cursor. `isearch` worked because it advances `window-start` as it scrolls.

The minibuffer that consult opens resizes the ghostel window twice (open + close). Each resize forces a redraw with `ghostel--redraw-resize-active` = t. The predicate's resize branch classified a window as anchored whenever it was absent from `ghostel--scroll-positions` — meant to cover Emacs's own `keep-point-visible` drift on `window-start` but ignored `window-point` entirely. After the user navigated point into scrollback, no plain redraw ran while the minibuffer was open, so `ghostel--scroll-positions` stayed empty; the closing resize then re-anchored the window and yanked `window-point` back to the live cursor.

Fix: a `window-point >= anchor` guard on the resize branch. The drifted-`window-start` case still passes; the scrollback-jump case no longer does.

### 2. Add OSC 133 imenu integration

Each shell prompt with OSC 133 'A'/'B'/'C' markers becomes an imenu entry of the form `<cwd>  <command>`, target landing on the prompt prefix's start. Composes with `consult-imenu`, `imenu-list`, evil's `]m`/`[m`, etc.

The cwd is captured at OSC 133 'C' (command-start) and pushed onto a chronological list; reading `default-directory` lazily at index time would mis-attribute every prior prompt to the current cwd after a `cd`.

Position-based tracking (text properties or markers) does not survive: the renderer's per-row delete+reinsert wipes ad-hoc text properties on dirty rows, and `eraseBuffer` (resize-cols, force-full redraw, scrollback edge cases) collapses every marker to `point-min`. Pairing chronological cwds with the `ghostel-prompt` regions in buffer order at index time is robust to both: resize reflows the grid but preserves prompt order; scrollback eviction is detected as `(cwd-count > region-count)` and trims the oldest cwds.

Selecting an entry leaves line and copy modes untouched (the user is already free to navigate); only semi-char and char modes switch to emacs mode so point can move at all.

## Test plan

- [x] `make -j4 all` — 331 elisp + 138 native tests pass; lint clean
- [x] New regression test `ghostel-test-redraw-resize-preserves-scrollback-jump` covers the consult-line scenario
- [x] 15 new imenu tests cover empty buffer, single/multi prompts, cwd attribution, multi-line commands, label truncation, scrollback eviction, and the goto behaviour in each input mode
- [x] Live verified in emacsclient: `consult-line`, `consult-imenu`, plain `imenu` all stick on the target line in line mode