### PR TITLE
Rewrite evil-ghostel from advice to command-remap architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           emacs --batch -Q -L /tmp/compat -L /tmp/evil -L lisp -L extensions/evil-ghostel \
             -l ert \
             -l test/evil-ghostel-test.el \
-            -f evil-ghostel-test-run-elisp
+            -f evil-ghostel-test-run
 
   build-native:
     strategy:

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -12,9 +12,20 @@
 
 ;;; Commentary:
 
-;; Provides evil-mode compatibility for the ghostel terminal emulator.
-;; Synchronizes the terminal cursor with Emacs point during evil state
-;; transitions so that normal-mode navigation works correctly.
+;; Evil-mode integration for the ghostel terminal emulator, modeled on
+;; `evil-collection-vterm'.
+;;
+;; Like vterm's, the surface area is tiny.  Basic motions (h l w b e $ 0)
+;; stay vanilla Evil, so point moves freely over the rendered row.  Only
+;; the commands that drive the shell's line editor are customized:
+;; operators (d c x s r and line variants) clamp their range to
+;; [input-start, input-end] and apply it over the PTY (arrows, backspaces,
+;; bracketed paste); i a I A drive the shell cursor to point; ^ jumps past
+;; the prompt; j / G stay on the live prompt; p / P paste; u sends
+;; readline undo.
+;;
+;; Outside semi-char input mode (`line' / `copy' / `emacs' / `char' modes,
+;; or an alt-screen TUI) every command falls through to `evil-*'.
 ;;
 ;; Enable by adding to your init:
 ;;
@@ -41,11 +52,8 @@
 
 (defcustom evil-ghostel-initial-state 'insert
   "Initial evil state for new `ghostel-mode' buffers.
