### PR TITLE
Emit OSC 7 last so it wins the prompt-callback race

### DIFF
--- a/etc/shell/ghostel.bash
+++ b/etc/shell/ghostel.bash
@@ -98,9 +98,14 @@ __ghostel_wrapped_prompt_command() {
     fi
 
     __ghostel_prompt_start
-    __ghostel_osc7
 
     eval "${__ghostel_original_prompt_command:-}"
+
+    # OSC 7 must fire AFTER the user/system PROMPT_COMMAND so we win the race
+    # against competing OSC 7 emitters.  Fedora's /etc/profile.d/vte.sh
+    # registers __vte_prompt_command which emits OSC 7 with $HOSTNAME
+    # (which may be polluted by container/toolbox runtimes; See #276).
+    __ghostel_osc7
 
     local __ghostel_p_initial='\[\e]133;P;k=i\a\]'
     if [[ "$PS1" != *"$__ghostel_p_initial"* ]]; then

--- a/etc/shell/ghostel.zsh
+++ b/etc/shell/ghostel.zsh
@@ -190,8 +190,18 @@ __ghostel_install_zle_hook() {
     precmd_functions=(${precmd_functions:#__ghostel_install_zle_hook})
 }
 
-precmd_functions=(__ghostel_save_status __ghostel_prompt_start __ghostel_osc7 "${precmd_functions[@]}")
-precmd_functions+=(__ghostel_ensure_prompt_wrap __ghostel_install_zle_hook)
+# `__ghostel_save_status' must run first so $? still reflects the last
+# command.  `__ghostel_prompt_start' emits the OSC 133;D boundary marker
+# for the previous command and is also order-sensitive.
+#
+# `__ghostel_osc7' is APPENDED (not prepended) so we win the race
+# against competing OSC 7 emitters in user/system precmds.  Same
+# rationale as the bash side: libghostty stores whichever OSC 7 fires
+# last per cycle, so a precmd like Fedora's __vte_prompt_command -
+# which emits OSC 7 using $HOSTNAME, possibly polluted by container
+# runtimes - would otherwise overwrite our value.
+precmd_functions=(__ghostel_save_status __ghostel_prompt_start "${precmd_functions[@]}")
+precmd_functions+=(__ghostel_osc7 __ghostel_ensure_prompt_wrap __ghostel_install_zle_hook)
 preexec_functions=(__ghostel_preexec "${preexec_functions[@]}")
 
 # Outbound `ssh' wrapper.  See etc/ghostel.bash for the full design

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -1830,6 +1830,97 @@ the buffer is misclassified as remote, switching on TRAMP."
         (should (ghostel--local-host-p emitted))))))
 
 ;; -----------------------------------------------------------------------
