### PR TITLE
Wrap shell via login(1) on macOS so .zprofile is sourced (#285)

### DIFF
--- a/lisp/ghostel-debug.el
+++ b/lisp/ghostel-debug.el
@@ -674,7 +674,9 @@ omit it when the connection itself is the suspected fault."
                     shell ghostel-shell
                     shell-integ ghostel-shell-integration
                     tramp-integ ghostel-tramp-shell-integration
-                    detected (ghostel--detect-shell ghostel-shell)
+                    detected (ghostel--detect-shell
+                              (car (ghostel--shell-program-and-args
+                                    ghostel-shell)))
                     term ghostel--term
                     term-rows ghostel--term-rows
                     term-cols ghostel--term-cols

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -102,8 +102,20 @@
   :prefix "ghostel-")
 
 (defcustom ghostel-shell (or (getenv "SHELL") "/bin/sh")
-  "Shell program to run in the terminal."
-  :type 'string)
+  "Shell program to run in the terminal.
+
+Either a string (just the executable path) or a list whose first
+element is the executable path and whose remaining elements are
+arguments passed to that executable.  For example:
+
+  (setq ghostel-shell \\='(\"/bin/zsh\" \"--login\"))
+
+On macOS, ghostel additionally wraps the shell via `login(1)' by
+default so the shell starts as a login shell (matching Apple's
+Terminal.app and Ghostty), which sources `~/.zprofile' /
+`~/.bash_profile' as users expect.  See `ghostel-macos-login-shell'."
+  :type '(choice (string :tag "Executable path")
+                 (repeat :tag "Executable + arguments" string)))
 
 (defcustom ghostel-term "xterm-ghostty"
   "Value of the TERM environment variable for ghostel processes.
@@ -611,6 +623,31 @@ nil        - do nothing; the user must install the module manually."
 When non-nil, ghostel modifies the shell invocation to automatically
 load shell integration scripts without requiring changes to the user's
 shell configuration files.  Supports bash, zsh, and fish."
+  :type 'boolean)
+
+(defcustom ghostel-macos-login-shell (eq system-type 'darwin)
+  "Wrap shell invocations on macOS so the shell starts as a login shell.
+
+When non-nil and `system-type' is `darwin', ghostel wraps the shell
+spawned by `ghostel--start-process' with `/usr/bin/login -flp $USER'
+followed by a tiny `/bin/bash --noprofile --norc -c \"exec -l <shell>
+[args]\"' shim.  This mirrors Apple's Terminal.app and Ghostty so that
+per-user login files (`~/.zprofile', `~/.bash_profile') are sourced as
+users expect on macOS.
+
+When `~/.hushlogin' exists, `-q' is passed to `login(1)' to suppress
+its banner.  The wrap preserves the calling environment via `login -p',
+so ghostel's shell-integration env (ZDOTDIR, ENV, XDG_DATA_DIRS,
+EMACS_GHOSTEL_PATH, INSIDE_EMACS) reaches the final shell.  Note that
+login(1) ALWAYS resets HOME, SHELL, LOGNAME, USER, and MAIL from the
+passwd entry — overrides for these in `ghostel-environment' do not
+survive the wrap.
+
+This wrap is only applied for the interactive shell spawned by
+`ghostel'.  It is not applied for `ghostel-exec' (the arbitrary-
+command entry point), for remote (TRAMP) sessions, or on non-Darwin
+platforms.  Set to nil to opt out and get a plain (non-login)
+interactive shell."
   :type 'boolean)
 
 (defcustom ghostel-tramp-shell-integration nil
@@ -5476,17 +5513,67 @@ METHOD is a TRAMP method string or t for the default."
           (or shell second))
       first)))
 