-Setting this option via `customize-set-variable', `setopt', or the
-Customize UI calls `evil-set-initial-state' so the change takes effect
-immediately.  Users who prefer the raw API can call
-`evil-set-initial-state' directly from their config — the registry is
-last-writer-wins."
+Setting via Customize, `setopt', or `customize-set-variable' applies the
+change immediately through `evil-set-initial-state'."
   :type '(choice (const :tag "Emacs" emacs)
                  (const :tag "Insert" insert)
                  (const :tag "Normal" normal)
@@ -57,50 +65,50 @@ last-writer-wins."
 (defcustom evil-ghostel-escape 'auto
   "Where insert-state ESC is routed in ghostel buffers.
 
-`auto'      — when the inner app is in alt-screen mode (DECSET 1049,
-              used by vim, less, htop, nvim, etc.) ESC is sent to the
-              terminal; otherwise evil's binding runs and switches to
-              normal state.
-`terminal'  — always send ESC to the terminal.
-`evil'      — always run evil's binding (ESC stays with evil).
+`auto'     - to the terminal in alt-screen mode (DECSET 1049: vim, less,
+             htop, …); otherwise evil's binding switches to normal state.
+`terminal' - always send ESC to the terminal.
+`evil'     - always run evil's binding.
 
-Sets the initial value of the buffer-local state.  Use
-\\[evil-ghostel-toggle-send-escape] to change it for the current buffer."
+Sets the initial value of the buffer-local routing mode; change it per
+buffer with \\[evil-ghostel-toggle-send-escape]."
   :type '(choice (const :tag "Auto (alt-screen heuristic)" auto)
                  (const :tag "Always to terminal" terminal)
                  (const :tag "Always to evil" evil)))
 
-;; Apply the current value at load.  Covers the case where the user set
-;; the variable with plain `setq' before loading the package — in that
-;; path `defcustom' preserves the value without invoking `:set'.
+(defcustom evil-ghostel-sync-render-max-iterations 10
+  "Iteration cap for the drain loop in `evil-ghostel--sync-render'.
+Each iteration waits up to 50 ms, bounding the total wait at ~500 ms so a
+runaway shell can't hang the caller."
+  :type 'integer)
+
+;; Apply at load: a plain `setq' before load skips the `:set' above.
 (evil-set-initial-state 'ghostel-mode evil-ghostel-initial-state)
 
 
-;; Guard predicate
+;; Guard predicates
 
 (defun evil-ghostel--active-p ()
-  "Return non-nil when evil-ghostel editing should intercept."
+  "Return non-nil when evil-ghostel PTY routing should intercept.
+True in `semi-char' input mode and outside alt-screen — the only state in
+which `evil-ghostel-*' commands send PTY keys rather than running `evil-*'."
   (and evil-ghostel-mode
        ghostel--term
        (not (ghostel--mode-enabled ghostel--term 1049))
        (eq ghostel--input-mode 'semi-char)))
 
 (defun evil-ghostel--ctrl-passthrough-active-p ()
-  "Return non-nil when insert-state Ctrl keys should go to the terminal.
-Unlike `evil-ghostel--active-p', this intentionally stays active in
-alt-screen mode: full-screen TUIs own the keyboard, so readline-style
-Ctrl keys like \\`C-u', \\`C-w', \\`C-r' must not fall back to Evil's
-insert-state editing commands."
+  "Return non-nil when insert-state Ctrl keys should reach the terminal.
+Active even in alt-screen, unlike `evil-ghostel--active-p', so a TUI's
+readline-style Ctrl keys are not eaten by evil."
   (and evil-ghostel-mode
        ghostel--term
        (eq ghostel--input-mode 'semi-char)))
 
 (defun evil-ghostel--line-mode-active-p ()
   "Return non-nil when line mode editing is in effect.
-Line mode buffers shell input as plain buffer text inside
-`[ghostel--line-input-start, ghostel--line-input-end]'.  evil's
-default editing operators (operating on buffer text) are exactly
-right there, so PTY-routing intercepts must stand down."
+Then shell input is plain buffer text between `ghostel--line-input-start'
+and `ghostel--line-input-end', so evil's operators apply directly."
   (and evil-ghostel-mode
        (eq ghostel--input-mode 'line)
        (markerp ghostel--line-input-start)
@@ -109,175 +117,55 @@ right there, so PTY-routing intercepts must stand down."
 
 ;; Cursor synchronization
 
-(defun evil-ghostel--reset-cursor-point ()
-  "Move Emacs point to the terminal cursor position.
-`ghostel--cursor-pos' holds the viewport-relative (COL . ROW), so
-the row must be offset by the scrollback line count."
-  (when (and ghostel--term ghostel--term-rows)
-    (let ((pos ghostel--cursor-pos))
-      (when pos
-        (let ((scrollback (max 0 (- (count-lines (point-min) (point-max))
-                                    ghostel--term-rows))))
-          (goto-char (point-min))
-          (forward-line (+ scrollback (cdr pos)))
-          (move-to-column (car pos)))))))
+(defun evil-ghostel--scrollback-lines ()
+  "Return the count of scrollback lines above the viewport."
+  (max 0 (- (count-lines (point-min) (point-max)) ghostel--term-rows)))
 
-(defun evil-ghostel--cursor-buffer-line ()
-  "Return the 0-indexed buffer line of the terminal cursor, or nil.
-Translates `ghostel--cursor-pos' (viewport-relative row) into a
-buffer line by adding the scrollback line count."
-  (when (and ghostel--term ghostel--term-rows)
-    (let ((pos ghostel--cursor-pos))
-      (when pos
-        (let ((scrollback (max 0 (- (count-lines (point-min) (point-max))
-                                    ghostel--term-rows))))
-          (+ scrollback (cdr pos)))))))
+(defun evil-ghostel--reset-cursor-point ()
+  "Move Emacs point to the terminal cursor.
+`ghostel--cursor-pos' is viewport-relative; its row is offset by scrollback."
+  (when (and ghostel--term ghostel--term-rows ghostel--cursor-pos)
+    (goto-char (point-min))
+    (forward-line (+ (evil-ghostel--scrollback-lines) (cdr ghostel--cursor-pos)))
+    (move-to-column (car ghostel--cursor-pos))))
 
 (defun evil-ghostel--point-viewport-row ()
   "Return the viewport row of point, 0-indexed, or nil.
-Subtracts the scrollback line count from the buffer line so the
-result is comparable to `ghostel--cursor-pos''s row."
+Comparable to `ghostel--cursor-pos''s row."
   (when ghostel--term-rows
-    (let ((scrollback (max 0 (- (count-lines (point-min) (point-max))
-                                ghostel--term-rows))))
-      (- (line-number-at-pos (point) t) 1 scrollback))))
+    (- (line-number-at-pos (point) t) 1 (evil-ghostel--scrollback-lines))))
 
-(defun evil-ghostel--point-on-cursor-line-p ()
-  "Return non-nil when point is on the buffer line of the terminal cursor.
-Reflects current state (libghostty cursor + Emacs buffer); only
-meaningful after a redraw has synchronized the two.  Inside
-`evil-ghostel--around-redraw' the libghostty cursor has already
-advanced past output that the buffer hasn't rendered yet, so this
-helper is unsafe there — use `evil-ghostel--last-cursor-line' instead."
-  (let ((cursor-line (evil-ghostel--cursor-buffer-line)))
-    (when cursor-line
-      (= (- (line-number-at-pos (point) t) 1) cursor-line))))
-
-(defvar-local evil-ghostel--last-cursor-line nil
-  "Buffer line where the previous redraw placed the terminal cursor.
-Used by `evil-ghostel--around-redraw' to distinguish prompt-following
-from scrollback navigation and same-line column motion.")
-
-(defvar-local evil-ghostel--shadow-cursor nil
-  "Pending terminal cursor (COL . VIEWPORT-ROW), or nil to read live state.
-Within a single advice call we may emit several key sequences
-\(arrow-key sync, then backspaces, then another sync) before any
-of them are echoed by the PTY.  `ghostel--cursor-pos' reflects
-the rendered state, which lags our queued keys, so a second
-sync that reads it would compute deltas from a stale baseline and
-over-correct.  The shadow models where the cursor will land once
-the queue drains; `evil-ghostel--cursor-to-point' reads it in
-preference to the live value.
-
-Reset by `evil-ghostel--around-redraw' after the renderer has
-processed the echo, and by operations whose cursor effect we
-cannot model (Ctrl-a/e/u, paste).")
-
-(defun evil-ghostel--shadow-or-live ()
-  "Return best-known terminal cursor (COL . VIEWPORT-ROW), or nil.
-Shadow value if set, otherwise the rendered cursor from `ghostel--cursor-pos'."
-  (or evil-ghostel--shadow-cursor ghostel--cursor-pos))
-
-(defun evil-ghostel--invalidate-shadow ()
-  "Clear `evil-ghostel--shadow-cursor'.
-Call after operations whose cursor effect we cannot model so the
-next read falls back to the live libghostty position."
-  (setq evil-ghostel--shadow-cursor nil))
-
-(defun evil-ghostel--cursor-to-point ()
-  "Move the terminal cursor to Emacs point by sending arrow keys.
-`ghostel--cursor-pos' holds the row within the viewport (the
-last `ghostel--term-rows' lines), so the buffer line must be
-converted to a viewport row by subtracting the scrollback offset —
-otherwise dy is wrong by exactly the scrollback line count.
-
-Reads `evil-ghostel--shadow-cursor' in preference to the live
-libghostty cursor (which lags any keys we have just sent), and
-updates the shadow to point's position so a follow-up call within
-the same operation sees the post-keys baseline rather than the
-still-stale live value."
-  (when ghostel--term
-    (let* ((tpos (evil-ghostel--shadow-or-live))
-           (tcol (car tpos))
-           (trow (cdr tpos))
-           (ecol (current-column))
-           (erow (or (evil-ghostel--point-viewport-row) 0))
-           (dy (- erow trow))
-           (dx (- ecol tcol)))
-      (cond ((> dy 0) (dotimes (_ dy) (ghostel--send-encoded "down" "")))
-            ((< dy 0) (dotimes (_ (abs dy)) (ghostel--send-encoded "up" ""))))
-      (cond ((> dx 0) (dotimes (_ dx) (ghostel--send-encoded "right" "")))
-            ((< dx 0) (dotimes (_ (abs dx)) (ghostel--send-encoded "left" ""))))
-      (setq evil-ghostel--shadow-cursor (cons ecol erow)))))
-
-
-;; Redraw: apply Evil-specific point and visual-marker semantics
-
-(defvar-local evil-ghostel--sync-point-on-next-redraw nil
-  "When non-nil, the next `ghostel--redraw' moves point to the terminal cursor.
-Set by operations that send PTY commands which will reposition the
-terminal cursor (e.g. the same-row `dd' Ctrl-u path) where Emacs
-point would otherwise be left at a now-stale position.")
+;; Redraw: preserve Evil point/visual semantics.  ghostel repaints the
+;; viewport on each redraw without snapping point to the cursor; right
+;; for normal state.  Point follows the cursor only in insert/emacs state
+;; (where typed chars land there); visual markers are restored around it.
 
 (defun evil-ghostel--around-redraw (orig-fn term &optional full)
-  "Apply Evil-specific point handling around `ghostel--redraw'.
-The renderer preserves normal buffer positions.  This advice only
-syncs point to the terminal cursor when Evil semantics require it:
-insert/Emacs states, explicit sync requests, and normal-state prompt
-movement.  Visual range markers are restored around the native redraw.
-
-ORIG-FN is the advised `ghostel--redraw' called with TERM and FULL.
-Skipped when the terminal is in alt-screen mode (1049)."
+  "Apply Evil point/visual handling around `ghostel--redraw'.
+ORIG-FN is the advised function (TERM, FULL).  Skipped in alt-screen (1049)."
   (if (and evil-ghostel-mode
            (not (ghostel--mode-enabled term 1049)))
-      (let* ((sync-point evil-ghostel--sync-point-on-next-redraw)
-             (visual-p (eq evil-state 'visual))
-             (track-prompt (and (not sync-point)
-                                (not visual-p)
-                                (not (memq evil-state '(insert emacs)))))
-             (pre-line (and track-prompt
-                            (- (line-number-at-pos (point) t) 1)))
-             (was-on-prompt-line (and pre-line
-                                      evil-ghostel--last-cursor-line
-                                      (= pre-line
-                                         evil-ghostel--last-cursor-line)))
+      (let* ((visual-p (eq evil-state 'visual))
              (saved-vb (and visual-p (bound-and-true-p evil-visual-beginning)
                             (marker-position evil-visual-beginning)))
              (saved-ve (and visual-p (bound-and-true-p evil-visual-end)
                             (marker-position evil-visual-end))))
         (funcall orig-fn term full)
-        (let* ((post-cursor-line (evil-ghostel--cursor-buffer-line))
-               (prompt-moved (and was-on-prompt-line
-                                  post-cursor-line
-                                  (not (= post-cursor-line pre-line)))))
-          (when sync-point
-            (setq evil-ghostel--sync-point-on-next-redraw nil))
-          (when (or sync-point prompt-moved (memq evil-state '(insert emacs)))
-            (evil-ghostel--reset-cursor-point))
-          (when visual-p
-            (let ((pmax (point-max)))
-              (when saved-vb
-                (set-marker evil-visual-beginning (min saved-vb pmax)))
-              (when saved-ve
-                (set-marker evil-visual-end (min saved-ve pmax)))))
-          ;; Record where the renderer placed the cursor so the next
-          ;; redraw can detect whether the user is still at the
-          ;; prompt line.
-          (setq evil-ghostel--last-cursor-line post-cursor-line))
-        ;; The renderer's draw reflects all PTY output processed up
-        ;; to this point — any shadow cursor we maintained for queued
-        ;; keys is at best stale, at worst wrong.  Reset so the next
-        ;; cursor read falls back to the live libghostty position.
-        (evil-ghostel--invalidate-shadow))
+        (when (memq evil-state '(insert emacs))
+          (evil-ghostel--reset-cursor-point))
+        (when visual-p
+          (let ((pmax (point-max)))
+            (when saved-vb
+              (set-marker evil-visual-beginning (min saved-vb pmax)))
+            (when saved-ve
+              (set-marker evil-visual-end (min saved-ve pmax))))))
     (funcall orig-fn term full)))
 
-
 ;; Cursor style: let evil control cursor shape
 
 (defun evil-ghostel--override-cursor-style (orig-fn style visible)
   "Let evil control cursor shape instead of the terminal.
-ORIG-FN is the advised setter called with STYLE and VISIBLE.
-In alt-screen mode, defer to the terminal's cursor style."
+ORIG-FN is the advised setter (STYLE, VISIBLE); deferred to in alt-screen."
   (if (and evil-ghostel-mode
            ghostel--term
            (not (ghostel--mode-enabled ghostel--term 1049)))
@@ -287,350 +175,570 @@ In alt-screen mode, defer to the terminal's cursor style."
 
 ;; Evil state hooks
 
-(defvar evil-ghostel--sync-inhibit nil
-  "When non-nil, skip arrow-key sync in the insert-state-entry hook.
-Set by the I/A advice which send Home/End directly.")
-
 (defun evil-ghostel--insert-state-entry ()
-  "Sync terminal cursor to Emacs point when entering `emacs-state'.
-Skipped when `evil-ghostel--sync-inhibit' is set (by I/A advice
-which already sent Ctrl-a/Ctrl-e).  Also skipped outside semi-char:
-in line mode point and the terminal cursor are intentionally
-decoupled (the user is editing buffer text, not driving the shell
-cursor); in copy/Emacs/char modes the sync would either fight a
-read-only buffer or be redundant.
-When point is on a different row from the terminal cursor, snap
-back to the terminal cursor instead of sending up/down arrows
-which the shell would interpret as history navigation."
-  (when (derived-mode-p 'ghostel-mode)
-    (if evil-ghostel--sync-inhibit
-        (setq evil-ghostel--sync-inhibit nil)
-      (when (evil-ghostel--active-p)
-        (let* ((tpos ghostel--cursor-pos)
-               (trow (cdr tpos))
-               ;; `tpos' is viewport-relative; convert point's buffer
-               ;; line to a viewport row before comparing — otherwise
-               ;; in any session with scrollback the rows compare as
-               ;; unequal even when point is on the cursor's row, and
-               ;; we drop into `reset-cursor-point' which snaps point
-               ;; back to the terminal cursor (silently undoing the
-               ;; user's `^', `$', `0' navigation).
-               (erow (or (evil-ghostel--point-viewport-row) 0)))
-          (if (= erow trow)
-              (evil-ghostel--cursor-to-point)
-            (evil-ghostel--reset-cursor-point)))))))
+  "Drive the terminal cursor to point on insert/emacs entry (safety net).
+On a different row, snap point back to the cursor instead — up/down arrows
+would be read as shell history navigation."
+  (when (and (derived-mode-p 'ghostel-mode)
+             (evil-ghostel--active-p))
+    (let ((trow (cdr ghostel--cursor-pos))
+          (erow (or (evil-ghostel--point-viewport-row) 0)))
+      (if (= erow trow)
+          (evil-ghostel-goto-input-position (point))
+        (evil-ghostel--reset-cursor-point)))))
 
 (defun evil-ghostel--escape-stay ()
-  "Disable `evil-move-cursor-back' in ghostel buffers.
-Moving the cursor back on ESC desynchronizes point from the terminal
-cursor."
+  "Disable `evil-move-cursor-back': moving back on ESC desyncs point."
   (setq-local evil-move-cursor-back nil))
 
+
+;; Input region: boundaries on the cursor row.  ghostel core provides the
+;; prompt boundary (`ghostel-input-start-point'); we add the right edge.
 
-;; Advice for beginning-of-line motions
+(defun evil-ghostel--fg-color (pos)
+  "Return the foreground color string of the cell at POS, or nil.
+The renderer stores each cell's color as a `face' plist `:foreground'."
+  (let ((face (get-text-property pos 'face)))
+    (cond ((and (consp face) (plist-member face :foreground))
+           (plist-get face :foreground))
+          ((facep face) (face-foreground face nil t)))))
 
-(defun evil-ghostel--around-beginning-of-line (orig-fn &rest args)
-  "Route `0' / `^' to `ghostel-beginning-of-input-or-line' on prompt rows.
-ORIG-FN is the advised motion called with ARGS.
+(defun evil-ghostel--greyed-out-p (color)
+  "Non-nil when COLOR (a hex string) is a dim, desaturated suggestion grey.
+Dim plus low-saturation is what separates a suggestion from a saturated
+syntax-highlight color (a cyan argument, a red invalid command)."
+  (let ((rgb (and (stringp color) (ignore-errors (color-values color)))))
+    (when rgb                              ; color-values channels are 0-65535
+      (let ((mx (apply #'max rgb))
+            (mn (apply #'min rgb)))
+        (and (< mx 49152)                  ; dim: not bright
+             (< (- mx mn) 13107))))))      ; grey: low saturation
 
-In a shell or REPL, the literal column 0 lands point on top of the
-prompt (`$ ', `>>> ') — almost never what the user wants.  When
-point is on a row that carries the `ghostel-prompt' text property
-or the line-mode input marker, jump to the start of the editable
-input instead so `0' / `^' followed by `i' lands typing at the
-expected place, and `d0' / `c0' don't try to delete the prompt
-characters.
+(defun evil-ghostel--suggestion-p (cursor region-end)
+  "Non-nil when [CURSOR, REGION-END) looks like an autosuggestion.
+That is a single greyed-out color run to the region end, past typed input.
+Keys on `evil-ghostel--greyed-out-p', not luminance or color difference,
+which misfire under syntax highlighting (see comments below)."
+  (and (evil-ghostel--input-start)            ; typed input precedes the cursor
+       (< cursor region-end)                  ; a trailing run exists
+       (let ((typed (evil-ghostel--fg-color (1- cursor)))
+             (trail (evil-ghostel--fg-color cursor)))
+         (and trail
+              (not (equal trail typed))       ; trailing color differs from typed
+              (evil-ghostel--greyed-out-p trail) ; …and is a greyed-out color
+              ;; …uniform all the way to the end of the region:
+              (>= (or (next-single-property-change cursor 'face nil region-end)
+                      region-end)
+                  region-end)))))
 
-Falls through to ORIG-FN when ghostel isn't active or the row has
-no prompt to skip — preserving standard motion semantics in
-scrollback, output, and non-prompt rows."
+(defun evil-ghostel--input-end ()
+  "Return the position just after typed input on the cursor row, or nil.
+Prefers the first `ghostel-input' region (OSC 133), else end-of-line minus
+padding; a trailing autosuggestion is excluded (boundary at the cursor)."
+  (when ghostel--cursor-char-pos
+    (save-excursion
+      (goto-char ghostel--cursor-char-pos)
+      (let* ((bol (line-beginning-position))
+             (eol (line-end-position))
+             (region-start (text-property-any bol eol 'ghostel-input t))
+             (region-end (and region-start
+                              (next-single-property-change
+                               region-start 'ghostel-input nil eol)))
+             (cursor ghostel--cursor-char-pos))
+        (cond
+         ((and region-end (< cursor region-end)
+               (evil-ghostel--suggestion-p cursor region-end))
+          cursor)
+         (region-end)
+         ;; No `ghostel-input' region: strip renderer padding back from
+         ;; EOL, but never past the live cursor — on an empty prompt that
+         ;; would strip the prompt's trailing space and land A / $ / the
+         ;; operator clamp inside the prompt.
+         (t (goto-char eol)
+            (skip-chars-backward " \t" bol)
+            (max (point) cursor)))))))
+
+(defun evil-ghostel--input-start ()
+  "Return the prompt boundary on the cursor row, or nil if undetected.
+Unlike `ghostel-input-start-point', returns nil (not the cursor) when no
+prompt is recognized, so an operator's BEG stays unclamped rather than
+collapsing the range — vterm's behaviour for shells without prompt tracking."
+  (let ((s (ghostel-input-start-point)))
+    (and s ghostel--cursor-char-pos (< s ghostel--cursor-char-pos) s)))
+
+(defun evil-ghostel--clamp (beg end)
+  "Clamp BEG..END to the editable input region; return a (BEG . END) cons.
+BEG is raised to `evil-ghostel--input-start', END lowered to
+`evil-ghostel--input-end', so motion overshoot (e.g. `dw' on the last
+word) can't over-delete past the live input.  END is never below BEG."
+  (let* ((start (evil-ghostel--input-start))
+         (input-end (evil-ghostel--input-end))
+         (beg (or beg (point)))
+         (end (or end beg))
+         (b (if start (max beg start) beg))
+         (e (if input-end (min end input-end) end)))
+    (cons b (max b e))))
+
+
+;; PTY-driven input editing.  Drive the shell's line editor (readline /
+;; zle / prompt_toolkit) with arrow keys, backspaces, and bracketed paste
+;; over the PTY.  Only meaningful in semi-char input mode.
+
+(defun evil-ghostel--sync-render ()
+  "Drain pending PTY output so cursor state reflects the latest echo.
+Loops `accept-process-output' (capped by
+`evil-ghostel-sync-render-max-iterations'), then flushes any deferred redraw."
+  (when (and ghostel--process (process-live-p ghostel--process))
+    (let ((iter 0))
+      (while (and (< iter evil-ghostel-sync-render-max-iterations)
+                  (accept-process-output ghostel--process 0.05 nil t))
+        (setq iter (1+ iter))))
+    (when ghostel--redraw-timer
+      (ghostel--redraw-now (current-buffer)))))
+
+(defun evil-ghostel-goto-input-position (pos)
+  "Drive the terminal cursor and Emacs point to buffer position POS.
+Returns t when the cursor reached POS.  Sends arrow keys to move the
+shell's line editor toward POS (analogous to `vterm-goto-char'), then
+snaps point to POS.  On rightward moves it detects and recovers from two
+inner-program echoes — literal \"^[[C\" arrow echo, and autosuggest
+accept-on-right-arrow — returning nil if either fired (see comments).
+Only meaningful in semi-char mode."
+  (when (and ghostel--term ghostel--cursor-pos)
+    (let* ((start-char-pos ghostel--cursor-char-pos)
+           (start-cursor ghostel--cursor-pos)
+           (start-col (car start-cursor))
+           (start-row-vp (cdr start-cursor))
+           (target-col (save-excursion (goto-char pos) (current-column)))
+           (target-row-vp (or (ghostel--viewport-row-at pos) start-row-vp))
+           (dy (- target-row-vp start-row-vp))
+           (dx (- target-col start-col))
+           (right-arrow-drained nil)
+           (reached
+            (progn
+              (cond ((> dy 0) (dotimes (_ dy) (ghostel--send-encoded "down" "")))
+                    ((< dy 0) (dotimes (_ (abs dy)) (ghostel--send-encoded "up" ""))))
+              (cond ((> dx 0) (dotimes (_ dx) (ghostel--send-encoded "right" "")))
+                    ((< dx 0) (dotimes (_ (abs dx)) (ghostel--send-encoded "left" ""))))
+              ;; Verify landing only on rightward moves (the ones that can
+              ;; trip literal-echo or autosuggest).  Echo detection needs a
+              ;; rendered baseline; without one, treat the send as success.
+              (if (or (<= dx 0) (null start-char-pos))
+                  t
+                (setq right-arrow-drained t)
+                (evil-ghostel--sync-render)
+                (let ((post-cur ghostel--cursor-char-pos))
+                  (cond
+                   ((and post-cur (= post-cur pos)) t)
+                   ;; Literal-echo: cursor advanced 4×dx and buffer ends
+                   ;; with "^[[C".  Echo is 4 chars per arrow; send 3
+                   ;; backspaces per arrow to undo.
+                   ((and post-cur (zerop dy)
+                         (= post-cur (+ start-char-pos (* 4 dx)))
+                         (save-excursion
+                           (goto-char post-cur)
+                           (looking-back (regexp-quote "^[[C") (min 4 post-cur))))
+                    (dotimes (_ (* 3 dx)) (ghostel--send-encoded "backspace" ""))
+                    nil)
+                   ;; Cursor jumped past target — autosuggest accepted.
+                   ((and post-cur (> post-cur pos))
+                    (ghostel--send-encoded "_" "ctrl")
+                    nil)
+                   (t nil)))))))
+      (when reached
+        ;; Drain so `ghostel--cursor-pos' reflects the move, unless the
+        ;; rightward branch already drained or no arrows were sent.
+        (when (and (not right-arrow-drained)
+                   (or (/= dx 0) (/= dy 0)))
+          (evil-ghostel--sync-render))
+        (goto-char pos))
+      reached)))
+
+(defun evil-ghostel-delete-input-region (beg end)
+  "Delete BEG..END from input by backspacing over the PTY; return the count.
+Soft-wrap newlines are skipped (renderer artifacts).  Leaves point at BEG;
+the delete lands when the shell echoes it.  Semi-char only."
+  (let ((count (length (ghostel--filter-soft-wraps (buffer-substring beg end)))))
+    (when (> count 0)
+      (evil-ghostel-goto-input-position end)
+      (dotimes (_ count)
+        (ghostel--send-encoded "backspace" ""))
+      ;; Drain so `ghostel--cursor-pos' reflects the post-backspace position
+      ;; before any caller (e.g. `evil-ghostel-insert' for cc / cw) reads it.
+      (evil-ghostel--sync-render)
+      (goto-char beg))
+    count))
+
+(defun evil-ghostel-replace-input-region (beg end string)
+  "Replace the BEG..END range with STRING via the terminal PTY.
+Deletes the range with `evil-ghostel-delete-input-region', then pastes
+STRING through bracketed paste.  Only meaningful in `semi-char' mode."
+  (let ((deleted (evil-ghostel-delete-input-region beg end)))
+    (when (and (> deleted 0) string (not (string-empty-p string)))
+      (ghostel--paste-text string))
+    deleted))
+
+
+;; Motions (the few that must be prompt-aware)
+
+(evil-define-motion evil-ghostel-first-non-blank ()
+  "Move point to the first input character after the prompt.
+On a prompt row, jumps past the prompt prefix; otherwise falls through
+to `evil-first-non-blank'."
+  :type exclusive
   (if (or (evil-ghostel--active-p)
           (evil-ghostel--line-mode-active-p))
       (ghostel-beginning-of-input-or-line)
-    (apply orig-fn args)))
+    (evil-first-non-blank)))
+
+(evil-define-motion evil-ghostel-end-of-line (count)
+  "Move to the last character of typed input on the cursor row.
+Like `evil-end-of-line' but stops before a trailing autosuggestion,
+right-aligned prompt, or padding (ghostel paints the whole row, so vanilla
+$ would walk into non-typed cells).  Off the cursor row, unchanged."
+  :type inclusive
+  (let ((input-end (and (evil-ghostel--active-p)
+                        (ghostel-point-on-cursor-row-p)
+                        (evil-ghostel--input-end))))
+    (evil-end-of-line count)
+    (when (and input-end (>= (point) input-end)
+               (ghostel-point-on-cursor-row-p)
+               (> input-end (line-beginning-position)))
+      (goto-char (1- input-end)))))
+
+(evil-define-motion evil-ghostel-next-line (count)
+  "Move COUNT lines down, but not past the terminal cursor's row.
+Prevents `j' from stranding the user on empty renderer rows below the
+live prompt.  Falls through to `evil-next-line' outside semi-char."
+  :type line
+  (if (not (evil-ghostel--active-p))
+      (evil-next-line count)
+    (let ((cursor-line (and ghostel--cursor-pos
+                            (save-excursion
+                              (evil-ghostel--reset-cursor-point)
+                              (1- (line-number-at-pos (point) t)))))
+          (col (current-column)))
+      (condition-case _err
+          (evil-next-line count)
+        ((beginning-of-buffer end-of-buffer) nil))
+      (when (and cursor-line
+                 (> (1- (line-number-at-pos (point) t)) cursor-line))
+        (goto-char (point-min))
+        (forward-line cursor-line)
+        (move-to-column col)))))
+
+(defun evil-ghostel-goto-cursor ()
+  "Move point to the live terminal cursor.
+Replaces `evil-goto-line' (G) in ghostel buffers — the natural \"go to
+the prompt\" gesture.  Outside semi-char, runs `evil-goto-line'."
+  (interactive)
+  (if (not (evil-ghostel--active-p))
+      (call-interactively #'evil-goto-line)
+    (evil-ghostel--reset-cursor-point)))
 
 
-;; Advice for evil insert-line / append-line
+;; Insert / Append
 
-(defun evil-ghostel--around-insert-line (orig-fn &rest args)
-  "Route `evil-insert-line' according to the current input mode.
-ORIG-FN is the advised `evil-insert-line' called with ARGS.
-In semi-char, sync the terminal cursor to point's row first so
-Ctrl-a operates on the line the user navigated to (the multi-line
-TUI case — without the row sync, kkI lands the cursor at the
-start of the input's last line instead of at the line above).
-Then send Ctrl-a so the shell moves its readline cursor to the
-start of that input line — `orig-fn' enters insert state and the
-buffer cursor is repositioned by the next redraw.
-In line mode, the input region is plain buffer text bounded by
-`ghostel--line-input-start' / `--line-input-end'; jump point there
-and enter insert state directly (`back-to-indentation' would land
-on the prompt, which is read-only).
-Outside ghostel, run unchanged."
+(defun evil-ghostel-insert ()
+  "Enter insert state at point, driving the shell cursor to match.
+Off the cursor row, snap to `ghostel-input-start-point'; on it, drive to
+point clamped to `evil-ghostel--input-end'.  Outside semi-char, `evil-insert'."
+  (interactive)
+  (cond
+   ((not (evil-ghostel--active-p))
+    (call-interactively #'evil-insert))
+   ((not (ghostel-point-on-cursor-row-p))
+    (when-let* ((target (ghostel-input-start-point)))
+      (evil-ghostel-goto-input-position target))
+    (evil-insert-state 1))
+   (t
+    (let* ((input-end (evil-ghostel--input-end))
+           (target (if input-end (min (point) input-end) (point))))
+      (evil-ghostel-goto-input-position target))
+    (evil-insert-state 1))))
+
+(defun evil-ghostel-insert-line ()
+  "Move to the start of input on the current line, then enter insert.
+Drives the shell cursor to `ghostel-input-start-point' (semi-char) or
+jumps to `ghostel--line-input-start' (line mode); else `evil-insert-line'."
+  (interactive)
   (cond
    ((evil-ghostel--active-p)
-    (evil-ghostel--cursor-to-point)
-    (ghostel--send-encoded "a" "ctrl")
-    (evil-ghostel--invalidate-shadow)
-    (setq evil-ghostel--sync-inhibit t)
-    (apply orig-fn args))
+    (when-let* ((target (ghostel-input-start-point)))
+      (evil-ghostel-goto-input-position target))
+    (evil-insert-state 1))
    ((evil-ghostel--line-mode-active-p)
     (goto-char (marker-position ghostel--line-input-start))
-    (setq evil-ghostel--sync-inhibit t)
     (evil-insert-state 1))
-   (t (apply orig-fn args))))
+   (t (call-interactively #'evil-insert-line))))
 
-(defun evil-ghostel--around-append-line (orig-fn &rest args)
-  "Route `evil-append-line' according to the current input mode.
-ORIG-FN is the advised `evil-append-line' called with ARGS.
-Symmetric to `evil-ghostel--around-insert-line': sync the terminal
-cursor to point's row, then send Ctrl-e in semi-char; jump to
-`--line-input-end' in line mode; otherwise unchanged."
+(defun evil-ghostel-append ()
+  "Append after point, driving the shell cursor to match.
+Target is one cell right of point (clamped to `evil-ghostel--input-end'),
+or point itself when point is at/past the cursor on a blank/eol cell.  Off
+the cursor row, snap to `ghostel-input-start-point'; else `evil-append'."
+  (interactive)
+  (cond
+   ((not (evil-ghostel--active-p))
+    (call-interactively #'evil-append))
+   ((not (ghostel-point-on-cursor-row-p))
+    (when-let* ((target (ghostel-input-start-point)))
+      (evil-ghostel-goto-input-position target))
+    (evil-insert-state 1))
+   (t
+    (let* ((cur (ghostel-cursor-point))
+           (target
+            (if (and cur (>= (point) cur)
+                     (save-excursion
+                       (goto-char cur)
+                       (or (eolp) (looking-at-p "[ \t]"))))
+                (point)
+              (let ((input-end (evil-ghostel--input-end)))
+                (min (1+ (point)) (or input-end (1+ (point))))))))
+      (evil-ghostel-goto-input-position target))
+    (evil-insert-state 1))))
+
+(defun evil-ghostel-append-line ()
+  "Move to the end of input on the current line, then enter insert.
+Symmetric to `evil-ghostel-insert-line': drives the cursor to
+`evil-ghostel--input-end' (semi-char) or `ghostel--line-input-end' (line)."
+  (interactive)
   (cond
    ((evil-ghostel--active-p)
-    (evil-ghostel--cursor-to-point)
-    (ghostel--send-encoded "e" "ctrl")
-    (evil-ghostel--invalidate-shadow)
-    (setq evil-ghostel--sync-inhibit t)
-    (apply orig-fn args))
+    (when-let* ((target (evil-ghostel--input-end)))
+      (evil-ghostel-goto-input-position target))
+    (evil-insert-state 1))
    ((evil-ghostel--line-mode-active-p)
     (goto-char (marker-position ghostel--line-input-end))
-    (setq evil-ghostel--sync-inhibit t)
     (evil-insert-state 1))
-   (t (apply orig-fn args))))
+   (t (call-interactively #'evil-append-line))))
 
 
-;; Editing primitives
+;; Delete
 
-(defun evil-ghostel--meaningful-length (text)
-  "Length of TEXT, stripping per-line trailing whitespace in multi-line ranges.
-Heuristic for TUIs that draw a fixed-width input box wider than the
-user's typed text (e.g. prompt_toolkit-based REPLs that fill each
-input row out to the box's right border).  The trailing spaces end
-up in the Emacs buffer because the terminal explicitly wrote them
-\(see `src/Renderer.zig' — only unwritten cells are trimmed), but
-they are not characters in the TUI's input model, and sending one
-backspace per buffer character would eat far past the actual input.
+(evil-define-operator evil-ghostel-delete
+  (beg end type register yank-handler)
+  "Delete BEG..END via the PTY (semi-char), else run `evil-delete'.
+`evil-ghostel--clamp' trims the range to live input so overshoot (e.g.
+`dw' on the last word) can't over-delete; block deletes go per row.
+Covers d, dd, x, X."
+  (interactive "<R><x><y>")
+  (if (not (evil-ghostel--active-p))
+      (evil-delete beg end type register yank-handler)
+    (let* ((clamped (evil-ghostel--clamp beg end))
+           (beg (car clamped))
+           (end (cdr clamped)))
+      (unless register
+        (let ((text (filter-buffer-substring beg end)))
+          (unless (string-match-p "\n" text)
+            (evil-set-register ?- text))))
+      (let ((evil-was-yanked-without-register nil))
+        (evil-yank beg end type register yank-handler))
+      (cond
+       ((eq type 'block)
+        (evil-apply-on-block #'evil-ghostel-delete-input-region beg end nil))
+       (t (evil-ghostel-delete-input-region beg end))))))
 
-Only applied when TEXT spans more than one buffer line.  In a
-single-line range (e.g. `dw' deleting `\"word \"'), trailing
-whitespace is treated as real user-typed content and counted —
-otherwise we'd send one fewer backspace than the deletion needs
-and leave a stray character behind.
+(evil-define-operator evil-ghostel-delete-line
+  (beg end type register yank-handler)
+  "Delete from point through end of line, PTY-routed in semi-char.
+In visual state the range is expanded linewise (like `evil-delete-line');
+otherwise routes through `evil-ghostel-delete' with END at line end.
+Covers D."
+  :motion nil
+  :keep-visual t
+  (interactive "<R><x><y>")
+  (if (not (evil-ghostel--active-p))
+      (evil-delete-line beg end type register yank-handler)
+    (let* ((beg (or beg (point)))
+           (end (or end beg))
+           (line-end (save-excursion (goto-char beg) (line-end-position))))
+      (when (evil-visual-state-p)
+        (unless (memq type '(line screen-line block))
+          (let ((range (evil-expand beg end 'line)))
+            (setq beg (evil-range-beginning range)
+                  end (evil-range-end range)
+                  type (evil-type range))))
+        (evil-exit-visual-state))
+      (cond
+       ((eq type 'block)
+        (evil-ghostel-delete beg end 'block register yank-handler))
+       ((memq type '(line screen-line))
+        (evil-ghostel-delete beg end type register yank-handler))
+       (t
+        (evil-ghostel-delete beg line-end type register yank-handler))))))
 
-Tradeoff: a line of pure user-typed indentation inside a multi-line
-range (e.g. `\"    \\nfoo\"') collapses on the first line and
-contributes 0 backspaces.  Acceptable cost — the alternative
-over-deletes on every prompt_toolkit-style TUI."
-  (if (string-match-p "\n" text)
-      (length (replace-regexp-in-string "[ \t]+\\(\n\\|\\'\\)" "\\1" text))
-    (length text)))
+(evil-define-operator evil-ghostel-delete-char (beg end type register)
+  "Delete the current character.  PTY-routed in semi-char."
+  :motion evil-forward-char
+  (interactive "<R><x>")
+  (evil-ghostel-delete beg end type register))
 
-(defun evil-ghostel--delete-region (beg end)
-  "Delete text between BEG and END via the terminal PTY.
-Moves terminal cursor to END, then sends one backspace per
-meaningful character (see `evil-ghostel--meaningful-length').
-Uses backspace rather than forward-delete because the Delete key
-escape sequence is not bound in all shell configurations.
-
-Updates `evil-ghostel--shadow-cursor' to reflect the post-backspace
-position — each backspace moves the cursor one column left without
-crossing rows in the cases we care about (readline clamps at start
-of input)."
-  (let ((count (evil-ghostel--meaningful-length
-                (buffer-substring-no-properties beg end))))
-    (when (> count 0)
-      (goto-char end)
-      (evil-ghostel--cursor-to-point)
-      (dotimes (_ count)
-        (ghostel--send-encoded "backspace" ""))
-      (goto-char beg)
-      (when evil-ghostel--shadow-cursor
-        (setcar evil-ghostel--shadow-cursor
-                (max 0 (- (car evil-ghostel--shadow-cursor) count)))))))
-
-(defun evil-ghostel--point-on-cursor-row-p ()
-  "Non-nil when Emacs point is on the same viewport row as the terminal cursor.
-Used by line-type `dd' / `cc' to dispatch between the readline-aware
-Ctrl-e/Ctrl-u shortcut (when point is on the cursor's line — the
-typical single-line shell case) and the explicit cursor-sync +
-backspace path (when point is on a different line, the multi-line
-TUI case from issue #218)."
-  (when ghostel--term
-    (let* ((tpos ghostel--cursor-pos)
-           (trow (cdr tpos))
-           (scrollback (if ghostel--term-rows
-                           (max 0 (- (count-lines (point-min) (point-max))
-                                     ghostel--term-rows))
-                         0))
-           (prow (- (line-number-at-pos (point) t) 1 scrollback)))
-      (= prow trow))))
-
-(defun evil-ghostel--clear-input-line ()
-  "Clear the active input line via Ctrl-e Ctrl-u.
-Readline / zle / prompt_toolkit all bind this to \"go to end of
-line, then kill from start of line to cursor\" — so the active
-input is cleared without us needing to know where the prompt ends.
-Sets `evil-ghostel--sync-point-on-next-redraw' so the redraw
-triggered by the shell's echo lands point at the new cursor
-position (start of the input area) rather than leaving it on the
-prompt at column 0."
-  (ghostel--send-encoded "e" "ctrl")
-  (ghostel--send-encoded "u" "ctrl")
-  (evil-ghostel--invalidate-shadow)
-  (setq evil-ghostel--sync-point-on-next-redraw t))
+(evil-define-operator evil-ghostel-delete-backward-char (beg end type register)
+  "Delete the previous character.  PTY-routed in semi-char."
+  :motion evil-backward-char
+  (interactive "<R><x>")
+  (evil-ghostel-delete beg end type register))
 
 
-;; Advice for evil editing operators
+;; Change
 
-(defun evil-ghostel--around-delete
-    (orig-fn beg end &optional type register yank-handler)
-  "Intercept `evil-delete' in ghostel buffers.
-ORIG-FN is the advised `evil-delete' called with BEG, END, TYPE,
-REGISTER, and YANK-HANDLER.
-Yanks text to REGISTER, then deletes via PTY.
-Covers d, dd, D, x, X."
-  (if (evil-ghostel--active-p)
-      (progn
-        (unless register
-          (let ((text (filter-buffer-substring beg end)))
-            (unless (string-match-p "\n" text)
-              (evil-set-register ?- text))))
-        (let ((evil-was-yanked-without-register nil))
-          (evil-yank beg end type register yank-handler))
-        (if (and (eq type 'line) (evil-ghostel--point-on-cursor-row-p))
-            ;; Single-line shell case: readline shortcut clears the
-            ;; input area without us needing prompt geometry.
-            (evil-ghostel--clear-input-line)
-          ;; Multi-line case (point on a different row from the
-          ;; terminal cursor): sync cursor to the deleted region's
-          ;; end then backspace through it.
-          (evil-ghostel--delete-region beg end)))
-    (funcall orig-fn beg end type register yank-handler)))
+(evil-define-operator evil-ghostel-change
+  (beg end type register yank-handler delete-func)
+  "Change BEG..END via the PTY then enter insert state.
+PTY-routed in semi-char, else `evil-change'.  `evil-ghostel-insert'
+drives the cursor itself, so empty ranges need no extra sync.
+Covers c, cc, s."
+  (interactive "<R><x><y>")
+  (if (not (evil-ghostel--active-p))
+      (evil-change beg end type register yank-handler delete-func)
+    (evil-ghostel-delete beg end type register yank-handler)
+    (evil-ghostel-insert)))
 
-(defun evil-ghostel--around-change
-    (orig-fn beg end type register yank-handler &optional delete-func)
-  "Intercept `evil-change' in ghostel buffers.
-ORIG-FN is the advised `evil-change' called with BEG, END, TYPE,
-REGISTER, YANK-HANDLER, and DELETE-FUNC.
-Deletes via PTY, then enters insert state.
-Covers c, cc, C, s, S.
+(evil-define-operator evil-ghostel-change-line
+  (beg end type register yank-handler)
+  "Change from point through end of line.  PTY-routed in semi-char.
 
-When `evil-ghostel--delete-region' actually sends keys (count > 0),
-it leaves point and the shadow cursor at BEG, so insert state will
-land on the correct row.  Only when the range is empty (count = 0,
-e.g. \\<evil-normal-state-map>\\[evil-change-line] at end-of-line on
-a non-cursor row) do we explicitly sync the terminal cursor —
-otherwise typed characters would land on whatever row the cursor
-was last parked on.  The line-type Ctrl-u branch runs its own
-redraw-time sync via `evil-ghostel--sync-point-on-next-redraw'."
-  (if (evil-ghostel--active-p)
-      (progn
-        (let ((evil-was-yanked-without-register nil))
-          (evil-yank beg end type register yank-handler))
-        (cond
-         ((and (eq type 'line) (evil-ghostel--point-on-cursor-row-p))
-          (evil-ghostel--clear-input-line))
-         (t
-          (let ((count (evil-ghostel--meaningful-length
-                        (buffer-substring-no-properties beg end))))
-            (evil-ghostel--delete-region beg end)
-            (when (zerop count)
-              (evil-ghostel--cursor-to-point)))))
-        (setq evil-ghostel--sync-inhibit t)
-        (evil-insert 1))
-    (funcall orig-fn beg end type register yank-handler delete-func)))
+Covers C."
+  :motion evil-end-of-line-or-visual-line
+  (interactive "<R><x><y>")
+  (if (not (evil-ghostel--active-p))
+      (evil-change-line beg end type register yank-handler)
+    (evil-ghostel-delete-line beg end type register yank-handler)
+    (evil-ghostel-insert)))
 
-(defun evil-ghostel--around-replace (orig-fn beg end type char)
-  "Intercept `evil-replace' in ghostel buffers.
-ORIG-FN is the advised `evil-replace' called with BEG, END, TYPE,
-and CHAR.
-Deletes the range, then inserts replacement characters.
-The paste count must match the delete count — both go through
-`evil-ghostel--meaningful-length' so trailing whitespace stripped
-from the deletion isn't re-added by the paste."
-  (if (evil-ghostel--active-p)
-      (when char
-        (let ((count (evil-ghostel--meaningful-length
-                      (buffer-substring-no-properties beg end))))
-          (evil-ghostel--delete-region beg end)
-          (when (> count 0)
-            (ghostel--paste-text (make-string count char))
-            (evil-ghostel--invalidate-shadow))))
-    (funcall orig-fn beg end type char)))
+(evil-define-operator evil-ghostel-substitute (beg end type register)
+  "Substitute the next character.  Covers s."
+  :motion evil-forward-char
+  (interactive "<R><x>")
+  (evil-ghostel-change beg end type register))
 
-(defun evil-ghostel--around-paste-after
-    (orig-fn count &optional register yank-handler)
-  "Intercept `evil-paste-after' in ghostel buffers.
-ORIG-FN is the advised `evil-paste-after' called with COUNT,
-REGISTER, and YANK-HANDLER.
-Pastes from REGISTER via the terminal PTY."
-  (if (evil-ghostel--active-p)
-      (let ((text (if register
-                      (evil-get-register register)
-                    (current-kill 0)))
-            (count (prefix-numeric-value count)))
-        (when text
-          (evil-ghostel--cursor-to-point)
-          (ghostel--send-encoded "right" "")
-          (dotimes (_ count)
-            (ghostel--paste-text text))
-          (evil-ghostel--invalidate-shadow)))
-    (funcall orig-fn count register yank-handler)))
+(evil-define-operator evil-ghostel-substitute-line
+  (beg end register yank-handler)
+  "Substitute the current line.  Covers S."
+  :motion evil-line-or-visual-line
+  :type line
+  (interactive "<r><x>")
+  (evil-ghostel-change beg end 'line register yank-handler))
 
-(defun evil-ghostel--around-paste-before
-    (orig-fn count &optional register yank-handler)
-  "Intercept `evil-paste-before' in ghostel buffers.
-ORIG-FN is the advised `evil-paste-before' called with COUNT,
-REGISTER, and YANK-HANDLER.
-Pastes from REGISTER via the terminal PTY."
-  (if (evil-ghostel--active-p)
-      (let ((text (if register
-                      (evil-get-register register)
-                    (current-kill 0)))
-            (count (prefix-numeric-value count)))
-        (when text
-          (evil-ghostel--cursor-to-point)
-          (dotimes (_ count)
-            (ghostel--paste-text text))
-          (evil-ghostel--invalidate-shadow)))
-    (funcall orig-fn count register yank-handler)))
+;; Mark our change operator as a change so `cw' / `cW' stop at the end of
+;; the word (vim's quirk) like `ce' / `cE', instead of eating the trailing
+;; space like `dw'.
+(add-to-list 'evil-change-commands 'evil-ghostel-change)
 
 
-;; Insert-state Ctrl key passthrough
+;; Replace
+
+(evil-define-operator evil-ghostel-replace (beg end type char)
+  "Replace BEG..END with CHAR via the PTY.  Covers r.
+Reads CHAR with `evil-read-key' like `evil-replace', then deletes the
+clamped range and pastes the replacement so the count matches."
+  :motion evil-forward-char
+  (interactive "<R>"
+               (unwind-protect
+                   (let ((evil-force-cursor 'replace))
+                     (evil-refresh-cursor)
+                     (list (evil-read-key)))
+                 (evil-refresh-cursor)))
+  (if (not (evil-ghostel--active-p))
+      (evil-replace beg end type char)
+    (when char
+      (let* ((clamped (evil-ghostel--clamp beg end))
+             (b (car clamped))
+             (e (cdr clamped))
+             (count (length (ghostel--filter-soft-wraps (buffer-substring b e)))))
+        (when (> count 0)
+          (evil-ghostel-replace-input-region b e (make-string count char)))))))
+
+
+;; Paste
+
+(defun evil-ghostel--do-paste (count register advance)
+  "Bracketed-paste the register/kill text COUNT times at the cursor.
+REGISTER selects the source register (nil = latest kill).  With ADVANCE,
+send one right arrow first so the paste lands after the cursor cell —
+unless at end-of-input, where a right arrow would accept a suggestion."
+  (let ((text (if register (evil-get-register register) (current-kill 0)))
+        (n (prefix-numeric-value count)))
+    (when text
+      (evil-ghostel-goto-input-position (point))
+      (when advance
+        (let ((ie (evil-ghostel--input-end)))
+          (unless (and ie (>= (point) ie))
+            (ghostel--send-encoded "right" ""))))
+      (dotimes (_ n)
+        (ghostel--paste-text text)))))
+
+(defun evil-ghostel-paste-after (&optional count register yank-handler)
+  "Paste after the cursor via bracketed paste.  Covers p.
+COUNT repeats; REGISTER selects a register; YANK-HANDLER is forwarded to
+`evil-paste-after' in the fall-through path."
+  (interactive "*P")
+  (if (evil-ghostel--active-p)
+      (evil-ghostel--do-paste count register t)
+    (evil-paste-after count register yank-handler)))
+
+(defun evil-ghostel-paste-before (&optional count register yank-handler)
+  "Paste before the cursor via bracketed paste.  Covers P.
+COUNT repeats; REGISTER selects a register; YANK-HANDLER is forwarded to
+`evil-paste-before' in the fall-through path."
+  (interactive "*P")
+  (if (evil-ghostel--active-p)
+      (evil-ghostel--do-paste count register nil)
+    (evil-paste-before count register yank-handler)))
+
+
+;; Undo / Redo
+
+(defun evil-ghostel-undo (count)
+  "Send Ctrl-_ (readline undo) COUNT times.  Covers u.
+Falls through to `evil-undo' outside semi-char."
+  (interactive "p")
+  (if (not (evil-ghostel--active-p))
+      (evil-undo count)
+    (dotimes (_ (or count 1))
+      (ghostel--send-encoded "_" "ctrl"))))
+
+(defun evil-ghostel-redo (count)
+  "Redo is not supported in the terminal.
+COUNT is forwarded to `evil-redo' in the fall-through path."
+  (interactive "p")
+  (if (not (evil-ghostel--active-p))
+      (evil-redo count)
+    (message "Redo not supported in terminal")))
+
+
+;; Keymap and insert-state Ctrl passthrough
 
 (defvar evil-ghostel-mode-map (make-sparse-keymap)
   "Keymap for `evil-ghostel-mode'.
-Insert-state Ctrl key bindings are set up via `evil-define-key*'.")
+Bindings for normal/visual editing commands and insert-state Ctrl
+passthrough are installed via `evil-define-key*'.")
 
 (defconst evil-ghostel--ctrl-passthrough-keys
-  '("a" "d" "e" "k" "n" "p" "r" "t" "u" "w" "y")
+  '("a" "b" "d" "e" "f" "k" "l" "n" "o" "p" "q" "r" "s" "t" "u" "v" "w" "y")
   "Ctrl+key combinations to pass through to the terminal in insert state.
-These keys all have standard readline/zle bindings (C-a beginning-of-line,
-C-d EOF, C-e end-of-line, C-k kill-line, etc.) that would otherwise be
-intercepted by evil's insert-state commands.")
+These have standard readline/zle bindings that evil's insert-state commands
+would otherwise shadow.  Mirrors vterm's set but leaves `C-z' to evil,
+keeping `evil-emacs-state' reachable.")
+
+(defun evil-ghostel--fallback-key (keys)
+  "Run KEYS's binding from the local map, else evil's insert-state map.
+Lets line mode's own bindings win over evil's insert-state defaults when
+PTY passthrough is inactive.  KEYS is a key vector."
+  (let* ((local (current-local-map))
+         (cmd (or (and local (lookup-key local keys))
+                  (lookup-key evil-insert-state-map keys))))
+    (when (commandp cmd)
+      (call-interactively cmd))))
 
 (defun evil-ghostel--passthrough-ctrl (key)
-  "Send Ctrl+KEY to the terminal PTY, or fall back to evil's binding.
-Used for insert-state Ctrl keys that have readline/zle equivalents.
-Outside semi-char the local map is consulted first so line mode's
-own bindings (e.g. \\`C-a' → `ghostel-beginning-of-input-or-line',
-\\`C-d' → `ghostel-line-mode-delete-char-or-eof') win over evil's
-defaults; without that, the minor-mode aux map containing this
-passthrough would shadow line mode's local-map binding."
+  "Send Ctrl+KEY to the terminal PTY, else fall back to evil's binding.
+Off semi-char the local map wins first, so line mode's own \\`C-a' →
+`ghostel-beginning-of-input-or-line' beats evil's default."
   (if (evil-ghostel--ctrl-passthrough-active-p)
-      (progn
-        (ghostel--send-encoded key "ctrl")
-        ;; C-a / C-e / C-u / C-w / C-r / C-n / C-p all reposition the
-        ;; readline cursor (or load a different input line entirely);
-        ;; the shadow's pre-keystroke baseline is no longer valid.
-        (evil-ghostel--invalidate-shadow))
-    (let* ((vec (kbd (concat "C-" key)))
-           (local (current-local-map))
-           (cmd (or (and local (lookup-key local vec))
-                    (lookup-key evil-insert-state-map vec))))
-      (when (commandp cmd)
-        (call-interactively cmd)))))
+      (ghostel--send-encoded key "ctrl")
+    (evil-ghostel--fallback-key (kbd (concat "C-" key)))))
 
 (dolist (key evil-ghostel--ctrl-passthrough-keys)
   (let ((k key))
@@ -642,21 +750,54 @@ passthrough would shadow line mode's local-map binding."
                           (evil-ghostel--passthrough-ctrl k))
                         (format "Send C-%s to the terminal or fall back to evil." k)))))
 
-(defun evil-ghostel--around-undo (orig-fn count)
-  "Intercept `evil-undo' in ghostel buffers.
-ORIG-FN is the advised `evil-undo' called with COUNT.
-Sends Ctrl+_ (readline undo) COUNT times."
+(defun evil-ghostel--passthrough-delete ()
+  "Forward-delete in the terminal in semi-char, else fall back to evil.
+Evil binds the delete key to `delete-char', which would edit buffer text
+rather than forward-delete in the shell."
+  (interactive)
   (if (evil-ghostel--active-p)
-      (dotimes (_ (or count 1))
-        (ghostel--send-encoded "_" "ctrl"))
-    (funcall orig-fn count)))
+      (ghostel--send-encoded "delete" "")
+    (evil-ghostel--fallback-key (kbd "<delete>"))))
 
-(defun evil-ghostel--around-redo (orig-fn count)
-  "Intercept `evil-redo' in ghostel buffers.
-ORIG-FN is the advised `evil-redo' called with COUNT."
-  (if (evil-ghostel--active-p)
-      (message "Redo not supported in terminal")
-    (funcall orig-fn count)))
+(evil-define-key* 'insert evil-ghostel-mode-map
+                  (kbd "<delete>") #'evil-ghostel--passthrough-delete)
+
+;; Editing operators in normal + visual.  Bindings remap the evil-* command
+;; (not literal keys) so user remappings flow through to our PTY variants.
+;; Basic motions (h l w b e $ 0) stay vanilla Evil; the operators clamp
+;; their range via `evil-ghostel--clamp', trimming overshoot at the operator.
+(evil-define-key* '(normal visual) evil-ghostel-mode-map
+                  [remap evil-delete]               #'evil-ghostel-delete
+                  [remap evil-delete-line]          #'evil-ghostel-delete-line
+                  [remap evil-delete-char]          #'evil-ghostel-delete-char
+                  [remap evil-delete-backward-char] #'evil-ghostel-delete-backward-char
+                  [remap evil-change]               #'evil-ghostel-change
+                  [remap evil-change-line]          #'evil-ghostel-change-line
+                  [remap evil-substitute]           #'evil-ghostel-substitute
+                  [remap evil-change-whole-line]    #'evil-ghostel-substitute-line
+                  [remap evil-replace]              #'evil-ghostel-replace
+                  [remap evil-paste-after]          #'evil-ghostel-paste-after
+                  [remap evil-paste-before]         #'evil-ghostel-paste-before
+                  [remap evil-undo]                 #'evil-ghostel-undo
+                  [remap evil-redo]                 #'evil-ghostel-redo)
+
+;; Insert/append are normal-only (visual has its own behaviour for `i').
+(evil-define-key* 'normal evil-ghostel-mode-map
+                  [remap evil-insert]               #'evil-ghostel-insert
+                  [remap evil-insert-line]          #'evil-ghostel-insert-line
+                  [remap evil-append]               #'evil-ghostel-append
+                  [remap evil-append-line]          #'evil-ghostel-append-line
+                  [remap evil-next-line]            #'evil-ghostel-next-line
+                  [remap evil-goto-line]            #'evil-ghostel-goto-cursor
+                  "[["                              #'ghostel-previous-prompt
+                  "]]"                              #'ghostel-next-prompt)
+
+;; `^' and `$' are the input-aware edges of the line, reachable in every
+;; state that can take a motion so `d^' / `d$' and visual `^' / `$' stop
+;; at the input boundaries too.  Other basic motions stay vanilla Evil.
+(evil-define-key* '(normal visual operator motion) evil-ghostel-mode-map
+                  [remap evil-first-non-blank]      #'evil-ghostel-first-non-blank
+                  [remap evil-end-of-line]          #'evil-ghostel-end-of-line)
 
 
 ;; ESC routing: terminal vs evil
@@ -671,11 +812,10 @@ Valid values: `auto', `terminal', `evil'.")
 
 (defun evil-ghostel--escape ()
   "Dispatch insert-state ESC based on `evil-ghostel--escape-mode'.
-Terminal-bound ESC runs through `ghostel--on-user-input' like every
-other typed key in `ghostel-mode-map'.  When falling back to evil and the
-user's `evil-insert-state-map' binding is missing or a chord prefix
-\(e.g. `evil-escape''s `jk'), use `evil-force-normal-state' so the
-keystroke is never silently dropped."
+Terminal-bound ESC runs through `ghostel--on-user-input'.  Falling back to
+evil uses `evil-force-normal-state' when the `evil-insert-state-map'
+binding is missing or a chord prefix (e.g. `evil-escape''s `jk'), so the
+keystroke is never dropped."
   (interactive)
   (let* ((mode evil-ghostel--escape-mode)
          (to-terminal (or (eq mode 'terminal)
@@ -691,11 +831,9 @@ keystroke is never silently dropped."
 
 (defun evil-ghostel-toggle-send-escape (&optional arg)
   "Cycle or set the ESC routing mode for the current buffer.
-Without ARG, cycle through `auto' → `terminal' → `evil' → `auto'.
-With numeric prefix 1, set to `auto'; 2 to `terminal'; 3 to `evil'.
-Other numeric prefixes signal a `user-error'.
-
-The mode is buffer-local; see `evil-ghostel-escape' for the default."
+Without ARG, cycle `auto' → `terminal' → `evil'.  With numeric prefix 1/2/3
+set `auto'/`terminal'/`evil'; other prefixes signal a `user-error'.  The
+mode is buffer-local; see `evil-ghostel-escape' for the default."
   (interactive "P")
   (let ((target
          (if arg
@@ -716,36 +854,44 @@ The mode is buffer-local; see `evil-ghostel-escape' for the default."
 
 ;; Minor mode
 
+(defun evil-ghostel--any-active-elsewhere-p (except-buffer)
+  "Return non-nil if any buffer but EXCEPT-BUFFER has `evil-ghostel-mode' on.
+Decides whether the global advice can be removed on the last disable."
+  (catch 'found
+    (dolist (b (buffer-list))
+      (when (and (not (eq b except-buffer))
+                 (buffer-local-value 'evil-ghostel-mode b))
+        (throw 'found t)))))
+
 ;;;###autoload
 (define-minor-mode evil-ghostel-mode
   "Minor mode for evil integration in ghostel terminal buffers.
-Synchronizes the terminal cursor with Emacs point during evil
-state transitions."
+Binds the `evil-ghostel-*' operators in `evil-ghostel-mode-map' and syncs
+the terminal cursor with point across evil state transitions.  It also advises
+`ghostel--redraw' and `ghostel--set-cursor-style' (to preserve point and the
+evil cursor style); since the mode is buffer-local but the advice global,
+the advice is installed on first enable and removed on the last disable."
   :lighter nil
   :keymap evil-ghostel-mode-map
   (if evil-ghostel-mode
       (progn
         (setq evil-ghostel--escape-mode evil-ghostel-escape)
         (evil-ghostel--escape-stay)
+        ;; Evil owns selection here (visual state + the visual operators), so
+        ;; opt this buffer out of ghostel's keyboard-mark->copy-mode switch:
+        ;; otherwise `v' activates the mark, `ghostel--mark-activated' flips the
+        ;; buffer to read-only copy mode, and the visual operators hit "Buffer
+        ;; is read-only".  Mouse selection stays governed by
+        ;; `ghostel-mouse-drag-input-mode', so it still picks its own mode.
+        (setq-local ghostel-mark-activation-input-mode nil)
         (add-hook 'evil-insert-state-entry-hook
                   #'evil-ghostel--insert-state-entry nil t)
         ;; Reuse the insert-state sync when entering emacs-state — both
         ;; states expect point to follow the terminal cursor.
         (add-hook 'evil-emacs-state-entry-hook
                   #'evil-ghostel--insert-state-entry nil t)
-        (advice-add 'evil-insert-line :around #'evil-ghostel--around-insert-line)
-        (advice-add 'evil-append-line :around #'evil-ghostel--around-append-line)
-        (advice-add 'evil-beginning-of-line :around
-                    #'evil-ghostel--around-beginning-of-line)
-        (advice-add 'evil-first-non-blank :around
-                    #'evil-ghostel--around-beginning-of-line)
-        (advice-add 'evil-delete :around #'evil-ghostel--around-delete)
-        (advice-add 'evil-change :around #'evil-ghostel--around-change)
-        (advice-add 'evil-replace :around #'evil-ghostel--around-replace)
-        (advice-add 'evil-paste-after :around #'evil-ghostel--around-paste-after)
-        (advice-add 'evil-paste-before :around #'evil-ghostel--around-paste-before)
-        (advice-add 'evil-undo :around #'evil-ghostel--around-undo)
-        (advice-add 'evil-redo :around #'evil-ghostel--around-redo)
+        ;; `advice-add' is idempotent per (symbol, fn), so re-adding on
+        ;; every enable is safe — no separate install flag needed.
         (advice-add 'ghostel--redraw :around #'evil-ghostel--around-redraw)
         (advice-add 'ghostel--set-cursor-style :around
                     #'evil-ghostel--override-cursor-style)
@@ -754,22 +900,11 @@ state transitions."
                  #'evil-ghostel--insert-state-entry t)
     (remove-hook 'evil-emacs-state-entry-hook
                  #'evil-ghostel--insert-state-entry t)
-    (advice-remove 'evil-insert-line #'evil-ghostel--around-insert-line)
-    (advice-remove 'evil-append-line #'evil-ghostel--around-append-line)
-    (advice-remove 'evil-beginning-of-line
-                   #'evil-ghostel--around-beginning-of-line)
-    (advice-remove 'evil-first-non-blank
-                   #'evil-ghostel--around-beginning-of-line)
-    (advice-remove 'evil-delete #'evil-ghostel--around-delete)
-    (advice-remove 'evil-change #'evil-ghostel--around-change)
-    (advice-remove 'evil-replace #'evil-ghostel--around-replace)
-    (advice-remove 'evil-paste-after #'evil-ghostel--around-paste-after)
-    (advice-remove 'evil-paste-before #'evil-ghostel--around-paste-before)
-    (advice-remove 'evil-undo #'evil-ghostel--around-undo)
-    (advice-remove 'evil-redo #'evil-ghostel--around-redo)
-    (advice-remove 'ghostel--redraw #'evil-ghostel--around-redraw)
-    (advice-remove 'ghostel--set-cursor-style
-                   #'evil-ghostel--override-cursor-style)))
+    (kill-local-variable 'ghostel-mark-activation-input-mode)
+    (unless (evil-ghostel--any-active-elsewhere-p (current-buffer))
+      (advice-remove 'ghostel--redraw #'evil-ghostel--around-redraw)
+      (advice-remove 'ghostel--set-cursor-style
+                     #'evil-ghostel--override-cursor-style))))
 
 (provide 'evil-ghostel)
 ;;; evil-ghostel.el ends here

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2114,11 +2114,15 @@ Falls back to raw escape sequences if the encoder doesn't produce output."
 Returns the sequence string, or nil for unknown keys."
   (let ((mod-num (ghostel--modifier-number mods)))
     (cond
-     ;; Ctrl + single letter
+     ;; Ctrl + a single ASCII char with a C0 control code.  Both a-z and
+     ;; the @ A-Z [ \ ] ^ _ range fold to (char & #x1f): ctrl-a=1,
+     ;; ctrl-z=26, ctrl-^=#x1e, ctrl-_=#x1f (readline / zle undo).
      ((and (= (length key-name) 1)
-           (<= ?a (aref key-name 0)) (<= (aref key-name 0) ?z)
+           (let ((c (aref key-name 0)))
+             (or (and (<= ?a c) (<= c ?z))
+                 (and (<= ?@ c) (<= c ?_))))
            (> (logand mod-num 4) 0))        ; ctrl bit
-      (string (- (aref key-name 0) 96)))    ; ctrl-a=1, ctrl-z=26
+      (string (logand (aref key-name 0) #x1f)))
      ;; Meta + printable ASCII → ESC + char (legacy alt encoding)
      ((and (= (length key-name) 1)
            (let ((c (aref key-name 0)))
@@ -2709,8 +2713,8 @@ handler so the selection survives release; without this,
 intercept keeps `mouse-set-region' from re-establishing the region.
 When the buffer is in semi-char mode, switches input mode once the
 region is set to the mode configured in `ghostel-mouse-drag-input-mode'.
-An empty drag, a click that wiggled into a `drag-mouse-1' without selecting
-anything, is dispatched to `ghostel-mouse-release-or-set-point',
+An empty drag (a click that wiggled into a drag event without selecting
+anything) is dispatched to `ghostel-mouse-release-or-set-point',
 so a focus click stays in semi-char like a plain click."
   (interactive "e")
   (cond

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -21,21 +21,24 @@
   "Create a ghostel buffer with ROWS x COLS, feed TEXT, render, then run BODY.
 The buffer has evil-mode and evil-ghostel-mode active.
 The variable `term' is bound to the terminal handle.
-Requires the native module."
+Requires the native module; without it the test is skipped
+(e.g. CI's elisp-only `test-evil' job)."
   (declare (indent 3) (debug t))
-  `(let* ((ghostel-max-scrollback 100)
-          (buf (ghostel--create " *evil-ghostel-test*" nil ,rows ,cols))
-          (term (buffer-local-value 'ghostel--term buf)))
-     (unwind-protect
-         (with-current-buffer buf
-           (ghostel--write-input term ,text)
-           (evil-local-mode 1)
-           (evil-ghostel-mode 1)
-           (let ((inhibit-read-only t))
-             (ghostel--redraw term t))
-           ,@body)
-       (when (buffer-live-p buf)
-         (kill-buffer buf)))))
+  `(progn
+     (skip-unless (fboundp 'ghostel--new))
+     (let* ((ghostel-max-scrollback 100)
+            (buf (ghostel--create " *evil-ghostel-test*" nil ,rows ,cols))
+            (term (buffer-local-value 'ghostel--term buf)))
+       (unwind-protect
+           (with-current-buffer buf
+             (ghostel--write-input term ,text)
+             (evil-local-mode 1)
+             (evil-ghostel-mode 1)
+             (let ((inhibit-read-only t))
+               (ghostel--redraw term t))
+             ,@body)
+         (when (buffer-live-p buf)
+           (kill-buffer buf))))))
 
 (defmacro evil-ghostel-test--with-evil-buffer (&rest body)
   "Set up a ghostel buffer with evil-mode active (no native module).
@@ -58,14 +61,40 @@ Uses mocks for native functions."
 ;; -----------------------------------------------------------------------
 
 (ert-deftest evil-ghostel-test-mode-activation ()
-  "Test that `evil-ghostel-mode' activates correctly."
+  "Test that `evil-ghostel-mode' activates correctly.
+Asserts that the insert-state-entry hook is wired up, the redraw
+advice is installed, and the command-remap bindings are in
+`evil-ghostel-mode-map' for normal and visual states.
+
+Bindings are remap-form (`[remap evil-FOO]') so user remappings of
+the underlying evil commands flow through to our PTY-routed
+variants — verified here by looking up the remap rather than a
+literal key."
   (evil-ghostel-test--with-evil-buffer
    (should evil-ghostel-mode)
    (should (memq 'evil-ghostel--insert-state-entry
                  evil-insert-state-entry-hook))
-   (should (advice--p (advice--symbol-function 'evil-insert-line)))
    (should (advice--p (advice--symbol-function 'ghostel--redraw)))
-   (should (advice--p (advice--symbol-function 'ghostel--set-cursor-style)))))
+   (should (advice--p (advice--symbol-function 'ghostel--set-cursor-style)))
+   ;; Editing operators are bound via [remap evil-FOO] in normal state.
+   (should (eq #'evil-ghostel-delete
+               (lookup-key (evil-get-auxiliary-keymap
+                            evil-ghostel-mode-map 'normal)
+                           [remap evil-delete])))
+   (should (eq #'evil-ghostel-change
+               (lookup-key (evil-get-auxiliary-keymap
+                            evil-ghostel-mode-map 'normal)
+                           [remap evil-change])))
+   ;; And in visual state.
+   (should (eq #'evil-ghostel-delete
+               (lookup-key (evil-get-auxiliary-keymap
+                            evil-ghostel-mode-map 'visual)
+                           [remap evil-delete])))
+   ;; Literal key bindings must NOT be present — that would shadow
+   ;; user remappings of the underlying evil commands.
+   (should-not (lookup-key (evil-get-auxiliary-keymap
+                            evil-ghostel-mode-map 'normal)
+                           "d"))))
 
 (ert-deftest evil-ghostel-test-mode-activation-no-normal-entry-hook ()
   "`evil-ghostel-mode' does not install a `normal-state-entry-hook'.
@@ -83,6 +112,77 @@ overwrite the position evil assigns at operator/visual completion."
    (should-not evil-ghostel-mode)
    (should-not (memq 'evil-ghostel--insert-state-entry
                      evil-insert-state-entry-hook))))
+
+(ert-deftest evil-ghostel-test-visual-inhibits-mark-copy-mode ()
+  "Entering evil visual must not flip ghostel into read-only copy mode.
+`ghostel-mode' wires `ghostel--mark-activated' onto `activate-mark-hook',
+which (for vanilla users) switches semi-char -> read-only `copy' mode when
+the mark activates.  Evil's `v' activates the mark, so without suppression
+the buffer goes read-only and the visual operators hit \"Buffer is
+read-only\".  `evil-ghostel-mode' sets `ghostel-mark-activation-input-mode'
+to nil buffer-locally so that chain yields to evil's own selection model."
+  (evil-ghostel-test--with-evil-buffer
+   ;; Preconditions the major mode established (mirrors a live buffer):
+   (should (eq ghostel--input-mode 'semi-char))
+   (should (memq #'ghostel--mark-activated activate-mark-hook))
+   ;; The minor mode opted the buffer out, buffer-locally:
+   (should (local-variable-p 'ghostel-mark-activation-input-mode))
+   (should (null ghostel-mark-activation-input-mode))
+   (let (copied)
+     (cl-letf (((symbol-function 'ghostel-copy-mode)
+                (lambda (&rest _) (setq copied t))))
+       ;; Opted out -> activating the mark is a no-op, mode stays editable.
+       (ghostel--mark-activated)
+       (should-not copied)
+       ;; Control (proves the test is not vacuous): restore the default knob
+       ;; and the same hook DOES switch -> the nil knob is exactly what gates it.
+       (let ((ghostel-mark-activation-input-mode 'copy))
+         (ghostel--mark-activated)
+         (should copied))))))
+
+(ert-deftest evil-ghostel-test-disable-restores-mark-activation ()
+  "Disabling `evil-ghostel-mode' restores ghostel's mark-activation behavior."
+  (evil-ghostel-test--with-evil-buffer
+   (should (local-variable-p 'ghostel-mark-activation-input-mode))
+   (evil-ghostel-mode -1)
+   (should-not (local-variable-p 'ghostel-mark-activation-input-mode))))
+
+(ert-deftest evil-ghostel-test-advice-survives-disable-in-other-buffer ()
+  "Global `ghostel--redraw' / cursor-style advice survives one buffer disabling.
+The advice is global but the mode is buffer-local; `advice-remove'
+during disable must wait until the LAST `evil-ghostel-mode' buffer
+is gone, otherwise toggling off in one buffer silently strips the
+wrapper from every other ghostel buffer."
+  (let ((a (generate-new-buffer " *evil-ghostel-test-advice-a*"))
+        (b (generate-new-buffer " *evil-ghostel-test-advice-b*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer a
+            (ghostel-mode)
+            (setq-local ghostel--term-rows 100)
+            (evil-local-mode 1)
+            (evil-ghostel-mode 1))
+          (with-current-buffer b
+            (ghostel-mode)
+            (setq-local ghostel--term-rows 100)
+            (evil-local-mode 1)
+            (evil-ghostel-mode 1))
+          (should (advice-member-p #'evil-ghostel--around-redraw
+                                   'ghostel--redraw))
+          ;; Disable in A — B still has the mode on, advice must stay.
+          (with-current-buffer a (evil-ghostel-mode -1))
+          (should (advice-member-p #'evil-ghostel--around-redraw
+                                   'ghostel--redraw))
+          (should (advice-member-p #'evil-ghostel--override-cursor-style
+                                   'ghostel--set-cursor-style))
+          ;; Disable in B — no buffers left, advice removed.
+          (with-current-buffer b (evil-ghostel-mode -1))
+          (should-not (advice-member-p #'evil-ghostel--around-redraw
+                                       'ghostel--redraw))
+          (should-not (advice-member-p #'evil-ghostel--override-cursor-style
+                                       'ghostel--set-cursor-style)))
+      (when (buffer-live-p a) (kill-buffer a))
+      (when (buffer-live-p b) (kill-buffer b)))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: initial-state defcustom
@@ -215,51 +315,6 @@ advice must not restore point or visual markers there."
    ;; Advice bypassed → the mock's point placement (point-min) wins.
    (should (= (point-min) (point)))))
 
-(ert-deftest evil-ghostel-test-around-redraw-snaps-point-on-prompt-line ()
-  "Point follows the new cursor line in normal state when on the prompt.
-Output that grows scrollback must not strand point above the live
-prompt."
-  (evil-ghostel-test--with-buffer 5 40 "$ "
-                                  (evil-normal-state)
-                                  ;; Start on the cursor line.
-                                  (evil-ghostel--reset-cursor-point)
-                                  (should (evil-ghostel--point-on-cursor-line-p))
-                                  ;; Stream output that overflows the 5-row viewport, growing
-                                  ;; scrollback.  The prompt-following heuristic should keep
-                                  ;; point on the live cursor row.
-                                  (ghostel--write-input term "\r\n")
-                                  (dotimes (i 8)
-                                    (ghostel--write-input term (format "out-%d\r\n" i)))
-                                  (ghostel--write-input term "$ ")
-                                  (let ((inhibit-read-only t))
-                                    (ghostel--redraw term nil))
-                                  ;; Point lands on the new cursor line, not above it.
-                                  (should (evil-ghostel--point-on-cursor-line-p))))
-
-(ert-deftest evil-ghostel-test-around-redraw-preserves-point-off-prompt ()
-  "Point is preserved in normal state when parked off the prompt line.
-Scrollback navigation must not be disturbed by output redraws."
-  (evil-ghostel-test--with-buffer 5 40 "alpha\r\nbeta\r\ngamma\r\n$ "
-                                  (evil-normal-state)
-                                  (save-window-excursion
-                                    (switch-to-buffer (current-buffer))
-                                  ;; Park point on a non-cursor line above the prompt.
-                                  (goto-char (point-min))
-                                  (search-forward "beta")
-                                  (beginning-of-line)
-                                  (should-not (evil-ghostel--point-on-cursor-line-p))
-                                  ;; Drive a redraw that doesn't grow scrollback (still fits).
-                                  (ghostel--write-input term "x")
-                                  (let ((inhibit-read-only t))
-                                    (ghostel--redraw term nil))
-                                  ;; Point still on the same content line, not snapped to cursor.
-                                  (should (string-match-p
-                                           "beta"
-                                           (buffer-substring-no-properties
-                                            (line-beginning-position)
-                                            (line-end-position))))
-                                    (should-not (evil-ghostel--point-on-cursor-line-p)))))
-
 ;; -----------------------------------------------------------------------
 ;; Test: reset-cursor-point
 ;; -----------------------------------------------------------------------
@@ -322,101 +377,76 @@ point in the scrollback region instead of the visible viewport."
               (current-column)))))
 
 ;; -----------------------------------------------------------------------
-;; Test: cursor-to-point (arrow key sending)
+;; Test: evil-ghostel-goto-input-position end-to-end with the native module
 ;; -----------------------------------------------------------------------
 
-(ert-deftest evil-ghostel-test-cursor-to-point ()
-  "Test that `evil-ghostel--cursor-to-point' sends correct arrow keys."
+(ert-deftest evil-ghostel-test-goto-input-position-end-to-end ()
+  "End-to-end: `evil-ghostel-goto-input-position' sends LEFT arrows.
+Verifies the lifted-from-evil-ghostel implementation against a real
+libghostty terminal (the Phase 1 mock tests exercise the bare
+algorithm; this one walks scrollback math and viewport offsets too)."
   (evil-ghostel-test--with-buffer 5 40 "$ echo hello world"
-                                  ;; Terminal cursor at col 18, row 0
                                   (should (equal '(18 . 0) ghostel--cursor-pos))
-                                  ;; Move point to col 7 (start of "hello")
-                                  (goto-char (point-min))
-                                  (move-to-column 7)
-                                  ;; Track what keys are sent
                                   (let ((keys-sent '()))
                                     (cl-letf (((symbol-function 'ghostel--send-encoded)
                                                (lambda (key _mods &rest _)
                                                  (push key keys-sent))))
-                                      (evil-ghostel--cursor-to-point))
-                                    ;; Should send 11 LEFT arrows (18 - 7 = 11)
+                                      ;; Target: position 8 = column 7
+                                      ;; (start of "hello").
+                                      (evil-ghostel-goto-input-position 8))
                                     (should (= 11 (length keys-sent)))
                                     (should (cl-every (lambda (k) (equal k "left")) keys-sent)))))
 
-(ert-deftest evil-ghostel-test-cursor-to-point-right ()
-  "Test arrow key sending when point is to the right of terminal cursor."
-  (evil-ghostel-test--with-buffer 5 40 "hello"
-                                  ;; Terminal cursor at col 5
-                                  ;; Move cursor left in terminal, then redraw so ghostel--cursor-pos
-                                  ;; reflects the new position (col 2).
-                                  (ghostel--write-input term "\e[3D") ; cursor left 3 → col 2
-                                  (let ((inhibit-read-only t)) (ghostel--redraw term t))
-                                  (goto-char (point-min))
-                                  (move-to-column 4) ; point at col 4
-                                  (let ((keys-sent '()))
-                                    (cl-letf (((symbol-function 'ghostel--send-encoded)
-                                               (lambda (key _mods &rest _)
-                                                 (push key keys-sent))))
-                                      (evil-ghostel--cursor-to-point))
-                                    ;; Should send 2 RIGHT arrows (4 - 2 = 2)
-                                    (should (= 2 (length keys-sent)))
-                                    (should (cl-every (lambda (k) (equal k "right")) keys-sent)))))
-
-(ert-deftest evil-ghostel-test-cursor-to-point-no-op ()
-  "Test that no arrows are sent when point matches terminal cursor."
-  (evil-ghostel-test--with-buffer 5 40 "hello"
-                                  ;; Put point at the terminal cursor.
-                                  (evil-ghostel--reset-cursor-point)
-                                  (let ((keys-sent '()))
-                                    (cl-letf (((symbol-function 'ghostel--send-encoded)
-                                               (lambda (key _mods &rest _)
-                                                 (push key keys-sent))))
-                                      (evil-ghostel--cursor-to-point))
-                                    (should (= 0 (length keys-sent))))))
-
-(ert-deftest evil-ghostel-test-cursor-to-point-with-scrollback ()
-  "Regression: cursor-to-point must subtract scrollback from buffer line.
-`ghostel--cursor-pos' holds viewport-relative rows, so a
-buffer line N must be converted to viewport row N-scrollback before
-diffing — otherwise dy is wrong by exactly the scrollback line count
-and the helper sends arrows that move the cursor off the input."
-  (evil-ghostel-test--with-buffer
-   5 40 ""
-   ;; Push 7 rows into scrollback so the viewport shows
-   ;; rows 8..12 plus the trailing cursor row.
-   (dotimes (i 12)
-     (ghostel--write-input term (format "row-%02d\r\n" i)))
-   (ghostel--write-input term "tail")
-   (let ((inhibit-read-only t))
-     (ghostel--redraw term t))
-   ;; Terminal cursor is on the last viewport row; move point to the
-   ;; first viewport row (one row above the cursor).
-   (let* ((tpos ghostel--cursor-pos)
-          (trow (cdr tpos))
-          (target-viewport-row (1- trow))
-          (line-count (count-lines (point-min) (point-max)))
-          (scrollback (max 0 (- line-count ghostel--term-rows))))
-     (goto-char (point-min))
-     (forward-line (+ scrollback target-viewport-row))
-     (move-to-column (car tpos))
-     (let ((keys-sent '()))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _)
-                    (push key keys-sent))))
-         (evil-ghostel--cursor-to-point))
-       ;; Exactly one UP, no horizontal motion (cols match).
-       (should (= 1 (length keys-sent)))
-       (should (equal "up" (car keys-sent)))))))
+(ert-deftest evil-ghostel-test-goto-input-position-with-scrollback ()
+  "Regression: goto-input-position must subtract scrollback from buffer line.
+`ghostel--cursor-pos' holds viewport-relative rows, so a buffer
+line N must be converted to viewport row N-scrollback before
+diffing — otherwise dy is wrong by the scrollback line count."
+  (skip-unless (fboundp 'ghostel--new))
+  (let ((term (ghostel--new 5 40 1000)))
+    ;; Push 12 rows so the viewport shows rows 8..12 plus a trailing
+    ;; cursor row.
+    (dotimes (i 12)
+      (ghostel--write-input term (format "row-%02d\r\n" i)))
+    (ghostel--write-input term "tail")
+    (with-temp-buffer
+      (ghostel-mode)
+      (setq-local ghostel--term term)
+      (setq-local ghostel--term-rows 5)
+      (evil-local-mode 1)
+      (evil-ghostel-mode 1)
+      (let ((inhibit-read-only t))
+        (ghostel--redraw term t))
+      ;; Terminal cursor is on the last viewport row; target a
+      ;; buffer position on the previous viewport row, same column.
+      (let* ((tpos ghostel--cursor-pos)
+             (trow (cdr tpos))
+             (target-viewport-row (1- trow))
+             (scrollback (max 0 (- (count-lines (point-min) (point-max))
+                                   ghostel--term-rows)))
+             (target-pos (save-excursion
+                           (goto-char (point-min))
+                           (forward-line (+ scrollback target-viewport-row))
+                           (move-to-column (car tpos))
+                           (point))))
+        (let ((keys-sent '()))
+          (cl-letf (((symbol-function 'ghostel--send-encoded)
+                     (lambda (key _mods &rest _)
+                       (push key keys-sent))))
+            (evil-ghostel-goto-input-position target-pos))
+          (should (= 1 (length keys-sent)))
+          (should (equal "up" (car keys-sent))))))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: redraw preserves point in normal state
 ;; -----------------------------------------------------------------------
 
 (ert-deftest evil-ghostel-test-redraw-preserves-point-normal ()
-  "Test that redraws preserve point in evil normal state.
-Specifically when point is parked off the cursor's buffer line —
-on-cursor-line normal state intentionally follows the cursor across
-redraws so the prompt isn't left behind by output."
+  "Redraws preserve point in evil normal state.
+Unlike vterm, the renderer does not snap point to the terminal cursor;
+in normal state point stays wherever the user navigated (the rewrite
+dropped the old prompt-following heuristic — only insert / emacs state
+sync point to the cursor)."
   (evil-ghostel-test--with-buffer 5 40 "first\r\nsecond\r\nthird"
                                   (evil-normal-state)
                                   (save-window-excursion
@@ -462,21 +492,23 @@ redrawing elsewhere."
 ;; Test: advice fires on evil-insert / evil-append
 ;; -----------------------------------------------------------------------
 
-(ert-deftest evil-ghostel-test-advice-on-insert ()
-  "Test that `evil-ghostel--before-insert' fires on `evil-insert'."
+(ert-deftest evil-ghostel-test-insert-drives-shell-cursor ()
+  "`evil-ghostel-insert' drives the shell cursor to point via arrow keys.
+The command calls `evil-ghostel-goto-input-position' which moves the
+terminal cursor to point's buffer position."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
              (ghostel--cursor-pos '(0 . 0)))
      (evil-normal-state)
      (let ((sync-called nil))
-       (cl-letf (((symbol-function 'evil-ghostel--cursor-to-point)
-                  (lambda () (setq sync-called t))))
-         (evil-insert 1))
+       (cl-letf (((symbol-function 'evil-ghostel-goto-input-position)
+                  (lambda (&rest _) (setq sync-called t))))
+         (evil-ghostel-insert))
        (should sync-called)))))
 
-(ert-deftest evil-ghostel-test-advice-on-append ()
-  "Test that `evil-ghostel--before-append' fires on `evil-append'."
+(ert-deftest evil-ghostel-test-append-drives-shell-cursor ()
+  "`evil-ghostel-append' drives the shell cursor to point via arrow keys."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "hello")
@@ -486,101 +518,174 @@ redrawing elsewhere."
      (goto-char (point-min))
      (move-to-column 2)
      (let ((sync-called nil))
-       (cl-letf (((symbol-function 'evil-ghostel--cursor-to-point)
-                  (lambda () (setq sync-called t))))
-         (evil-append 1))
+       (cl-letf (((symbol-function 'evil-ghostel-goto-input-position)
+                  (lambda (&rest _) (setq sync-called t))))
+         (evil-ghostel-append))
        (should sync-called)))))
 
-(ert-deftest evil-ghostel-test-advice-insert-line-sends-home ()
-  "Test that `evil-insert-line' sends C-a and inhibits hook sync."
+(ert-deftest evil-ghostel-test-append-at-cursor-does-not-advance ()
+  "Regression: `evil-ghostel-append' at the terminal cursor does not forward-char.
+Reproduces noctuid's report: with zsh-autosuggestions / RPROMPT
+painting cells past the typed input, vanilla `evil-append' would
+`forward-char' onto a non-input padding cell so the visual cursor
+lands one cell past `d' while the PTY cursor (and backspace target)
+stays on `d'.  The guard skips the +1 step when point is at or past
+`ghostel-cursor-point' and the cell at the cursor is blank/eol."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
+   ;; Simulate RPROMPT padding: typed "word" + 10 padding cells +
+   ;; faux right-prompt content.  Terminal cursor sits at the end of
+   ;; the typed input (pos 5), not at end of line.
+   (let ((inhibit-read-only t))
+     (insert "word")
+     (insert (make-string 10 ?\s))
+     (insert "rprompt"))
    (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(0 . 0)))
+             ;; Isolate target-computation from PTY mechanics: simulate
+             ;; goto-input-position's net effect on point.
+             ((symbol-function 'evil-ghostel-goto-input-position)
+              (lambda (pos &rest _) (goto-char pos) t))
+             ((symbol-function 'evil-ghostel--insert-state-entry) #'ignore)
+             (ghostel--cursor-pos '(4 . 0))
+             (ghostel--cursor-char-pos 5))
      (evil-normal-state)
-     (let ((keys-sent '()))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _)
-                    (push key keys-sent))))
-         (evil-insert-line 1))
-       (should (member "a" keys-sent))
-       ;; Hook should NOT have sent additional arrow keys
-       (should-not (member "left" keys-sent))
-       (should-not (member "right" keys-sent))))))
+     (goto-char 5) ; point AT cursor-char-pos (end of typed input)
+     (evil-ghostel-append)
+     ;; Without the guard, target would be pos 6 (onto a padding space).
+     ;; The guard keeps target = point so the cursor stays put.
+     (should (= 5 (point)))
+     (should (eq 'insert evil-state)))))
 
-(ert-deftest evil-ghostel-test-advice-append-line-sends-end ()
-  "Test that `evil-append-line' sends C-e and inhibits hook sync."
+(ert-deftest evil-ghostel-test-append-after-cursor-moved-mid-input-advances ()
+  "Regression: after the insert-state-entry hook moved the terminal cursor
+mid-input (typical of `i' then `<esc>' then `a'), pressing `a' must
+still advance one char.  The padding-cell guard correctly falls
+through when the cell at the cursor is non-blank typed text."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
+   ;; Buffer: "hi" (the user typed `hi').  Then they pressed `i', and
+   ;; the insert-state-entry hook moved the terminal cursor from pos 3
+   ;; (end of input) back to pos 2 (on `i').  Now they press `<esc>'
+   ;; then `a' — the cursor is at pos 2, the same as point.
+   (insert "hi")
    (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(0 . 0)))
+             ((symbol-function 'evil-ghostel-goto-input-position)
+              (lambda (pos &rest _) (goto-char pos) t))
+             ((symbol-function 'evil-ghostel--insert-state-entry) #'ignore)
+             ;; Cursor moved to mid-input by a previous sync.
+             (ghostel--cursor-pos '(1 . 0))
+             (ghostel--cursor-char-pos 2))
      (evil-normal-state)
-     (let ((keys-sent '()))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _)
-                    (push key keys-sent))))
-         (evil-append-line 1))
-       (should (member "e" keys-sent))
-       ;; Hook should NOT have sent additional arrow keys
-       (should-not (member "left" keys-sent))
-       (should-not (member "right" keys-sent))))))
+     (goto-char 2) ; point on `i', same as cursor
+     (evil-ghostel-append)
+     ;; Cell at cursor (pos 2, "i") is non-blank typed text → the
+     ;; guard falls through; target = (1+ point) = 3.
+     (should (= 3 (point)))
+     (should (eq 'insert evil-state)))))
 
-(ert-deftest evil-ghostel-test-insert-line-multiline-syncs-row ()
-  "Regression: `I' on a different row must sync the terminal cursor first.
-Without the row sync, the Ctrl-a sent by the advice operates on the
-last input line (where the terminal cursor was parked), not on the
-line the user navigated to with `kk'."
+(ert-deftest evil-ghostel-test-append-before-cursor-uses-vanilla ()
+  "Append mid-input advances by one cell.
+Point inside the input region but before the terminal cursor must
+still advance by one cell (vim semantics)."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "hello world")
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ((symbol-function 'evil-ghostel-goto-input-position)
+              (lambda (pos &rest _) (goto-char pos) t))
+             ((symbol-function 'evil-ghostel--insert-state-entry) #'ignore)
+             (ghostel--cursor-pos '(11 . 0))
+             (ghostel--cursor-char-pos 12))
+     (evil-normal-state)
+     (goto-char 3) ; point on 'e' of "hello"
+     (evil-ghostel-append)
+     ;; Target = (min (1+ point) row-end) = 4.
+     (should (= 4 (point)))
+     (should (eq 'insert evil-state)))))
+
+(ert-deftest evil-ghostel-test-insert-line-sends-arrows-to-input-start ()
+  "`evil-ghostel-insert-line' drives the shell cursor to input-start via arrows.
+The vterm-style shape uses `evil-ghostel-goto-input-position' rather
+than sending readline's C-a — deterministic regardless of the shell's
+`bindkey -v' / vi-mode key bindings, which is what Bug B (issue #264)
+was exposing."
+  (evil-ghostel-test--with-input-fixture "$ " "hello"
+    (evil-normal-state)
+    (let ((keys-sent '()))
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key mods &rest _)
+                   (push (cons key mods) keys-sent)))
+                ((symbol-function 'evil-ghostel--sync-render) #'ignore)
+                ;; Mock the entry hook to avoid double-counting arrows: in
+                ;; tests `sync-render' is a no-op so `ghostel--cursor-pos'
+                ;; doesn't track the move, and the hook's idempotent re-run
+                ;; would otherwise re-send the same arrows.
+                ((symbol-function 'evil-ghostel--insert-state-entry) #'ignore))
+        (evil-ghostel-insert-line))
+      ;; Cursor at col 7 (end of "hello"), input-start at col 2 → 5 lefts.
+      (should (= 5 (cl-count '("left" . "") keys-sent :test #'equal)))
+      ;; Critically: no readline C-a — Bug B (#264) determinism.
+      (should-not (cl-find '("a" . "ctrl") keys-sent :test #'equal))
+      (should (evil-insert-state-p)))))
+
+(ert-deftest evil-ghostel-test-append-line-sends-arrows-to-row-end ()
+  "`evil-ghostel-append-line' drives the shell cursor to row-end via arrows.
+Same vterm-style shape as `I' — no readline C-e, deterministic
+regardless of shell vi-mode."
+  (evil-ghostel-test--with-input-fixture "$ " "hello"
+    (evil-normal-state)
+    (goto-char 3) ; point at input-start ("h" of "hello"); cursor at 8 (eol).
+    (let ((keys-sent '()))
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key mods &rest _)
+                   (push (cons key mods) keys-sent)))
+                ((symbol-function 'evil-ghostel--sync-render) #'ignore)
+                ((symbol-function 'evil-ghostel--insert-state-entry) #'ignore))
+        (evil-ghostel-append-line))
+      ;; Cursor at col 7, row-end at col 7 (after "hello", no padding) →
+      ;; goto-input-position with target == cursor-pos is a no-op horizontally.
+      (should-not (cl-find '("e" . "ctrl") keys-sent :test #'equal))
+      (should (evil-insert-state-p)))))
+
+(ert-deftest evil-ghostel-test-insert-line-pins-point-at-input-start ()
+  "Regression for Bug A (#264): `I' lands point at `ghostel-input-start-point'.
+After the vterm-style rewrite point is set deterministically before
+`evil-insert-state' runs — no async redraw can drag point past the
+right prompt (Bug A's \"until first keystroke\" symptom)."
+  (evil-ghostel-test--with-input-fixture "$ " "hello"
+    (evil-normal-state)
+    (cl-letf (((symbol-function 'ghostel--send-encoded) #'ignore)
+              ((symbol-function 'evil-ghostel--sync-render) #'ignore)
+              ((symbol-function 'evil-ghostel--insert-state-entry) #'ignore))
+      (evil-ghostel-insert-line))
+    (should (= 3 (point))) ; right after "$ "
+    (should (evil-insert-state-p))))
+
+(ert-deftest evil-ghostel-test-append-line-pins-point-at-row-end ()
+  "Regression for Bug A (#264): `A' lands point at end of typed input."
+  (evil-ghostel-test--with-input-fixture "$ " "hello"
+    (evil-normal-state)
+    (goto-char (point-min))
+    (cl-letf (((symbol-function 'ghostel--send-encoded) #'ignore)
+              ((symbol-function 'evil-ghostel--sync-render) #'ignore)
+              ((symbol-function 'evil-ghostel--insert-state-entry) #'ignore))
+      (evil-ghostel-append-line))
+    (should (= 8 (point))) ; end of "hello"
+    (should (evil-insert-state-p))))
+
+(ert-deftest evil-ghostel-test-change-eol-snaps-point-to-cursor ()
+  "`C' at eol of a non-cursor row enters insert state at the live cursor.
+Off the cursor row there's no PTY-routed editing to be done — the
+delete is a no-op on the scrollback line, then `evil-ghostel-insert'
+takes the off-row branch and the entry hook's `reset-cursor-point'
+pulls point onto the live cursor's row.  No history-navigation `up'
+arrows are sent (which the old `sync-inhibit' path mistakenly did)."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "line one\nline two\nline three")
-   ;; Terminal cursor at end of line three (row 2); point on row 0.
    (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
              (ghostel--cursor-pos '(10 . 2)))
      (evil-normal-state)
-     (goto-char (point-min))
-     (let ((keys-sent '()))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key mods &rest _)
-                    (push (cons key mods) keys-sent))))
-         (evil-insert-line 1))
-       ;; Two `up' arrows precede the Ctrl-a so the shell's readline
-       ;; cursor lands on the right input row before going to bol.
-       (should (= 2 (cl-count '("up" . "") keys-sent :test #'equal)))
-       (should (cl-find '("a" . "ctrl") keys-sent :test #'equal))))))
-
-(ert-deftest evil-ghostel-test-append-line-multiline-syncs-row ()
-  "Regression: `A' on a different row must sync the terminal cursor first.
-Symmetric to the `I' multi-row case — without the row sync the Ctrl-e
-goes to the end of the last input line."
-  (evil-ghostel-test--with-evil-buffer
-   (setq-local ghostel--term t)
-   (insert "line one\nline two\nline three")
-   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(10 . 2)))
-     (evil-normal-state)
-     (goto-char (point-min))
-     (let ((keys-sent '()))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key mods &rest _)
-                    (push (cons key mods) keys-sent))))
-         (evil-append-line 1))
-       (should (= 2 (cl-count '("up" . "") keys-sent :test #'equal)))
-       (should (cl-find '("e" . "ctrl") keys-sent :test #'equal))))))
-
-(ert-deftest evil-ghostel-test-change-eol-syncs-cursor-to-point ()
-  "Regression: `C' at eol of a non-cursor row must sync before insert.
-With point at end of line one and the terminal cursor at end of line
-three, `C' produces an empty range (count = 0).  Without an explicit
-sync after `delete-region', insert state would inherit the terminal
-cursor from line three and the user's typed characters would land on
-the last input line — what was reported as `C deletes the last line'."
-  (evil-ghostel-test--with-evil-buffer
-   (setq-local ghostel--term t)
-   (insert "line one\nline two\nline three")
-   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(10 . 2)))
-     (evil-normal-state)
-     ;; Point at end of line one (just before the first newline).
      (goto-char (point-min))
      (end-of-line)
      (let ((keys-sent '())
@@ -588,25 +693,22 @@ the last input line — what was reported as `C deletes the last line'."
        (cl-letf (((symbol-function 'ghostel--send-encoded)
                   (lambda (key mods &rest _)
                     (push (cons key mods) keys-sent))))
-         ;; `C' at eol → evil-change with empty range.
-         (evil-change eol-pos eol-pos 'inclusive nil nil
-                      #'evil-delete-line))
-       ;; The post-delete cursor-to-point must emit two `up' arrows so
-       ;; the terminal cursor lands on point's row before insert state.
-       (should (= 2 (cl-count '("up" . "") keys-sent :test #'equal)))))))
+         (evil-ghostel-change-line eol-pos eol-pos 'inclusive nil nil))
+       (should-not (cl-find '("up" . "") keys-sent :test #'equal))
+       (should (evil-insert-state-p))))))
 
 ;; -----------------------------------------------------------------------
-;; Test: advice is no-op outside ghostel buffers
+;; Test: insert-state-entry hook is a no-op outside ghostel buffers
 ;; -----------------------------------------------------------------------
 
-(ert-deftest evil-ghostel-test-advice-no-op-outside-ghostel ()
-  "Test that advice does nothing when `evil-ghostel-mode' is nil."
+(ert-deftest evil-ghostel-test-insert-state-entry-no-op-outside-ghostel ()
+  "Insert-state-entry hook is buffer-local: nothing fires in unrelated buffers."
   (with-temp-buffer
     (evil-local-mode 1)
     (evil-normal-state)
     (let ((sync-called nil))
-      (cl-letf (((symbol-function 'evil-ghostel--cursor-to-point)
-                 (lambda () (setq sync-called t))))
+      (cl-letf (((symbol-function 'evil-ghostel-goto-input-position)
+                 (lambda (&rest _) (setq sync-called t))))
         (evil-insert 1))
       (should-not sync-called))))
 
@@ -630,51 +732,174 @@ the last input line — what was reported as `C deletes the last line'."
 ;; -----------------------------------------------------------------------
 
 (ert-deftest evil-ghostel-test-delete-region ()
-  "Test that `evil-ghostel--delete-region' sends correct keys."
+  "End-to-end: `evil-ghostel-delete-input-region' sends the expected keys."
   (evil-ghostel-test--with-buffer 5 40 "$ echo hello"
                                   ;; Delete "hello" (col 7-12)
                                   (let ((keys-sent '()))
                                     (cl-letf (((symbol-function 'ghostel--send-encoded)
                                                (lambda (key _mods &rest _)
                                                  (push key keys-sent))))
-                                      (evil-ghostel--delete-region 8 13))
+                                      (evil-ghostel-delete-input-region 8 13))
                                     ;; Should send arrow keys to move cursor, then 5 backspaces
                                     (should (= 5 (cl-count "backspace" keys-sent :test #'equal))))))
 
 ;; -----------------------------------------------------------------------
-;; Test: meaningful-length helper (render padding stripping)
+;; Test: input-region helpers (input-end, clamp)
 ;; -----------------------------------------------------------------------
 
-(ert-deftest evil-ghostel-test-meaningful-length-strips-trailing ()
-  "Trailing whitespace counts only when TEXT spans multiple lines.
-Single-line `\"word \"' is real user content (e.g. `dw' over a word
-plus its trailing space); multi-line ranges may contain TUI box
-padding that should be stripped per line."
-  (should (= 0 (evil-ghostel--meaningful-length "")))
-  (should (= 3 (evil-ghostel--meaningful-length "AAA")))
-  ;; Single-line: trailing whitespace is preserved (real content).
-  (should (= 9 (evil-ghostel--meaningful-length "AAA      ")))
-  (should (= 5 (evil-ghostel--meaningful-length "word ")))
-  ;; Multi-line: per-line trailing whitespace stripped (TUI padding).
-  (should (= 7 (evil-ghostel--meaningful-length "AAA      \nBBB     ")))
-  (should (= 4 (evil-ghostel--meaningful-length "AAA      \n")))
-  ;; Inner whitespace preserved either way.
-  (should (= 7 (evil-ghostel--meaningful-length "A B C  ")))
-  (should (= 8 (evil-ghostel--meaningful-length "A B C  D"))))
+(defmacro evil-ghostel-test--with-input-fixture (prompt input &rest body)
+  "Set up a mock terminal buffer with PROMPT (carrying `ghostel-prompt')
+followed by INPUT, with `ghostel--cursor-char-pos' positioned at the
+end of INPUT.  Runs BODY in the buffer.
+
+Evil and `evil-ghostel-mode' are enabled so tests can invoke evil
+commands.  Mocks the terminal handle and viewport so the
+input-region helpers can derive prompt boundaries and viewport rows
+without a real native module."
+  (declare (indent 2))
+  `(let ((buf (generate-new-buffer " *evil-ghostel-test-input*")))
+     (unwind-protect
+         (with-current-buffer buf
+           (ghostel-mode)
+           (let ((inhibit-read-only t))
+             (insert (propertize ,prompt 'ghostel-prompt t))
+             (insert ,input))
+           (setq ghostel--term 'fake)
+           (setq ghostel--term-rows 1)
+           (setq ghostel--cursor-char-pos (point))
+           (setq ghostel--cursor-pos (cons (current-column) 0))
+           (evil-local-mode 1)
+           (evil-ghostel-mode 1)
+           (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                      (lambda (&rest _) nil)))
+             ,@body))
+       (kill-buffer buf))))
+
+(ert-deftest evil-ghostel-test-goto-input-position-sends-arrows-unit ()
+  "Unit: |dx| left arrows are sent when point is left of the cursor."
+  (evil-ghostel-test--with-input-fixture "$ " "hello world"
+    ;; cursor-pos col 13 (after "$ hello world"); target is col 7 (start
+    ;; of "hello"), so 6 LEFT arrows.
+    (let ((keys-sent '()))
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key _mods &rest _)
+                   (push key keys-sent))))
+        (evil-ghostel-goto-input-position 8)) ; pos 8 = column 7
+      (should (= 6 (length keys-sent)))
+      (should (cl-every (lambda (k) (equal k "left")) keys-sent)))))
+
+(ert-deftest evil-ghostel-test-goto-input-position-no-op-at-target ()
+  "No keys are sent when point already matches the terminal cursor."
+  (evil-ghostel-test--with-input-fixture "$ " "hello"
+    (let ((keys-sent '()))
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key _mods &rest _)
+                   (push key keys-sent))))
+        (evil-ghostel-goto-input-position ghostel--cursor-char-pos))
+      (should (zerop (length keys-sent))))))
+
+(ert-deftest evil-ghostel-test-sync-render-forces-deferred-redraw ()
+  "`sync-render' force-runs `ghostel--redraw-now' after a bulk-output drain.
+The filter only takes the synchronous redraw path for small echoes
+arriving within `ghostel-immediate-redraw-interval' of the last
+keystroke.  Larger echoes (e.g. `cc' sending 100 backspaces) take
+the bulk-output branch, which queues a timer-driven redraw — so
+`ghostel--cursor-pos' / `ghostel--cursor-char-pos' are stale until
+the timer fires.  `sync-render' must close the gap by forcing the
+deferred redraw before returning, otherwise the next operator
+(e.g. `i' after `cc') reads stale cursor state and computes a
+wrong arrow delta."
+  (evil-ghostel-test--with-input-fixture "$ " "hello"
+    (let* ((redraw-calls 0)
+           ;; Pretend the filter deferred a redraw to its timer.
+           (fake-timer (run-with-timer 999 nil #'ignore))
+           (ghostel--redraw-timer fake-timer)
+           (ghostel--process 'fake-proc))
+      (unwind-protect
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_) t))
+                    ((symbol-function 'accept-process-output)
+                     (lambda (&rest _) nil))
+                    ;; Stubbed redraw stands in for the real
+                    ;; `ghostel--redraw-now', which cancels the timer.
+                    ((symbol-function 'ghostel--redraw-now)
+                     (lambda (_buf) (cl-incf redraw-calls))))
+            (evil-ghostel--sync-render)
+            (should (= 1 redraw-calls)))
+        (when (timerp fake-timer) (cancel-timer fake-timer))))))
+
+(ert-deftest evil-ghostel-test-sync-render-no-op-when-nothing-deferred ()
+  "`sync-render' does NOT force a redraw when the filter handled the echo.
+Small interactive echoes are drawn synchronously inside
+`ghostel--filter''s immediate-redraw branch, which clears
+`ghostel--redraw-timer'.  In that state `sync-render' must not call
+`ghostel--redraw-now' a second time — the cursor state is already
+current."
+  (evil-ghostel-test--with-input-fixture "$ " "hello"
+    (let ((redraw-calls 0)
+          (ghostel--redraw-timer nil)
+          (ghostel--process 'fake-proc))
+      (cl-letf (((symbol-function 'process-live-p) (lambda (_) t))
+                ((symbol-function 'accept-process-output)
+                 (lambda (&rest _) nil))
+                ((symbol-function 'ghostel--redraw-now)
+                 (lambda (_buf) (cl-incf redraw-calls))))
+        (evil-ghostel--sync-render)
+        (should (zerop redraw-calls))))))
+
+(ert-deftest evil-ghostel-test-sync-render-drain-loop-respects-cap ()
+  "`sync-render' caps the drain loop at `*-max-iterations'.
+A runaway shell that returns non-nil from every
+`accept-process-output' call must not hang the caller.  The cap
+bounds total wait at ~max-iter × 50 ms."
+  (evil-ghostel-test--with-input-fixture "$ " "hello"
+    (let ((accept-calls 0)
+          (evil-ghostel-sync-render-max-iterations 5)
+          (ghostel--redraw-timer nil)
+          (ghostel--process 'fake-proc))
+      (cl-letf (((symbol-function 'process-live-p) (lambda (_) t))
+                ((symbol-function 'accept-process-output)
+                 (lambda (&rest _) (cl-incf accept-calls) t))
+                ((symbol-function 'ghostel--redraw-now) #'ignore))
+        (evil-ghostel--sync-render)
+        ;; Loop exits via the iteration cap, not via accept returning nil.
+        (should (= 5 accept-calls))))))
+
+(ert-deftest evil-ghostel-test-delete-input-region-sends-backspaces ()
+  "`evil-ghostel-delete-input-region' sends one backspace per meaningful char."
+  (evil-ghostel-test--with-input-fixture "$ " "hello"
+    (let ((keys-sent '()))
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key _mods &rest _)
+                   (push key keys-sent))))
+        (evil-ghostel-delete-input-region 3 ghostel--cursor-char-pos))
+      (should (= 5 (cl-count "backspace" keys-sent :test #'equal))))))
+
+(ert-deftest evil-ghostel-test-replace-input-region-deletes-then-pastes ()
+  "`evil-ghostel-replace-input-region' first deletes, then pastes new text."
+  (evil-ghostel-test--with-input-fixture "$ " "abc"
+    (let ((pasted nil)
+          (keys-sent '()))
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key _mods &rest _) (push key keys-sent)))
+                ((symbol-function 'ghostel--paste-text)
+                 (lambda (text) (setq pasted text))))
+        (evil-ghostel-replace-input-region 3 ghostel--cursor-char-pos "XYZ"))
+      (should (= 3 (cl-count "backspace" keys-sent :test #'equal)))
+      (should (equal "XYZ" pasted)))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: evil-delete advice
 ;; -----------------------------------------------------------------------
 
 (ert-deftest evil-ghostel-test-delete-sends-backspace-keys ()
-  "Test that `evil-delete' advice sends backspace keys via PTY."
+  "`evil-ghostel-delete' sends backspace keys via the PTY."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "hello world")
    (goto-char (point-min))
    (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
              (ghostel--cursor-pos '(0 . 0))
-             ((symbol-function 'evil-ghostel--cursor-to-point) #'ignore))
+             ((symbol-function 'evil-ghostel-goto-input-position) #'ignore))
      (evil-normal-state)
      (let ((bs-count 0))
        (cl-letf (((symbol-function 'ghostel--send-encoded)
@@ -682,62 +907,72 @@ padding that should be stripped per line."
                     (when (equal key "backspace")
                       (cl-incf bs-count)))))
          ;; Delete 5 chars (simulates dw on "hello")
-         (evil-delete 1 6 'inclusive nil nil))
+         (evil-ghostel-delete 1 6 'inclusive nil nil))
        (should (= 5 bs-count))))))
 
-(ert-deftest evil-ghostel-test-delete-line-same-row-uses-ctrl-u ()
-  "Test that `dd' on the cursor's own line uses the Ctrl-e/Ctrl-u shortcut.
-Single-line shell case: the buffer line includes the prompt prefix,
-so backspacing through the buffer text would hit the prompt boundary
-and silently no-op.  Readline's Ctrl-u clears just the input area.
-See issue #218 for the multi-line counterpart."
+(ert-deftest evil-ghostel-test-delete-line-same-row-uses-backspaces ()
+  "`dd' on the cursor's own line routes through `delete-input-region'.
+vterm-collection's shape: same code path as every other delete.
+The clamped range is [input-start, row-end], so the backspace count
+equals the typed input length (5 for `hello'); no readline C-e/C-u
+shortcut is invoked."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
-   (insert "$ hello")
-   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
-             ;; Terminal cursor on the same row as point.
-             (ghostel--cursor-pos '(7 . 0)))
+   (let ((inhibit-read-only t))
+     (insert (propertize "$ " 'ghostel-prompt t))
+     (insert "hello"))
+   (setq-local ghostel--cursor-pos '(7 . 0))
+   (setq-local ghostel--cursor-char-pos 8)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil)))
      (evil-normal-state)
      (let ((keys-sent '()))
        (cl-letf (((symbol-function 'ghostel--send-encoded)
                   (lambda (key mods &rest _)
-                    (push (cons key mods) keys-sent))))
-         (evil-delete (line-beginning-position) (line-end-position) 'line nil nil))
-       (should (cl-find '("e" . "ctrl") keys-sent :test #'equal))
-       (should (cl-find '("u" . "ctrl") keys-sent :test #'equal))
-       (should-not (cl-find '("backspace" . "") keys-sent :test #'equal))
-       ;; Flag set so the next redraw snaps point to the cursor's new
-       ;; position (start of input area) instead of leaving point on the
-       ;; prompt at column 0.
-       (should evil-ghostel--sync-point-on-next-redraw)))))
+                    (push (cons key mods) keys-sent)))
+                 ((symbol-function 'evil-ghostel--sync-render) #'ignore))
+         (evil-ghostel-delete (line-beginning-position) (line-end-position)
+                              'line nil nil))
+       ;; 5 backspaces — one per char of "hello".
+       (should (= 5 (cl-count '("backspace" . "") keys-sent :test #'equal)))
+       ;; No readline shortcuts.
+       (should-not (cl-find '("e" . "ctrl") keys-sent :test #'equal))
+       (should-not (cl-find '("u" . "ctrl") keys-sent :test #'equal))))))
 
-(ert-deftest evil-ghostel-test-change-line-same-row-uses-ctrl-u ()
-  "Test that `cc' on the cursor's own line uses Ctrl-e/Ctrl-u then enters insert.
-Same single-line shell rationale as `dd' — see
-`evil-ghostel-test-delete-line-same-row-uses-ctrl-u'."
+(ert-deftest evil-ghostel-test-change-line-same-row-uses-backspaces ()
+  "`cc' on the cursor's own line routes through `delete-input-region'
+then enters insert state.  Same vterm-style shape as `dd'."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
-   (insert "$ hello")
-   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(7 . 0)))
+   (let ((inhibit-read-only t))
+     (insert (propertize "$ " 'ghostel-prompt t))
+     (insert "hello"))
+   (setq-local ghostel--cursor-pos '(7 . 0))
+   (setq-local ghostel--cursor-char-pos 8)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil)))
      (evil-normal-state)
      (let ((keys-sent '()))
        (cl-letf (((symbol-function 'ghostel--send-encoded)
                   (lambda (key mods &rest _)
-                    (push (cons key mods) keys-sent))))
-         (evil-change (line-beginning-position) (line-end-position)
-                      'line nil nil nil))
-       (should (cl-find '("e" . "ctrl") keys-sent :test #'equal))
-       (should (cl-find '("u" . "ctrl") keys-sent :test #'equal))
-       (should-not (cl-find '("backspace" . "") keys-sent :test #'equal))
+                    (push (cons key mods) keys-sent)))
+                 ((symbol-function 'evil-ghostel--sync-render) #'ignore)
+                 ((symbol-function 'evil-ghostel--insert-state-entry) #'ignore))
+         (evil-ghostel-change (line-beginning-position) (line-end-position)
+                              'line nil nil))
+       (should (= 5 (cl-count '("backspace" . "") keys-sent :test #'equal)))
+       (should-not (cl-find '("e" . "ctrl") keys-sent :test #'equal))
+       (should-not (cl-find '("u" . "ctrl") keys-sent :test #'equal))
+       ;; Bug fix: point lands at input-start (pos 3, just after "$ "),
+       ;; NOT at column 0 of the buffer line.
+       (should (= 3 (point)))
        (should (eq evil-state 'insert))))))
 
 (ert-deftest evil-ghostel-test-delete-line-multiline-syncs-cursor ()
-  "Regression for #218: line-type delete must sync terminal cursor first.
-With a multi-line input where the terminal cursor sits on the last line,
-pressing dd on the first line must move the terminal cursor up to that
-line before deleting — otherwise Ctrl+U / shortcut-style deletion would
-target the line the cursor sat on (the last input line)."
+  "Regression for #218: line-type delete syncs terminal cursor first.
+With a multi-line input where the terminal cursor sits on the last
+line, pressing `dd' on the first line moves the terminal cursor up
+to that line before deleting — otherwise Ctrl+U / shortcut-style
+deletion would target the line the cursor sat on (the last input
+line)."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "line one\nline two\nline three")
@@ -751,7 +986,7 @@ target the line the cursor sat on (the last input line)."
                   (lambda (key mods &rest _)
                     (push (cons key mods) keys-sent))))
          ;; Line 1 spans positions 1..10 ("line one" + newline = 9 chars)
-         (evil-delete 1 10 'line nil nil))
+         (evil-ghostel-delete 1 10 'line nil nil))
        ;; Sync from row 2 to row 1 (end of deleted region = bol of line 2)
        (should (= 1 (cl-count '("up" . "") keys-sent :test #'equal)))
        ;; Sync from col 10 to col 0
@@ -760,51 +995,18 @@ target the line the cursor sat on (the last input line)."
        (should (= 9 (cl-count '("backspace" . "") keys-sent :test #'equal)))
        (should-not (cl-find '("u" . "ctrl") keys-sent :test #'equal))))))
 
-(ert-deftest evil-ghostel-test-delete-line-strips-render-padding ()
-  "Regression for #218: multi-line `dd' must not backspace TUI box-padding.
-TUIs that draw a fixed-width input box (e.g. prompt_toolkit) write
-spaces past the user's input out to the box border; those land in
-the Emacs buffer but are not characters in the TUI's input model.
-Backspace count must equal trimmed line length + newline.
-Forces the multi-line backspace path by placing the terminal cursor
-on a different row than point."
-  (evil-ghostel-test--with-evil-buffer
-   (setq-local ghostel--term t)
-   ;; "AAA" + 77 box-padding spaces + newline + "BBB" + 77 box-padding spaces.
-   (insert (concat "AAA" (make-string 77 ?\s) "\n"
-                   "BBB" (make-string 77 ?\s)))
-   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
-             ;; Terminal cursor on row 1 (BBB); point will be on row 0 (AAA).
-             (ghostel--cursor-pos '(0 . 1))
-             ((symbol-function 'evil-ghostel--cursor-to-point) #'ignore))
-     (evil-normal-state)
-     (goto-char (point-min))
-     (let ((bs-count 0))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _)
-                    (when (equal key "backspace")
-                      (cl-incf bs-count)))))
-         ;; Line 1 spans bol..bol-of-line-2 (81 chars including newline).
-         (evil-delete (point-min) (line-beginning-position 2) 'line nil nil))
-       ;; Trimmed: "AAA\n" = 4 backspaces, not 81.
-       (should (= 4 bs-count))))))
-
 (ert-deftest evil-ghostel-test-delete-char ()
-  "Test that `evil-delete-char' (x) works without error.
-Regression: yank-handler arg was not optional in advice signature,
-so calls from `evil-delete-char' (which passes only 4 args to
-`evil-delete') raised `wrong-number-of-arguments'."
+  "`evil-ghostel-delete-char' (x) routes through PTY and stays in normal."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "hello")
    (goto-char (point-min))
    (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
              (ghostel--cursor-pos '(0 . 0))
-             ((symbol-function 'evil-ghostel--cursor-to-point) #'ignore)
+             ((symbol-function 'evil-ghostel-goto-input-position) #'ignore)
              ((symbol-function 'ghostel--send-encoded) #'ignore))
      (evil-normal-state)
-     ;; evil-delete-char calls evil-delete without yank-handler
-     (evil-delete-char 1 2 'exclusive nil)
+     (evil-ghostel-delete-char 1 2 'exclusive nil)
      (should (eq evil-state 'normal)))))
 
 ;; -----------------------------------------------------------------------
@@ -812,27 +1014,26 @@ so calls from `evil-delete-char' (which passes only 4 args to
 ;; -----------------------------------------------------------------------
 
 (ert-deftest evil-ghostel-test-change-deletes-and-inserts ()
-  "Test that `evil-change' advice deletes via PTY and enters insert state."
+  "`evil-ghostel-change' deletes via PTY and enters insert state."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "hello world")
    (goto-char (point-min))
    (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
              (ghostel--cursor-pos '(0 . 0))
-             ((symbol-function 'evil-ghostel--cursor-to-point) #'ignore))
+             ((symbol-function 'evil-ghostel-goto-input-position) #'ignore))
      (evil-normal-state)
      (let ((bs-count 0))
        (cl-letf (((symbol-function 'ghostel--send-encoded)
                   (lambda (key _mods &rest _)
                     (when (equal key "backspace")
                       (cl-incf bs-count)))))
-         (evil-change 1 6 'inclusive nil nil nil))
+         (evil-ghostel-change 1 6 'inclusive nil nil))
        (should (= 5 bs-count))
        (should (eq evil-state 'insert))))))
 
 (ert-deftest evil-ghostel-test-change-whole-line ()
-  "Test that `evil-change-whole-line' (cc/S) works without error.
-Regression: delete-func arg was not optional in advice signature."
+  "`evil-ghostel-substitute-line' (cc/S) runs without error."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "hello world")
@@ -841,8 +1042,7 @@ Regression: delete-func arg was not optional in advice signature."
              (ghostel--cursor-pos '(0 . 0))
              ((symbol-function 'ghostel--send-encoded) #'ignore))
      (evil-normal-state)
-     ;; evil-change-whole-line calls evil-change without delete-func
-     (evil-change-whole-line 1 12 nil nil)
+     (evil-ghostel-substitute-line 1 12 nil nil)
      (should (eq evil-state 'insert)))))
 
 ;; -----------------------------------------------------------------------
@@ -850,14 +1050,14 @@ Regression: delete-func arg was not optional in advice signature."
 ;; -----------------------------------------------------------------------
 
 (ert-deftest evil-ghostel-test-replace-deletes-and-inserts ()
-  "Test that `evil-replace' deletes then inserts replacement text."
+  "`evil-ghostel-replace' deletes then inserts replacement text."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "hello")
    (goto-char (point-min))
    (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
              (ghostel--cursor-pos '(0 . 0))
-             ((symbol-function 'evil-ghostel--cursor-to-point) #'ignore))
+             ((symbol-function 'evil-ghostel-goto-input-position) #'ignore))
      (evil-normal-state)
      (let ((bs-count 0)
            (pasted nil))
@@ -867,60 +1067,29 @@ Regression: delete-func arg was not optional in advice signature."
                       (cl-incf bs-count))))
                  ((symbol-function 'ghostel--paste-text)
                   (lambda (text) (setq pasted text))))
-         (evil-replace 1 4 'inclusive ?X))
+         (evil-ghostel-replace 1 4 'inclusive ?X))
        (should (= 3 bs-count))
        (should (equal "XXX" pasted))))))
-
-(ert-deftest evil-ghostel-test-replace-counts-match-on-trailing-space ()
-  "Regression: paste count and delete count must agree.
-Both `evil-ghostel--delete-region' and the paste in
-`evil-ghostel--around-replace' use `evil-ghostel--meaningful-length'
-on the same substring, so the values must agree even when trailing
-whitespace handling differs (multi-line ranges strip; single-line
-ranges don't)."
-  (evil-ghostel-test--with-evil-buffer
-   (setq-local ghostel--term t)
-   ;; Multi-line range with TUI-style padding on the first row.
-   ;; meaningful-length strips per-line padding → 4 chars: "AB\nC".
-   (insert "AB   \nC")
-   (goto-char (point-min))
-   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(0 . 0))
-             ((symbol-function 'evil-ghostel--cursor-to-point) #'ignore))
-     (evil-normal-state)
-     (let ((bs-count 0)
-           (pasted nil))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _)
-                    (when (equal key "backspace")
-                      (cl-incf bs-count))))
-                 ((symbol-function 'ghostel--paste-text)
-                  (lambda (text) (setq pasted text))))
-         (evil-replace 1 8 'inclusive ?X))
-       ;; Pre-fix: bs-count read meaningful-length (4) but pasted used
-       ;; raw substring length (7), leaving a stray "XXX" on screen.
-       (should (= 4 bs-count))
-       (should (equal "XXXX" pasted))))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: evil-paste advice
 ;; -----------------------------------------------------------------------
 
 (ert-deftest evil-ghostel-test-paste-after ()
-  "Test that `evil-paste-after' pastes via PTY."
+  "`evil-ghostel-paste-after' pastes the kill ring's head via PTY."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "hello")
    (kill-new "world")
    (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
              (ghostel--cursor-pos '(0 . 0))
-             ((symbol-function 'evil-ghostel--cursor-to-point) #'ignore))
+             ((symbol-function 'evil-ghostel-goto-input-position) #'ignore))
      (evil-normal-state)
      (let ((pasted nil))
        (cl-letf (((symbol-function 'ghostel--paste-text)
                   (lambda (text) (setq pasted text)))
                  ((symbol-function 'ghostel--send-encoded) #'ignore))
-         (evil-paste-after 1))
+         (evil-ghostel-paste-after 1))
        (should (equal "world" pasted))))))
 
 ;; -----------------------------------------------------------------------
@@ -944,22 +1113,9 @@ ranges don't)."
            (evil-ghostel--passthrough-ctrl key))
          (should (cl-find (cons key "ctrl") keys-sent :test #'equal)))))))
 
-(ert-deftest evil-ghostel-test-ctrl-passthrough-invalidates-shadow ()
-  "Ctrl passthrough must invalidate the shadow cursor.
-C-a / C-e / C-u / C-w / C-r / C-n / C-p reposition the readline
-cursor or swap in a different input line — a stale shadow would
-mislead the next `cursor-to-point' into computing deltas from a
-position the cursor no longer holds."
-  (evil-ghostel-test--with-evil-buffer
-   (setq-local ghostel--term t)
-   (insert "hello")
-   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(5 . 0))
-             ((symbol-function 'ghostel--send-encoded) #'ignore))
-     (evil-insert-state)
-     (setq evil-ghostel--shadow-cursor (cons 5 0))
-     (evil-ghostel--passthrough-ctrl "a")
-     (should-not evil-ghostel--shadow-cursor))))
+;; (Removed: evil-ghostel-test-ctrl-passthrough-invalidates-shadow.
+;; The shadow-cursor model is gone — the new architecture reads
+;; `ghostel--cursor-pos' directly each time.)
 
 (ert-deftest evil-ghostel-test-ctrl-passthrough-sends-in-alt-screen ()
   "Insert-state Ctrl passthrough remains active in alt-screen TUIs.
@@ -1073,8 +1229,8 @@ Point and the terminal cursor are intentionally decoupled there."
     (cl-letf ((ghostel--cursor-pos '(0 . 0)))
       (evil-normal-state)
       (let ((sync-called nil))
-        (cl-letf (((symbol-function 'evil-ghostel--cursor-to-point)
-                   (lambda () (setq sync-called t)))
+        (cl-letf (((symbol-function 'evil-ghostel-goto-input-position)
+                   (lambda (&rest _) (setq sync-called t)))
                   ((symbol-function 'evil-ghostel--reset-cursor-point)
                    (lambda () (setq sync-called t))))
           (evil-insert-state))
@@ -1089,8 +1245,8 @@ Point and the terminal cursor are intentionally decoupled there."
              (ghostel--cursor-pos '(0 . 0)))
      (evil-normal-state)
      (let ((sync-called nil))
-       (cl-letf (((symbol-function 'evil-ghostel--cursor-to-point)
-                  (lambda () (setq sync-called t)))
+       (cl-letf (((symbol-function 'evil-ghostel-goto-input-position)
+                  (lambda (&rest _) (setq sync-called t)))
                  ((symbol-function 'evil-ghostel--reset-cursor-point)
                   (lambda () (setq sync-called t))))
          (evil-insert-state))
@@ -1104,7 +1260,7 @@ Point and the terminal cursor are intentionally decoupled there."
     (let ((keys-sent '()))
       (cl-letf (((symbol-function 'ghostel--send-encoded)
                  (lambda (key _mods &rest _) (push key keys-sent))))
-        (evil-insert-line 1))
+        (evil-ghostel-insert-line))
       (should (= (point) 3))
       (should (evil-insert-state-p))
       (should-not (member "a" keys-sent)))))
@@ -1117,7 +1273,7 @@ Point and the terminal cursor are intentionally decoupled there."
     (let ((keys-sent '()))
       (cl-letf (((symbol-function 'ghostel--send-encoded)
                  (lambda (key _mods &rest _) (push key keys-sent))))
-        (evil-append-line 1))
+        (evil-ghostel-append-line))
       (should (= (point) 13))
       (should (evil-insert-state-p))
       (should-not (member "e" keys-sent)))))
@@ -1158,7 +1314,7 @@ C-d (`ghostel-line-mode-delete-char-or-eof')."
 ;; -----------------------------------------------------------------------
 
 (ert-deftest evil-ghostel-test-undo-sends-ctrl-underscore ()
-  "Test that `evil-undo' sends Ctrl+_ to the terminal."
+  "`evil-ghostel-undo' sends Ctrl+_ to the terminal."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
@@ -1168,7 +1324,7 @@ C-d (`ghostel-line-mode-delete-char-or-eof')."
        (cl-letf (((symbol-function 'ghostel--send-encoded)
                   (lambda (key mods &rest _)
                     (push (cons key mods) keys-sent))))
-         (evil-undo 3))
+         (evil-ghostel-undo 3))
        (should (= 3 (cl-count '("_" . "ctrl") keys-sent :test #'equal)))))))
 
 ;; -----------------------------------------------------------------------
@@ -1327,102 +1483,22 @@ rather than silently dropping the keystroke."
 ;; Test: beginning-of-line lands at input start, not column 0
 ;; -----------------------------------------------------------------------
 
-(ert-deftest evil-ghostel-test-beginning-of-line-skips-prompt ()
-  "`0' / `^' jump to start of input on a prompt row, not column 0.
-Without this, `0' lands point on top of the `$ ' prompt and `0i'
-inserts at the prompt position rather than at the input start."
-  (evil-ghostel-test--with-evil-buffer
-   (setq-local ghostel--term t)
-   (insert "$ command")
-   ;; Mark the prompt prefix so ghostel-beginning-of-input-or-line
-   ;; treats it as a prompt row.
-   (put-text-property 1 3 'ghostel-prompt t)
-   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil)))
-     (evil-normal-state)
-     (goto-char (point-max))
-     (evil-beginning-of-line)
-     ;; Lands at col 2 (after "$ "), not col 0.
-     (should (= 2 (current-column)))
-     (goto-char (point-max))
-     (evil-first-non-blank)
-     (should (= 2 (current-column))))))
-
-(ert-deftest evil-ghostel-test-beginning-of-line-falls-through-no-prompt ()
-  "On rows without a prompt property `0' / `^' keep their default
-column-0 / first-non-blank behaviour — scrollback navigation must
-not be hijacked."
-  (evil-ghostel-test--with-evil-buffer
-   (setq-local ghostel--term t)
-   (insert "  output line")  ; no ghostel-prompt property anywhere
-   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil)))
-     (evil-normal-state)
-     (goto-char (point-max))
-     (evil-beginning-of-line)
-     (should (= 0 (current-column))))))
-
-;; -----------------------------------------------------------------------
-;; Test: shadow cursor (queued-key model)
-;; -----------------------------------------------------------------------
-
-(ert-deftest evil-ghostel-test-shadow-cursor-tracks-cursor-to-point ()
-  "After `cursor-to-point' the shadow holds point's viewport position.
-A second `cursor-to-point' call within the same operation must read
-from the shadow rather than the still-stale live libghostty cursor —
-otherwise it computes deltas from the wrong baseline and emits extra
-arrows.  Mocks the live cursor at (17 . 0) and verifies the second
-sync emits zero keys once point is at col 6."
-  (evil-ghostel-test--with-evil-buffer
-   (setq-local ghostel--term t)
-   (insert "word1 word2 word3")
-   (goto-char (point-min))
-   (move-to-column 6)
-   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(17 . 0)))
-     (let ((first-keys '()) (second-keys '()))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _) (push key first-keys))))
-         (evil-ghostel--cursor-to-point))
-       (should (= 11 (length first-keys)))
-       (should (equal '(6 . 0) evil-ghostel--shadow-cursor))
-       ;; Second sync — point is unchanged, shadow already at (6 . 0),
-       ;; so no further keys should be emitted.
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _) (push key second-keys))))
-         (evil-ghostel--cursor-to-point))
-       (should (= 0 (length second-keys)))))))
-
-(ert-deftest evil-ghostel-test-shadow-cursor-tracks-delete-region ()
-  "After `delete-region' the shadow advances by COUNT columns.
-A follow-up `cursor-to-point' from BEG should be a no-op."
-  (evil-ghostel-test--with-evil-buffer
-   (setq-local ghostel--term t)
-   (insert "word1 word2 word3")
-   (goto-char (point-min))
-   (move-to-column 6)
-   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(17 . 0)))
-     (cl-letf (((symbol-function 'ghostel--send-encoded) #'ignore))
-       (evil-ghostel--delete-region 7 12))
-     ;; Shadow is at end-col (11) - count (5) = 6, viewport row 0.
-     (should (equal '(6 . 0) evil-ghostel--shadow-cursor))
-     ;; Point is at col 6 (beg).  cursor-to-point should now be a no-op.
-     (let ((extra-keys '()))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _) (push key extra-keys))))
-         (evil-ghostel--cursor-to-point))
-       (should (= 0 (length extra-keys)))))))
+;; (Removed: evil-ghostel-test-shadow-cursor-tracks-cursor-to-point and
+;; evil-ghostel-test-shadow-cursor-tracks-delete-region.  The shadow-cursor
+;; model is gone — the new operators read `ghostel--cursor-pos' directly
+;; each time and don't rely on a queued-key projection.  See the
+;; "Shadow-cursor: drop" analysis in plans/evil-rewrite-plan.md.)
 
 ;; -----------------------------------------------------------------------
 ;; Test: cw doesn't emit redundant left arrows after delete
 ;; -----------------------------------------------------------------------
 
 (ert-deftest evil-ghostel-test-delete-word-with-trailing-space ()
-  "Regression: `dw' over `\"word \"' must send 5 backspaces, not 4.
-With the old `meaningful-length' the trailing space was always
-stripped, so `dw' on `\"word word word\" + ESC bb' sent only 4
-backspaces — leaving a stray `w' behind (`word wword' instead of
-`word word').  Trailing whitespace in single-line ranges is real
-content."
+  "Regression: `dw' over `\"word \"' sends 5 backspaces, not 4.
+Trailing whitespace in single-line ranges is real user content.
+\(With the old per-line stripping heuristic applied to single-line
+ranges, `dw' over `\"word word word\" + ESC bb' would send only 4
+backspaces — leaving a stray `w' behind.)"
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "word word word")
@@ -1435,36 +1511,90 @@ content."
                   (lambda (key _mods &rest _)
                     (when (equal key "backspace") (cl-incf bs-count)))))
          ;; `dw' from col 5 deletes "word " (chars 6..10, exclusive end 11).
-         (evil-delete 6 11 'exclusive nil nil))
+         (evil-ghostel-delete 6 11 'exclusive nil nil))
        (should (= 5 bs-count))))))
 
+(ert-deftest evil-ghostel-test-delete-word-on-last-word-clamps-overshoot ()
+  "Regression: `dw' on the last input word clamps motion overshoot.
+With input `\"word word\"' and cursor mid-input, the motion `w'
+walks off the cursor row (no next word on this line) so END
+lands on a buffer row below the cursor.  The operator-level
+clamp trims END to `evil-ghostel--input-end' so backspaces
+target only the typed characters, not the renderer-painted
+padding/blanks past end-of-input."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   ;; Simulate the post-bbcw state: prompt-prefixed input "word word"
+   ;; with cursor mid-input and several blank renderer rows below.
+   (let ((inhibit-read-only t))
+     (insert (propertize "% " 'ghostel-prompt t))
+     (insert "word word")
+     (insert "\n\n\n\n"))  ; blank renderer rows below row 0
+   (goto-char 8)  ; col 5 in input = start of last "word"
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             (ghostel--cursor-pos '(7 . 0))
+             (ghostel--cursor-char-pos 8))
+     (evil-normal-state)
+     (let ((bs-count 0))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _)
+                    (when (equal key "backspace") (cl-incf bs-count)))))
+         ;; Motion `w' from pos 8 walks past end-of-input to a blank
+         ;; row below — simulate by passing END beyond the cursor row.
+         (evil-ghostel-delete 8 13 'exclusive nil nil))
+       ;; Clamp trims END to row-end (pos 12, after "word"), so the
+       ;; delete sends 4 backspaces for "word", not 5+ for "word\n..."
+       (should (= 4 bs-count))))))
+
 (ert-deftest evil-ghostel-test-change-partial-no-post-delete-sync ()
-  "After `cw' (count > 0) `around-change' must not run a second
-post-delete cursor-to-point.  The redundant sync used to read the
-stale live cursor and emit extra left arrows that pushed the
-terminal cursor past the start of input — observed as `cw seems
-to move the point to the beginning of the line'."
+  "After `cw' (count > 0) the post-delete `evil-ghostel-insert' is idempotent.
+Once the shell has echoed our 6 LEFT + 5 BACKSPACE the live cursor
+sits at the same buffer position as point — `evil-ghostel-insert' →
+`goto-input-position' computes dx=dy=0 and sends nothing further.
+The mock updates `ghostel--cursor-pos' from the keys we emit to
+mirror that drain behaviour."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "word1 word2 word3")
    (goto-char (point-min))
    (move-to-column 6)
+   (setq ghostel--cursor-pos '(17 . 0))
+   (setq ghostel--cursor-char-pos (+ (point-min) 17))
    (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(17 . 0)))
+             ((symbol-function 'evil-ghostel--sync-render)
+              (lambda (&rest _) nil))) ; we already update pos inline
      (let ((keys-sent '()))
        (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _) (push key keys-sent))))
-         (evil-change 7 12 'exclusive nil nil))
+                  (lambda (key _mods &rest _)
+                    (push key keys-sent)
+                    ;; Simulate the shell echo updating cursor-pos.
+                    (pcase key
+                      ((or "left" "backspace")
+                       (let ((col (car ghostel--cursor-pos))
+                             (row (cdr ghostel--cursor-pos)))
+                         (setq ghostel--cursor-pos (cons (max 0 (1- col)) row))
+                         (when ghostel--cursor-char-pos
+                           (setq ghostel--cursor-char-pos
+                                 (max (point-min)
+                                      (1- ghostel--cursor-char-pos))))))
+                      ("right"
+                       (let ((col (car ghostel--cursor-pos))
+                             (row (cdr ghostel--cursor-pos)))
+                         (setq ghostel--cursor-pos (cons (1+ col) row))
+                         (when ghostel--cursor-char-pos
+                           (setq ghostel--cursor-char-pos
+                                 (1+ ghostel--cursor-char-pos)))))))))
+         (evil-ghostel-change 7 12 'exclusive nil nil))
        (let* ((seq (nreverse keys-sent))
               (left-count (cl-count "left" seq :test #'equal))
+              (right-count (cl-count "right" seq :test #'equal))
               (bs-count (cl-count "backspace" seq :test #'equal)))
-         ;; Exactly one initial sync (6 lefts: col 17 → col 11 = end)
-         ;; and the 5 backspaces.  No second sync after backspaces —
-         ;; with the bug, that second sync read the stale live cursor
-         ;; (col 17) against point's now-col-6 and emitted 11 more
-         ;; left arrows, pushing the terminal cursor past col 0.
+         ;; 6 LEFTs to drive cursor to END (col 17 → 11) then 5 backspaces.
+         ;; The post-delete `evil-ghostel-insert' is a no-op once cursor-pos
+         ;; has caught up — no extra LEFTs, no spurious RIGHT.
          (should (= 6 left-count))
-         (should (= 5 bs-count)))))))
+         (should (= 5 bs-count))
+         (should (zerop right-count)))))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: insert-state-entry uses viewport row, not buffer line
@@ -1492,10 +1622,10 @@ and silently undoing the user's `^' / `$' / `0' navigation."
      (let ((reset-called nil) (sync-called nil))
        (cl-letf (((symbol-function 'evil-ghostel--reset-cursor-point)
                   (lambda () (setq reset-called t)))
-                 ((symbol-function 'evil-ghostel--cursor-to-point)
-                  (lambda () (setq sync-called t))))
+                 ((symbol-function 'evil-ghostel-goto-input-position)
+                  (lambda (&rest _) (setq sync-called t))))
          (evil-ghostel--insert-state-entry))
-       ;; Same viewport row → cursor-to-point, NOT reset-cursor-point.
+       ;; Same viewport row → goto-input-position, NOT reset-cursor-point.
        (should sync-called)
        (should-not reset-called)))))
 
@@ -1524,64 +1654,438 @@ sticks."
                                   (should (= 1 (line-number-at-pos)))))
 
 ;; -----------------------------------------------------------------------
+;; Test: forward-char / backward-char / end-of-line clamps
+;; -----------------------------------------------------------------------
+
+(ert-deftest evil-ghostel-test-end-of-line-falls-through-off-cursor-row ()
+  "Off the cursor row, `$' falls through to vanilla `evil-end-of-line'."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (let ((inhibit-read-only t))
+     (insert "long scrollback line\n")
+     (insert (propertize "$ " 'ghostel-prompt t)))
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             (ghostel--cursor-pos '(2 . 1))
+             (ghostel--cursor-char-pos 24))
+     (evil-normal-state)
+     (goto-char (point-min)) ; row 0
+     (evil-ghostel-end-of-line 1)
+     ;; Vanilla end-of-line reaches the actual buffer-line end on row 0.
+     ;; In normal state evil places point one column before the \n, so
+     ;; column == length - 1 = 19 for "long scrollback line".
+     (should (= 1 (line-number-at-pos)))
+     (should (= (1- (length "long scrollback line")) (current-column))))))
+
+;; -----------------------------------------------------------------------
+;; Test: next-line clamp (j cannot go below cursor row)
+;; -----------------------------------------------------------------------
+
+(ert-deftest evil-ghostel-test-next-line-clamps-at-cursor-row ()
+  "`evil-ghostel-next-line' (`j') doesn't move below the cursor's row.
+Prevents stranding the user on empty renderer rows below the live
+prompt."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (setq-local ghostel--term-rows 5)
+   (let ((inhibit-read-only t))
+     (insert (propertize "$ " 'ghostel-prompt t))
+     (insert "cmd")
+     (insert "\n\n\n\n"))  ; blank renderer rows below row 0
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             (ghostel--cursor-pos '(5 . 0)))
+     (evil-normal-state)
+     (goto-char (point-min))
+     (evil-ghostel-next-line 10)
+     ;; Clamped to the cursor's buffer line (line 1).
+     (should (= 1 (line-number-at-pos))))))
+
+(ert-deftest evil-ghostel-test-next-line-falls-through-outside-semi-char ()
+  "Outside semi-char `evil-ghostel-next-line' delegates to vanilla."
+  (evil-ghostel-test--with-evil-buffer
+   ;; ghostel--term nil → evil-ghostel--active-p returns nil.
+   (let ((inhibit-read-only t))
+     (insert "a\nb\nc\nd\ne\n"))
+   (evil-normal-state)
+   (goto-char (point-min))
+   (evil-ghostel-next-line 2)
+   (should (= 3 (line-number-at-pos)))))
+
+;; -----------------------------------------------------------------------
+;; Test: G (goto-cursor) maps to live terminal cursor
+;; -----------------------------------------------------------------------
+
+(ert-deftest evil-ghostel-test-goto-cursor-resets-to-cursor ()
+  "`evil-ghostel-goto-cursor' (`G') invokes `reset-cursor-point' in
+semi-char.  Replaces `evil-goto-line' so `G' lands on the live
+prompt instead of the (post-cursor) end of buffer."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil)))
+     (let ((reset-called nil))
+       (cl-letf (((symbol-function 'evil-ghostel--reset-cursor-point)
+                  (lambda () (setq reset-called t))))
+         (evil-ghostel-goto-cursor))
+       (should reset-called)))))
+
+(ert-deftest evil-ghostel-test-goto-cursor-falls-through-outside-semi-char ()
+  "`G' falls through to `evil-goto-line' when not in semi-char."
+  (evil-ghostel-test--with-evil-buffer
+   ;; ghostel--term nil → not active.
+   (let ((goto-called nil))
+     (cl-letf (((symbol-function 'evil-goto-line)
+                ;; `call-interactively' requires `interactive', so the
+                ;; mock must declare it even though we ignore arguments.
+                (lambda (&rest _) (interactive) (setq goto-called t))))
+       (evil-ghostel-goto-cursor))
+     (should goto-called))))
+
+;; -----------------------------------------------------------------------
+;; Test: append vanilla-fallthrough clamps to row-end
+;; -----------------------------------------------------------------------
+
+(ert-deftest evil-ghostel-test-append-before-cursor-clamps-to-row-end ()
+  "Regression: `a' before the cursor must clamp the `forward-char'
+landing position to `evil-ghostel--input-end'.  Without
+the clamp `forward-char' can walk past end-of-input onto trailing
+renderer cells (RPROMPT, autosuggest, stale glyphs) and the visual
+cursor jumps to the right edge of the window."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (let ((inhibit-read-only t))
+     (insert (propertize "$ " 'ghostel-prompt t))
+     ;; "cmd" + render padding to column 20 (e.g. RPROMPT padding).
+     (insert "cmd")
+     (insert "                 "))
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             ;; Live cursor at column 5 (just after "cmd").  Point is
+             ;; one to the left of the cursor — vanilla fall-through.
+             (ghostel--cursor-pos '(5 . 0))
+             (ghostel--cursor-char-pos 6))
+     (evil-normal-state)
+     (goto-char 5) ; on "d", before cursor
+     (evil-ghostel-append)
+     ;; After append: forward-char would reach pos 7, but row-end is 6
+     ;; (after "cmd").  Clamped to 6.
+     (should (= 6 (point))))))
+
+;; -----------------------------------------------------------------------
+;; Test: <delete> insert-state sends PTY key
+;; -----------------------------------------------------------------------
+
+(ert-deftest evil-ghostel-test-delete-key-sends-pty ()
+  "`<delete>' in insert state sends the `delete' PTY key in semi-char."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil)))
+     (let ((keys-sent '()))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _) (push key keys-sent))))
+         (evil-ghostel--passthrough-delete))
+       (should (equal '("delete") keys-sent))))))
+
+(ert-deftest evil-ghostel-test-delete-key-bound-in-insert-state ()
+  "`<delete>' is bound to `evil-ghostel--passthrough-delete' in insert state."
+  (should (eq #'evil-ghostel--passthrough-delete
+              (lookup-key (evil-get-auxiliary-keymap
+                           evil-ghostel-mode-map 'insert)
+                          (kbd "<delete>")))))
+
+;; -----------------------------------------------------------------------
+;; Test: prompt-nav bindings and extended Ctrl passthrough
+;; -----------------------------------------------------------------------
+
+(ert-deftest evil-ghostel-test-prompt-nav-bound-in-normal ()
+  "`[[' and `]]' are bound to ghostel's prompt-nav commands."
+  (should (eq #'ghostel-previous-prompt
+              (lookup-key (evil-get-auxiliary-keymap
+                           evil-ghostel-mode-map 'normal)
+                          (kbd "[["))))
+  (should (eq #'ghostel-next-prompt
+              (lookup-key (evil-get-auxiliary-keymap
+                           evil-ghostel-mode-map 'normal)
+                          (kbd "]]")))))
+
+(ert-deftest evil-ghostel-test-ctrl-passthrough-includes-vterm-set ()
+  "Passthrough list contains every Ctrl key vterm passes through
+except `z' (kept for `evil-emacs-state' escape hatch)."
+  (dolist (k '("a" "b" "d" "e" "f" "k" "l" "n" "o" "p"
+               "q" "r" "s" "t" "u" "v" "w" "y"))
+    (should (member k evil-ghostel--ctrl-passthrough-keys)))
+  (should-not (member "z" evil-ghostel--ctrl-passthrough-keys)))
+
+;; -----------------------------------------------------------------------
 ;; Runner
 ;; -----------------------------------------------------------------------
 
-(defconst evil-ghostel-test--elisp-tests
-  '(evil-ghostel-test-mode-activation
-    evil-ghostel-test-mode-deactivation
-    evil-ghostel-test-escape-stay
-    evil-ghostel-test-advice-on-insert
-    evil-ghostel-test-advice-on-append
-    evil-ghostel-test-advice-insert-line-sends-home
-    evil-ghostel-test-advice-append-line-sends-end
-    evil-ghostel-test-insert-line-multiline-syncs-row
-    evil-ghostel-test-append-line-multiline-syncs-row
-    evil-ghostel-test-change-eol-syncs-cursor-to-point
-    evil-ghostel-test-advice-no-op-outside-ghostel
-    evil-ghostel-test-meaningful-length-strips-trailing
-    evil-ghostel-test-delete-sends-backspace-keys
-    evil-ghostel-test-delete-line-same-row-uses-ctrl-u
-    evil-ghostel-test-change-line-same-row-uses-ctrl-u
-    evil-ghostel-test-delete-line-multiline-syncs-cursor
-    evil-ghostel-test-delete-line-strips-render-padding
-    evil-ghostel-test-replace-counts-match-on-trailing-space
-    evil-ghostel-test-delete-char
-    evil-ghostel-test-change-deletes-and-inserts
-    evil-ghostel-test-replace-deletes-and-inserts
-    evil-ghostel-test-paste-after
-    evil-ghostel-test-undo-sends-ctrl-underscore
-    evil-ghostel-test-change-whole-line
-    evil-ghostel-test-delete-no-op-outside-ghostel
-    evil-ghostel-test-escape-init-from-defcustom
-    evil-ghostel-test-escape-mode-terminal-sends-pty
-    evil-ghostel-test-escape-terminal-runs-user-input-hook
-    evil-ghostel-test-escape-mode-evil-stays
-    evil-ghostel-test-escape-auto-altscreen-sends-pty
-    evil-ghostel-test-escape-auto-no-altscreen-stays
-    evil-ghostel-test-escape-toggle-cycle
-    evil-ghostel-test-escape-toggle-prefix-set
-    evil-ghostel-test-escape-toggle-prefix-invalid
-    evil-ghostel-test-escape-mode-buffer-local
-    evil-ghostel-test-escape-evil-fallback-when-lookup-nil
-    evil-ghostel-test-beginning-of-line-skips-prompt
-    evil-ghostel-test-beginning-of-line-falls-through-no-prompt
-    evil-ghostel-test-shadow-cursor-tracks-cursor-to-point
-    evil-ghostel-test-shadow-cursor-tracks-delete-region
-    evil-ghostel-test-delete-word-with-trailing-space
-    evil-ghostel-test-change-partial-no-post-delete-sync
-    evil-ghostel-test-insert-entry-same-viewport-row-with-scrollback
-    evil-ghostel-test-ctrl-passthrough-invalidates-shadow
-    evil-ghostel-test-ctrl-passthrough-sends-in-alt-screen)
-  "Tests that require only Elisp (no native module).")
+;; -----------------------------------------------------------------------
+;; Test: input-region boundary (vterm-style; input-end + clamp)
+;; -----------------------------------------------------------------------
 
-(defun evil-ghostel-test-run-elisp ()
-  "Run only pure Elisp tests (no native module required)."
-  (ert-run-tests-batch-and-exit
-   `(member ,@evil-ghostel-test--elisp-tests)))
+(ert-deftest evil-ghostel-test-input-end-returns-eol-no-property ()
+  "`evil-ghostel--input-end' strips trailing whitespace when no OSC 133.
+Without a `ghostel-input' property it falls back to end-of-line with
+renderer padding stripped."
+  (evil-ghostel-test--with-input-fixture "$ " "hello"
+    (should (= (point-max) (evil-ghostel--input-end)))))
+
+(ert-deftest evil-ghostel-test-input-end-empty-prompt-is-cursor ()
+  "On an empty prompt the input end is the cursor, not inside the prompt.
+The fallback strips trailing whitespace from EOL; on `\"$ \"' with no
+typed input that would strip the prompt's own trailing space and land
+the boundary at col 1 (left of the live cursor), breaking `A' / `$' /
+the operator clamp.  It must floor at the cursor."
+  (evil-ghostel-test--with-input-fixture "$ " ""
+    ;; Cursor sits just after the prompt (point-max here).
+    (should (= ghostel--cursor-char-pos (evil-ghostel--input-end)))
+    ;; And the operator clamp is not inverted there.
+    (let ((c (evil-ghostel--clamp ghostel--cursor-char-pos
+                                  ghostel--cursor-char-pos)))
+      (should (<= (car c) (cdr c))))))
+
+(ert-deftest evil-ghostel-test-input-end-via-input-property ()
+  "OSC 133;B `ghostel-input' cells decide the input end.
+Padding / hint cells past the input (no `ghostel-input') are ignored."
+  (let ((buf (generate-new-buffer " *eg-input-prop*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((inhibit-read-only t))
+            (insert (propertize "$ " 'ghostel-prompt t))
+            (insert (propertize "hello" 'ghostel-input t))
+            (insert "   hint"))
+          (setq ghostel--term 'fake ghostel--term-rows 1
+                ghostel--cursor-char-pos 8 ghostel--cursor-pos '(7 . 0))
+          (should (= 8 (evil-ghostel--input-end))))
+      (kill-buffer buf))))
+
+(ert-deftest evil-ghostel-test-input-end-uses-first-region ()
+  "Two `ghostel-input' regions (typed input + a right prompt that
+libghostty also tags input): the end of the FIRST region wins."
+  (let ((buf (generate-new-buffer " *eg-fish-rprompt*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((inhibit-read-only t))
+            (insert (propertize "$ " 'ghostel-prompt t))
+            (insert (propertize "foo bar" 'ghostel-input t))
+            (insert (make-string 20 ?\s))
+            (insert (propertize "main *" 'ghostel-input t)))
+          (setq ghostel--term 'fake ghostel--term-rows 1
+                ghostel--cursor-char-pos 10 ghostel--cursor-pos '(9 . 0))
+          (should (= 10 (evil-ghostel--input-end))))
+      (kill-buffer buf))))
+
+(ert-deftest evil-ghostel-test-input-end-excludes-autosuggestion ()
+  "A faint autosuggestion after the cursor is not counted as input.
+zsh / fish render POSTDISPLAY in a dimmer foreground; the typed input
+ends at the cursor, so `evil-ghostel--input-end' stops there."
+  (let ((buf (generate-new-buffer " *eg-autosuggest*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((inhibit-read-only t))
+            (insert (propertize "$ " 'ghostel-prompt t))
+            ;; Typed input: bright foreground.
+            (insert (propertize "echo" 'ghostel-input t
+                                'face '(:foreground "#ffffff")))
+            ;; Autosuggestion: same `ghostel-input', faint foreground.
+            (insert (propertize " world" 'ghostel-input t
+                                'face '(:foreground "#4d4d4d"))))
+          (setq ghostel--term 'fake ghostel--term-rows 1
+                ;; Cursor sits at the typed/suggestion boundary (after "echo").
+                ghostel--cursor-char-pos 7 ghostel--cursor-pos '(6 . 0))
+          ;; Input ends at the cursor (7), not at the end of " world" (13).
+          (should (= 7 (evil-ghostel--input-end))))
+      (kill-buffer buf))))
+
+(ert-deftest evil-ghostel-test-input-end-excludes-brighter-suggestion ()
+  "A suggestion is excluded even when it is BRIGHTER than the typed text.
+fish paints an invalid command red (`#ee0000', darker than its own grey
+`#4d4d4d' suggestion), so a luminance test misses the suggestion; the
+color-difference test still finds it because the trailing run is a
+uniform color distinct from the typed char."
+  (let ((buf (generate-new-buffer " *eg-autosuggest-bright*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((inhibit-read-only t))
+            (insert (propertize "$ " 'ghostel-prompt t))
+            ;; Typed "ec": red, DARKER than the grey suggestion.
+            (insert (propertize "ec" 'ghostel-input t 'face '(:foreground "#ee0000")))
+            ;; Suggestion: grey, BRIGHTER than the red typed text.
+            (insert (propertize "ho hello" 'ghostel-input t
+                                'face '(:foreground "#4d4d4d"))))
+          (setq ghostel--term 'fake ghostel--term-rows 1
+                ;; Cursor at the typed/suggestion boundary (after "ec").
+                ghostel--cursor-char-pos 5 ghostel--cursor-pos '(4 . 0))
+          ;; Input ends at the cursor (5), not at the end of the brighter
+          ;; suggestion (13).
+          (should (= 5 (evil-ghostel--input-end))))
+      (kill-buffer buf))))
+
+(ert-deftest evil-ghostel-test-input-end-keeps-input-when-cursor-at-start ()
+  "Trailing colored input is NOT mistaken for a suggestion at the line start.
+After deleting the first word the cursor sits at the input start over
+recolored real input (fish repaints it red).  With no typed text before
+the cursor there can be no suggestion, so the whole line stays editable —
+the luminance test used to compare the red input against the white prompt
+space and collapse the region."
+  (let ((buf (generate-new-buffer " *eg-no-suggest-at-start*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((inhibit-read-only t))
+            (insert (propertize "$ " 'ghostel-prompt t))
+            ;; Real input, recolored (red command, cyan arg); cursor at its start.
+            (insert (propertize "hello" 'ghostel-input t 'face '(:foreground "#ee0000")))
+            (insert (propertize " world" 'ghostel-input t
+                                'face '(:foreground "#00cdcd"))))
+          (setq ghostel--term 'fake ghostel--term-rows 1
+                ;; Cursor at the input start (3) — no typed text precedes it.
+                ghostel--cursor-char-pos 3 ghostel--cursor-pos '(2 . 0))
+          ;; Input runs to the real end (14), not collapsed to the cursor.
+          (should (= 14 (evil-ghostel--input-end))))
+      (kill-buffer buf))))
+
+(ert-deftest evil-ghostel-test-input-end-keeps-mid-input-colored-tail ()
+  "A saturated uniform tail under a mid-input cursor is NOT a suggestion.
+With the terminal cursor parked on the last word (e.g. a cyan argument),
+the run from the cursor to the line end is one color distinct from the
+char before it — but it is a *saturated* syntax color, not the greyed-out
+autosuggestion style, so the editable input must still run to the real
+end (else `D'/`C'/`$' under-act)."
+  (let ((buf (generate-new-buffer " *eg-mid-input-tail*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((inhibit-read-only t))
+            (insert (propertize "$ " 'ghostel-prompt t))
+            ;; Typed "echo " (white) then a cyan argument "bar".
+            (insert (propertize "echo " 'ghostel-input t 'face '(:foreground "#ffffff")))
+            (insert (propertize "bar" 'ghostel-input t 'face '(:foreground "#00cdcd"))))
+          (setq ghostel--term 'fake ghostel--term-rows 1
+                ;; Terminal cursor parked on "bar" (pos 8), mid-input.
+                ghostel--cursor-char-pos 8 ghostel--cursor-pos '(7 . 0))
+          ;; "bar" is bright/saturated, not greyed-out → input runs to 11,
+          ;; not collapsed to the cursor (8).
+          (should (= 11 (evil-ghostel--input-end))))
+      (kill-buffer buf))))
+
+(ert-deftest evil-ghostel-test-clamp-narrows-on-cursor-row ()
+  "`evil-ghostel--clamp' raises BEG to the prompt boundary."
+  (evil-ghostel-test--with-input-fixture "$ " "hello"
+    (let ((clamped (evil-ghostel--clamp 1 ghostel--cursor-char-pos)))
+      (should (= 3 (car clamped)))
+      (should (= ghostel--cursor-char-pos (cdr clamped))))))
+
+(ert-deftest evil-ghostel-test-clamp-trims-end-past-input ()
+  "`evil-ghostel--clamp' lowers END to the end of typed input."
+  (evil-ghostel-test--with-input-fixture "$ " "hello"
+    (let ((inhibit-read-only t))
+      (save-excursion (insert "   ")))  ; renderer padding past the cursor
+    (let ((clamped (evil-ghostel--clamp 3 (+ ghostel--cursor-char-pos 3))))
+      (should (= 3 (car clamped)))
+      (should (= ghostel--cursor-char-pos (cdr clamped))))))
+
+(ert-deftest evil-ghostel-test-clamp-leaves-beg-without-prompt ()
+  "Without a detectable prompt, BEG is left alone (no collapse).
+`ghostel-input-start-point' degenerates to the cursor when no prompt
+is found; `evil-ghostel--input-start' returns nil there so the clamp
+does not push BEG up to the cursor and collapse the range."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "word1 word2")
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             (ghostel--cursor-pos '(11 . 0))
+             (ghostel--cursor-char-pos (point)))
+     (let ((clamped (evil-ghostel--clamp 1 7)))
+       (should (= 1 (car clamped)))
+       (should (= 7 (cdr clamped)))))))
+
+(ert-deftest evil-ghostel-test-end-of-line-stops-at-last-typed-char ()
+  "`$' lands on the last typed char, not on trailing renderer padding."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (let ((inhibit-read-only t))
+     (insert (propertize "$ " 'ghostel-prompt t))
+     (insert "cmd   "))  ; trailing renderer padding
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             (ghostel--cursor-pos '(5 . 0))
+             (ghostel--cursor-char-pos 6))
+     (evil-normal-state)
+     (goto-char 3)
+     (evil-ghostel-end-of-line 1)
+     ;; Last typed char is 'd' at pos 5 (col 4), before the padding.
+     (should (= 5 (point))))))
+
+(ert-deftest evil-ghostel-test-end-of-line-excludes-autosuggestion ()
+  "`$' stops at the last typed char even with a faint suggestion after it."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (let ((inhibit-read-only t))
+     (insert (propertize "$ " 'ghostel-prompt t))
+     (insert (propertize "echo" 'ghostel-input t 'face '(:foreground "#ffffff")))
+     (insert (propertize " ls" 'ghostel-input t 'face '(:foreground "#4d4d4d"))))
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             (ghostel--cursor-pos '(6 . 0))
+             (ghostel--cursor-char-pos 7))  ; after "echo"
+     (evil-normal-state)
+     (goto-char 3)
+     (evil-ghostel-end-of-line 1)
+     ;; Last typed char 'o' is pos 6 (col 5); the " ls" suggestion is skipped.
+     (should (= 6 (point))))))
+
+(ert-deftest evil-ghostel-test-first-non-blank-skips-prompt ()
+  "`^' jumps to the first input char on a prompt row, not column 0."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "$ command")
+   (put-text-property 1 3 'ghostel-prompt t)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil)))
+     (evil-normal-state)
+     (goto-char (point-max))
+     (evil-ghostel-first-non-blank)
+     (should (= 2 (current-column))))))
+
+(ert-deftest evil-ghostel-test-replace-count-excludes-soft-wraps ()
+  "`r' deletes and re-pastes the same count, excluding soft-wrap newlines.
+A `ghostel-wrap' newline is a renderer line break, not a real input
+character, so it must not consume a backspace or a replacement char."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   ;; "AB" + soft-wrap newline + "C" -> 3 real input chars.
+   (let ((inhibit-read-only t))
+     (insert "AB")
+     (insert (propertize "\n" 'ghostel-wrap t))
+     (insert "C"))
+   ;; Terminal cursor at the end of input (after "C"), as right after
+   ;; typing; the input region spans the whole buffer.
+   (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil))
+             (ghostel--cursor-pos '(1 . 0))
+             (ghostel--cursor-char-pos (point-max))
+             ((symbol-function 'evil-ghostel-goto-input-position) #'ignore))
+     (evil-normal-state)
+     (let ((bs-count 0) (pasted nil))
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key _mods &rest _)
+                    (when (equal key "backspace") (cl-incf bs-count))))
+                 ((symbol-function 'ghostel--paste-text)
+                  (lambda (text) (setq pasted text))))
+         (evil-ghostel-replace (point-min) (point-max) 'inclusive ?X))
+       (should (= 3 bs-count))
+       (should (equal "XXX" pasted))))))
+
+(ert-deftest evil-ghostel-test-change-registered-for-cw-to-ce ()
+  "`evil-ghostel-change' is registered in `evil-change-commands' so
+`cw' / `cW' behave like `ce' / `cE' (stop at the word end)."
+  (should (memq 'evil-ghostel-change evil-change-commands)))
 
 (defun evil-ghostel-test-run ()
-  "Run all evil-ghostel tests."
+  "Run all evil-ghostel tests.
+Most tests mock the native module; the few that drive a real terminal
+guard themselves with `skip-unless', so this one regex runner serves both
+`make test-evil' (module built, all run) and CI's elisp-only `test-evil'
+job (native tests skipped)."
   (ert-run-tests-batch-and-exit "^evil-ghostel-test-"))
 
 ;;; evil-ghostel-test.el ends here

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -28,6 +28,10 @@
   (should (equal "\x01" (ghostel--raw-key-sequence "a" "ctrl")))      ; ctrl-a
   (should (equal "\x03" (ghostel--raw-key-sequence "c" "ctrl")))      ; ctrl-c
   (should (equal "\x1a" (ghostel--raw-key-sequence "z" "ctrl")))      ; ctrl-z
+  ;; Ctrl + C0 symbol chars (@ A-Z [ \ ] ^ _) fold to (char & #x1f)
+  (should (equal "\x1f" (ghostel--raw-key-sequence "_" "ctrl")))      ; ctrl-_ (undo)
+  (should (equal "\x1e" (ghostel--raw-key-sequence "^" "ctrl")))      ; ctrl-^
+  (should (equal "\x00" (ghostel--raw-key-sequence "@" "ctrl")))      ; ctrl-@ (NUL)
   ;; Function keys
   (should (equal "\eOP" (ghostel--raw-key-sequence "f1" "")))         ; f1
   (should (equal "\e[15~" (ghostel--raw-key-sequence "f5" "")))       ; f5

--- a/test/ghostel-mouse-paste-test.el
+++ b/test/ghostel-mouse-paste-test.el
@@ -824,9 +824,9 @@ on the next redraw - neither copy nor Emacs mode is entered."
       (should-not emacs-mode-called))))
 
 (ert-deftest ghostel-test-mouse-1-drag-focus-click-microdrag-stays-semi-char ()
-  "A focus-click micro-drag (drag-mouse-1, no region) stays in semi-char.
+  "A focus-click micro-drag (no region) stays in semi-char.
 A tiny pointer wiggle on a click that only focuses the window makes Emacs
-report `drag-mouse-1' with equal start/end points; it sets no region, snaps
+report a drag with equal start/end points; it sets no region, snaps
 to the live cursor, and does not enter copy mode."
   :tags '(native)
   (let ((fake-event `(drag-mouse-1


### PR DESCRIPTION
## Summary

Rewrites evil-ghostel from an advice-based design to proper evil command definitions, and makes input-boundary detection autosuggestion-aware.

- Replaces ~13 `advice-add` hooks on `evil-*` commands with `evil-define-operator` / `evil-define-motion` definitions bound in `evil-ghostel-mode-map` for normal and visual states (vterm-collection style). Drops the shadow-cursor model — operators read `ghostel--cursor-pos` directly each call.
- **Operator clamp** trims an operator's range to the live input region, so `dw` on the last input word no longer over-deletes into the blank renderer rows below the prompt. Forward-word motions stay vanilla in operator-pending state so `dw` / `cw` can overshoot and get trimmed by the clamp.
- **Autosuggestion-aware boundaries.** Shell suggestions (zsh-autosuggestions, fish) are tagged `ghostel-input` like typed text and differ only by a dimmer `:foreground`. `evil-ghostel--suggestion-p` / `--input-end` keep `bdw` / `bcw` / `dw` / `^` / `$` from running into the grey suggestion, and never return a position left of the cursor (fixes `A` / `$` / `d$` driving a left-arrow into the prompt on an empty prompt).
- **Visual selection works.** `evil-ghostel-mode` opts the buffer out of ghostel's keyboard-mark→copy-mode switch (buffer-local `ghostel-mark-activation-input-mode` nil), so `v` and the visual operators no longer flip the buffer to read-only copy mode and hit "Buffer is read-only". Mouse selection stays governed by `ghostel-mouse-drag-input-mode`.
- Keeps the essential plumbing advice (`ghostel--redraw` / `ghostel--set-cursor-style`) and the insert-state-entry hook, installed on first mode-enable and removed only when the **last** `evil-ghostel-mode` buffer disables.
- Three-way insert-state ESC routing (`evil-ghostel-escape`: `auto` / `terminal` / `evil`), toggleable per buffer.
- `evil-ghostel-goto-input-position` drives the terminal cursor with arrow keys, including vterm-style recovery for literal `^[[C` echo and bash-autosuggest accept-on-right-arrow.

## Fixes (#264 reports)

- fish's right-aligned prompt cells — which libghostty's per-cell heuristic tags `SEMANTIC_INPUT` despite emitting no OSC 133;B — are no longer captured by `i` / `a` / `I` / `A` / `$`.
- `r` reads its replacement via `evil-read-key` (the prior `<c>` interactive code captured COUNT, not the char, so `r` was a no-op).
- `cw` → `ce` via `evil-change-commands`; delete count excludes soft-wrap newlines.

## Test plan

- [x] `make -j8 all test-evil` clean; **107** evil-ghostel tests, 0 unexpected.
- [x] New regression coverage for suggestion-aware boundaries, empty-prompt left-arrow, the advice lifecycle, and the `--sync-render` forced-redraw path.
- [x] Live-verified in a sandboxed live Emacs against `zsh`: `v` stays in semi-char and editable (no read-only freeze), `^ v l l d` deletes input over the PTY, and suggestion-aware boundaries hold.

## Notes for reviewers

- The `evil-ghostel.el` size delta vs evil-collection-vterm is dominated by `evil-ghostel--around-redraw` (ghostel's renderer wipes the viewport region, vterm doesn't), the cursor↔point viewport-row sync helpers, the insert-state-entry hook (vterm's cursor *is* the buffer cursor), and the three-way ESC routing.