+;; Test: bash OSC 7 wins the race against competing prompt-command emitters
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-bash-osc7-wins-race-vs-prompt-command ()
+  "Bash `__ghostel_osc7' must fire last so it wins the OSC 7 race.
+
+When a system/user rcfile registers a PROMPT_COMMAND that emits its
+own OSC 7 (e.g. Fedora's /etc/profile.d/vte.sh emits one via
+__vte_prompt_command using $HOSTNAME), libghostty stores whichever
+OSC 7 fires last per prompt cycle.  If ours fires first, the
+competing emitter overwrites our value and downstream classification
+\(local vs TRAMP) is wrong - which is exactly the #276 follow-up bug.
+
+The probe pre-registers a competing PROMPT_COMMAND that emits an OSC
+7 with a bogus host, then sources ghostel.bash (which captures the
+existing PROMPT_COMMAND), then manually invokes
+`__ghostel_wrapped_prompt_command'.  The last OSC 7 in the captured
+output must be ours, not the competing one."
+  (skip-unless (executable-find "bash"))
+  (let* ((root (or (ghostel--resource-root)
+                   (file-name-directory (locate-library "ghostel"))))
+         (shell-bash (expand-file-name "etc/shell/ghostel.bash" root)))
+    (skip-unless (file-exists-p shell-bash))
+    (let* ((probe
+            (concat
+             "PROMPT_COMMAND='printf \"\\e]7;file://competing-host/path\\a\"';"
+             (format " source %s;" shell-bash)
+             " __ghostel_wrapped_prompt_command"))
+           (process-environment
+            (append '("INSIDE_EMACS=ghostel") process-environment))
+           (output (with-temp-buffer
+                     (call-process "bash" nil (current-buffer) nil
+                                   "--noprofile" "--norc" "-c" probe)
+                     (buffer-string)))
+           (osc7s nil)
+           (start 0))
+      (while (string-match "\e\\]7;\\([^\a]*\\)\a" output start)
+        (push (match-string 1 output) osc7s)
+        (setq start (match-end 0)))
+      (setq osc7s (nreverse osc7s))
+      ;; Sanity: both emitters fired - otherwise the race isn't exercised.
+      (should (>= (length osc7s) 2))
+      (should (cl-some (lambda (s) (string-match-p "competing-host" s))
+                       osc7s))
+      ;; The LAST OSC 7 must be ours, not the competing one - libghostty
+      ;; stores whichever fires last per cycle.
+      (should-not (string-match-p "competing-host" (car (last osc7s)))))))
+
+;; -----------------------------------------------------------------------
+;; Test: zsh OSC 7 wins the race against competing precmd emitters
+;; -----------------------------------------------------------------------
+
+(ert-deftest ghostel-test-zsh-osc7-wins-race-vs-precmd ()
+  "Zsh `__ghostel_osc7' must run last among precmd_functions emitters.
+
+A user/system rcfile may register a precmd_function that emits OSC 7
+\(e.g. distro VTE-integration hooks).  Whichever runs last per cycle
+sets libghostty's recorded cwd.  Mirrors the bash race test."
+  (skip-unless (executable-find "zsh"))
+  (let* ((root (or (ghostel--resource-root)
+                   (file-name-directory (locate-library "ghostel"))))
+         (shell-zsh (expand-file-name "etc/shell/ghostel.zsh" root)))
+    (skip-unless (file-exists-p shell-zsh))
+    (let* ((probe
+            (concat
+             "_competing_osc7() { "
+             "printf '\\e]7;file://competing-host/path\\a' "
+             "}; "
+             "precmd_functions=(_competing_osc7); "
+             (format "source %s; " shell-zsh)
+             "for f in $precmd_functions; do $f; done"))
+           (process-environment
+            (append '("INSIDE_EMACS=ghostel") process-environment))
+           (output (with-temp-buffer
+                     (call-process "zsh" nil (current-buffer) nil
+                                   "-f" "-c" probe)
+                     (buffer-string)))
+           (osc7s nil)
+           (start 0))
+      (while (string-match "\e\\]7;\\([^\a]*\\)\a" output start)
+        (push (match-string 1 output) osc7s)
+        (setq start (match-end 0)))
+      (setq osc7s (nreverse osc7s))
+      ;; Sanity: both emitters fired - otherwise the race isn't exercised.
+      (should (>= (length osc7s) 2))
+      (should (cl-some (lambda (s) (string-match-p "competing-host" s))
+                       osc7s))
+      ;; The LAST OSC 7 must be ours.
+      (should-not (string-match-p "competing-host" (car (last osc7s)))))))
+
+;; -----------------------------------------------------------------------
 ;; Test: OSC 7 end-to-end through libghostty
 ;; -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Follow-up to #277. libghostty stores whichever OSC 7 fires *last* per prompt cycle. ghostel's bash and zsh integrations both emit OSC 7 *before* the user/system's wrapped PROMPT_COMMAND / `precmd_functions` chain — so any competing emitter runs after us and overwrites our cwd report.

This is exactly what's happening for #276 reporters whose toolbox image still pollutes `$HOSTNAME=fedora`:

- Fedora ships `/etc/profile.d/vte.sh`, which registers `__vte_prompt_command` in `PROMPT_COMMAND`. That function emits `\e]7;file://$HOSTNAME$PWD\a` — i.e. it uses the *polluted* `$HOSTNAME` value.
- ghostel's `__ghostel_osc7` (using `gethostname(2)` via `\H`, the fix from #277) fires *before* `__vte_prompt_command`, so vte's wrong OSC 7 wins.
- Net result: `default-directory` still becomes `/scp:fedora:/...` even with the #277 fix in place.

Compare ghostty's own shell integration: their bash hook *appends* itself to `PROMPT_COMMAND`, and their zsh hook *appends + self-reorders* to stay last in `precmd_functions`. They explicitly designed for this race; we didn't.

### Changes

- **`etc/shell/ghostel.bash`**: inside `__ghostel_wrapped_prompt_command`, move `__ghostel_osc7` from before the `eval` of the captured original `PROMPT_COMMAND` to after it. Comment links to #276.
- **`etc/shell/ghostel.zsh`**: change `precmd_functions=` from prepending `__ghostel_osc7` to appending it. Mirrors the bash fix and matches the self-reorder pattern we already use for `__ghostel_ensure_prompt_wrap`.
- **`test/ghostel-test.el`**: two new race tests (`ghostel-test-{bash,zsh}-osc7-wins-race-vs-{prompt-command,precmd}`). Each pre-registers a competing OSC 7 emitter with a sentinel host, invokes the prompt callback chain, parses all OSC 7s out of the captured output, and asserts the last one is ours, not the competing one.

### Out of scope

Fish has the same structural issue (handlers fire in `--on-event` definition order, and our `vendor_conf.d` loads before user `config.fish`), but fixing it cleanly would require more than a reorder. Skipped per maintainer's call.

## Test plan

- [ ] `make -j4 all` passes (382 tests).
- [ ] New tests pass against this branch.
- [ ] Same tests fail against `main` (last OSC 7 is the competing sentinel, exactly the race condition).
- [ ] `bash -n` clean on bash 5.x and `/bin/bash` 3.2.
- [ ] `zsh -n` clean.
- [ ] Manual smoke: `bash -c 'PROMPT_COMMAND="printf \"\e]7;file://wrong/\a\""; source etc/shell/ghostel.bash; __ghostel_wrapped_prompt_command'` — last OSC 7 in output is `file://<hostname>/...`.