### PR TITLE
Bind `Shift-PageUp`/`Down` to `scroll-down`/`up-command`

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -634,7 +634,7 @@ When nil, falls back to `tramp-default-method'."
                  string))
 
 (defcustom ghostel-keymap-exceptions
-  '("C-c" "C-x" "C-u" "C-h" "M-x" "M-o" "M-:" "C-\\")
+  '("C-c" "C-x" "C-u" "C-h" "M-x" "M-o" "M-:" "C-\\" "S-<prior>" "S-<next>")
   "Key sequences that should not be sent to the terminal.
 These keys pass through to Emacs instead."
   :type '(repeat string))
@@ -1560,6 +1560,9 @@ Input modes (`ghostel-semi-char-mode-map', `ghostel-char-mode-map',
   "C-c C-y"          #'ghostel-paste
   "C-c M-l"          #'ghostel-clear-scrollback
   "C-c C-q"          #'ghostel-send-next-key
+  ;; Scrolling
+  "S-<prior>"        #'scroll-down-command
+  "S-<next>"         #'scroll-up-command
   ;; Hyperlink navigation (OSC 8, auto-detected URLs, file:line refs)
   "C-c C-n"          #'ghostel-next-hyperlink
   "C-c C-p"          #'ghostel-previous-hyperlink

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -10173,6 +10173,22 @@ instead of running Emacs commands like `forward-sexp'."
           (should-not (eq binding #'ghostel--send-event))
         (should (eq binding #'ghostel--send-event))))))
 
+(ert-deftest ghostel-test-shift-page-up-down-bindings ()
+  "S-<prior> and S-<next> should be bound to scrolling commands.
+They are excluded from terminal-key definitions by `ghostel-keymap-exceptions'
+and inherited from `ghostel-mode-map'."
+  (should (eq (lookup-key ghostel-mode-map (kbd "S-<prior>")) #'scroll-down-command))
+  (should (eq (lookup-key ghostel-mode-map (kbd "S-<next>")) #'scroll-up-command))
+  ;; Inherited in semi-char mode
+  (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "S-<prior>")) #'scroll-down-command))
+  (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "S-<next>")) #'scroll-up-command)))
+
+(ert-deftest ghostel-test-char-mode-shift-page-up-down-bindings ()
+  "In char-mode, S-<prior> and S-<next> SHOULD be sent to the terminal.
+Char mode ignores exceptions and binds everything to `ghostel--send-event'."
+  (should (eq (lookup-key ghostel-char-mode-map (kbd "S-<prior>")) #'ghostel--send-event))
+  (should (eq (lookup-key ghostel-char-mode-map (kbd "S-<next>")) #'ghostel--send-event)))
+
 (ert-deftest ghostel-test-encode-key-legacy-control-meta ()
   "Control-Meta letter chords encode to ESC + control byte in legacy mode.
 Regression test for issue #239: these byte sequences match readline


### PR DESCRIPTION
This change allows users to use `Shift-PageUp` and `Shift-PageDown` to scroll through terminal scrollback in `semi-char` mode, matching the behavior of traditional terminal emulators.

- Add `S-<prior>` and `S-<next>` to `ghostel-keymap-exceptions`.
- Bind `S-<prior>` and `S-<next>` in `ghostel-mode-map`.
- Add regression tests for `semi-char` and `char` modes.