### PR TITLE
Make native module updates safe under a running Emacs

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -582,6 +582,16 @@ per-redraw scan stays cheap."
 When absent, the match is linkified as a bare file/directory
 reference opened at its start.")
 
+(defcustom ghostel-module-directory nil
+  "Directory holding the ghostel native module.
+When nil (the default), the module is read from and written to the
+ghostel package directory.  Set this to a path outside your package
+manager's tree (for example, \"~/.config/emacs/ghostel/\") so that
+rebuilds or re-installs by the package manager do not delete or
+overwrite the module file while Emacs has it loaded."
+  :type '(choice (const :tag "Use package directory" nil)
+                 (directory :tag "Custom directory")))
+
 (defcustom ghostel-module-auto-install 'ask
   "What to do when the native module is missing at first interactive use.
 This setting is consulted only when the user invokes an interactive
@@ -926,6 +936,7 @@ Returns non-nil on success."
         (when url
           (unless (string-prefix-p "https://" url)
             (error "Refusing non-HTTPS download URL: %s" url))
+          (make-directory dir t)
           (let ((dest (expand-file-name
                        (concat "ghostel-module" module-file-suffix) dir)))
             (message "ghostel: downloading native module from %s..." url)
@@ -936,26 +947,38 @@ Returns non-nil on success."
      (message "ghostel: download failed: %s" (error-message-string err))
      nil)))
 
