### PR TITLE
Bind C-Backspace to send C-w in semi-char mode

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1815,7 +1815,8 @@ Most keys are sent to the terminal.  Keys in
   "C-y"            #'ghostel-yank
   "S-<insert>"     #'ghostel-yank
   "<remap> <yank>" #'ghostel-yank
-  "M-y"            #'ghostel-yank-pop)
+  "M-y"            #'ghostel-yank-pop
+  "C-<backspace>"  #'ghostel-backward-kill-word)
 
 ;; No parent — char mode captures everything, including C-c.
 (defvar-keymap ghostel-char-mode-map
@@ -3621,6 +3622,12 @@ marker."
         (when (and ghostel--process (process-live-p ghostel--process))
           (process-send-string ghostel--process "\C-d"))
       (delete-char 1))))
+
+(defun ghostel-backward-kill-word ()
+  "Send C-w to the terminal process."
+  (interactive)
+  (ghostel--snap-to-input)
+  (ghostel--send-string "\C-w"))
 
 (defun ghostel-beginning-of-input-or-line ()
   "Move point to the start of input on a prompt row, else `beginning-of-line'.

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -12163,6 +12163,23 @@ on every empty prompt the user pressed `RET' to.)"
     (let ((ghostel-prompt-regexp nil))
       (should (null (ghostel--regex-prompt-end 1))))))
 
+(ert-deftest ghostel-test-backward-kill-word-bindings ()
+  "`C-<backspace>' are bound to `ghostel-backward-kill-word'."
+  (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "C-<backspace>"))
+              #'ghostel-backward-kill-word)))
+
+(ert-deftest ghostel-test-backward-kill-word-semi-char-sends-c-w ()
+  "`ghostel-backward-kill-word' snaps to input and sends C-w."
+  (let ((sent nil)
+        (snapped nil))
+    (cl-letf (((symbol-function 'ghostel--snap-to-input)
+               (lambda () (setq snapped t)))
+              ((symbol-function 'ghostel--send-string)
+               (lambda (s) (setq sent s))))
+      (ghostel-backward-kill-word)
+      (should snapped)
+      (should (equal sent "\C-w")))))
+
 (ert-deftest ghostel-test-line-mode-interrupt ()
   "Line-mode interrupt discards input, sends SIGINT, and exits."
   (let ((buf (generate-new-buffer " *ghostel-test-line-interrupt*"))
@@ -15163,6 +15180,8 @@ slip past the unit tests."
     ghostel-test-regex-prompt-end-empty-prompt-returns-match
     ghostel-test-regex-prompt-end-matches-content
     ghostel-test-regex-prompt-end-nil-regex-returns-nil
+    ghostel-test-backward-kill-word-bindings
+    ghostel-test-backward-kill-word-semi-char-sends-c-w
     ghostel-test-line-mode-interrupt
     ghostel-test-line-mode-exit-sends-pending
     ghostel-test-line-mode-eof-on-empty


### PR DESCRIPTION
## Summary

Adds a `C-<backspace>` binding in semi-char mode that sends `C-w` to the terminal.

This gives shell prompts/readline-style editors the common 'kill previous word' behaviour when pressing `C-Backspace` in ghostel. Vterm, for example, has this behaviour by default.

No worries if this is considered too opinionated; I can keep it in my local config.

Ps. Thanks for making ghostel. It works great and has replaced my vterm/shell usage.