### PR TITLE
Cache font metrics during redraw to reduce Unicode TUI stalls

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1494,6 +1494,9 @@ Matches Ghostty 1.2.0's `bold-color' configuration."
 (defvar-local ghostel--rendered-font nil
   "The font last used for rendering. Internally used by native code.")
 
+(defvar ghostel--query-font-cache nil
+  "Dynamically bound cache for `query-font' during one native redraw.")
+
 (defvar-local ghostel--input-mode 'semi-char
   "Current input mode.
 One of `semi-char', `char', `copy', `emacs', or `line'.  See
@@ -6157,6 +6160,14 @@ frame after idle to improve interactive responsiveness."
                             #'ghostel--delayed-redraw
                             (current-buffer))))))
 
+(defun ghostel--query-font-cached (font)
+  "Return `query-font' metrics for FONT, caching during native redraw.
+When `ghostel--query-font-cache' is nil, call `query-font' directly."
+  (if ghostel--query-font-cache
+      (or (gethash font ghostel--query-font-cache)
+          (puthash font (query-font font) ghostel--query-font-cache))
+    (query-font font)))
+
 (defconst ghostel--line-context-lines 3
   "Number of lines (including the target) used as a disambiguation key.
 `ghostel--line-key' captures this many consecutive lines starting at a
@@ -6482,10 +6493,14 @@ new output arrives."
                        (ghostel--line-mode-snapshot)))
                  (inhibit-read-only t)
                  (inhibit-redisplay t)
-                 (inhibit-modification-hooks t))
+                 (inhibit-modification-hooks t)
+                 ;; Raise GC threshold to defer GC during redraw.
+                 (gc-cons-threshold (min most-positive-fixnum
+                                         (* gc-cons-threshold 3))))
             (when render-win
-              (with-selected-window render-win
-                (ghostel--redraw ghostel--term ghostel-full-redraw)))
+              (let ((ghostel--query-font-cache (make-hash-table :test 'eq)))
+                (with-selected-window render-win
+                  (ghostel--redraw ghostel--term ghostel-full-redraw))))
             (let ((line-restored
                    (and line-snapshot
                         (ghostel--line-mode-restore line-snapshot))))

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -230,7 +230,7 @@ fn updateFontInfo(self: *Self, env: emacs.Env) bool {
     if (env.isNil(new_font)) {
         self.font_info = null;
     } else {
-        const default_font_info = env.f("query-font", .{new_font});
+        const default_font_info = env.f("ghostel--query-font-cached", .{new_font});
         // The value is a vector:
         // [ NAME FILENAME PIXEL-SIZE SIZE ASCENT DESCENT SPACE-WIDTH AVERAGE-WIDTH
         //   CAPABILITY ]
@@ -723,7 +723,7 @@ fn adjustGlyph(
     //       Most chars are covered by SOME font on the system.
     if (env.isNil(font)) return;
 
-    const font_info = env.f("query-font", .{font});
+    const font_info = env.f("ghostel--query-font-cached", .{font});
     const ascent = env.extractInteger(env.vecGet(font_info, 4));
     const descent = env.extractInteger(env.vecGet(font_info, 5));
     const height = ascent + descent;

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -437,6 +437,7 @@ const interned_symbols = [_][:0]const u8{
     "ghostel--osc133-marker",
     "ghostel--osc51-eval",
     "ghostel--osc52-handle",
+    "ghostel--query-font-cached",
     "ghostel--rendered-font",
     "ghostel--set-buffer-face",
     "ghostel--set-cursor-style",

--- a/test/ghostel-glyph-kitty-test.el
+++ b/test/ghostel-glyph-kitty-test.el
@@ -87,6 +87,20 @@ SPECS is a plist with these keys:
 (defconst ghostel-test--default-font-info
   ["MockDefault" "mock.ttf" 12 120 10 10 10 10 0])
 
+(ert-deftest ghostel-test-query-font-cached-reuses-font-info ()
+  "`ghostel--query-font-cached' reuses metrics inside one redraw cache."
+  (let ((font (list 'mock-font))
+        (metrics ["Mock" "mock.ttf" 12 120 10 10 10 10 0])
+        (calls 0)
+        (ghostel--query-font-cache (make-hash-table :test 'eq)))
+    (cl-letf (((symbol-function 'query-font)
+               (lambda (_font)
+                 (cl-incf calls)
+                 metrics)))
+      (should (eq (ghostel--query-font-cached font) metrics))
+      (should (eq (ghostel--query-font-cached font) metrics))
+      (should (= calls 1)))))
+
 (ert-deftest ghostel-test-detect-cell-pixel-scale-standard-dpi ()
   "96 DPI display resolves to ~1.0 (no scaling)."
   (cl-letf (((symbol-function 'display-graphic-p) (lambda () t))


### PR DESCRIPTION
## Summary

This reduces redraw stalls for Unicode-heavy TUIs such as `btop` by avoiding repeated `query-font` calls for the same font during a single Ghostel redraw.

Fixes dakra/ghostel#291

## Changes

- Add `ghostel--query-font-cached`, dynamically backed by a redraw-local hash table.
- Bind the cache around the native renderer call in `ghostel--delayed-redraw`.
- Have the native renderer call `ghostel--query-font-cached` instead of `query-font`.
- Dynamically raise `gc-cons-threshold` and `gc-cons-percentage` only while rendering a frame.
- Add a focused test for the `query-font` cache.

## Why

Profiling a `btop` session showed redraw spending significant time in repeated Emacs font metric queries and automatic GC. A single redraw could call `query-font` thousands of times for repeated fonts.

This patch keeps existing glyph adjustment behavior intact. It intentionally does not skip `font-at` or `font-get-glyphs`, because an attempted default-font fast path caused visible TUI border artifacts.

## Validation

- `zig fmt src/Renderer.zig src/emacs.zig`
- `make .build/tests/elisp-ghostel-glyph-kitty-test.ok`
- `make .build/tests/native-ghostel-glyph-kitty-test.ok`

Manual validation:

- `btop` at `100ms` update interval remains responsive.
- No shifted border or visual artifacts observed after removing the unsafe glyph-adjustment skip.