-(defun ghostel--compile-module (dir)
-  "Compile the native module from source in DIR.
-Runs synchronously and returns non-nil on success."
-  (let ((default-directory dir))
+(defun ghostel--compile-module (dest-dir)
+  "Compile the native module from source and install it in DEST-DIR.
+The build runs in `ghostel--resource-root' (which holds build.zig);
+on success the produced module is renamed into DEST-DIR."
+  (let* ((source-dir (ghostel--resource-root))
+         (default-directory source-dir))
     (message "ghostel: compiling native module with zig build (this may take a moment)...")
     (condition-case err
         (let ((ret (process-file "zig" nil "*ghostel-build*" nil
                                  "build" "-Doptimize=ReleaseFast" "-Dcpu=baseline")))
-          (if (eq ret 0)
-              (progn (message "ghostel: native module compiled successfully") t)
-            (display-warning 'ghostel
-                             "Module compilation failed.  See *ghostel-build* buffer for details.")
-            nil))
+          (if (not (eq ret 0))
+              (display-warning 'ghostel
+                               "Module compilation failed.  See *ghostel-build* buffer for details.")
+            (let* ((file-name (concat "ghostel-module" module-file-suffix))
+                   (built (expand-file-name file-name source-dir))
+                   (final (expand-file-name file-name dest-dir)))
+              (cond
+               ((not (file-exists-p built))
+                (display-warning 'ghostel
+                                 (format "Build succeeded but module not produced at %s"
+                                         built)))
+               ((equal built final)
+                (message "ghostel: native module compiled successfully"))
+               (t
+                (make-directory dest-dir t)
+                (rename-file built final t)
+                (message "ghostel: native module compiled successfully"))))))
       (file-missing
        (display-warning 'ghostel
-                        (format "zig executable not found while compiling in %s" dir))
-       nil)
+                        (format "zig executable not found while compiling in %s" source-dir)))
       (error
-       (display-warning 'ghostel (error-message-string err))
-       nil))))
+       (display-warning 'ghostel (error-message-string err))))))
 
 (defun ghostel--ensure-module (dir)
   "Ensure the native module exists in DIR.
@@ -1000,10 +1023,18 @@ Choice: " url)
       (?s nil))))
 
 (defun ghostel--download-file (url dest)
-  "Download URL to DEST.  Return non-nil on success."
-  (condition-case nil
-      (let ((url-request-method "GET")
-            (url-show-status nil))
+  "Download URL to DEST atomically.  Return non-nil on success.
+Writes to a sibling temp file in the same directory and renames it
+into place once the download succeeds.  Renaming swaps the directory
+entry to a new inode, so any process (notably a running Emacs) that
+has the previous DEST file mmap'd keeps a valid mapping to the old
+file content.  Writing to DEST directly would truncate the existing
+inode and corrupt that mapping."
+  (let* ((url-request-method "GET")
+         (url-show-status nil)
+         (tmp (make-temp-name (concat dest ".tmp.")))
+         (ok nil))
+    (unwind-protect
         (let ((buf (url-retrieve-synchronously url t t 30)))
           (when buf
             (unwind-protect
@@ -1015,12 +1046,16 @@ Choice: " url)
                       (let ((coding-system-for-write 'binary)
                             (start (point)))
                         (when (< start (point-max))
-                          (write-region start (point-max) dest nil 'silent)
-                          (set-file-modes dest #o755)
-                          t)))))
+                          (write-region start (point-max) tmp nil 'silent)
+                          (set-file-modes tmp #o755)
+                          (rename-file tmp dest t)
+                          (setq ok t))))))
               (when (buffer-live-p buf)
-                (kill-buffer buf))))))
-    (error nil)))
+                (kill-buffer buf)))))
+      (unless ok
+        (when (file-exists-p tmp)
+          (ignore-errors (delete-file tmp)))))
+    ok))
 
 (defun ghostel--package-directory ()
   "Return the directory ghostel is loaded from, or nil."
@@ -1046,12 +1081,20 @@ shipped resources), so callers always get a sensible
           (and (file-directory-p (expand-file-name "etc" parent)) parent))
         lisp-dir)))
 
+(defun ghostel--module-directory ()
+  "Return the absolute directory where the native module lives.
+Honours `ghostel-module-directory' when set, otherwise falls back to
+the shipped resource root."
+  (when-let* ((dir (or ghostel-module-directory
+                       (ghostel--resource-root))))
+    (file-name-as-directory (expand-file-name dir))))
+
 (defun ghostel-download-module (&optional prompt-for-version)
   "Interactively download the pre-built native module for this platform.
 With PROMPT-FOR-VERSION, prompt for a release tag to download.
 Leaving the prompt empty downloads the latest release."
   (interactive "P")
-  (let* ((dir (ghostel--resource-root))
+  (let* ((dir (ghostel--module-directory))
          (mod (expand-file-name
                (concat "ghostel-module" module-file-suffix) dir))
          (version (when prompt-for-version
@@ -1067,12 +1110,47 @@ Leaving the prompt empty downloads the latest release."
           (message "ghostel: module loaded successfully"))
       (user-error "Download failed.  Try M-x ghostel-module-compile to build from source"))))
 
+(defun ghostel--install-built-module-on-finish (compile-buf source-dir dest-dir)
+  "Move the built module from SOURCE-DIR into DEST-DIR when COMPILE-BUF finishes.
+Registers a one-shot `compilation-finish-functions' handler that
+filters on COMPILE-BUF and removes itself on first match.  Used so the
+interactive `ghostel-module-compile' honours `ghostel-module-directory'."
+  (let* ((file-name (concat "ghostel-module" module-file-suffix))
+         handler)
+    (setq handler
+          (lambda (buf status)
+            (when (eq buf compile-buf)
+              (remove-hook 'compilation-finish-functions handler)
+              (when (string-match-p "finished" status)
+                (let ((built (expand-file-name file-name source-dir))
+                      (final (expand-file-name file-name dest-dir)))
+                  (when (file-exists-p built)
+                    (condition-case err
+                        (progn
+                          (make-directory dest-dir t)
+                          (rename-file built final t)
+                          (message "ghostel: module installed at %s" final))
+                      (error
+                       (display-warning
+                        'ghostel
+                        (format "Build succeeded but moving %s to %s failed: %s"
+                                built final (error-message-string err)))))))))))
+    (add-hook 'compilation-finish-functions handler)))
+
 (defun ghostel-module-compile ()
   "Compile the ghostel native module by running zig build.
-The output is shown in a *ghostel-build* compilation buffer."
+The output is shown in a `*compilation*' buffer.  When
+`ghostel-module-directory' points outside the package tree, the
+produced module is moved into that directory once the build
+finishes."
   (interactive)
-  (let ((default-directory (ghostel--resource-root)))
-    (compile "zig build -Doptimize=ReleaseFast -Dcpu=baseline" t)))
+  (let* ((source-dir (ghostel--resource-root))
+         (dest-dir (ghostel--module-directory))
+         (default-directory source-dir)
+         (compile-buf (compile "zig build -Doptimize=ReleaseFast -Dcpu=baseline" t)))
+    (unless (equal (file-name-as-directory (expand-file-name source-dir))
+                   (file-name-as-directory (expand-file-name dest-dir)))
+      (ghostel--install-built-module-on-finish compile-buf source-dir dest-dir))))
 
 
 (defun ghostel--check-module-version (dir &optional prompt-user)
@@ -1110,7 +1188,7 @@ covers the pure-Elisp test path where `cl-letf' stubs the native
 entry points so tests run without the module present."
   (unless (or (featurep 'ghostel-module)
               (fboundp 'ghostel--new))
-    (let* ((dir (ghostel--resource-root))
+    (let* ((dir (ghostel--module-directory))
            (mod (expand-file-name
                  (concat "ghostel-module" module-file-suffix) dir)))
       (when (and prompt-user (not (file-exists-p mod)))

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -8615,14 +8615,172 @@ hand nil to the native module."
         (should (null captured-version))
         (should captured-latest)))))
 
+(ert-deftest ghostel-test-download-file-is-atomic ()
+  "`ghostel--download-file' writes via a temp sibling and renames into place.
+The destination inode must change so any Emacs that has the previous
+file mmap'd keeps a valid mapping (issue #247)."
+  (let* ((dir (make-temp-file "ghostel-dl-" t))
+         (dest (expand-file-name "ghostel-module.so" dir)))
+    (unwind-protect
+        (progn
+          (with-temp-file dest (insert "old-payload"))
+          (set-file-modes dest #o644)
+          (let ((old-inode (file-attribute-inode-number (file-attributes dest))))
+            (cl-letf (((symbol-function 'url-retrieve-synchronously)
+                       (lambda (&rest _)
+                         (let ((buf (generate-new-buffer " *ghostel-fake-http*")))
+                           (with-current-buffer buf
+                             (set-buffer-multibyte nil)
+                             (insert "HTTP/1.1 200 OK\r\n\r\nnew-payload"))
+                           buf))))
+              (should (ghostel--download-file "https://example.invalid/x" dest)))
+            (should (equal "new-payload"
+                           (with-temp-buffer
+                             (set-buffer-multibyte nil)
+                             (insert-file-contents-literally dest)
+                             (buffer-string))))
+            (let ((new-inode (file-attribute-inode-number (file-attributes dest))))
+              (should-not (equal old-inode new-inode)))
+            ;; No stale temp files left behind on success.
+            (dolist (f (directory-files dir nil "\\." t))
+              (should-not (string-match-p "\\.tmp\\." f)))))
+      (when (file-exists-p dir)
+        (delete-directory dir t)))))
+
+(ert-deftest ghostel-test-download-module-creates-missing-directory ()
+  "`ghostel--download-module' creates DIR before writing the module.
+Regression for the auto-install path: setting `ghostel-module-directory'
+to a path that does not yet exist used to fail silently because the
+temp-file write under that directory errored out."
+  (let* ((parent (make-temp-file "ghostel-dl-parent-" t))
+         (dir (expand-file-name "sub/dir/" parent))
+         (asset "ghostel-module-x86_64-linux.so"))
+    (unwind-protect
+        (progn
+          (should-not (file-exists-p dir))
+          (cl-letf (((symbol-function 'ghostel--module-asset-name)
+                     (lambda () asset))
+                    ((symbol-function 'url-retrieve-synchronously)
+                     (lambda (&rest _)
+                       (let ((buf (generate-new-buffer " *ghostel-fake-http*")))
+                         (with-current-buffer buf
+                           (set-buffer-multibyte nil)
+                           (insert "HTTP/1.1 200 OK\r\n\r\npayload"))
+                         buf))))
+            (should (ghostel--download-module dir nil t)))
+          (should (file-directory-p dir))
+          (should (file-exists-p (expand-file-name
+                                  (concat "ghostel-module" module-file-suffix)
+                                  dir))))
+      (when (file-exists-p parent)
+        (delete-directory parent t)))))
+
+(ert-deftest ghostel-test-download-file-cleans-up-on-failure ()
+  "A failed HTTP response leaves no stale temp file behind."
+  (let* ((dir (make-temp-file "ghostel-dl-" t))
+         (dest (expand-file-name "ghostel-module.so" dir)))
+    (unwind-protect
+        (progn
+          (cl-letf (((symbol-function 'url-retrieve-synchronously)
+                     (lambda (&rest _)
+                       (let ((buf (generate-new-buffer " *ghostel-fake-http*")))
+                         (with-current-buffer buf
+                           (set-buffer-multibyte nil)
+                           (insert "HTTP/1.1 404 Not Found\r\n\r\nnope"))
+                         buf))))
+            (should-not (ghostel--download-file "https://example.invalid/x" dest)))
+          (should-not (file-exists-p dest))
+          (dolist (f (directory-files dir nil "\\." t))
+            (should-not (string-match-p "\\.tmp\\." f))))
+      (when (file-exists-p dir)
+        (delete-directory dir t)))))
+
+(ert-deftest ghostel-test-module-directory-defaults-to-resource-root ()
+  "When `ghostel-module-directory' is nil, the resource root is used."
+  (let ((ghostel-module-directory nil))
+    (cl-letf (((symbol-function 'ghostel--resource-root)
+               (lambda () "/pkg/ghostel/")))
+      (should (equal (downcase (file-name-as-directory
+                                (expand-file-name "/pkg/ghostel/")))
+                     (downcase (ghostel--module-directory)))))))
+
+(ert-deftest ghostel-test-module-directory-honours-custom-value ()
+  "When set, `ghostel-module-directory' takes precedence."
+  (let ((ghostel-module-directory "~/custom/ghostel/"))
+    (cl-letf (((symbol-function 'ghostel--resource-root)
+               (lambda () "/pkg/ghostel/")))
+      (should (equal (downcase (file-name-as-directory
+                                (expand-file-name "~/custom/ghostel/")))
+                     (downcase (ghostel--module-directory)))))))
+
+(ert-deftest ghostel-test-download-module-targets-custom-directory ()
+  "Interactive download writes into `ghostel-module-directory' when set."
+  (let ((ghostel-module-directory "/custom/dir/")
+        (captured-dir nil))
+    (let ((native-comp-enable-subr-trampolines nil))
+      (cl-letf (((symbol-function 'ghostel--resource-root)
+                 (lambda () "/pkg/ghostel/"))
+                ((symbol-function 'file-exists-p)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'make-directory)
+                 (lambda (&rest _)))
+                ((symbol-function 'ghostel--read-module-download-version)
+                 (lambda () nil))
+                ((symbol-function 'ghostel--download-module)
+                 (lambda (dir &optional _v _l)
+                   (setq captured-dir dir)
+                   (throw 'ghostel-test-bail nil)))
+                ((symbol-function 'message)
+                 (lambda (&rest _))))
+        (catch 'ghostel-test-bail
+          (ghostel-download-module nil))
+        (should (equal (downcase (file-name-as-directory
+                                  (expand-file-name "/custom/dir/")))
+                       (downcase captured-dir)))))))
+
+(ert-deftest ghostel-test-load-module-looks-in-custom-directory ()
+  "`ghostel--load-module' loads the module from `ghostel-module-directory'."
+  (let* ((ghostel-module-directory "/custom/dir/")
+         (loaded-path nil)
+         (had-feat (featurep 'ghostel-module))
+         (saved-new (and (fboundp 'ghostel--new)
+                         (symbol-function 'ghostel--new))))
+    (unwind-protect
+        (progn
+          (when had-feat
+            (setq features (delq 'ghostel-module features)))
+          (when saved-new
+            (fmakunbound 'ghostel--new))
+          (cl-letf (((symbol-function 'ghostel--resource-root)
+                     (lambda () "/pkg/ghostel/"))
+                    ((symbol-function 'file-exists-p)
+                     (lambda (path)
+                       (string-prefix-p (expand-file-name "/custom/dir/") path)))
+                    ((symbol-function 'module-load)
+                     (lambda (path) (setq loaded-path path)))
+                    ((symbol-function 'ghostel--check-module-version)
+                     (lambda (&rest _))))
+            (ghostel--load-module)))
+      (when saved-new
+        (fset 'ghostel--new saved-new))
+      (when had-feat
+        (cl-pushnew 'ghostel-module features)))
+    (should loaded-path)
+    (should (string-prefix-p (expand-file-name "/custom/dir/")
+                             loaded-path))))
+
 (ert-deftest ghostel-test-compile-module-invokes-zig-build ()
-  "Source compilation runs zig build directly."
+  "Source compilation runs zig build in the resource root."
   (let ((default-directory nil)
         (messages nil)
         (warnings nil)
         (process-invocation nil))
     (let ((native-comp-enable-subr-trampolines nil))
-      (cl-letf (((symbol-function 'message)
+      (cl-letf (((symbol-function 'ghostel--resource-root)
+                 (lambda () "C:/ghostel/"))
+                ((symbol-function 'file-exists-p)
+                 (lambda (_) t))
+                ((symbol-function 'message)
                  (lambda (fmt &rest args)
                    (push (apply #'format fmt args) messages)))
                 ((symbol-function 'display-warning)
@@ -8633,28 +8791,135 @@ hand nil to the native module."
                    (setq process-invocation
                          (list program infile buffer display args default-directory))
                    0)))
-        (should (ghostel--compile-module "C:/ghostel/"))
+        (ghostel--compile-module "C:/ghostel/")
         (should (equal
                  '("zig" nil "*ghostel-build*" nil ("build" "-Doptimize=ReleaseFast" "-Dcpu=baseline") "C:/ghostel/")
                  process-invocation))
         (should-not warnings)))))
 
+(ert-deftest ghostel-test-compile-module-moves-to-dest-dir ()
+  "Compilation moves the produced module into DEST-DIR when it differs."
+  (let ((rename-args nil)
+        (made-dirs nil)
+        (warnings nil))
+    (let ((native-comp-enable-subr-trampolines nil))
+      (cl-letf (((symbol-function 'ghostel--resource-root)
+                 (lambda () "/src/ghostel/"))
+                ((symbol-function 'file-exists-p)
+                 (lambda (_) t))
+                ((symbol-function 'make-directory)
+                 (lambda (dir &rest _) (push dir made-dirs)))
+                ((symbol-function 'rename-file)
+                 (lambda (from to &optional _ok)
+                   (push (list from to) rename-args)))
+                ((symbol-function 'message) (lambda (&rest _)))
+                ((symbol-function 'display-warning)
+                 (lambda (&rest args) (push args warnings)))
+                ((symbol-function 'process-file)
+                 (lambda (&rest _) 0)))
+        (ghostel--compile-module "/custom/dir/")
+        (should-not warnings)
+        (should (equal 1 (length rename-args)))
+        (let ((args (car rename-args)))
+          (should (equal (downcase (expand-file-name
+                                    (concat "ghostel-module" module-file-suffix)
+                                    "/src/ghostel/"))
+                         (downcase (nth 0 args))))
+          (should (equal (downcase (expand-file-name
+                                    (concat "ghostel-module" module-file-suffix)
+                                    "/custom/dir/"))
+                         (downcase (nth 1 args)))))
+        (should (member "/custom/dir/" made-dirs))))))
+
+(ert-deftest ghostel-test-compile-module-warns-when-build-missing ()
+  "When the build returns success but no module file appears, warn."
+  (let ((warnings nil))
+    (let ((native-comp-enable-subr-trampolines nil))
+      (cl-letf (((symbol-function 'ghostel--resource-root)
+                 (lambda () "/src/ghostel/"))
+                ((symbol-function 'file-exists-p)
+                 (lambda (_) nil))
+                ((symbol-function 'message) (lambda (&rest _)))
+                ((symbol-function 'display-warning)
+                 (lambda (&rest args) (push args warnings)))
+                ((symbol-function 'process-file)
+                 (lambda (&rest _) 0)))
+        (ghostel--compile-module "/src/ghostel/")
+        (should warnings)))))
+
 (ert-deftest ghostel-test-module-compile-command-uses-zig-build ()
   "Interactive compilation uses zig build directly."
   (let ((compile-invocation nil)
-        (default-directory nil))
+        (default-directory nil)
+        (ghostel-module-directory nil))
     (let ((native-comp-enable-subr-trampolines nil))
-      (cl-letf (((symbol-function 'locate-library)
-                 (lambda (_) "C:/ghostel/ghostel.el"))
+      (cl-letf (((symbol-function 'ghostel--resource-root)
+                 (lambda () "C:/ghostel/"))
                 ((symbol-function 'compile)
                  (lambda (command &optional comint)
-                   (setq compile-invocation (list command comint default-directory)))))
+                   (setq compile-invocation (list command comint default-directory))
+                   (current-buffer))))
         (ghostel-module-compile)
         (should (equal "zig build -Doptimize=ReleaseFast -Dcpu=baseline"
                        (nth 0 compile-invocation)))
         (should (eq t (nth 1 compile-invocation)))
         (should (equal (downcase "C:/ghostel/")
                        (downcase (nth 2 compile-invocation))))))))
+
+(ert-deftest ghostel-test-module-compile-installs-when-dest-differs ()
+  "Interactive compile installs the built module into `ghostel-module-directory'.
+A `compilation-finish-functions' handler renames the artifact when
+the dest directory differs from the source root."
+  (let* ((compile-buf (generate-new-buffer " *ghostel-test-compile*"))
+         (compilation-finish-functions nil)
+         (rename-args nil)
+         (made-dirs nil)
+         (default-directory nil)
+         (ghostel-module-directory "/custom/dir/"))
+    (unwind-protect
+        (let ((native-comp-enable-subr-trampolines nil))
+          (cl-letf (((symbol-function 'ghostel--resource-root)
+                     (lambda () "/src/ghostel/"))
+                    ((symbol-function 'compile)
+                     (lambda (&rest _) compile-buf))
+                    ((symbol-function 'file-exists-p)
+                     (lambda (_) t))
+                    ((symbol-function 'make-directory)
+                     (lambda (dir &rest _) (push dir made-dirs)))
+                    ((symbol-function 'rename-file)
+                     (lambda (from to &optional _ok)
+                       (push (list from to) rename-args)))
+                    ((symbol-function 'message) (lambda (&rest _))))
+            (ghostel-module-compile)
+            (should (equal 1 (length compilation-finish-functions)))
+            ;; Simulate compilation completion.
+            (funcall (car compilation-finish-functions) compile-buf "finished\n")
+            (should (null compilation-finish-functions))
+            (should (equal 1 (length rename-args)))
+            (let ((args (car rename-args)))
+              (should (equal (downcase (expand-file-name
+                                        (concat "ghostel-module" module-file-suffix)
+                                        "/src/ghostel/"))
+                             (downcase (nth 0 args))))
+              (should (equal (downcase (expand-file-name
+                                        (concat "ghostel-module" module-file-suffix)
+                                        "/custom/dir/"))
+                             (downcase (nth 1 args)))))))
+      (when (buffer-live-p compile-buf)
+        (kill-buffer compile-buf)))))
+
+(ert-deftest ghostel-test-module-compile-no-install-when-dest-same ()
+  "When dest matches source, no finish handler is registered."
+  (let ((compilation-finish-functions nil)
+        (default-directory nil)
+        (ghostel-module-directory nil))
+    (let ((native-comp-enable-subr-trampolines nil))
+      (cl-letf (((symbol-function 'ghostel--resource-root)
+                 (lambda () "/src/ghostel/"))
+                ((symbol-function 'compile)
+                 (lambda (&rest _) (current-buffer))))
+        (ghostel-module-compile)
+        (should (null compilation-finish-functions))))))
 
 (ert-deftest ghostel-test-module-version-match ()
   "Test that version check does nothing when module meets minimum."
@@ -14111,12 +14376,23 @@ slip past the unit tests."
     ghostel-test-copy-all
     ghostel-test-copy-mode-buffer-navigation
     ghostel-test-compile-module-invokes-zig-build
+    ghostel-test-compile-module-moves-to-dest-dir
+    ghostel-test-compile-module-warns-when-build-missing
     ghostel-test-module-compile-command-uses-zig-build
+    ghostel-test-module-compile-installs-when-dest-differs
+    ghostel-test-module-compile-no-install-when-dest-same
     ghostel-test-module-download-url-uses-requested-version
     ghostel-test-module-download-url-uses-latest-release
     ghostel-test-download-module-defaults-to-minimum-version
     ghostel-test-download-module-prefix-uses-requested-version
     ghostel-test-download-module-prefix-empty-uses-latest
+    ghostel-test-download-file-is-atomic
+    ghostel-test-download-file-cleans-up-on-failure
+    ghostel-test-download-module-creates-missing-directory
+    ghostel-test-module-directory-defaults-to-resource-root
+    ghostel-test-module-directory-honours-custom-value
+    ghostel-test-download-module-targets-custom-directory
+    ghostel-test-load-module-looks-in-custom-directory
     ghostel-test-module-version-match
     ghostel-test-module-version-mismatch
     ghostel-test-module-version-newer-than-minimum


### PR DESCRIPTION
## Summary
- Atomic download: `ghostel--download-file` writes to a sibling temp file and `rename-file`s it into place, so an Emacs still holding the previous file mmap'd retains a valid mapping.
- New `ghostel-module-directory` defcustom lets users park the module outside the package manager's tree (e.g. elpaca's repos dir), where rebuilds won't delete or overwrite it under a running Emacs.
- `ghostel--compile-module` and the interactive `ghostel-module-compile` build in the resource root and rename the artifact into the configured directory when it differs.

Fixes #247 (crash side; performance side-note left for a separate ticket).

## Test plan
- [x] `make -j4 all` — build, lint, 78 evil + 173 native + 353 elisp tests
- [x] Manually: `M-x ghostel-download-module` while a ghostel buffer is live; verify Emacs doesn't crash and is told to restart to pick up the new module
- [x] Manually: `(setq ghostel-module-directory "~/.config/emacs/ghostel/")`, then `M-x ghostel-download-module`; verify the file lands there and `M-x ghostel` loads from it
- [x] Manually: with `ghostel-module-directory` set, `M-x ghostel-module-compile`; verify the artifact is moved into the configured directory once the build finishes