### PR TITLE
Add multi-terminal navigation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,6 +811,7 @@ inside a light Emacs):
 | `ghostel-tramp-default-method`   | `nil`                | TRAMP method for new remote paths from OSC 7 (nil uses `tramp-default-method`) |
 | `ghostel-tramp-shell-integration` | `nil`               | Auto-inject shell integration for remote TRAMP sessions  |
 | `ghostel-buffer-name`            | `"*ghostel*"`        | Default buffer name                                      |
+| `ghostel-project-buffer-scope`   | `both`               | How `ghostel-project-{next,previous,list-buffers}` decide project membership: `default-directory`, `identity`, or `both` |
 | `ghostel-max-scrollback`         | `5MB`                | Maximum scrollback size in bytes (materialized into the Emacs buffer; ~5,000 rows on 80-col terminals) |
 | `ghostel-timer-delay`            | `0.033`              | Base redraw delay in seconds (~30fps)                    |
 | `ghostel-adaptive-fps`           | `t`                  | Adaptive frame rate (shorter delay after idle, stop timer when idle) |
@@ -882,6 +883,12 @@ When `evil-ghostel-mode` is active:
 | `M-x ghostel`                  | Open a new terminal (create new buffer with prefix arg) |
 | `M-x ghostel-project`          | Open a terminal in the current project root (create new buffer with prefix arg)  |
 | `M-x ghostel-other`            | Switch to next terminal or create one        |
+| `M-x ghostel-next`             | Cycle to next ghostel buffer (sorted by name, wraps) |
+| `M-x ghostel-previous`         | Cycle to previous ghostel buffer             |
+| `M-x ghostel-list-buffers`     | Pick a ghostel buffer via `read-buffer`      |
+| `M-x ghostel-project-next`     | Cycle to next ghostel buffer in current project |
+| `M-x ghostel-project-previous` | Cycle to previous ghostel buffer in current project |
+| `M-x ghostel-project-list-buffers` | Pick a project-scoped ghostel buffer     |
 | `M-x ghostel-clear`            | Clear screen and scrollback                  |
 | `M-x ghostel-clear-scrollback` | Clear scrollback only                        |
 | `M-x ghostel-semi-char-mode`   | Switch to semi-char input mode (default)     |

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -36,9 +36,15 @@
 ;;
 ;; Usage:
 ;;
-;;   M-x ghostel          Open a new terminal
-;;   M-x ghostel-project  Open a terminal in the current project root
-;;   M-x ghostel-other    Switch to next terminal or create one
+;;   M-x ghostel               Open a new terminal
+;;   M-x ghostel-project       Open a terminal in the current project root
+;;   M-x ghostel-other         Switch to next terminal or create one
+;;   M-x ghostel-next / ghostel-previous
+;;                             Cycle through all ghostel buffers
+;;   M-x ghostel-list-buffers  Pick a ghostel buffer to switch to
+;;   M-x ghostel-project-next / ghostel-project-previous /
+;;       ghostel-project-list-buffers
+;;                             Same, scoped to the current project
 ;;
 ;; Key bindings in the terminal buffer:
 ;;
@@ -351,6 +357,24 @@ aggressive partial screen updates, but may use more CPU."
 (defcustom ghostel-buffer-name "*ghostel*"
   "Default buffer name for ghostel terminals."
   :type 'string)
+
+(defcustom ghostel-project-buffer-scope 'both
+  "How `ghostel-project-next', `-previous', and `-list-buffers' scope buffers.
+Controls which ghostel buffers are considered part of the current
+project:
+- `default-directory': match each buffer's `default-directory'
+  against the current project root.  Follows shell `cd'.
+  A terminal that walked out of the project is excluded; a plain
+  `ghostel' buffer that cd'd into the project is included.
+- `identity': match each buffer's `ghostel--buffer-identity'
+  against the value `project-prefixed-buffer-name' would produce
+  for the current project.  Stable across `cd', but only finds
+  buffers originally created via `ghostel-project'.
+- `both' (default): union of the two - `default-directory' first,
+  then identity-matched buffers not already covered."
+  :type '(choice (const :tag "Match by buffer default-directory" default-directory)
+                 (const :tag "Match by creation-time project identity" identity)
+                 (const :tag "Both (union)" both)))
 
 (defcustom ghostel-set-title-function #'ghostel--set-title-default
   "Function called when the terminal reports a new title (OSC 2).
@@ -6913,6 +6937,146 @@ Returns the buffer."
         (pop-to-buffer (car others) (append display-buffer--same-window-action
                                             '((category . comint))))
       (ghostel))))
