### PR TITLE
Bind S-<insert> and remap yank to ghostel-yank

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1613,13 +1613,13 @@ Most keys are sent to the terminal.  Keys in
 \\`C-c' prefix from `ghostel-mode-map'."
   :parent ghostel-mode-map)
 (ghostel--define-terminal-keys ghostel-semi-char-mode-map)
-;; Yank bindings layer on top of the helper's `M-y' →
-;; `ghostel--send-event' default so the kill ring wins.
+;; Yank bindings layer on top of the helper's defaults so the kill
+;; ring wins over `ghostel--send-event' for `M-y', `S-<insert>', etc.
 (define-keymap :keymap ghostel-semi-char-mode-map
-  "C-y" #'ghostel-yank
-  "M-y" #'ghostel-yank-pop)
-(when (eq system-type 'darwin)
-  (define-key ghostel-semi-char-mode-map (kbd "s-v") #'ghostel-yank))
+  "C-y"            #'ghostel-yank
+  "S-<insert>"     #'ghostel-yank
+  "<remap> <yank>" #'ghostel-yank
+  "M-y"            #'ghostel-yank-pop)
 
 ;; No parent — char mode captures everything, including C-c.
 (defvar-keymap ghostel-char-mode-map
@@ -1666,17 +1666,16 @@ When `ghostel-readonly-fast-exit' is non-nil, the additional
 bindings in `ghostel-readonly-fast-exit-mode-map' are layered on
 top so that \\`q', \\`C-g', or any self-insert key exits."
   :parent ghostel-mode-map
