### PR TITLE
Fix mouse-2 paste and RET in copy mode

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1448,8 +1448,8 @@ Input modes (`ghostel-semi-char-mode-map', `ghostel-char-mode-map',
   "<down-mouse-1>"   #'ghostel-mouse-press-or-copy-mode
   "<mouse-1>"        #'ghostel-mouse-release-or-set-point
   "<drag-mouse-1>"   #'ghostel-mouse-drag-or-set-region
-  "<down-mouse-2>"   #'ghostel--mouse-press
-  "<mouse-2>"        #'ghostel--mouse-release
+  "<down-mouse-2>"   #'ghostel-mouse-down-2-or-noop
+  "<mouse-2>"        #'ghostel-mouse-paste-primary-or-release
   "<down-mouse-3>"   #'ghostel--mouse-press
   "<mouse-3>"        #'ghostel--mouse-release
   "<drag-mouse-2>"   #'ghostel--mouse-drag
@@ -1555,12 +1555,16 @@ See `ghostel-readonly-fast-exit'."
   :parent ghostel-readonly-mode-map
   ;; Normal letter keys exit and send the key to the terminal.
   "<remap> <self-insert-command>" #'ghostel-readonly-exit-and-send
+  ;; RET / <return> follow self-insert: open link at point if there
+  ;; is one, otherwise exit and send a CR to the terminal.  Without
+  ;; fast-exit, the parent map's `ghostel-open-link-at-point' wins.
+  "RET"                           #'ghostel-readonly-RET-or-exit-and-send
+  "<return>"                      #'ghostel-readonly-RET-or-exit-and-send
+  "C-c M-l"                       #'ghostel-readonly-exit-and-clear
   "q"                             #'ghostel-readonly-exit
+  "C-c C-e"                       #'ghostel-readonly-exit
   "C-c C-t"                       #'ghostel-readonly-exit
-  "C-g"                           #'ghostel-readonly-exit
-  ;; C-c C-l overrides the parent's `ghostel-line-mode' binding so
-  ;; clearing scrollback from inside read-only mode also exits cleanly.
-  "C-c C-l"                       #'ghostel-readonly-exit-and-clear)
+  "C-g"                           #'ghostel-readonly-exit)
 
 ;; Char mode must override minor-mode keymaps.  Without this, a user
 ;; config that binds, say, \\`C-c' as a prefix in a global minor mode
@@ -2197,6 +2201,36 @@ intercept keeps `mouse-set-region' from re-establishing the region."
       (ghostel--mouse-drag event)
     (mouse-set-region event)))
 