+
+(defun ghostel--all-buffers ()
+  "Return all live `ghostel-mode' buffers, sorted alphabetically by name.
+Sorted (not `buffer-list' order) so cycle commands advance through
+the same sequence regardless of recent buffer-switch history."
+  (sort (cl-remove-if-not
+         (lambda (b) (with-current-buffer b (derived-mode-p 'ghostel-mode)))
+         (buffer-list))
+        (lambda (a b) (string< (buffer-name a) (buffer-name b)))))
+
+(defun ghostel--project-buffers ()
+  "Return ghostel buffers belonging to the current project, sorted by name.
+Scoping is controlled by `ghostel-project-buffer-scope'.  Signals
+`user-error' if there is no current project.
+
+Buffers whose `default-directory' is remote are skipped in the
+`default-directory' scope branch — querying `project-current'
+against a TRAMP path would walk the remote filesystem
+synchronously on every cycle."
+  (let* ((proj (project-current t))
+         (root (project-root proj))
+         (identity-prefix
+          (let ((ghostel-buffer-name
+                 (project-prefixed-buffer-name
+                  (string-trim ghostel-buffer-name "*" "*"))))
+            ghostel-buffer-name))
+         (scope ghostel-project-buffer-scope)
+         (all (ghostel--all-buffers))
+         (by-dir
+          (and (memq scope '(default-directory both))
+               (cl-remove-if-not
+                (lambda (b)
+                  (let ((bd (buffer-local-value 'default-directory b)))
+                    (and bd
+                         (not (file-remote-p bd))
+                         (ignore-errors
+                           (let ((bp (project-current nil bd)))
+                             (and bp (equal (project-root bp) root)))))))
+                all)))
+         (by-id
+          (and (memq scope '(identity both))
+               (cl-remove-if-not
+                (lambda (b)
+                  (equal (buffer-local-value 'ghostel--buffer-identity b)
+                         identity-prefix))
+                all))))
+    (sort (cl-delete-duplicates (append by-dir by-id) :test #'eq)
+          (lambda (a b) (string< (buffer-name a) (buffer-name b))))))
+
+(defun ghostel--cycle (bufs direction empty-msg single-msg)
+  "Pop to the BUFS entry DIRECTION steps from current; wraps around.
+DIRECTION is +1 or -1.  Signals `user-error' with EMPTY-MSG when
+BUFS is empty.  Shows SINGLE-MSG when BUFS contains only the
+current buffer.  If the current buffer is not in BUFS, jump to
+the first or last entry depending on DIRECTION."
+  (cond
+   ((null bufs)
+    (user-error "%s" empty-msg))
+   ((and (= (length bufs) 1) (eq (car bufs) (current-buffer)))
+    (message "%s" single-msg))
+   (t
+    (let* ((current (current-buffer))
+           (idx (cl-position current bufs))
+           (n (length bufs))
+           (next (cond
+                  ((null idx) (if (> direction 0) (car bufs) (car (last bufs))))
+                  (t (nth (mod (+ idx direction) n) bufs)))))
+      (pop-to-buffer next (append display-buffer--same-window-action
+                                  '((category . comint))))))))
+
+;;;###autoload
+(defun ghostel-next ()
+  "Switch to the next ghostel buffer (sorted by name, wraps around)."
+  (interactive)
+  (ghostel--cycle (ghostel--all-buffers) +1
+                  "No ghostel buffers"
+                  "Only one ghostel buffer"))
+
+;;;###autoload
+(defun ghostel-previous ()
+  "Switch to the previous ghostel buffer (sorted by name, wraps around)."
+  (interactive)
+  (ghostel--cycle (ghostel--all-buffers) -1
+                  "No ghostel buffers"
+                  "Only one ghostel buffer"))
+
+;;;###autoload
+(defun ghostel-project-next ()
+  "Switch to the next ghostel buffer in the current project (wraps around).
+Project membership is determined by `ghostel-project-buffer-scope'."
+  (interactive)
+  (ghostel--cycle (ghostel--project-buffers) +1
+                  "No ghostel buffers in this project"
+                  "Only one ghostel buffer in this project"))
+
+;;;###autoload
+(defun ghostel-project-previous ()
+  "Switch to the previous ghostel buffer in the current project (wraps around).
+Project membership is determined by `ghostel-project-buffer-scope'."
+  (interactive)
+  (ghostel--cycle (ghostel--project-buffers) -1
+                  "No ghostel buffers in this project"
+                  "Only one ghostel buffer in this project"))
+
+(defun ghostel--read-buffer (prompt bufs)
+  "Prompt with PROMPT for one of BUFS via `read-buffer'.
+Default candidate is the buffer `ghostel-next' would land on, so RET
+matches the forward-cycle direction.  Returns the chosen buffer or
+signals `user-error' if BUFS is empty."
+  (when (null bufs)
+    (user-error "No ghostel buffers"))
+  (let* ((names (mapcar #'buffer-name bufs))
+         (current (current-buffer))
+         (idx (cl-position current bufs))
+         (default (cond
+                   ((null idx) (car names))
+                   (t (nth (mod (1+ idx) (length bufs)) names))))
+         (chosen (read-buffer prompt default t
+                              (lambda (cand)
+                                (let ((name (if (consp cand) (car cand) cand)))
+                                  (member name names))))))
+    (get-buffer chosen)))
+
+;;;###autoload
+(defun ghostel-list-buffers ()
+  "Pick a ghostel buffer to switch to via `read-buffer'."
+  (interactive)
+  (pop-to-buffer (ghostel--read-buffer "Ghostel buffer: " (ghostel--all-buffers))
+                 (append display-buffer--same-window-action
+                         '((category . comint)))))
+
+;;;###autoload
+(defun ghostel-project-list-buffers ()
+  "Pick a ghostel buffer in the current project via `read-buffer'.
+Project membership is determined by `ghostel-project-buffer-scope'."
+  (interactive)
+  (pop-to-buffer (ghostel--read-buffer "Project ghostel buffer: "
+                                       (ghostel--project-buffers))
+                 (append display-buffer--same-window-action
+                         '((category . comint)))))
 
 (provide 'ghostel)
 

--- a/test/ghostel-buffers-test.el
+++ b/test/ghostel-buffers-test.el
@@ -1,0 +1,235 @@
+;;; ghostel-buffers-test.el --- Tests for ghostel: multi-buffer navigation -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Cycle commands, list pickers, and project-scoped variants.
+;; All tests are pure elisp — no native module required.
+
+;;; Code:
+
+(require 'ghostel-test-helpers)
+
+(defun ghostel-buffers-test--make (name &optional dir identity)
+  "Create a fake ghostel-mode buffer for tests.
+NAME is the buffer name.  Optional DIR sets `default-directory'
+and IDENTITY sets `ghostel--buffer-identity'.  The buffer claims
+`ghostel-mode' via `major-mode' without invoking the mode
+function (which would require the native module)."
+  (let ((buf (generate-new-buffer name)))
+    (with-current-buffer buf
+      (setq major-mode 'ghostel-mode)
+      (when dir (setq default-directory dir))
+      (when identity (setq-local ghostel--buffer-identity identity)))
+    buf))
+
+(defmacro ghostel-buffers-test--with-bufs (bindings &rest body)
+  "Run BODY with fake ghostel buffers from BINDINGS, killing them after.
+Each BINDING is (VAR NAME [DIR [IDENTITY]])."
+  (declare (indent 1))
+  `(let ,(mapcar (lambda (b)
+                   `(,(car b) (ghostel-buffers-test--make ,@(cdr b))))
+                 bindings)
+     (unwind-protect (progn ,@body)
+       ,@(mapcar (lambda (b) `(when (buffer-live-p ,(car b))
+                                (kill-buffer ,(car b))))
+                 bindings))))
+
+(ert-deftest ghostel-test-all-buffers-sorted ()
+  "`ghostel--all-buffers' returns ghostel buffers sorted by name."
+  (ghostel-buffers-test--with-bufs ((c "*ghostel-c*")
+                                    (a "*ghostel-a*")
+                                    (b "*ghostel-b*"))
+    (let ((bufs (ghostel--all-buffers)))
+      (should (equal (mapcar #'buffer-name bufs)
+                     '("*ghostel-a*" "*ghostel-b*" "*ghostel-c*"))))))
+
+(ert-deftest ghostel-test-all-buffers-excludes-non-ghostel ()
+  "`ghostel--all-buffers' skips buffers without `ghostel-mode'."
+  (ghostel-buffers-test--with-bufs ((g "*ghostel-x*"))
+    (let ((other (generate-new-buffer "*not-ghostel*")))
+      (unwind-protect
+          (let ((bufs (ghostel--all-buffers)))
+            (should (memq g bufs))
+            (should-not (memq other bufs)))
+        (kill-buffer other)))))
+
+(ert-deftest ghostel-test-next-cycles-and-wraps ()
+  "`ghostel-next' advances forward and wraps from last to first."
+  (ghostel-buffers-test--with-bufs ((a "*ghostel-a*")
+                                    (b "*ghostel-b*")
+                                    (c "*ghostel-c*"))
+    (let (popped)
+      (cl-letf (((symbol-function 'pop-to-buffer)
+                 (lambda (buf &rest _) (setq popped buf))))
+        (with-current-buffer a (ghostel-next))
+        (should (eq popped b))
+        (with-current-buffer b (ghostel-next))
+        (should (eq popped c))
+        (with-current-buffer c (ghostel-next))
+        (should (eq popped a))))))
+
+(ert-deftest ghostel-test-previous-cycles-and-wraps ()
+  "`ghostel-previous' advances backward and wraps from first to last."
+  (ghostel-buffers-test--with-bufs ((a "*ghostel-a*")
+                                    (b "*ghostel-b*")
+                                    (c "*ghostel-c*"))
+    (let (popped)
+      (cl-letf (((symbol-function 'pop-to-buffer)
+                 (lambda (buf &rest _) (setq popped buf))))
+        (with-current-buffer c (ghostel-previous))
+        (should (eq popped b))
+        (with-current-buffer b (ghostel-previous))
+        (should (eq popped a))
+        (with-current-buffer a (ghostel-previous))
+        (should (eq popped c))))))
+
+(ert-deftest ghostel-test-cycle-non-ghostel-current ()
+  "From a non-ghostel buffer, `ghostel-next' jumps to first; `-previous' to last."
+  (ghostel-buffers-test--with-bufs ((a "*ghostel-a*")
+                                    (b "*ghostel-b*"))
+    (let ((other (generate-new-buffer "*scratch-x*")) popped)
+      (unwind-protect
+          (cl-letf (((symbol-function 'pop-to-buffer)
+                     (lambda (buf &rest _) (setq popped buf))))
+            (with-current-buffer other (ghostel-next))
+            (should (eq popped a))
+            (with-current-buffer other (ghostel-previous))
+            (should (eq popped b)))
+        (kill-buffer other)))))
+
+(ert-deftest ghostel-test-cycle-single-buffer-no-op ()
+  "Cycling with one buffer that is current is a no-op, with a clean message."
+  (ghostel-buffers-test--with-bufs ((a "*ghostel-a*"))
+    (let (popped captured-msg)
+      (cl-letf (((symbol-function 'pop-to-buffer)
+                 (lambda (buf &rest _) (setq popped buf)))
+                ((symbol-function 'message)
+                 (lambda (fmt &rest args)
+                   (setq captured-msg (apply #'format fmt args)))))
+        (with-current-buffer a (ghostel-next))
+        (should-not popped)
+        (should (equal captured-msg "Only one ghostel buffer"))
+        (setq captured-msg nil)
+        (with-current-buffer a (ghostel-previous))
+        (should-not popped)
+        (should (equal captured-msg "Only one ghostel buffer"))))))
+
+(ert-deftest ghostel-test-cycle-no-buffers-errors ()
+  "`ghostel-next'/`-previous' with zero ghostel buffers signals `user-error'."
+  (should-error (ghostel-next) :type 'user-error)
+  (should-error (ghostel-previous) :type 'user-error))
+
+(ert-deftest ghostel-test-list-buffers-predicate ()
+  "`ghostel-list-buffers' offers only ghostel buffers to `read-buffer'."
+  (ghostel-buffers-test--with-bufs ((a "*ghostel-a*")
+                                    (b "*ghostel-b*"))
+    (let ((other (generate-new-buffer "*not-ghostel*")) captured-pred)
+      (unwind-protect
+          (cl-letf (((symbol-function 'read-buffer)
+                     (lambda (_prompt _default _require-match pred)
+                       (setq captured-pred pred)
+                       (buffer-name a)))
+                    ((symbol-function 'pop-to-buffer) (lambda (&rest _) nil)))
+            (ghostel-list-buffers)
+            (should captured-pred)
+            (should (funcall captured-pred (buffer-name a)))
+            (should (funcall captured-pred (buffer-name b)))
+            (should-not (funcall captured-pred (buffer-name other))))
+        (kill-buffer other)))))
+
+(ert-deftest ghostel-test-list-buffers-default-is-next ()
+  "`ghostel-list-buffers' defaults to the forward-cycle buffer."
+  (ghostel-buffers-test--with-bufs ((a "*ghostel-a*")
+                                    (b "*ghostel-b*")
+                                    (c "*ghostel-c*"))
+    (let (captured-default)
+      (cl-letf (((symbol-function 'read-buffer)
+                 (lambda (_prompt default &rest _)
+                   (setq captured-default default)
+                   (buffer-name a)))
+                ((symbol-function 'pop-to-buffer) (lambda (&rest _) nil)))
+        (with-current-buffer b (ghostel-list-buffers))
+        (should (equal captured-default (buffer-name c)))))))
+
+(ert-deftest ghostel-test-list-buffers-no-buffers-errors ()
+  "`ghostel-list-buffers' signals `user-error' when none exist."
+  (should-error (ghostel-list-buffers) :type 'user-error))
+
+;;; Project-scope helpers
+
+(defun ghostel-buffers-test--proj-stub (root)
+  "Return a `project-current' stub: project rooted at ROOT, else nil."
+  (lambda (&optional _maybe-prompt &rest rest)
+    (let ((dir (or (car rest) default-directory)))
+      (when (and dir (string-prefix-p root (expand-file-name dir)))
+        (cons 'transient root)))))
+
+(ert-deftest ghostel-test-project-buffers-default-directory ()
+  "Scope `default-directory' matches buffers under the project root."
+  (let ((root "/tmp/myproj/"))
+    (ghostel-buffers-test--with-bufs
+        ((inside "*ghostel-in*" "/tmp/myproj/src/")
+         (outside "*ghostel-out*" "/tmp/other/")
+         (also-in "*ghostel-also*" "/tmp/myproj/"))
+      (cl-letf (((symbol-function 'project-current)
+                 (ghostel-buffers-test--proj-stub root))
+                ((symbol-function 'project-root) (lambda (p) (cdr p)))
+                ((symbol-function 'project-prefixed-buffer-name)
+                 (lambda (name) (format "*myproj-%s*" name))))
+        (let ((default-directory root)
+              (ghostel-project-buffer-scope 'default-directory))
+          (let ((bufs (ghostel--project-buffers)))
+            (should (memq inside bufs))
+            (should (memq also-in bufs))
+            (should-not (memq outside bufs))))))))
+
+(ert-deftest ghostel-test-project-buffers-identity ()
+  "Scope `identity' matches buffers whose identity is the project-prefixed name."
+  (let ((root "/tmp/myproj/")
+        (ghostel-buffer-name "*ghostel*"))
+    (ghostel-buffers-test--with-bufs
+        ((tagged "*ghostel-tagged*" "/tmp/other/" "*myproj-ghostel*")
+         (untagged "*ghostel-untag*" "/tmp/myproj/" nil))
+      (cl-letf (((symbol-function 'project-current)
+                 (ghostel-buffers-test--proj-stub root))
+                ((symbol-function 'project-root) (lambda (p) (cdr p)))
+                ((symbol-function 'project-prefixed-buffer-name)
+                 (lambda (name) (format "*myproj-%s*" name))))
+        (let ((default-directory root)
+              (ghostel-project-buffer-scope 'identity))
+          (let ((bufs (ghostel--project-buffers)))
+            (should (memq tagged bufs))
+            (should-not (memq untagged bufs))))))))
+
+(ert-deftest ghostel-test-project-buffers-both ()
+  "Scope `both' unions `default-directory' and identity matches; no duplicates."
+  (let ((root "/tmp/myproj/")
+        (ghostel-buffer-name "*ghostel*"))
+    (ghostel-buffers-test--with-bufs
+        ((by-dir "*ghostel-d*" "/tmp/myproj/" nil)
+         (by-id "*ghostel-i*" "/tmp/other/" "*myproj-ghostel*")
+         (both "*ghostel-b*" "/tmp/myproj/sub/" "*myproj-ghostel*")
+         (neither "*ghostel-n*" "/tmp/other/" nil))
+      (cl-letf (((symbol-function 'project-current)
+                 (ghostel-buffers-test--proj-stub root))
+                ((symbol-function 'project-root) (lambda (p) (cdr p)))
+                ((symbol-function 'project-prefixed-buffer-name)
+                 (lambda (name) (format "*myproj-%s*" name))))
+        (let ((default-directory root)
+              (ghostel-project-buffer-scope 'both))
+          (let ((bufs (ghostel--project-buffers)))
+            (should (memq by-dir bufs))
+            (should (memq by-id bufs))
+            (should (memq both bufs))
+            (should-not (memq neither bufs))
+            (should (= 1 (cl-count both bufs)))))))))
+
+(ert-deftest ghostel-test-project-next-without-project-errors ()
+  "`ghostel-project-next' errors when there is no current project."
+  (cl-letf (((symbol-function 'project-current)
+             (lambda (&optional maybe-prompt &rest _)
+               (when maybe-prompt (user-error "No project")))))
+    (should-error (ghostel-project-next) :type 'user-error)))
+
+(provide 'ghostel-buffers-test)
+;;; ghostel-buffers-test.el ends here


### PR DESCRIPTION
## Summary

- Adds `ghostel-next`, `ghostel-previous`, and `ghostel-list-buffers` for cycling and picking among ghostel terminal buffers (closes #53).
- Adds project-scoped variants: `ghostel-project-next`, `ghostel-project-previous`, `ghostel-project-list-buffers`.
- Adds `ghostel-project-buffer-scope` defcustom (`default-directory` | `identity` | `both`, default `both`) controlling how the `-project-` commands decide buffer membership.

Cycle commands sort by buffer name (stable across recent buffer-switch history) and wrap around. Pickers default to the forward-cycle buffer so `RET` matches `ghostel-next`. The `default-directory` scope skips remote (TRAMP) buffers to avoid synchronous remote-FS walks on every cycle.

`ghostel-other` is left untouched — its create-on-demand semantics differ from the new commands' explicit no-buffer error.

## Test plan

- [x] `make -j4 all` (build + 14 new pure-elisp tests + lint, all green)
- [x] Live: open three terminals, bind `ghostel-next`/`ghostel-previous` to keys, confirm cycle + wrap.
- [x] Live: `M-x ghostel-list-buffers` lists only ghostel buffers; default candidate matches forward cycle.
- [x] Live: from inside a project, `M-x ghostel-project-next` skips out-of-project terminals; same command outside any project signals a user-error.