### PR TITLE
Fix: clicking a ghostel window no longer enters copy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ All notable changes to this project will be documented in this file.
   [#244](https://github.com/dakra/ghostel/issues/244).
 
 ### Added
+- Left-clicking a ghostel window no longer auto-enters copy mode on
+  press — a bare click only focuses the window and sets point,
+  matching standard Emacs behavior.  A drag still switches input
+  mode on release so streaming output cannot clobber the selection;
+  the target is picked by the new `ghostel-mouse-drag-input-mode`
+  (default `copy`).  Choices are `copy` (freezes redraws; selection
+  is rock-solid), `emacs` (terminal keeps streaming; buffer becomes
+  read-only), and `nil` (stay in semi-char; scrollback selections
+  still survive, selections over live-redrawn rows can be lost).
+  Closes [#257](https://github.com/dakra/ghostel/issues/257).
 - `ghostel-detect-password-prompts` — defcustom (default t) gating
   the entire detector.  ghostel-compile binds it to nil
   buffer-locally because compile buffers run with `stty -echo' to

--- a/README.md
+++ b/README.md
@@ -267,6 +267,28 @@ letter sends it to the terminal and returns to semi-char mode.
 
 Soft-wrapped newlines are automatically stripped from copied text.
 
+### Mouse selection
+
+Click-and-drag inside a ghostel buffer creates a region.  On release,
+`ghostel-mouse-drag-or-set-region` switches input mode so streaming
+terminal output cannot clobber the selection — the target is picked
+by `ghostel-mouse-drag-input-mode` (default `'copy`):
+
+- `'copy` — enter copy mode.  Redraws pause; the selection is
+  stable regardless of where it sits.
+- `'emacs` — enter Emacs mode.  The terminal keeps streaming and the
+  buffer becomes read-only; selections wholly in scrollback survive,
+  selections over rows the live program rewrites can still be lost.
+- `nil` — stay in semi-char.  Same selection-survival guarantees as
+  `'emacs`, but `M-w` is forwarded to the shell so it cannot copy
+  the region — pick this only if you copy via primary selection or
+  the GUI menu.
+
+A pure click without a drag only focuses the window and sets point —
+no mode switch.  When a TUI has DEC mouse-tracking enabled
+(1000/1002/1003 — htop, lazygit, etc.) the click is forwarded to the
+program and none of the above applies.
+
 ### Line mode
 
 Entered with `C-c C-l`.  Line mode buffers the user's input locally in

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -675,6 +675,24 @@ Customize the faces `ghostel-fake-cursor' and
 `ghostel-fake-cursor-box' to tune the appearance."
   :type 'boolean)
 
+(defcustom ghostel-mouse-drag-input-mode 'copy
+  "Input mode to switch to after a left-button drag selects a region.
+
+- `copy' (default): enter `ghostel-copy-mode'.  Pauses redraws -
+  the selection is stable and the buffer is read-only.
+- `emacs': enter `ghostel-emacs-mode'.  Terminal output keeps
+  streaming; the buffer is read-only.  Pick this when you do not
+  want the terminal to pause for a selection.
+- nil: stay in semi-char.  Best-effort - the selection could get
+  clobbered by the next redraw, and `M-w' is not bound here.
+
+Has no effect when a DEC mouse-tracking mode (1000/1002/1003) is
+active (the press is forwarded to the program) or when the buffer
+is not in semi-char-mode when the drag completes."
+  :type '(choice (const :tag "Copy mode (default)" copy)
+                 (const :tag "Emacs mode"          emacs)
+                 (const :tag "Do not switch"       nil)))
+
 (defcustom ghostel-scroll-on-input t
   "Automatically scroll to the bottom when typing in the terminal.
 When non-nil, any character typed while the viewport is scrolled
@@ -2197,20 +2215,16 @@ to consume mouse input."
 When a DEC mouse-tracking mode (1000/1002/1003) is enabled, behaves
 like `ghostel--mouse-press' and forwards the press to the running
 program.  Otherwise hands EVENT off to `mouse-drag-region' so Emacs's
-standard click-to-set-point and drag-to-select work; if the buffer is
-in semi-char mode (where typing normally goes to the terminal) it
-also switches to `ghostel-copy-mode' first so the buffer is frozen
-and read-only for the duration of the selection."
+standard click-to-set-point and drag-to-select work.  Copy mode is
+not entered here - a pure click should only focus the window and
+move point.  When the press grows into a drag,
+`ghostel-mouse-drag-or-set-region' enters copy mode after the region
+is set so subsequent terminal output cannot clobber the selection."
   (interactive "e")
   (select-window (posn-window (event-start event)))
-  (cond
-   ((ghostel--mouse-tracking-active-p)
-    (ghostel--mouse-press event))
-   ((eq ghostel--input-mode 'semi-char)
-    (ghostel-copy-mode)
-    (mouse-drag-region event))
-   (t
-    (mouse-drag-region event))))
+  (if (ghostel--mouse-tracking-active-p)
+      (ghostel--mouse-press event)
+    (mouse-drag-region event)))
 
 (defun ghostel-mouse-release-or-set-point (event)
   "Forward EVENT to the terminal, or hand off to `mouse-set-point'.
@@ -2228,11 +2242,17 @@ Companion to `ghostel-mouse-press-or-copy-mode' for the left-button
 drag event.  With tracking off, defers to Emacs's standard drag
 handler so the selection survives release; without this,
 `mouse-drag-track's exit hook deactivates the mark and our
-intercept keeps `mouse-set-region' from re-establishing the region."
+intercept keeps `mouse-set-region' from re-establishing the region.
+When the buffer is in semi-char mode, switches input mode once the
+region is set to mode configured in `ghostel-mouse-drag-input-mode'."
   (interactive "e")
   (if (ghostel--mouse-tracking-active-p)
       (ghostel--mouse-drag event)
-    (mouse-set-region event)))
+    (mouse-set-region event)
+    (when (eq ghostel--input-mode 'semi-char)
+      (pcase ghostel-mouse-drag-input-mode
+        ('copy  (ghostel-copy-mode))
+        ('emacs (ghostel-emacs-mode))))))
 
 (defun ghostel-mouse-down-2-or-noop (event)
   "Forward EVENT to the terminal when a mouse-tracking mode is on.

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -9163,10 +9163,11 @@ redraw and produce visible flicker, so point is left alone."
         (kill-local-variable 'pre-command-hook)))))
 
 (ert-deftest ghostel-test-mouse-1-press-no-tracking-semi-char ()
-  "Left-press in semi-char with no tracking enters copy mode and drags.
-Hands EVENT off to `mouse-drag-region' after switching to copy mode so
-Emacs's standard click-set-point and drag-to-select work, with the
-buffer frozen for selection."
+  "Left-press in semi-char with no tracking does NOT enter copy mode.
+The press only hands EVENT off to `mouse-drag-region' so that pure
+clicks merely focus the window and set point.  Copy mode is entered
+later by `ghostel-mouse-drag-or-set-region' if the press grows into
+a drag, so streaming output cannot clobber the resulting region."
   (let ((fake-event `(down-mouse-1 (,(selected-window) 1 (10 . 5) 0)))
         (copy-mode-called nil)
         (drag-region-arg nil))
@@ -9181,7 +9182,7 @@ buffer frozen for selection."
                  (lambda (event) (setq drag-region-arg event)))
                 ((symbol-function 'select-window) (lambda (_w) nil)))
         (ghostel-mouse-press-or-copy-mode fake-event))
-      (should copy-mode-called)
+      (should-not copy-mode-called)
       (should (equal fake-event drag-region-arg)))))
 
 (ert-deftest ghostel-test-mouse-1-press-no-tracking-copy-mode ()
@@ -9268,23 +9269,170 @@ mode or otherwise interfere."
   "Drag-end with no tracking hands off to `mouse-set-region'.
 This is the bug guard: without it, `mouse-drag-track's exit hook
 deactivates the mark, our intercept blocks `mouse-set-region', and
-the user-visible region disappears on release."
+the user-visible region disappears on release.  The buffer here is
+not in semi-char mode, so copy mode must not be entered."
   (let ((fake-event `(drag-mouse-1
                       (,(selected-window) 1 (5 . 2) 0)
                       (,(selected-window) 7 (10 . 4) 0)))
         (set-region-arg nil)
+        (copy-mode-called nil)
         (mouse-event-called nil))
     (with-temp-buffer
       (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'emacs)
       (cl-letf (((symbol-function 'ghostel--mode-enabled)
                  (lambda (_term _mode) nil))
                 ((symbol-function 'mouse-set-region)
                  (lambda (event) (setq set-region-arg event)))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t)))
                 ((symbol-function 'ghostel--mouse-event)
                  (lambda (&rest _) (setq mouse-event-called t) t)))
         (ghostel-mouse-drag-or-set-region fake-event))
       (should (equal fake-event set-region-arg))
+      (should-not copy-mode-called)
       (should-not mouse-event-called))))
+
+(ert-deftest ghostel-test-mouse-1-drag-no-tracking-semi-char-enters-copy-mode ()
+  "Drag-end in semi-char with no tracking enters copy mode after region.
+The press handler no longer freezes the buffer, so freezing happens
+here once the region is established — terminal output that arrives
+after release would otherwise overwrite the highlighted cells.
+Exercises the `copy' target of `ghostel-mouse-drag-input-mode'."
+  (let ((fake-event `(drag-mouse-1
+                      (,(selected-window) 1 (5 . 2) 0)
+                      (,(selected-window) 7 (10 . 4) 0)))
+        (ghostel-mouse-drag-input-mode 'copy)
+        (set-region-arg nil)
+        (copy-mode-called nil)
+        (emacs-mode-called nil)
+        (call-order nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-region)
+                 (lambda (event)
+                   (setq set-region-arg event)
+                   (push 'set-region call-order)))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda ()
+                   (setq copy-mode-called t)
+                   (push 'copy-mode call-order)))
+                ((symbol-function 'ghostel-emacs-mode)
+                 (lambda () (setq emacs-mode-called t))))
+        (ghostel-mouse-drag-or-set-region fake-event))
+      (should (equal fake-event set-region-arg))
+      (should copy-mode-called)
+      (should-not emacs-mode-called)
+      ;; Region must be set before copy mode freezes the buffer.
+      (should (equal '(set-region copy-mode) (nreverse call-order))))))
+
+(ert-deftest ghostel-test-mouse-1-drag-no-tracking-semi-char-emacs-target ()
+  "Drag-end in semi-char with `ghostel-mouse-drag-input-mode' = `emacs'.
+Enters Emacs mode (not copy) so the user keeps streaming output but
+gains a read-only buffer that preserves the selection."
+  (let ((fake-event `(drag-mouse-1
+                      (,(selected-window) 1 (5 . 2) 0)
+                      (,(selected-window) 7 (10 . 4) 0)))
+        (ghostel-mouse-drag-input-mode 'emacs)
+        (set-region-arg nil)
+        (copy-mode-called nil)
+        (emacs-mode-called nil)
+        (call-order nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-region)
+                 (lambda (event)
+                   (setq set-region-arg event)
+                   (push 'set-region call-order)))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t)))
+                ((symbol-function 'ghostel-emacs-mode)
+                 (lambda ()
+                   (setq emacs-mode-called t)
+                   (push 'emacs-mode call-order))))
+        (ghostel-mouse-drag-or-set-region fake-event))
+      (should (equal fake-event set-region-arg))
+      (should emacs-mode-called)
+      (should-not copy-mode-called)
+      (should (equal '(set-region emacs-mode) (nreverse call-order))))))
+
+(ert-deftest ghostel-test-mouse-1-drag-no-tracking-semi-char-nil-target-stays ()
+  "Drag-end in semi-char with `ghostel-mouse-drag-input-mode' = nil.
+Stays in semi-char so the selection is best-effort and will be lost
+on the next redraw - neither copy nor Emacs mode is entered."
+  (let ((fake-event `(drag-mouse-1
+                      (,(selected-window) 1 (5 . 2) 0)
+                      (,(selected-window) 7 (10 . 4) 0)))
+        (ghostel-mouse-drag-input-mode nil)
+        (set-region-arg nil)
+        (copy-mode-called nil)
+        (emacs-mode-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-region)
+                 (lambda (event) (setq set-region-arg event)))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t)))
+                ((symbol-function 'ghostel-emacs-mode)
+                 (lambda () (setq emacs-mode-called t))))
+        (ghostel-mouse-drag-or-set-region fake-event))
+      (should (equal fake-event set-region-arg))
+      (should-not copy-mode-called)
+      (should-not emacs-mode-called))))
+
+(ert-deftest ghostel-test-mouse-1-drag-no-tracking-copy-mode-no-toggle ()
+  "Drag-end in copy mode does not call `ghostel-copy-mode' again.
+Calling `ghostel-copy-mode' from within copy mode would toggle it
+off, dropping the user back into semi-char and unfreezing the
+buffer right after they finished selecting."
+  (let ((fake-event `(drag-mouse-1
+                      (,(selected-window) 1 (5 . 2) 0)
+                      (,(selected-window) 7 (10 . 4) 0)))
+        (set-region-arg nil)
+        (copy-mode-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'copy)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-region)
+                 (lambda (event) (setq set-region-arg event)))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t))))
+        (ghostel-mouse-drag-or-set-region fake-event))
+      (should (equal fake-event set-region-arg))
+      (should-not copy-mode-called))))
+
+(ert-deftest ghostel-test-mouse-1-drag-no-tracking-line-mode-no-copy-mode ()
+  "Drag-end in line mode does not enter copy mode.
+Line mode keeps its own buffer state and must not be flipped into
+copy mode behind the user's back."
+  (let ((fake-event `(drag-mouse-1
+                      (,(selected-window) 1 (5 . 2) 0)
+                      (,(selected-window) 7 (10 . 4) 0)))
+        (set-region-arg nil)
+        (copy-mode-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'line)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-region)
+                 (lambda (event) (setq set-region-arg event)))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t))))
+        (ghostel-mouse-drag-or-set-region fake-event))
+      (should (equal fake-event set-region-arg))
+      (should-not copy-mode-called))))
 
 (ert-deftest ghostel-test-mouse-1-drag-tracking-forwards ()
   "Drag-end with active tracking forwards via `ghostel--mouse-drag'."


### PR DESCRIPTION
## Summary

- Closes #257. Left-clicking a ghostel window in semi-char mode used to freeze the buffer into copy mode on every press, including pure focus clicks. The freeze is now deferred to drag completion.
- `ghostel-mouse-press-or-copy-mode` no longer enters copy mode; it just hands off to `mouse-drag-region`. `ghostel-mouse-drag-or-set-region` enters `ghostel-copy-mode` after `mouse-set-region` if the buffer is in semi-char, so streaming terminal output still cannot clobber a real selection.
- A pure click now only focuses the window and moves point, matching the reporter's expectation.

## Test plan

- [x] `make -j4 all` clean (343 tests, 0 unexpected, 2 unrelated skips).
- [x] `ghostel-test-mouse-1-press-no-tracking-semi-char` flipped to assert no copy-mode entry on press.
- [x] Existing `ghostel-test-mouse-1-drag-no-tracking-sets-region` hardened to also assert no copy-mode entry.
- [x] New tests cover the drag path: semi-char enters copy mode after region is set (with call ordering), copy mode does not re-toggle, line mode is unaffected.
- [ ] Live verification in emacsclient: click an unfocused ghostel window — focuses without entering copy mode. Click within a focused window — point moves, no copy mode. Drag-select — region holds, mode-line shows `:Copy`. With a tracking app (e.g. `htop`), clicks still forward.