### PR TITLE
Enforce strict error handling in Zig native module

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -72,3 +72,13 @@ Any function with `callconv(.c)` is part of a fixed ABI contract with libghostty
 After editing any `.zig` file:
 1. `zig build` — must pass before moving on
 2. Format via Emacs: `(with-current-buffer (find-file-noselect "/path/to/file.zig") (indent-region (point-min) (point-max)) (save-buffer))`
+
+## Logging and Formatting
+
+- **Logging Format:** Always prefix log and signal messages with `ghostel: ` and follow the pattern `ghostel: [function_name] failed: {s}` where `{s}` is the error name.
+- **Line Length:** Keep logic lines within the **80-100 column** range.
+- **Wrapping Logging Calls:** When a `catch` block with logging exceeds the line length, wrap it consistently:
+  ```zig
+  term.setColorForeground(&default_fg) catch |err|
+      env.logErrorf("ghostel: setColorForeground failed: {s}", .{@errorName(err)});
+  ```

--- a/src/module.zig
+++ b/src/module.zig
@@ -145,8 +145,10 @@ fn fnNew(raw_env: ?*c.emacs_env, nargs: isize, args: [*c]c.emacs_value, _: ?*any
     // Set default colors (light gray on black)
     const default_fg = gt.ColorRgb{ .r = 204, .g = 204, .b = 204 };
     const default_bg = gt.ColorRgb{ .r = 0, .g = 0, .b = 0 };
-    term.setColorForeground(&default_fg) catch {};
-    term.setColorBackground(&default_bg) catch {};
+    term.setColorForeground(&default_fg) catch |err|
+        env.logErrorf("ghostel: setColorForeground failed: {s}", .{@errorName(err)});
+    term.setColorBackground(&default_bg) catch |err|
+        env.logErrorf("ghostel: setColorBackground failed: {s}", .{@errorName(err)});
 
     // Enable kitty graphics protocol if storage limit > 0.
     if (kitty_storage_limit > 0) {
@@ -155,7 +157,8 @@ fn fnNew(raw_env: ?*c.emacs_env, nargs: isize, args: [*c]c.emacs_value, _: ?*any
             (kitty_mediums & 0x1) != 0,
             (kitty_mediums & 0x2) != 0,
             (kitty_mediums & 0x4) != 0,
-        ) catch {};
+        ) catch |err|
+            env.logErrorf("ghostel: enableKittyGraphics failed: {s}", .{@errorName(err)});
     }
 
     return env.makeUserPtr(&Terminal.emacsFinalize, term);
@@ -350,7 +353,8 @@ fn dispatchPostWriteOscs(env: emacs.Env, term: *Terminal, data: []const u8) void
             7 => {
                 if (osc.payload.len == 0) continue;
                 const gs = gt.GhosttyString{ .ptr = osc.payload.ptr, .len = osc.payload.len };
-                term.setPwd(&gs) catch {};
+                term.setPwd(&gs) catch |err|
+                    env.logErrorf("ghostel: setPwd failed: {s}", .{@errorName(err)});
             },
             // OSC 51;E: whitelisted Elisp eval (ghostel extension).
             51 => {
@@ -443,7 +447,8 @@ fn dispatchOsc9(env: emacs.Env, term: *Terminal, payload: []const u8) void {
             const path = rest[1..];
             if (path.len > 0) {
                 const gs = gt.GhosttyString{ .ptr = path.ptr, .len = path.len };
-                term.setPwd(&gs) catch {};
+                term.setPwd(&gs) catch |err|
+                    env.logErrorf("ghostel: setPwd failed: {s}", .{@errorName(err)});
             }
             return;
         }
@@ -951,8 +956,8 @@ fn fnSetPalette(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
         pos += 7;
     }
 
-    term.setColorPalette(&palette) catch {
-        env.signalError("ghostel: failed to set color palette");
+    term.setColorPalette(&palette) catch |err| {
+        env.signalErrorf("ghostel: failed to set color palette: {s}", .{@errorName(err)});
         return env.nil();
     };
     return env.t();
@@ -1009,12 +1014,12 @@ fn fnSetDefaultColors(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value,
         return env.nil();
     };
 
-    term.setColorForeground(&fg) catch {
-        env.signalError("ghostel: failed to set foreground color");
+    term.setColorForeground(&fg) catch |err| {
+        env.signalErrorf("ghostel: failed to set foreground color: {s}", .{@errorName(err)});
         return env.nil();
     };
-    term.setColorBackground(&bg) catch {
-        env.signalError("ghostel: failed to set background color");
+    term.setColorBackground(&bg) catch |err| {
+        env.signalErrorf("ghostel: failed to set background color: {s}", .{@errorName(err)});
         return env.nil();
     };
     return env.t();

--- a/src/render.zig
+++ b/src/render.zig
@@ -506,7 +506,9 @@ pub fn render(env: emacs.Env, term: *Terminal, skip: usize, force_full: bool) !v
         while (gt.rs_row_next(term.row_iterator)) : (row_count += 1) {
             defer {
                 // Clear per-row dirty flag
-                gt.rs_row.set(term.row_iterator, gt.RS_ROW_OPT_DIRTY, false) catch {};
+                gt.rs_row.set(term.row_iterator, gt.RS_ROW_OPT_DIRTY, false) catch |err| {
+                    env.logErrorf("ghostel: rs_row.set(DIRTY, false) failed: {s}", .{@errorName(err)});
+                };
             }
 
             if (row_count < skip) continue;


### PR DESCRIPTION
Replace swallowed errors (bare `catch {}`) with explicit logging to the Emacs `*Messages*` buffer using `env.logErrorf()` and `env.signalErrorf()`. This aligns the codebase with the guidelines in `src/AGENTS.md` and improves observability for failures in color configuration, PWD updates, and render state management.

Standardize logging messages to the `ghostel: [function] failed: [error]` pattern.

> Written by Gemini, lightly audited by me.