### PR TITLE
Fix flickering when exiting copy mode

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2686,7 +2686,8 @@ returns to whichever input mode was active before."
       (pcase target
         ('char  (ghostel-char-mode))
         ('emacs (ghostel-emacs-mode))
-        (_      (ghostel-semi-char-mode))))
+        (_      (ghostel-semi-char-mode)))
+      (ghostel-force-redraw))
     (message "Read-only mode exited")))
 
 (defun ghostel-readonly-exit-and-clear ()


### PR DESCRIPTION
When exiting read-only modes (like copy mode or Emacs mode), the viewport is snapped back to the live terminal cursor, which involves jumping point to the end of the buffer. Previously, this process scheduled an asynchronous delayed redraw.

During the delay before the timer fired, control returned to the Emacs redisplay engine. Emacs would observe point at `point-max` and attempt to violently recenter the window around it. Once the `ghostel--delayed-redraw` timer finally fired a few milliseconds later, it would calculate the true active area (the `viewport-start`) and anchor the window back into place, resulting in a visible and jarring flicker.

This commit adds a synchronous call to `ghostel-force-redraw` at the end of the read-only exit sequence. By forcing the redraw immediately, the window is correctly anchored to the terminal's active viewport before Emacs has a chance to perform an unanchored redisplay cycle.

Fixes #269.