-  "C-a"      #'ghostel-beginning-of-input-or-line
-  "C-y"      #'ghostel-yank
-  "M-w"      #'ghostel-readonly-copy
-  "C-w"      #'ghostel-readonly-copy
-  "M->"      #'ghostel-readonly-end-of-buffer
-  "C-e"      #'ghostel-readonly-end-of-line
-  "C-l"      #'ghostel-readonly-recenter
-  "RET"      #'ghostel-open-link-at-point
-  "<return>" #'ghostel-open-link-at-point)
-(when (eq system-type 'darwin)
-  (define-key ghostel-readonly-mode-map (kbd "s-v") #'ghostel-yank))
+  "C-a"            #'ghostel-beginning-of-input-or-line
+  "C-y"            #'ghostel-yank
+  "<remap> <yank>" #'ghostel-yank
+  "M-w"            #'ghostel-readonly-copy
+  "C-w"            #'ghostel-readonly-copy
+  "M->"            #'ghostel-readonly-end-of-buffer
+  "C-e"            #'ghostel-readonly-end-of-line
+  "C-l"            #'ghostel-readonly-recenter
+  "RET"            #'ghostel-open-link-at-point
+  "<return>"       #'ghostel-open-link-at-point)
 
 (defvar-keymap ghostel-readonly-fast-exit-mode-map
   :doc "Keymap layered on `ghostel-readonly-mode-map' when fast exit is on.

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -10161,6 +10161,51 @@ by the input-mode refactor)."
   ;; ghostel--send-event instead of global backward-kill-word.
   (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "M-DEL")) #'ghostel--send-event)))
 
+(ert-deftest ghostel-test-yank-remap-bindings ()
+  "Alternative paste keys all route to `ghostel-yank'.
+Regression test for issue #263.  `C-y' is bound explicitly so user
+rebinds of the global `yank' key cannot break ghostel paste.
+`S-<insert>' is bound explicitly in `ghostel-semi-char-mode-map'
+because `ghostel--define-terminal-keys' otherwise routes it through
+`ghostel--send-event' as part of the `<insert>' modifier expansion.
+The `<remap> <yank>' entry catches everything else that Emacs binds
+to `yank' globally — `s-v' on macOS, plus any user rebinds.  In
+char mode all paste keys go to the terminal; line mode keeps
+Emacs's regular `yank' so paste lands in the input region."
+  ;; The remap entry itself in the maps that want ghostel-yank.
+  (should (eq (lookup-key ghostel-semi-char-mode-map [remap yank])
+              #'ghostel-yank))
+  (should (eq (lookup-key ghostel-readonly-mode-map [remap yank])
+              #'ghostel-yank))
+  ;; Line mode must NOT remap yank — regular yank into the input
+  ;; region is the right behavior there.
+  (should-not (lookup-key ghostel-line-mode-map [remap yank]))
+  ;; Char mode has no parent and no remap — every key is sent to
+  ;; the terminal.
+  (should-not (lookup-key ghostel-char-mode-map [remap yank]))
+  (should (eq (lookup-key ghostel-char-mode-map (kbd "S-<insert>"))
+              #'ghostel--send-event))
+  ;; End-to-end: with a ghostel buffer active, `key-binding' walks
+  ;; the active maps and follows the remap chain.
+  (let ((buf (generate-new-buffer " *ghostel-test-yank-remap*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          ;; Default mode is semi-char.
+          (should (eq (key-binding (kbd "C-y")) #'ghostel-yank))
+          (should (eq (key-binding (kbd "S-<insert>")) #'ghostel-yank))
+          ;; `s-v' relies on `term/ns-win.el' binding `[?\s-v]' to
+          ;; `yank' globally, which only happens when an NS window
+          ;; system loads.  On macOS batch builds without that
+          ;; binding (e.g. CI's Emacs) the remap has nothing to ride
+          ;; on, so only assert when the prerequisite is actually
+          ;; present.
+          (when (and (eq system-type 'darwin)
+                     (eq (lookup-key (current-global-map) (kbd "s-v"))
+                         'yank))
+            (should (eq (key-binding (kbd "s-v")) #'ghostel-yank))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-control-meta-key-bindings ()
   "Every non-exception Control-Meta letter chord routes to `ghostel--send-event'.
 Regression test for issue #239: these chords must reach the shell as ESC +


### PR DESCRIPTION
## Summary
- Bind `S-<insert>` to `ghostel-yank` in semi-char and readonly modes — the conventional alternative paste shortcut in browsers, terminal emulators, and file managers.
- Add `<remap> <yank>` to both maps so anything Emacs globally binds to `yank` (notably `s-v` on macOS, plus user rebinds) routes through `ghostel-yank` without a per-key entry. The darwin `s-v` special-case blocks in both maps are now redundant and removed.
- `C-y` stays explicitly bound so user rebinds of `yank`'s global key cannot break ghostel paste. Line mode keeps Emacs's regular `yank` (paste lands in the editable input region). Char mode is unchanged.

Closes #263.

## Why `S-<insert>` needs an explicit binding (not just the remap)
`ghostel--define-terminal-keys` iterates `<insert>` × `(S- C- M- C-S- M-S- C-M-)` and binds every combo to `ghostel--send-event`. That's a *direct* binding in `ghostel-semi-char-mode-map`, and direct bindings win over the `<remap>` chain — remap only fires on the command that the literal-key lookup resolves to. `s-v` flows through the remap fine because the helper's modifier list excludes super. Readonly mode never calls the helper, so the remap is enough there.

## Test plan
- [x] `make -j4 all` — 354 tests, 352 pass, 0 unexpected, 2 pre-existing skips (bash-completion availability).
- [x] New ert: `ghostel-test-yank-remap-bindings` covers the `[remap yank]` entries in semi-char/readonly, the *absence* of the remap in line/char modes, char mode's `S-<insert>` still going to `ghostel--send-event`, and end-to-end `key-binding` resolution of `C-y`/`S-<insert>`/`s-v` (darwin) in an active ghostel buffer.
- [x] Fresh `emacs --batch` confirms `C-y`, `S-<insert>`, and `s-v` all resolve to `ghostel-yank` in semi-char mode.
- [ ] Manual: open a ghostel buffer in emacsclient, kill text from another buffer, press `S-<insert>` and confirm bracketed paste arrives at the shell prompt; repeat in Emacs/copy mode.