### PR TITLE
Show a hint cursor at the live position in copy/Emacs modes

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -653,6 +653,19 @@ and affected buffers will pick up the new value on the next mode transition."
              (when (memq ghostel--input-mode '(copy emacs))
                (use-local-map (ghostel--readonly-keymap)))))))
 
+(defcustom ghostel-readonly-fake-cursor t
+  "When non-nil, draw a hint cursor at the live terminal position.
+Active in copy and Emacs modes whenever point is somewhere other than
+the live terminal cursor - the hint shows where new output will land.
+
+The hint's shape follows `cursor-in-non-selected-windows':
+hollow and box render as their respective faces; nil hides the
+hint; t derives the shape from the saved `cursor-type' (box
+variants render as hollow); bar and hbar fall back to hollow.
+Customize the faces `ghostel-fake-cursor' and
+`ghostel-fake-cursor-box' to tune the appearance."
+  :type 'boolean)
+
 (defcustom ghostel-scroll-on-input t
   "Automatically scroll to the bottom when typing in the terminal.
 When non-nil, any character typed while the viewport is scrolled
@@ -782,6 +795,15 @@ or when the `bash-completion' package is not installed."
 (defface ghostel-color-bright-white
   '((t :inherit ansi-color-bright-white))
   "Face used to render bright white color code.")
+
+(defface ghostel-fake-cursor
+  '((t :box (:line-width (-1 . -1))))
+  "Face for the hollow hint cursor drawn in copy and Emacs modes.")
+
+(defface ghostel-fake-cursor-box
+  '((t :inherit cursor))
+  "Face for the solid hint cursor drawn for box-style cursors.
+Used when `cursor-in-non-selected-windows' resolves to box.")
 
 (defvar ghostel-color-palette
   [ghostel-color-black
@@ -2305,12 +2327,15 @@ redraw timer — that is the caller's job when freezing."
   (setq cursor-type (default-value 'cursor-type))
   (when ghostel--saved-hl-line-mode
     (hl-line-mode 1))
-  (setq buffer-read-only t))
+  (setq buffer-read-only t)
+  (add-hook 'pre-redisplay-functions #'ghostel--fake-cursor-update nil t))
 
 (defun ghostel--leave-readonly-state ()
   "Common teardown when leaving a read-only mode.
 Restores the cursor style, deactivates the mark, disables
 `hl-line-mode' again, and clears `buffer-read-only'."
+  (remove-hook 'pre-redisplay-functions #'ghostel--fake-cursor-update t)
+  (ghostel--fake-cursor-clear)
   (setq cursor-type ghostel--saved-cursor-type)
   (deactivate-mark)
   (when ghostel--saved-hl-line-mode
@@ -2322,6 +2347,70 @@ Restores the cursor style, deactivates the mark, disables
   (when ghostel--redraw-timer
     (cancel-timer ghostel--redraw-timer)
     (setq ghostel--redraw-timer nil)))
+
+(defvar-local ghostel--fake-cursor-overlay nil
+  "Overlay rendering the hint cursor in copy and Emacs modes.
+See `ghostel-readonly-fake-cursor'.")
+
+(defun ghostel--fake-cursor-style ()
+  "Resolve `cursor-in-non-selected-windows' to `hollow', `box', or nil.
+Honours the variable's full range: nil returns nil; t derives
+from `ghostel--saved-cursor-type' with box variants becoming
+hollow; hollow and box pass through; bar and hbar fall back to
+hollow."
+  (pcase cursor-in-non-selected-windows
+    ('nil nil)
+    ('t (pcase ghostel--saved-cursor-type
+          ('nil nil)
+          (_ 'hollow)))
+    ('hollow 'hollow)
+    ((or 'box `(box . ,_)) 'box)
+    (_ 'hollow)))
+
+(defun ghostel--fake-cursor-clear ()
+  "Delete the hint cursor overlay if any."
+  (when ghostel--fake-cursor-overlay
+    (delete-overlay ghostel--fake-cursor-overlay)
+    (setq ghostel--fake-cursor-overlay nil)))
+
+(defun ghostel--fake-cursor-update (&optional _window)
+  "Refresh the hint cursor overlay.
+Draws an overlay at the live terminal cursor position when in
+copy or Emacs mode, point is somewhere other than the live cursor,
+and `ghostel-readonly-fake-cursor' is non-nil with a non-nil
+resolved style.  Otherwise clears the overlay.
+
+Accepts an optional unused WINDOW argument so it can serve as a
+`pre-redisplay-functions' entry."
+  (let ((style (and ghostel-readonly-fake-cursor
+                    (memq ghostel--input-mode '(copy emacs))
+                    (ghostel--fake-cursor-style)))
+        (pos (and ghostel--term (ghostel--cursor-buffer-pos))))
+    (cond
+     ((or (null style) (null pos) (= pos (point)))
+      (ghostel--fake-cursor-clear))
+     (t
+      (let* ((face (if (eq style 'box)
+                       'ghostel-fake-cursor-box
+                     'ghostel-fake-cursor))
+             (eol (or (= pos (point-max))
+                      (= pos (save-excursion
+                               (goto-char pos)
+                               (line-end-position)))))
+             (ov (or ghostel--fake-cursor-overlay
+                     (let ((new (make-overlay 1 1 nil t nil)))
+                       (overlay-put new 'priority 100)
+                       (setq ghostel--fake-cursor-overlay new)))))
+        (cond
+         (eol
+          (move-overlay ov pos pos)
+          (overlay-put ov 'face nil)
+          (overlay-put ov 'after-string
+                       (propertize " " 'face face)))
+         (t
+          (move-overlay ov pos (1+ pos))
+          (overlay-put ov 'after-string nil)
+          (overlay-put ov 'face face))))))))
 
 
 ;;; Input mode switching commands
@@ -2436,7 +2525,8 @@ a non-read-only mode."
     (setq ghostel--input-mode mode)
     (use-local-map (ghostel--readonly-keymap))
     (setq ghostel--mode-line-tag label)
-    (ghostel--mode-line-refresh)))
+    (ghostel--mode-line-refresh)
+    (ghostel--fake-cursor-update)))
 
 (defun ghostel-emacs-mode ()
   "Switch to Emacs mode — read-only buffer with the terminal still running.
@@ -2604,8 +2694,8 @@ renderer (chars typed via the PTY in a previous mode).  Cleared to
 many backspaces to erase them — keeps a subsequent send from
 duplicating the prefix when the shell echoes our line back.")
 
-(defun ghostel--line-mode-cursor-buffer-pos ()
-  "Return the buffer position of the terminal cursor, or nil.
+(defun ghostel--cursor-buffer-pos ()
+  "Return the buffer position of the live terminal cursor, or nil.
 Maps libghostty's viewport (COL . ROW) to a buffer position: walks
 ROW lines down from `ghostel--viewport-start' (the renderer
 guarantees one buffer line per viewport row), then advances by
@@ -2647,7 +2737,7 @@ return the position right after the last contiguous
 `ghostel-prompt' char on that row; otherwise return the cursor
 position itself.  Returns nil when neither path can locate a
 position (no cursor and no prompt prop)."
-  (let ((cursor-pos (ghostel--line-mode-cursor-buffer-pos)))
+  (let ((cursor-pos (ghostel--cursor-buffer-pos)))
     (cond
      (cursor-pos
       (let* ((row-start (save-excursion
@@ -4928,6 +5018,8 @@ PROCESS is the shell process, EVENT describes the state change."
                 ghostel--plain-link-detection-begin nil
                 ghostel--plain-link-detection-end nil))
         (ghostel--spinner-stop)
+        (remove-hook 'pre-redisplay-functions #'ghostel--fake-cursor-update t)
+        (ghostel--fake-cursor-clear)
         (run-hook-with-args 'ghostel-exit-functions buf event)
         (if ghostel-kill-buffer-on-exit
             (kill-buffer buf)

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -7721,6 +7721,248 @@ hand nil to the native module."
         (kill-buffer buf)))))
 
 ;; -----------------------------------------------------------------------
+;; Test: read-only-mode hint cursor (fake cursor)
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-fake-cursor-style-resolution ()
+  "`ghostel--fake-cursor-style' maps `cursor-in-non-selected-windows'."
+  (with-temp-buffer
+    (let ((cursor-in-non-selected-windows nil))
+      (should (null (ghostel--fake-cursor-style))))
+    (let ((cursor-in-non-selected-windows 'hollow))
+      (should (eq 'hollow (ghostel--fake-cursor-style))))
+    (let ((cursor-in-non-selected-windows 'box))
+      (should (eq 'box (ghostel--fake-cursor-style))))
+    (let ((cursor-in-non-selected-windows '(box . 4)))
+      (should (eq 'box (ghostel--fake-cursor-style))))
+    ;; bar / hbar fall back to hollow
+    (let ((cursor-in-non-selected-windows 'bar))
+      (should (eq 'hollow (ghostel--fake-cursor-style))))
+    (let ((cursor-in-non-selected-windows '(bar . 2)))
+      (should (eq 'hollow (ghostel--fake-cursor-style))))
+    (let ((cursor-in-non-selected-windows 'hbar))
+      (should (eq 'hollow (ghostel--fake-cursor-style))))
+    ;; t with a saved box cursor-type → hollow
+    (setq-local ghostel--saved-cursor-type 'box)
+    (let ((cursor-in-non-selected-windows t))
+      (should (eq 'hollow (ghostel--fake-cursor-style))))
+    ;; t with no saved cursor-type → nil (terminal hid the cursor)
+    (setq-local ghostel--saved-cursor-type nil)
+    (let ((cursor-in-non-selected-windows t))
+      (should (null (ghostel--fake-cursor-style))))))
+
+(ert-deftest ghostel-test-fake-cursor-overlay-when-point-off-cursor ()
+  "Overlay appears at the live cursor position when point is elsewhere."
+  (with-temp-buffer
+    (insert "abcdef\nghijkl")
+    (setq-local ghostel--term 'fake)
+    (setq-local ghostel--input-mode 'copy)
+    (setq-local ghostel--saved-cursor-type 'box)
+    (let ((ghostel-readonly-fake-cursor t)
+          (cursor-in-non-selected-windows 'hollow))
+      (cl-letf (((symbol-function 'ghostel--cursor-buffer-pos)
+                 (lambda () 5)))
+        (goto-char 1)
+        (ghostel--fake-cursor-update)
+        (should ghostel--fake-cursor-overlay)
+        (should (= 5 (overlay-start ghostel--fake-cursor-overlay)))
+        (should (= 6 (overlay-end ghostel--fake-cursor-overlay)))
+        (should (eq 'ghostel-fake-cursor
+                    (overlay-get ghostel--fake-cursor-overlay 'face)))))))
+
+(ert-deftest ghostel-test-fake-cursor-cleared-when-point-coincides ()
+  "Overlay is removed when point lands on the live cursor position."
+  (with-temp-buffer
+    (insert "abcdef\nghijkl")
+    (setq-local ghostel--term 'fake)
+    (setq-local ghostel--input-mode 'copy)
+    (setq-local ghostel--saved-cursor-type 'box)
+    (let ((ghostel-readonly-fake-cursor t)
+          (cursor-in-non-selected-windows 'hollow))
+      (cl-letf (((symbol-function 'ghostel--cursor-buffer-pos)
+                 (lambda () 5)))
+        (goto-char 1)
+        (ghostel--fake-cursor-update)
+        (should ghostel--fake-cursor-overlay)
+        (goto-char 5)
+        (ghostel--fake-cursor-update)
+        (should-not ghostel--fake-cursor-overlay)))))
+
+(ert-deftest ghostel-test-fake-cursor-disabled-by-defcustom ()
+  "No overlay is created when `ghostel-readonly-fake-cursor' is nil."
+  (with-temp-buffer
+    (insert "abcdef")
+    (setq-local ghostel--term 'fake)
+    (setq-local ghostel--input-mode 'copy)
+    (setq-local ghostel--saved-cursor-type 'box)
+    (let ((ghostel-readonly-fake-cursor nil)
+          (cursor-in-non-selected-windows 'hollow))
+      (cl-letf (((symbol-function 'ghostel--cursor-buffer-pos)
+                 (lambda () 5)))
+        (goto-char 1)
+        (ghostel--fake-cursor-update)
+        (should-not ghostel--fake-cursor-overlay)))))
+
+(ert-deftest ghostel-test-fake-cursor-disabled-by-cinsw ()
+  "No overlay when `cursor-in-non-selected-windows' resolves to nil."
+  (with-temp-buffer
+    (insert "abcdef")
+    (setq-local ghostel--term 'fake)
+    (setq-local ghostel--input-mode 'copy)
+    (setq-local ghostel--saved-cursor-type 'box)
+    (let ((ghostel-readonly-fake-cursor t)
+          (cursor-in-non-selected-windows nil))
+      (cl-letf (((symbol-function 'ghostel--cursor-buffer-pos)
+                 (lambda () 5)))
+        (goto-char 1)
+        (ghostel--fake-cursor-update)
+        (should-not ghostel--fake-cursor-overlay)))))
+
+(ert-deftest ghostel-test-fake-cursor-not-in-semi-char ()
+  "No overlay outside copy / Emacs mode."
+  (with-temp-buffer
+    (insert "abcdef")
+    (setq-local ghostel--term 'fake)
+    (setq-local ghostel--saved-cursor-type 'box)
+    (let ((ghostel-readonly-fake-cursor t)
+          (cursor-in-non-selected-windows 'hollow))
+      (cl-letf (((symbol-function 'ghostel--cursor-buffer-pos)
+                 (lambda () 5)))
+        (dolist (mode '(semi-char char line))
+          (setq-local ghostel--input-mode mode)
+          (goto-char 1)
+          (ghostel--fake-cursor-update)
+          (should-not ghostel--fake-cursor-overlay))))))
+
+(ert-deftest ghostel-test-fake-cursor-box-style-uses-box-face ()
+  "`box' resolution paints with the solid face."
+  (with-temp-buffer
+    (insert "abcdef")
+    (setq-local ghostel--term 'fake)
+    (setq-local ghostel--input-mode 'copy)
+    (setq-local ghostel--saved-cursor-type 'box)
+    (let ((ghostel-readonly-fake-cursor t)
+          (cursor-in-non-selected-windows 'box))
+      (cl-letf (((symbol-function 'ghostel--cursor-buffer-pos)
+                 (lambda () 5)))
+        (goto-char 1)
+        (ghostel--fake-cursor-update)
+        (should (eq 'ghostel-fake-cursor-box
+                    (overlay-get ghostel--fake-cursor-overlay 'face)))))))
+
+(ert-deftest ghostel-test-fake-cursor-eol-uses-after-string ()
+  "At end-of-line / end-of-buffer, the overlay uses an after-string."
+  (with-temp-buffer
+    (insert "abc")                    ; eob = 4
+    (setq-local ghostel--term 'fake)
+    (setq-local ghostel--input-mode 'copy)
+    (setq-local ghostel--saved-cursor-type 'box)
+    (let ((ghostel-readonly-fake-cursor t)
+          (cursor-in-non-selected-windows 'hollow))
+      (cl-letf (((symbol-function 'ghostel--cursor-buffer-pos)
+                 (lambda () 4)))
+        (goto-char 1)
+        (ghostel--fake-cursor-update)
+        (should ghostel--fake-cursor-overlay)
+        (let ((after (overlay-get ghostel--fake-cursor-overlay 'after-string)))
+          (should (stringp after))
+          (should (eq 'ghostel-fake-cursor
+                      (get-text-property 0 'face after))))
+        (should (null (overlay-get ghostel--fake-cursor-overlay 'face)))))))
+
+(ert-deftest ghostel-test-fake-cursor-cleared-on-leave-readonly ()
+  "`ghostel--leave-readonly-state' clears the overlay and the hook."
+  (with-temp-buffer
+    (insert "abcdef")
+    (setq-local ghostel--term 'fake)
+    (setq-local ghostel--input-mode 'copy)
+    (setq-local ghostel--saved-cursor-type 'box)
+    (let ((ghostel-readonly-fake-cursor t)
+          (cursor-in-non-selected-windows 'hollow))
+      (cl-letf (((symbol-function 'ghostel--cursor-buffer-pos)
+                 (lambda () 5)))
+        (goto-char 1)
+        (add-hook 'pre-redisplay-functions #'ghostel--fake-cursor-update nil t)
+        (ghostel--fake-cursor-update)
+        (should ghostel--fake-cursor-overlay)
+        (should (memq #'ghostel--fake-cursor-update pre-redisplay-functions))
+        (ghostel--leave-readonly-state)
+        (should-not ghostel--fake-cursor-overlay)
+        (should-not (memq #'ghostel--fake-cursor-update pre-redisplay-functions))))))
+
+(ert-deftest ghostel-test-fake-cursor-toggles-between-eol-and-mid-line ()
+  "Same overlay flips between `face' and `after-string' as it crosses EOL."
+  (with-temp-buffer
+    (insert "abcdef\nghijkl")          ; eol of line 1 = 7
+    (setq-local ghostel--term 'fake)
+    (setq-local ghostel--input-mode 'copy)
+    (setq-local ghostel--saved-cursor-type 'box)
+    (let ((ghostel-readonly-fake-cursor t)
+          (cursor-in-non-selected-windows 'hollow)
+          (live-pos 3))
+      (cl-letf (((symbol-function 'ghostel--cursor-buffer-pos)
+                 (lambda () live-pos)))
+        (goto-char 1)
+        ;; Mid-line: face set, no after-string.
+        (ghostel--fake-cursor-update)
+        (let ((ov ghostel--fake-cursor-overlay))
+          (should ov)
+          (should (eq 'ghostel-fake-cursor (overlay-get ov 'face)))
+          (should-not (overlay-get ov 'after-string))
+          ;; Move live cursor to EOL: same overlay flips to after-string.
+          (setq live-pos 7)
+          (ghostel--fake-cursor-update)
+          (should (eq ov ghostel--fake-cursor-overlay))
+          (should-not (overlay-get ov 'face))
+          (should (stringp (overlay-get ov 'after-string)))
+          ;; Move back to mid-line: flips back.
+          (setq live-pos 4)
+          (ghostel--fake-cursor-update)
+          (should (eq ov ghostel--fake-cursor-overlay))
+          (should (eq 'ghostel-fake-cursor (overlay-get ov 'face)))
+          (should-not (overlay-get ov 'after-string)))))))
+
+(ert-deftest ghostel-test-fake-cursor-reuses-overlay-across-positions ()
+  "Successive updates with different positions reuse one overlay."
+  (with-temp-buffer
+    (insert "abcdef")
+    (setq-local ghostel--term 'fake)
+    (setq-local ghostel--input-mode 'copy)
+    (setq-local ghostel--saved-cursor-type 'box)
+    (let ((ghostel-readonly-fake-cursor t)
+          (cursor-in-non-selected-windows 'hollow)
+          (live-pos 3))
+      (cl-letf (((symbol-function 'ghostel--cursor-buffer-pos)
+                 (lambda () live-pos)))
+        (goto-char 1)
+        (ghostel--fake-cursor-update)
+        (let ((ov ghostel--fake-cursor-overlay))
+          (should ov)
+          (should (= 3 (overlay-start ov)))
+          (setq live-pos 5)
+          (ghostel--fake-cursor-update)
+          (should (eq ov ghostel--fake-cursor-overlay))
+          (should (= 5 (overlay-start ov))))))))
+
+(ert-deftest ghostel-test-fake-cursor-clears-when-term-nil ()
+  "Overlay is cleared when `ghostel--term' becomes nil (process exit)."
+  (with-temp-buffer
+    (insert "abcdef")
+    (setq-local ghostel--term 'fake)
+    (setq-local ghostel--input-mode 'copy)
+    (setq-local ghostel--saved-cursor-type 'box)
+    (let ((ghostel-readonly-fake-cursor t)
+          (cursor-in-non-selected-windows 'hollow))
+      (cl-letf (((symbol-function 'ghostel--cursor-buffer-pos)
+                 (lambda () 5)))
+        (goto-char 1)
+        (ghostel--fake-cursor-update)
+        (should ghostel--fake-cursor-overlay)
+        (setq-local ghostel--term nil)
+        (ghostel--fake-cursor-update)
+        (should-not ghostel--fake-cursor-overlay)))))
+
+;; -----------------------------------------------------------------------
 ;; Test: ghostel-project buffer naming
 ;; -----------------------------------------------------------------------
 
@@ -13432,6 +13674,18 @@ slip past the unit tests."
     ghostel-test-copy-mode-cursor
     ghostel-test-ignore-cursor-change
     ghostel-test-copy-mode-hl-line
+    ghostel-test-fake-cursor-style-resolution
+    ghostel-test-fake-cursor-overlay-when-point-off-cursor
+    ghostel-test-fake-cursor-cleared-when-point-coincides
+    ghostel-test-fake-cursor-disabled-by-defcustom
+    ghostel-test-fake-cursor-disabled-by-cinsw
+    ghostel-test-fake-cursor-not-in-semi-char
+    ghostel-test-fake-cursor-box-style-uses-box-face
+    ghostel-test-fake-cursor-eol-uses-after-string
+    ghostel-test-fake-cursor-cleared-on-leave-readonly
+    ghostel-test-fake-cursor-toggles-between-eol-and-mid-line
+    ghostel-test-fake-cursor-reuses-overlay-across-positions
+    ghostel-test-fake-cursor-clears-when-term-nil
     ghostel-test-project-buffer-name
     ghostel-test-project-universal-arg
     ghostel-test-reuses-identity-match-after-rename


### PR DESCRIPTION
## Summary
- Drops a thin overlay at the live terminal cursor position whenever point is somewhere else in copy or Emacs mode, so the next-output spot stays visible while the user reads scrollback.
- Style follows `cursor-in-non-selected-windows`: nil hides; t derives from the saved `cursor-type` (box variants → hollow); hollow / box pass through to dedicated faces; bar / hbar fall back to hollow. Two new customisable faces (`ghostel-fake-cursor`, `ghostel-fake-cursor-box`); gated by `ghostel-readonly-fake-cursor` (default t).
- Driven by `pre-redisplay-functions` installed buffer-locally on read-only entry — no `post-command-hook` overhead, fires only when redisplay is happening, and a single mechanism handles both point movement and the live cursor advancing under streaming Emacs-mode output.
- Renames the internal helper `ghostel--line-mode-cursor-buffer-pos` → `ghostel--cursor-buffer-pos` (no longer line-mode-specific). Single in-tree caller updated.

## Test plan
- [x] `make -j4 all` (340 elisp+native tests, lint, build, Zig)
- [x] `make test-evil` (78/78)
- [x] Live: split a window with the ghostel buffer, type into the prompt, `M-x ghostel-emacs-mode`, navigate point up into scrollback — the hint should appear at the prompt position
- [x] Live: trigger background output (e.g. `sleep 5 && ls &`) — hint should track the new cursor row in Emacs mode
- [x] Live: `M-x ghostel-copy-mode` — hint stays put (terminal frozen)
- [x] Live: `setq cursor-in-non-selected-windows nil` while in copy mode — next redisplay clears the overlay
- [x] Live: try with `'box`, `'hollow`, `'bar` to confirm style resolution