+(defun ghostel--shell-program-and-args (spec)
+  "Split a `ghostel-shell'-style SPEC into (PROGRAM . ARGS).
+SPEC may be a string (just the program path) or a list whose first
+element is the program path and the remaining elements are arguments."
+  (cond
+   ((stringp spec) (cons spec nil))
+   ((and (consp spec) (stringp (car spec)))
+    (cons (car spec) (cdr spec)))
+   (t (error "Invalid ghostel-shell value: %S" spec))))
+
 (defun ghostel--get-shell ()
-  "Get the shell to run, respecting TRAMP remote connections.
+  "Get the shell program to run, respecting TRAMP remote connections.
 When `default-directory' is a remote TRAMP path, consult
-`ghostel-tramp-shells' for the appropriate shell."
+`ghostel-tramp-shells' for the appropriate shell.  Returns the
+executable path as a string.  When `ghostel-shell' is a list,
+only its first element (the program) is returned; use
+`ghostel--resolve-shell-spec' to also obtain the extra arguments."
+  (let ((value
+         (if (file-remote-p default-directory)
+             (with-parsed-tramp-file-name default-directory nil
+               (or (ghostel--tramp-get-shell method)
+                   (ghostel--tramp-get-shell t)
+                   (with-connection-local-variables shell-file-name)
+                   ghostel-shell))
+           ghostel-shell)))
+    (car (ghostel--shell-program-and-args value))))
+
+(defun ghostel--resolve-shell-spec ()
+  "Return (PROGRAM . EXTRA-ARGS) for the shell to spawn.
+For local sessions, splits `ghostel-shell' (string or list).
+For remote (TRAMP) sessions, defers to `ghostel--get-shell',
+which always returns a string — no extra args."
   (if (file-remote-p default-directory)
-      (with-parsed-tramp-file-name default-directory nil
-        (or (ghostel--tramp-get-shell method)
-            (ghostel--tramp-get-shell t)
-            (with-connection-local-variables shell-file-name)
-            ghostel-shell))
-    ghostel-shell))
+      (cons (ghostel--get-shell) nil)
+    (ghostel--shell-program-and-args ghostel-shell)))
+
+(defun ghostel--macos-login-wrap (program args)
+  "Wrap PROGRAM/ARGS via `/usr/bin/login' to produce a macOS login shell.
+Returns (LOGIN-PROGRAM . LOGIN-ARGS).  Mirrors Ghostty's wrap:
+
+  /usr/bin/login [-q] -flp USER \\
+    /bin/bash --noprofile --norc -c \"exec -l PROGRAM [args]\"
+
+`-q' is added when `~/.hushlogin' exists so login(1) suppresses
+its banner.  The bash builtin `exec -l' prepends `-' to argv[0]
+of the final shell, which is what makes it a login shell.
+PROGRAM and ARGS are shell-quoted into the `-c' command."
+  (let* ((user (user-login-name))
+         (hush (file-exists-p (expand-file-name "~/.hushlogin")))
+         (quoted (mapconcat #'shell-quote-argument
+                            (cons program args) " "))
+         (cmd (concat "exec -l " quoted))
+         ;; Quote from Ghostty source:
+         ;; We use "bash" instead of other shells that ship with macOS because
+         ;; as of macOS Sonoma, we found with a microbenchmark that bash can
+         ;; exec into the desired command ~2x faster than zsh.
+         (login-args (append (and hush '("-q"))
+                             (list "-flp" user
+                                   "/bin/bash" "--noprofile" "--norc"
+                                   "-c" cmd))))
+    (cons "/usr/bin/login" login-args)))
 
 (defun ghostel--read-local-file (path)
   "Return the contents of local file PATH as a string."
@@ -5900,7 +5987,9 @@ on the remote host."
   (let* ((height (max 1 ghostel--term-rows))
          (width (max 1 ghostel--term-cols))
          (remote-p (file-remote-p default-directory))
-         (shell (ghostel--get-shell))
+         (shell-spec (ghostel--resolve-shell-spec))
+         (shell (car shell-spec))
+         (extra-shell-args (cdr shell-spec))
          (ghostel-dir (ghostel--resource-root))
          ;; Detect shell type when integration is enabled.
          ;; For remote, also check ghostel-tramp-shell-integration.
@@ -5958,12 +6047,13 @@ on the remote host."
                            (format "XDG_DATA_DIRS=%s:%s" integ-dir xdg)
                            (format "GHOSTEL_SHELL_INTEGRATION_XDG_DIR=%s"
                                    integ-dir))))))))))
-         (shell-args (cond
-                      (remote-integration
-                       (plist-get remote-integration :args))
-                      ((and (eq shell-type 'bash) integration-env)
-                       (list "--posix"))
-                      (t nil)))
+         (integration-args (cond
+                            (remote-integration
+                             (plist-get remote-integration :args))
+                            ((and (eq shell-type 'bash) integration-env)
+                             (list "--posix"))
+                            (t nil)))
+         (shell-args (append extra-shell-args integration-args))
          (stty-flags (if remote-integration
                          (plist-get remote-integration :stty)
                        ghostel--default-stty))
@@ -5971,7 +6061,17 @@ on the remote host."
                      (unless remote-p
                        (list (format "EMACS_GHOSTEL_PATH=%s" ghostel-dir)))
                      integration-env))
-         (proc (ghostel--spawn-pty shell shell-args height width
+         ;; On macOS, wrap with `/usr/bin/login' so the shell starts as a login shell.
+         ;; See `ghostel-macos-login-shell' for the rationale.
+         ;; Skipped for remote spawns - login(1) is a local-session concept.
+         (spawn-spec (if (and ghostel-macos-login-shell
+                              (not remote-p)
+                              (eq system-type 'darwin))
+                         (ghostel--macos-login-wrap shell shell-args)
+                       (cons shell shell-args)))
+         (spawn-program (car spawn-spec))
+         (spawn-args (cdr spawn-spec))
+         (proc (ghostel--spawn-pty spawn-program spawn-args height width
                                    stty-flags extra-env remote-p)))
     (when remote-integration
       (ghostel--cleanup-temp-paths

--- a/test/ghostel-test.el
+++ b/test/ghostel-test.el
@@ -13210,6 +13210,189 @@ External packages may still call the old internal name."
         (ghostel-shell "/bin/zsh"))
     (should (equal "/bin/zsh" (ghostel--get-shell)))))
 
+(ert-deftest ghostel-test-shell-program-and-args-string ()
+  "String SPEC splits into (PROGRAM . nil)."
+  (should (equal '("/bin/zsh") (ghostel--shell-program-and-args "/bin/zsh"))))
+
+(ert-deftest ghostel-test-shell-program-and-args-list ()
+  "List SPEC splits into (PROGRAM . ARGS)."
+  (let ((split (ghostel--shell-program-and-args '("/bin/zsh" "--login" "-i"))))
+    (should (equal "/bin/zsh" (car split)))
+    (should (equal '("--login" "-i") (cdr split)))))
+
+(ert-deftest ghostel-test-shell-program-and-args-invalid ()
+  "Invalid SPEC signals an error."
+  (should-error (ghostel--shell-program-and-args 42))
+  (should-error (ghostel--shell-program-and-args nil))
+  (should-error (ghostel--shell-program-and-args '()))
+  (should-error (ghostel--shell-program-and-args '(nil "foo"))))
+
+(ert-deftest ghostel-test-get-shell-local-returns-program-from-list ()
+  "When `ghostel-shell' is a list, `ghostel--get-shell' returns just the program."
+  (let ((default-directory "/tmp/")
+        (ghostel-shell '("/bin/zsh" "--login")))
+    (should (equal "/bin/zsh" (ghostel--get-shell)))))
+
+(ert-deftest ghostel-test-macos-login-wrap-basic ()
+  "Login wrap produces /usr/bin/login + bash shim with exec -l <prog>."
+  (cl-letf (((symbol-function 'user-login-name) (lambda () "alice"))
+            ((symbol-function 'file-exists-p) (lambda (_) nil)))
+    (let* ((wrap (ghostel--macos-login-wrap "/bin/zsh" nil))
+           (program (car wrap))
+           (args (cdr wrap)))
+      (should (equal "/usr/bin/login" program))
+      ;; No -q without hushlogin.
+      (should-not (member "-q" args))
+      (should (equal "-flp" (nth 0 args)))
+      (should (equal "alice" (nth 1 args)))
+      (should (equal "/bin/bash" (nth 2 args)))
+      (should (equal "--noprofile" (nth 3 args)))
+      (should (equal "--norc" (nth 4 args)))
+      (should (equal "-c" (nth 5 args)))
+      ;; exec -l <quoted-program>; no extra args.
+      (should (equal "exec -l /bin/zsh" (nth 6 args))))))
+
+(ert-deftest ghostel-test-macos-login-wrap-hushlogin ()
+  "When ~/.hushlogin exists, -q is prepended."
+  (let ((hush-path (expand-file-name "~/.hushlogin")))
+    (cl-letf (((symbol-function 'user-login-name) (lambda () "alice"))
+              ((symbol-function 'file-exists-p)
+               (lambda (p) (equal p hush-path))))
+      (let* ((wrap (ghostel--macos-login-wrap "/bin/zsh" nil))
+             (args (cdr wrap)))
+        (should (equal "-q" (nth 0 args)))
+        (should (equal "-flp" (nth 1 args)))
+        (should (equal "alice" (nth 2 args)))))))
+
+(ert-deftest ghostel-test-macos-login-wrap-extra-args ()
+  "Extra ARGS are shell-quoted into the `exec -l' command string."
+  (cl-letf (((symbol-function 'user-login-name) (lambda () "alice"))
+            ((symbol-function 'file-exists-p) (lambda (_) nil)))
+    (let* ((wrap (ghostel--macos-login-wrap "/bin/bash" '("--login" "--posix")))
+           (cmd (nth 6 (cdr wrap))))
+      (should (equal "exec -l /bin/bash --login --posix" cmd)))))
+
+(defmacro ghostel-test--with-spawn-capture (capture &rest body)
+  "Bind CAPTURE to the (PROGRAM . ARGS) cons passed to `ghostel--spawn-pty'.
+Stubs out `ghostel--spawn-pty' so no real process is spawned.  BODY
+runs with the stub in place."
+  (declare (indent 1))
+  `(let (,capture)
+     (cl-letf (((symbol-function 'ghostel--spawn-pty)
+                (lambda (program args &rest _)
+                  (setq ,capture (cons program args))
+                  nil)))
+       ,@body)))
+
+(ert-deftest ghostel-test-start-process-darwin-login-wrap ()
+  "On darwin with `ghostel-macos-login-shell', wrap shell via `/usr/bin/login'."
+  (cl-letf (((symbol-function 'user-login-name) (lambda () "alice"))
+            ((symbol-function 'file-exists-p) (lambda (_) nil)))
+    (ghostel-test--with-spawn-capture spawn
+      (with-temp-buffer
+        (setq-local ghostel--term-rows 24
+                    ghostel--term-cols 80)
+        (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+               (ghostel-shell "/bin/zsh")
+               (ghostel-shell-integration nil)
+               (ghostel-macos-login-shell t)
+               (system-type 'darwin)
+               (default-directory "/tmp/"))
+          (ghostel--start-process)
+          (should (equal "/usr/bin/login" (car spawn)))
+          (let ((args (cdr spawn)))
+            (should-not (member "-q" args))
+            (should (equal '("-flp" "alice"
+                             "/bin/bash" "--noprofile" "--norc"
+                             "-c" "exec -l /bin/zsh")
+                           args))))))))
+
+(ert-deftest ghostel-test-start-process-darwin-login-wrap-opt-out ()
+  "Setting `ghostel-macos-login-shell' to nil disables the wrap on darwin."
+  (ghostel-test--with-spawn-capture spawn
+    (with-temp-buffer
+      (setq-local ghostel--term-rows 24
+                  ghostel--term-cols 80)
+      (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+             (ghostel-shell "/bin/zsh")
+             (ghostel-shell-integration nil)
+             (ghostel-macos-login-shell nil)
+             (system-type 'darwin)
+             (default-directory "/tmp/"))
+        (ghostel--start-process)
+        (should (equal "/bin/zsh" (car spawn)))
+        (should (null (cdr spawn)))))))
+
+(ert-deftest ghostel-test-start-process-non-darwin-no-login-wrap ()
+  "Login wrap is not applied on non-Darwin platforms even when opted in."
+  (ghostel-test--with-spawn-capture spawn
+    (with-temp-buffer
+      (setq-local ghostel--term-rows 24
+                  ghostel--term-cols 80)
+      (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+             (ghostel-shell "/bin/zsh")
+             (ghostel-shell-integration nil)
+             (ghostel-macos-login-shell t)
+             (system-type 'gnu/linux)
+             (default-directory "/tmp/"))
+        (ghostel--start-process)
+        (should (equal "/bin/zsh" (car spawn)))
+        (should (null (cdr spawn)))))))
+
+(ert-deftest ghostel-test-start-process-list-shell-passes-args ()
+  "When `ghostel-shell' is a list, extra args reach `ghostel--spawn-pty'."
+  (ghostel-test--with-spawn-capture spawn
+    (with-temp-buffer
+      (setq-local ghostel--term-rows 24
+                  ghostel--term-cols 80)
+      (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+             (ghostel-shell '("/bin/zsh" "--login"))
+             (ghostel-shell-integration nil)
+             (ghostel-macos-login-shell nil)
+             (system-type 'gnu/linux)
+             (default-directory "/tmp/"))
+        (ghostel--start-process)
+        (should (equal "/bin/zsh" (car spawn)))
+        (should (equal '("--login") (cdr spawn)))))))
+
+(ert-deftest ghostel-test-start-process-list-shell-combines-with-integration ()
+  "List shell args combine with bash integration's `--posix' arg."
+  (ghostel-test--with-spawn-capture spawn
+    (with-temp-buffer
+      (setq-local ghostel--term-rows 24
+                  ghostel--term-cols 80)
+      (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+             (ghostel-shell '("/bin/bash" "--login"))
+             (ghostel-shell-integration t)
+             (ghostel-macos-login-shell nil)
+             (system-type 'gnu/linux)
+             (default-directory "/tmp/"))
+        (ghostel--start-process)
+        (should (equal "/bin/bash" (car spawn)))
+        ;; Extra args precede integration args.
+        (should (equal '("--login" "--posix") (cdr spawn)))))))
+
+(ert-deftest ghostel-test-start-process-darwin-login-wrap-with-integration ()
+  "Wrap + list shell + bash integration: all three layers compose correctly."
+  (cl-letf (((symbol-function 'user-login-name) (lambda () "alice"))
+            ((symbol-function 'file-exists-p) (lambda (_) nil)))
+    (ghostel-test--with-spawn-capture spawn
+      (with-temp-buffer
+        (setq-local ghostel--term-rows 24
+                    ghostel--term-cols 80)
+        (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+               (ghostel-shell '("/bin/bash" "--login"))
+               (ghostel-shell-integration t)
+               (ghostel-macos-login-shell t)
+               (system-type 'darwin)
+               (default-directory "/tmp/"))
+          (ghostel--start-process)
+          (should (equal "/usr/bin/login" (car spawn)))
+          (should (equal '("-flp" "alice"
+                           "/bin/bash" "--noprofile" "--norc"
+                           "-c" "exec -l /bin/bash --login --posix")
+                         (cdr spawn))))))))
+
 (ert-deftest ghostel-test-start-process-sets-size-via-stty-not-env ()
   "Initial terminal size must be baked into the `stty' wrapper, not env vars.
 Setting `LINES'/`COLUMNS' env vars freezes ncurses apps like htop at
@@ -13688,6 +13871,10 @@ integration script runs, so input echo must be enabled before exec.
         (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
                (ghostel-shell "/bin/bash")
                (ghostel-shell-integration t)
+               ;; Pin the wrap off so the assertion targets the un-nested
+               ;; `exec /bin/bash --posix' form.  Login-wrap behavior is
+               ;; covered by its own dedicated tests.
+               (ghostel-macos-login-shell nil)
                (default-directory "/tmp/")
                (proc (ghostel--start-process)))
           (unwind-protect
@@ -15337,6 +15524,19 @@ slip past the unit tests."
     ghostel-test-local-host-p
     ghostel-test-update-directory-remote
     ghostel-test-get-shell-local
+    ghostel-test-shell-program-and-args-string
+    ghostel-test-shell-program-and-args-list
+    ghostel-test-shell-program-and-args-invalid
+    ghostel-test-get-shell-local-returns-program-from-list
+    ghostel-test-macos-login-wrap-basic
+    ghostel-test-macos-login-wrap-hushlogin
+    ghostel-test-macos-login-wrap-extra-args
+    ghostel-test-start-process-darwin-login-wrap
+    ghostel-test-start-process-darwin-login-wrap-opt-out
+    ghostel-test-start-process-non-darwin-no-login-wrap
+    ghostel-test-start-process-list-shell-passes-args
+    ghostel-test-start-process-list-shell-combines-with-integration
+    ghostel-test-start-process-darwin-login-wrap-with-integration
     ghostel-test-fish-auto-inject-loads-integration
     ghostel-test-tramp-inside-emacs-preserves-ghostel-prefix
     ghostel-test-remote-term-preamble


### PR DESCRIPTION
Closes #285.

## Summary

- Mirror Apple's Terminal.app / Ghostty on macOS: wrap the interactive shell with `/usr/bin/login [-q] -flp $USER /bin/bash --noprofile --norc -c "exec -l <shell> [args]"` so it starts as a login shell and `~/.zprofile` / `~/.bash_profile` get sourced.
- New `ghostel-macos-login-shell` defcustom (defaults `t` on Darwin, `nil` elsewhere). Opt-out is a single `setq`.
- `ghostel-shell` now accepts a list — `'("/bin/zsh" "--login")` — so the vterm-style workaround works on any platform. (It didn't before because the spawn wrapper shell-quotes the program as one token.)
- `ghostel-debug-info` is taught to split the list form before passing to `ghostel--detect-shell`.

## Why login(1) and a bash shim

This is what Ghostty does on macOS (`src/termio/Exec.zig:1428-1546`). `login(1)` produces a proper login session (sets `SHELL`, fixes `getlogin()`, applies PAM, honors hushlogin); `-p` preserves the integration env (`ZDOTDIR`, `ENV`, `XDG_DATA_DIRS`, `EMACS_GHOSTEL_PATH`, `INSIDE_EMACS`); `-l` skips chdir-to-home. The `/bin/bash` shim runs only `exec -l <shell>` — that builtin prepends `-` to argv[0], which is what causes the final shell to read its login files. `--noprofile --norc` keep the shim's own bash from loading anything. Ghostty's comment notes bash is ~2x faster than zsh at `exec` on Sonoma; that's why bash is the shim regardless of the user's actual shell.

Wrap is gated: only when `system-type` is `darwin`, `ghostel-macos-login-shell` is non-nil, and `default-directory` is local. TRAMP and `ghostel-exec` (arbitrary commands) are not wrapped.

Note `login -p` *always* resets `HOME`, `SHELL`, `LOGNAME`, `USER`, and `MAIL` from passwd — documented in the defcustom's docstring.

## Why not Linux

On Linux the env from `~/.profile` is already loaded by the display manager / systemd user session (`pam_env`, `~/.xprofile`). Re-running it per terminal would re-fire `PATH` appends and grow the env. macOS has no equivalent; nothing loads `.zprofile` unless the terminal is a login shell. Ghostty applies the same Darwin-only gate. Linux users who want a login shell can use the new list form: `(setq ghostel-shell '("/bin/zsh" "-l"))`.

## Test plan

- [x] `make -j4 all` clean: 78 zig + 183 native + 395 elisp pass (2 pre-existing skips), lint clean
- [x] 13 new ERT tests: splitter (string/list/invalid/nil/empty), wrap helper (basic/hushlogin/extra-args), `ghostel--start-process` (darwin wrap on / opt-out / non-darwin / list shell / list + bash `--posix` integration / wrap + list + integration composed)
- [x] Live verify on macOS with sandbox `ZDOTDIR` and a marker file in `.zprofile`:
  - `ghostel-macos-login-shell t` → `.zprofile` sourced ✓
  - `ghostel-shell '("/bin/zsh" "--login")` → `.zprofile` sourced ✓
  - control (plain non-login) → `.zprofile` NOT sourced (correct baseline)
- [x] Existing `ghostel-test-start-process-local-bash-integration-keeps-early-echo` pinned `ghostel-macos-login-shell nil` so its `exec /bin/bash --posix` assertion still targets the un-nested form; the new wrap path is covered by the new composed-integration test