### PR TITLE
Disable auto-composition on TTY frames to fix emoji width drift

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -6493,6 +6493,20 @@ PROCESS is the shell process, WINDOWS is the list of windows."
     ;; after this function returns.  nil suppresses the call.
     size))
 
+(defun ghostel--sync-tty-composition (window)
+  "Sync `auto-composition-mode' with WINDOW's frame for ghostel buffers.
+On a TTY frame, set the buffer-local value to the frame's `tty-type'
+so composition is inhibited there (works around TTY column drift on
+VS-16 emoji clusters, see debbugs#81052).
+On a GUI frame, leave the value alone: it is either t (mode-init default;
+composition stays on) or a string from a prior TTY display (string never
+matches a GUI's nil `tty-type', so composition still stays on for the GUI
+and the TTY display that needs it off keeps working in parallel)."
+  (when (windowp window)
+    (when-let* ((tt (tty-type (window-frame window))))
+      (unless (equal auto-composition-mode tt)
+        (setq-local auto-composition-mode tt)))))
+
 (defun ghostel--reshow-snap (window)
   "Mark WINDOW for viewport-snap on the next redraw.
 Intended for buffer-local `window-buffer-change-functions'.  Fires
@@ -6553,8 +6567,8 @@ output is arriving."
   (add-function :after after-focus-change-function #'ghostel--focus-change)
   (add-hook 'window-selection-change-functions #'ghostel--focus-change)
   (add-hook 'window-buffer-change-functions #'ghostel--focus-change)
-  (add-hook 'window-buffer-change-functions
-            #'ghostel--reshow-snap nil t)
+  (add-hook 'window-buffer-change-functions #'ghostel--reshow-snap nil t)
+  (add-hook 'window-buffer-change-functions #'ghostel--sync-tty-composition nil t)
   (ghostel--suppress-interfering-modes)
   (ghostel-imenu-setup)
   (setq ghostel--scroll-intercept-active t)


### PR DESCRIPTION
## Summary

Fixes the "garbled buffer in TTY Emacs that `M-x redraw-display` cleans up" symptom reported in #274. The cause is a column-count mismatch on grapheme clusters like 🗂️ (U+1F5C2 + U+FE0F):

- `(char-width #x1F5C2)` ⇒ 1, `(char-width #xFE0F)` ⇒ 0 → Emacs's TTY redisplay treats the cluster as 1 column.
- VS-16-honoring terminals (Ghostty, iTerm2, foot, kitty, …) paint the cluster as 2 columns.

The off-by-one accumulates in Emacs's TTY screen cache as windows scroll. `redraw-display` works because it invalidates the cache. This is a fundamental limitation of Emacs's TTY redisplay (`char-width` is context-free; VS-16's emoji-presentation promotion is contextual on the *following* codepoint) — confirmed by Eli Zaretskii on `bug-gnu-emacs` (debbugs#81052).

## Fix

Use the per-frame string form of `auto-composition-mode` to inhibit composition only on TTY frames showing a ghostel buffer:

- On a TTY frame, set the buffer-local value to that frame's `tty-type`. `composite.c:1007` compares the value to `tty_type_name (Qnil)` at display time, so this matches and composition is off for that window.
- On a GUI frame, leave the value alone. A `nil` tty-type never equals a string, so GUI rendering is never affected — including when both GUI and TTY clients view the same buffer simultaneously.

Same mechanism `term/linux.el` uses (`(setq-default auto-composition-mode "linux")` because "Compositions confuse cursor movement" on the Linux console).

Synced from `window-buffer-change-functions` so a buffer first created on the daemon's initial non-display frame still gets the right value when later displayed via `emacsclient -nw`.

## Test plan

- [x] Cold daemon → `emacsclient -nw` → open ghostel → `cat capture.log` repeatedly → no drift after scrollback.
- [x] `emacsclient -c` → open ghostel → emoji renders normally in GUI; then `emacsclient -nw` and `C-x b *ghostel*` → no drift in TTY, GUI still renders normally.
- [x] In GUI session, copy-mode browse a ghostel buffer with non-Latin/CJK text → composition still works.
- [x] `make -j4 all` passes.