+(defun ghostel-mouse-down-2-or-noop (event)
+  "Forward EVENT to the terminal when a mouse-tracking mode is on.
+Otherwise no-op so the matching release handler can paste the
+primary selection without a stray press byte being sent first."
+  (interactive "e")
+  (when (ghostel--mouse-tracking-active-p)
+    (ghostel--mouse-press event)))
+
+(defun ghostel-mouse-paste-primary-or-release (event)
+  "Forward EVENT to the terminal, or paste the primary selection.
+Selects the click's window first so a middle-click into an
+unfocused ghostel window pastes into that terminal, not whichever
+buffer happened to be current.  With a DEC mouse-tracking mode
+active, behaves like `ghostel--mouse-release'.  Otherwise pastes
+the X primary selection at the live cursor via `ghostel--paste-text',
+which uses bracketed paste when the terminal has DEC 2004 enabled.
+When in copy or Emacs mode and `ghostel-readonly-fast-exit' is
+non-nil, exits to the prior input mode first so the paste lands at
+the prompt."
+  (interactive "e")
+  (select-window (posn-window (event-start event)))
+  (if (ghostel--mouse-tracking-active-p)
+      (ghostel--mouse-release event)
+    (let ((text (gui-get-primary-selection)))
+      (when (and text (not (string-empty-p text)))
+        (when (and (memq ghostel--input-mode '(copy emacs))
+                   ghostel-readonly-fast-exit)
+          (ghostel-readonly-exit))
+        (ghostel--paste-text text)))))
+
 
 ;;; Input modes — state helpers
 
@@ -2472,6 +2506,20 @@ accepts terminal input (semi-char or char)."
     (ghostel-readonly-exit)
     (when (and ghostel--term (memq target '(semi-char char)))
       (ghostel--self-insert))))
+
+(defun ghostel-readonly-RET-or-exit-and-send ()
+  "Open the link at point, or exit read-only mode and send RET.
+Bound to RET / `<return>' in `ghostel-readonly-fast-exit-mode-map'
+so RET behaves like other input keys when fast exit is on: a
+press at a hyperlink still opens the link, while a press anywhere
+else exits the read-only mode and forwards a CR to the terminal."
+  (interactive)
+  (if (ghostel--uri-at-pos (point))
+      (ghostel-open-link-at-point)
+    (let ((target (or ghostel--pre-readonly-mode 'semi-char)))
+      (ghostel-readonly-exit)
+      (when (and ghostel--term (memq target '(semi-char char)))
+        (ghostel--send-encoded "return" "")))))
 
 (defun ghostel--filter-soft-wraps (text)
   "Remove newlines from TEXT that were inserted by soft line wrapping.

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -8783,6 +8783,241 @@ Never enters copy mode and never hands off to `mouse-drag-region'."
       (should (equal 5 (nth 2 mouse-event-args)))   ; row
       (should (equal 10 (nth 3 mouse-event-args)))))) ; col
 
+(ert-deftest ghostel-test-mouse-2-down-no-tracking-noop ()
+  "Middle-press with no tracking is a no-op.
+The matching release handler does the paste; the press must not
+forward bytes that the running program never asked for."
+  (let ((fake-event `(down-mouse-2 (,(selected-window) 1 (10 . 5) 0)))
+        (mouse-event-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'ghostel--mouse-event)
+                 (lambda (&rest _) (setq mouse-event-called t) t)))
+        (ghostel-mouse-down-2-or-noop fake-event))
+      (should-not mouse-event-called))))
+
+(ert-deftest ghostel-test-mouse-2-down-tracking-forwards ()
+  "Middle-press with active tracking forwards to libghostty."
+  (let ((fake-event `(down-mouse-2 (,(selected-window) 1 (10 . 5) 0)))
+        (mouse-event-args nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--process 'fake)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term mode) (eq mode 1000)))
+                ((symbol-function 'ghostel--mouse-event)
+                 (lambda (_term action button row col mods)
+                   (setq mouse-event-args (list action button row col mods))
+                   t))
+                ((symbol-function 'process-live-p) (lambda (_p) t))
+                ((symbol-function 'select-window) (lambda (_w) nil)))
+        (ghostel-mouse-down-2-or-noop fake-event))
+      (should (equal 0 (nth 0 mouse-event-args)))     ; action = press
+      (should (equal 3 (nth 1 mouse-event-args)))))) ; ghostty middle = 3
+
+(ert-deftest ghostel-test-mouse-2-release-no-tracking-pastes-primary ()
+  "Middle-release with no tracking pastes the primary selection."
+  (let ((fake-event `(mouse-2 (,(selected-window) 1 (10 . 5) 0)))
+        (paste-arg nil)
+        (mouse-event-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'gui-get-primary-selection)
+                 (lambda () "hello primary"))
+                ((symbol-function 'ghostel--paste-text)
+                 (lambda (text) (setq paste-arg text)))
+                ((symbol-function 'ghostel--mouse-event)
+                 (lambda (&rest _) (setq mouse-event-called t) t))
+                ((symbol-function 'select-window) (lambda (_w) nil)))
+        (ghostel-mouse-paste-primary-or-release fake-event))
+      (should (equal "hello primary" paste-arg))
+      (should-not mouse-event-called))))
+
+(ert-deftest ghostel-test-mouse-2-release-empty-primary-no-paste ()
+  "Middle-release with an empty primary selection does not paste."
+  (let ((fake-event `(mouse-2 (,(selected-window) 1 (10 . 5) 0)))
+        (paste-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'gui-get-primary-selection)
+                 (lambda () ""))
+                ((symbol-function 'ghostel--paste-text)
+                 (lambda (_t) (setq paste-called t)))
+                ((symbol-function 'select-window) (lambda (_w) nil)))
+        (ghostel-mouse-paste-primary-or-release fake-event))
+      (should-not paste-called))))
+
+(ert-deftest ghostel-test-mouse-2-release-tracking-forwards ()
+  "Middle-release with active tracking forwards to libghostty."
+  (let ((fake-event `(mouse-2 (,(selected-window) 1 (10 . 5) 0)))
+        (paste-called nil)
+        (mouse-event-args nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--process 'fake)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term mode) (eq mode 1000)))
+                ((symbol-function 'gui-get-primary-selection)
+                 (lambda () "should not be used"))
+                ((symbol-function 'ghostel--paste-text)
+                 (lambda (_t) (setq paste-called t)))
+                ((symbol-function 'ghostel--mouse-event)
+                 (lambda (_term action button row col mods)
+                   (setq mouse-event-args (list action button row col mods))
+                   t))
+                ((symbol-function 'process-live-p) (lambda (_p) t))
+                ((symbol-function 'select-window) (lambda (_w) nil)))
+        (ghostel-mouse-paste-primary-or-release fake-event))
+      (should-not paste-called)
+      (should (equal 1 (nth 0 mouse-event-args)))     ; action = release
+      (should (equal 3 (nth 1 mouse-event-args)))))) ; ghostty middle = 3
+
+(ert-deftest ghostel-test-mouse-2-paste-fast-exit-leaves-copy-mode ()
+  "Middle-click pasting in copy mode exits when fast-exit is on."
+  (let ((fake-event `(mouse-2 (,(selected-window) 1 (10 . 5) 0)))
+        (exit-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'copy)
+      (let ((ghostel-readonly-fast-exit t))
+        (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                   (lambda (_term _mode) nil))
+                  ((symbol-function 'gui-get-primary-selection)
+                   (lambda () "x"))
+                  ((symbol-function 'ghostel--paste-text) #'ignore)
+                  ((symbol-function 'ghostel-readonly-exit)
+                   (lambda () (setq exit-called t)))
+                  ((symbol-function 'select-window) (lambda (_w) nil)))
+          (ghostel-mouse-paste-primary-or-release fake-event)))
+      (should exit-called))))
+
+(ert-deftest ghostel-test-mouse-2-paste-no-fast-exit-stays-in-copy-mode ()
+  "Middle-click pasting in copy mode stays put when fast-exit is off."
+  (let ((fake-event `(mouse-2 (,(selected-window) 1 (10 . 5) 0)))
+        (exit-called nil)
+        (paste-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'copy)
+      (let ((ghostel-readonly-fast-exit nil))
+        (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                   (lambda (_term _mode) nil))
+                  ((symbol-function 'gui-get-primary-selection)
+                   (lambda () "x"))
+                  ((symbol-function 'ghostel--paste-text)
+                   (lambda (_t) (setq paste-called t)))
+                  ((symbol-function 'ghostel-readonly-exit)
+                   (lambda () (setq exit-called t)))
+                  ((symbol-function 'select-window) (lambda (_w) nil)))
+          (ghostel-mouse-paste-primary-or-release fake-event)))
+      (should-not exit-called)
+      (should paste-called))))
+
+(ert-deftest ghostel-test-mouse-2-release-selects-clicks-window ()
+  "Middle-release retargets the click's window before pasting.
+Without this, a middle-click in an unfocused ghostel window would
+read `ghostel--input-mode' / `ghostel--process' from whatever
+buffer happened to be current and paste into the wrong terminal."
+  (let* ((target-window 'fake-window)
+         (fake-event `(mouse-2 (,target-window 1 (10 . 5) 0)))
+         (selected-arg nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'gui-get-primary-selection)
+                 (lambda () "x"))
+                ((symbol-function 'ghostel--paste-text) #'ignore)
+                ((symbol-function 'select-window)
+                 (lambda (w) (setq selected-arg w))))
+        (ghostel-mouse-paste-primary-or-release fake-event))
+      (should (eq target-window selected-arg)))))
+
+(ert-deftest ghostel-test-readonly-RET-on-link-opens-link ()
+  "RET on a hyperlink opens the link instead of exiting copy mode."
+  (let ((open-called nil)
+        (exit-called nil)
+        (send-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'copy)
+      (cl-letf (((symbol-function 'ghostel--uri-at-pos)
+                 (lambda (_p) "https://example.com"))
+                ((symbol-function 'ghostel-open-link-at-point)
+                 (lambda () (setq open-called t)))
+                ((symbol-function 'ghostel-readonly-exit)
+                 (lambda () (setq exit-called t)))
+                ((symbol-function 'ghostel--send-encoded)
+                 (lambda (&rest _) (setq send-called t))))
+        (ghostel-readonly-RET-or-exit-and-send))
+      (should open-called)
+      (should-not exit-called)
+      (should-not send-called))))
+
+(ert-deftest ghostel-test-readonly-RET-off-link-exits-and-sends ()
+  "RET off a hyperlink exits read-only mode and sends a CR."
+  (let ((open-called nil)
+        (exit-called nil)
+        (send-args nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'copy)
+      (setq-local ghostel--pre-readonly-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--uri-at-pos)
+                 (lambda (_p) nil))
+                ((symbol-function 'ghostel-open-link-at-point)
+                 (lambda () (setq open-called t)))
+                ((symbol-function 'ghostel-readonly-exit)
+                 (lambda () (setq exit-called t)))
+                ((symbol-function 'ghostel--send-encoded)
+                 (lambda (key mods &rest _)
+                   (setq send-args (list key mods)))))
+        (ghostel-readonly-RET-or-exit-and-send))
+      (should-not open-called)
+      (should exit-called)
+      (should (equal '("return" "") send-args)))))
+
+(ert-deftest ghostel-test-readonly-RET-no-send-when-returning-to-emacs-mode ()
+  "RET in copy mode returning to Emacs mode exits but does not send a CR.
+Emacs mode is read-only too — sending RET would do nothing useful."
+  (let ((exit-called nil)
+        (send-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'copy)
+      (setq-local ghostel--pre-readonly-mode 'emacs)
+      (cl-letf (((symbol-function 'ghostel--uri-at-pos)
+                 (lambda (_p) nil))
+                ((symbol-function 'ghostel-readonly-exit)
+                 (lambda () (setq exit-called t)))
+                ((symbol-function 'ghostel--send-encoded)
+                 (lambda (&rest _) (setq send-called t))))
+        (ghostel-readonly-RET-or-exit-and-send))
+      (should exit-called)
+      (should-not send-called))))
+
+(ert-deftest ghostel-test-readonly-RET-bound-only-with-fast-exit ()
+  "RET hits `ghostel-readonly-RET-or-exit-and-send' only when fast-exit is on.
+With fast-exit off the parent map's `ghostel-open-link-at-point'
+binding wins."
+  (should (eq #'ghostel-readonly-RET-or-exit-and-send
+              (lookup-key ghostel-readonly-fast-exit-mode-map (kbd "RET"))))
+  (should (eq #'ghostel-readonly-RET-or-exit-and-send
+              (lookup-key ghostel-readonly-fast-exit-mode-map (kbd "<return>"))))
+  (should (eq #'ghostel-open-link-at-point
+              (lookup-key ghostel-readonly-mode-map (kbd "RET"))))
+  (should (eq #'ghostel-open-link-at-point
+              (lookup-key ghostel-readonly-mode-map (kbd "<return>")))))
+
 (ert-deftest ghostel-test-scroll-intercept-unselected-window ()
   "Wheel events on an unselected ghostel window must not loop.
 


### PR DESCRIPTION
## Summary

Fixes #251.

- Middle-click (`<mouse-2>`) now pastes the X primary selection at the live prompt via bracketed paste, even when no DEC mouse-tracking mode (1000/1002/1003) is active. Selects the click's window first so middle-clicking an unfocused ghostel window pastes into that terminal, not whichever buffer happened to be current. In copy/Emacs mode with `ghostel-readonly-fast-exit` on, the wrapper exits to the prior input mode first so the paste lands at the prompt.
- RET / `<return>` in `ghostel-readonly-fast-exit-mode-map` no longer feels stuck after #242 flipped the buffer into copy mode on a focus click. New `ghostel-readonly-RET-or-exit-and-send` opens a link at point if there is one, otherwise exits read-only and forwards a CR. Without fast-exit, the parent map's `ghostel-open-link-at-point` still wins.
- Drive-by: rename `C-c C-l` to `C-c M-l` in the fast-exit map so the parent's `ghostel-line-mode` binding is no longer shadowed, and add `C-c C-e` for symmetry with semi-char mode.

## Test plan

- [x] `make -j6 all` (78 evil + 161 native + 331 elisp tests, 0 unexpected, lint clean)
- [x] New tests cover: middle-click tracking on/off forwarding, empty primary no-op, fast-exit on/off auto-exit, the new `select-window` retarget regression, RET on/off a link, no-CR when returning to Emacs mode, fast-exit-only RET binding gating
- [ ] Live (Linux): select text in browser → middle-click in a ghostel window → primary selection appears at prompt via bracketed paste
- [ ] Live: `RET` in copy mode (with fast-exit) → exits to prior mode and prompt redraws
- [ ] Live: tmux with `set -g mouse on` and htop still receive forwarded mouse events when tracking is active