### PR TITLE
Route OSC actions through a custom stream handler

### DIFF
--- a/src/GhostelHandler.zig
+++ b/src/GhostelHandler.zig
@@ -1,0 +1,259 @@
+//! Custom stream handler that delegates almost everything to libghostty's
+//! standard terminal handler but intercepts OSC-related actions so we can route
+//! them to Elisp callbacks instead of re-parsing the same bytes ourselves.
+
+const std = @import("std");
+
+const emacs = @import("emacs.zig");
+const gt = @import("ghostty-vt");
+const GhostelTerm = @import("terminal.zig");
+
+const Self = @This();
+
+inner: gt.TerminalStream.Handler,
+
+pub fn init(terminal: *gt.Terminal) Self {
+    return .{ .inner = .init(terminal) };
+}
+
+/// Called by `gt.Stream.deinit`.
+pub fn deinit(self: *Self) void {
+    self.inner.deinit();
+}
+
+/// Dispatcher invoked by `gt.Stream` for every parser action.  Anything
+/// outside the OSC arms below is forwarded verbatim to the standard
+/// handler so terminal state stays consistent.
+pub fn vt(
+    self: *Self,
+    comptime action: gt.StreamAction.Tag,
+    value: gt.StreamAction.Value(action),
+) void {
+    switch (action) {
+        // For `semantic_prompt` and `color_operation` we forward FIRST
+        // so the standard handler updates terminal state (per-row
+        // semantic flag, palette/dynamic color sets), then fire the
+        // Elisp callback / emit the query reply.
+        .semantic_prompt => {
+            self.inner.vt(action, value);
+            self.handleSemanticPrompt(value);
+        },
+        .color_operation => {
+            self.inner.vt(action, value);
+            self.handleColorOperation(value);
+        },
+
+        // For these, the standard handler is a no-op (see
+        // `stream_terminal.zig` — they are listed in the "no
+        // terminal-modifying effect" arm), so we handle them
+        // entirely here.
+        .report_pwd => self.handleReportPwd(value),
+        .clipboard_contents => self.handleClipboardContents(value),
+        .show_desktop_notification => self.handleNotification(value),
+        .progress_report => self.handleProgressReport(value),
+
+        else => self.inner.vt(action, value),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OSC 133 — semantic prompt
+// ---------------------------------------------------------------------------
+
+/// Fire `ghostel--osc133-marker` for the marker types ghostel's
+/// navigation tracks: A/N (fresh-line prompt), P (explicit prompt start),
+/// B (end of prompt prefix), C (start of output), D (end of command).
+///
+/// PARAM is the raw options string from the OSC - elisp parses it on
+/// demand (e.g. `(string-to-number param)` for the 'D' exit code).
+fn handleSemanticPrompt(self: *Self, sp: gt.osc.Command.SemanticPrompt) void {
+    const marker_char: u8 = switch (sp.action) {
+        .fresh_line_new_prompt, .new_command => 'A',
+        .prompt_start => 'P',
+        .end_prompt_start_input => 'B',
+        .end_input_start_output => 'C',
+        .end_command => 'D',
+        else => return,
+    };
+    const e = self.env() orelse return;
+    const type_str: [1]u8 = .{marker_char};
+    const param_val = if (sp.options_unvalidated.len > 0)
+        e.makeString(sp.options_unvalidated)
+    else
+        e.nil();
+    _ = e.f("ghostel--osc133-marker", .{ &type_str, param_val });
+}
+
+// ---------------------------------------------------------------------------
+// OSC 7 / OSC 9;9 — report PWD
+// ---------------------------------------------------------------------------
+
+/// Save the reported PWD on the terminal so the renderer's later
+/// `terminal.getPwd()` picks it up.
+fn handleReportPwd(self: *Self, v: gt.StreamAction.ReportPwd) void {
+    if (v.url.len == 0) return;
+    self.inner.terminal.setPwd(v.url) catch |err| {
+        if (self.env()) |e|
+            e.logError("setPwd failed: %s", .{@errorName(err)});
+    };
+}
+
+// ---------------------------------------------------------------------------
+// OSC 52 — clipboard contents
+// ---------------------------------------------------------------------------
+
+/// Forward clipboard SET requests to Elisp.  Queries ("?") and empty
+/// payloads carry no clipboard content, so they don't cross the FFI boundary.
+fn handleClipboardContents(self: *Self, v: gt.StreamAction.ClipboardContents) void {
+    if (v.data.len == 0) return;
+    if (v.data.len == 1 and v.data[0] == '?') return;
+    const e = self.env() orelse return;
+    const kind_str: [1]u8 = .{v.kind};
+    _ = e.f("ghostel--osc52-handle", .{ &kind_str, v.data });
+}
+
+// ---------------------------------------------------------------------------
+// OSC 9 (iTerm) / OSC 777 — desktop notification
+// ---------------------------------------------------------------------------
+
+/// An entirely empty notification (`\x1b]9;\x1b\\` or
+/// `\x1b]777;notify;;\x1b\\`) carries no content; the elisp default
+/// handler would just show the buffer name with an empty body.  Drop
+/// it at the FFI boundary rather than pay the call for nothing.
+fn handleNotification(self: *Self, v: gt.StreamAction.ShowDesktopNotification) void {
+    if (v.title.len == 0 and v.body.len == 0) return;
+    const e = self.env() orelse return;
+    _ = e.f("ghostel--handle-notification", .{ v.title, v.body });
+}
+
+// ---------------------------------------------------------------------------
+// OSC 9;4 — ConEmu progress
+// ---------------------------------------------------------------------------
+
+/// Forward the state and progress verbatim from ghostty's parser.
+fn handleProgressReport(self: *Self, v: gt.osc.Command.ProgressReport) void {
+    const e = self.env() orelse return;
+    const state_str: []const u8 = switch (v.state) {
+        .remove => "remove",
+        .set => "set",
+        .@"error" => "error",
+        .indeterminate => "indeterminate",
+        .pause => "pause",
+    };
+    const progress_val = if (v.progress) |p|
+        e.makeInteger(@intCast(p))
+    else
+        e.nil();
+    _ = e.f("ghostel--osc-progress", .{ state_str, progress_val });
+}
+
+// ---------------------------------------------------------------------------
+// OSC 4 / 10 / 11 — color query reply
+// ---------------------------------------------------------------------------
+
+/// Walk the request list looking for `.query` entries and emit a reply for each.
+/// The standard handler has already applied any `.set` / `.reset` entries in
+/// the same list, so the colors we read are the post-update values - which
+/// matches what shells expect when a single OSC carries both a set and a query.
+///
+/// We reply for OSC 4 (palette), OSC 10 (foreground), and OSC 11 (background).
+/// Other dynamic colors (cursor, pointer, highlight, tektronix) are queryable through
+/// this same action but ghostel doesn't track them, so their queries silently drop.
+fn handleColorOperation(self: *Self, v: gt.StreamAction.ColorOperation) void {
+    const e = self.env() orelse return;
+
+    var it = v.requests.constIterator(0);
+    while (it.next()) |req| {
+        const target = switch (req.*) {
+            .query => |t| t,
+            else => continue,
+        };
+        switch (target) {
+            .palette => |idx| {
+                const color = self.inner.terminal.colors.palette.current[idx];
+                sendPaletteColorReply(e, idx, color, v.terminator);
+            },
+            .dynamic => |d| switch (d) {
+                .foreground => {
+                    if (self.inner.terminal.colors.foreground.get()) |color|
+                        sendDynamicColorReply(e, 10, color, v.terminator);
+                },
+                .background => {
+                    if (self.inner.terminal.colors.background.get()) |color|
+                        sendDynamicColorReply(e, 11, color, v.terminator);
+                },
+                else => {}, // cursor / highlight / pointer / tektronix — drop
+            },
+            .special => {}, // OSC 5 — drop
+        }
+    }
+}
+
+/// Send `OSC N;rgb:RRRR/GGGG/BBBB <term>` for a dynamic color (OSC 10/11).
+fn sendDynamicColorReply(
+    e: emacs.Env,
+    osc_num: u8,
+    color: gt.color.RGB,
+    terminator: gt.osc.Terminator,
+) void {
+    var buf: [64]u8 = undefined;
+    const written = std.fmt.bufPrint(
+        &buf,
+        "\x1b]{d};rgb:{x:0>2}{x:0>2}/{x:0>2}{x:0>2}/{x:0>2}{x:0>2}{s}",
+        .{
+            osc_num,
+            color.r,
+            color.r,
+            color.g,
+            color.g,
+            color.b,
+            color.b,
+            terminator.string(),
+        },
+    ) catch return;
+    _ = e.f("ghostel--flush-output", .{written});
+}
+
+/// Send `OSC 4;INDEX;rgb:RRRR/GGGG/BBBB <term>` for a palette entry.
+fn sendPaletteColorReply(
+    e: emacs.Env,
+    index: u8,
+    color: gt.color.RGB,
+    terminator: gt.osc.Terminator,
+) void {
+    var buf: [64]u8 = undefined;
+    const written = std.fmt.bufPrint(
+        &buf,
+        "\x1b]4;{d};rgb:{x:0>2}{x:0>2}/{x:0>2}{x:0>2}/{x:0>2}{x:0>2}{s}",
+        .{
+            index,
+            color.r,
+            color.r,
+            color.g,
+            color.g,
+            color.b,
+            color.b,
+            terminator.string(),
+        },
+    ) catch return;
+    _ = e.f("ghostel--flush-output", .{written});
+}
+
+// ---------------------------------------------------------------------------
+// Env lookup
+// ---------------------------------------------------------------------------
+
+/// Reach back to the parent `GhostelTerm` so we can pick up its cached
+/// Emacs env.  Same pattern as `writePtyCallback` and friends in
+/// `module.zig`: the standard handler's `terminal` field points at
+/// `&GhostelTerm.terminal`, and `Self` is itself embedded in
+/// `GhostelTerm` via `Stream(Self).handler`.
+///
+/// Returns null when no Elisp call is in flight; under `zig build test`
+/// also short-circuits to null so unit tests can drive the dispatcher
+/// without standing up a real `GhostelTerm` and Emacs env.
+fn env(self: *Self) ?emacs.Env {
+    if (@import("builtin").is_test) return null;
+    const term: *GhostelTerm = @fieldParentPtr("terminal", self.inner.terminal);
+    return term.env;
+}

--- a/src/module.zig
+++ b/src/module.zig
@@ -260,14 +260,6 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
 
     const raw = data.?;
 
-    // Respond to OSC 4/10/11 color queries BEFORE feeding libghostty.
-    // libghostty will synchronously emit responses for other queries in
-    // the same write (e.g. CSI 6n cursor-position report) via the
-    // write_pty callback, and termenv-based programs read only the first
-    // response chunk — so the color reply must be on the wire first or
-    // the program discards our reply as noise.
-    extractOscColorQueries(env, term, raw);
-
     // Normalize CRLF by streaming directly into libghostty's parser.
     // Emacs PTYs lack ONLCR, so bare \n arrives without \r — insert
     // one before each bare \n by feeding the preceding segment verbatim
@@ -280,6 +272,10 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
     // starting with \n — is not mis-normalized into \r\r\n.  The final
     // value is persisted back for the next call. An empty input
     // round-trips the flag unchanged.
+    //
+    // All standard OSC sequences (4, 7, 9, 10, 11, 52, 133, 777) are
+    // intercepted by `GhostelHandler` inside the stream itself — no
+    // post-write byte scan is needed for them.
     var seg_start: usize = 0;
     var prev_was_cr: bool = term.last_input_was_cr;
     for (raw, 0..) |ch, i| {
@@ -297,406 +293,75 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
     }
     term.last_input_was_cr = prev_was_cr;
 
-    // Scan for OSC sequences that libghostty-vt discards (7, 51, 52, 133).
-    // One pass, dispatched by code in document order.
-    dispatchPostWriteOscs(env, term, raw);
+    // OSC 51;E (ghostel's elisp-eval extension) is not a standard OSC,
+    // so ghostty's parser drops it without firing an action.  Scan the
+    // raw input for it ourselves.
+    dispatchOsc51(env, raw);
 
     return env.nil();
 }
 
 // ---------------------------------------------------------------------------
-// OSC sequence helpers
+// OSC 51 (ghostel extension) — elisp eval
 // ---------------------------------------------------------------------------
 
-/// An OSC sequence extracted by `OscIterator`.
-const OscEntry = struct {
-    /// Decimal OSC code (e.g. 4, 7, 10, 11, 51, 52, 133).
-    code: u32,
-    /// Payload bytes between the code's trailing `;` and the terminator.
-    payload: []const u8,
-    /// Terminator bytes (BEL or ESC \) — forwarded back on replies.
-    terminator: []const u8,
-};
+// TODO: Ghostty's parser is a whitelist state machine and if a 5 is
+//   followed by 1, the parser transitions to .invalid.
+//   Replace this with either an upstream fix or change to OSC52;E
+//   OSC 52 is the clipboard parser where only the "c, p, s, q, 0-7"
+//   kinds are used.
 
-/// Single-pass iterator over well-formed OSC sequences in a byte slice.
-/// Advances past `ESC ]`, parses the decimal code up to `;`, locates the
-/// BEL/ST terminator, and yields `(code, payload, terminator)`.
+/// Only OSC 51 (ghostel's elisp-eval extension) still needs a byte scan
+/// because it is not a standard OSC that ghostty's parser knows about.
 ///
-/// An OSC payload is bounded by a real terminator (BEL or ESC \) OR by
-/// the next OSC introducer (ESC ]).  Stopping at a following introducer
-/// handles malformed input where one OSC is missing its terminator
-/// before the next begins — otherwise the partial OSC would cannibalize
-/// the following OSC's bytes (including its terminator) as its own
-/// payload, producing a garbage dispatch AND starving the next OSC.
-/// On partial detection we advance past the current introducer and let
-/// iteration continue, so well-formed OSCs later in the same buffer
-/// still dispatch.
-const OscIterator = struct {
-    data: []const u8,
-    pos: usize = 0,
-
-    fn next(self: *OscIterator) ?OscEntry {
-        while (self.pos < self.data.len) {
-            const intro = std.mem.indexOfPos(u8, self.data, self.pos, "\x1b]") orelse {
-                self.pos = self.data.len;
-                return null;
-            };
-            const code_start = intro + 2;
-
-            // Decimal code up to the first `;`.
-            var code_end = code_start;
-            while (code_end < self.data.len and self.data[code_end] >= '0' and self.data[code_end] <= '9') {
-                code_end += 1;
+/// Dispatch each `ESC ] 51 ; E <payload> (BEL|ST)` in `data` to
+/// `ghostel--osc51-eval`.  Other OSC 51 sub-codes (used by other
+/// terminals for things unrelated to elisp eval) are ignored.
+///
+/// Single-pass scan: the `intermediate` introducer carries the literal
+/// "E" so we can match the full prefix in one `indexOfPos`.  Limitation:
+/// an OSC 51 split across two `ghostel--write-input` calls is dropped
+/// entirely — we keep no carry-over state between calls.  Unlike
+/// ghostty's `Parser`, which buffers an OSC body across chunks, this
+/// scanner only sees one `data` slice at a time.  Adding carry-over
+/// would require per-`GhostelTerm` state; not worth it until an
+/// OSC 51 chunk-spanning case actually shows up.
+fn dispatchOsc51(env: emacs.Env, data: []const u8) void {
+    const intro = "\x1b]51;E";
+    var pos: usize = 0;
+    while (pos + intro.len <= data.len) {
+        const start = std.mem.indexOfPos(u8, data, pos, intro) orelse return;
+        const payload_start = start + intro.len;
+        // Find BEL or ST terminator.  Stops at the next OSC introducer
+        // too: a missing terminator on the current OSC should not
+        // cannibalize the following one.
+        var end = payload_start;
+        var term_len: usize = 0;
+        while (end < data.len) : (end += 1) {
+            const ch = data[end];
+            if (ch == 0x07) {
+                term_len = 1;
+                break;
             }
-            if (code_end == code_start or code_end >= self.data.len or self.data[code_end] != ';') {
-                self.pos = code_start;
-                continue;
-            }
-            const payload_start = code_end + 1;
-
-            // Scan for a terminator (BEL or ESC \) or the next OSC
-            // introducer (ESC ]), whichever comes first. An intervening
-            // introducer means the current OSC is partial.
-            var end = payload_start;
-            var term_len: usize = 0;
-            while (end < self.data.len) : (end += 1) {
-                const ch = self.data[end];
-                if (ch == 0x07) {
-                    term_len = 1;
+            if (ch == 0x1b and end + 1 < data.len) {
+                const next_ch = data[end + 1];
+                if (next_ch == '\\') {
+                    term_len = 2;
                     break;
                 }
-                if (ch == 0x1b and end + 1 < self.data.len) {
-                    const next_ch = self.data[end + 1];
-                    if (next_ch == '\\') {
-                        term_len = 2;
-                        break;
-                    }
-                    if (next_ch == ']') {
-                        // Next introducer — current OSC is partial.
-                        break;
-                    }
-                }
+                if (next_ch == ']') break; // next OSC — current is partial
             }
-            if (term_len == 0) {
-                // Partial OSC: skip past the current introducer (which
-                // we already parsed) and resume scanning. If `end` is
-                // still `self.data.len` there were no more introducers,
-                // and the next indexOfPos call will terminate iteration.
-                self.pos = if (end > code_start) end else code_start;
-                continue;
-            }
-
-            self.pos = end + term_len;
-            const code = std.fmt.parseInt(u32, self.data[code_start..code_end], 10) catch continue;
-            return .{
-                .code = code,
-                .payload = self.data[payload_start..end],
-                .terminator = self.data[end .. end + term_len],
-            };
         }
-        return null;
-    }
-};
-
-/// Dispatch OSC 7 / 51 / 52 / 133 from `data` in document order.
-/// These are the post-vtWrite sequences that libghostty-vt discards,
-/// so ghostel has to scan for them itself.  All four used to scan the
-/// buffer independently; one unified pass is strictly less work for
-/// bulk output and preserves source-order dispatch.  (OSC 4/10/11
-/// color queries use the same iterator but run before vtWrite — see
-/// `extractOscColorQueries`.)
-///
-/// Runs AFTER `vtWrite` so libghostty has already seen the bytes —
-/// OSC 7 calls back into libghostty (`setPwd`) and the others call
-/// Elisp.
-fn dispatchPostWriteOscs(env: emacs.Env, term: *GhostelTerm, data: []const u8) void {
-    var it = OscIterator{ .data = data };
-    while (it.next()) |osc| {
-        switch (osc.code) {
-            // OSC 7: working directory as a file:// URL.
-            7 => {
-                if (osc.payload.len == 0) continue;
-                term.terminal.setPwd(osc.payload) catch |err|
-                    env.logError("setPwd failed: %s", .{@errorName(err)});
-            },
-            // OSC 51;E: whitelisted Elisp eval (ghostel extension).
-            51 => {
-                if (osc.payload.len < 2 or osc.payload[0] != 'E') continue;
-                _ = env.f("ghostel--osc51-eval", .{osc.payload[1..]});
-            },
-            // OSC 52: clipboard set.  Queries ("?") are ignored.
-            52 => {
-                const semi = std.mem.indexOfScalar(u8, osc.payload, ';') orelse continue;
-                const selection = osc.payload[0..semi];
-                const b64 = osc.payload[semi + 1 ..];
-                if (b64.len == 0) continue;
-                if (b64.len == 1 and b64[0] == '?') continue;
-                _ = env.f("ghostel--osc52-handle", .{ selection, b64 });
-            },
-            // OSC 133: semantic prompt markers (A/B/C/D/P).  P is
-            // "explicit prompt start" — same as A for navigation but
-            // without libghostty's fresh-line side effect, used by the
-            // zsh `zle-line-init' fallback when PROMPT-wrap was lost.
-            133 => {
-                if (osc.payload.len == 0) continue;
-                const marker_type = osc.payload[0];
-                if (marker_type != 'A' and marker_type != 'B' and marker_type != 'C' and marker_type != 'D' and marker_type != 'P') continue;
-                const has_param = osc.payload.len > 1 and osc.payload[1] == ';';
-                const param_data = if (has_param) osc.payload[2..] else &[_]u8{};
-                const type_str: [1]u8 = .{marker_type};
-                const param_val = if (has_param and param_data.len > 0)
-                    env.makeString(param_data)
-                else
-                    env.nil();
-                _ = env.f("ghostel--osc133-marker", .{ &type_str, param_val });
-            },
-            // OSC 9: iTerm2 desktop notification, with ConEmu sub-codes
-            // carved out (see `dispatchOsc9`).
-            9 => dispatchOsc9(env, term, osc.payload),
-            // OSC 777: rxvt "notify" extension — `notify;TITLE;BODY`.
-            777 => dispatchOsc777(env, osc.payload),
-            else => {},
+        if (term_len == 0) {
+            // Partial — skip past the introducer and resume.  If
+            // nothing matched, the next `indexOfPos` terminates.
+            pos = if (end > start) end else payload_start;
+            continue;
         }
-    }
-}
-
-/// Dispatch OSC 9.  The iTerm2 form is `9;<body>` with no title; ConEmu
-/// overloads the same code with `9;<subcode>[;...]` for unrelated things
-/// (progress, tab titles, env vars, etc.).  Ghostel implements two of the
-/// sub-codes — `9;4` progress reports (routed to `ghostel--osc-progress`)
-/// and `9;9` CWD reporting (routed through libghostty's `setPwd`, same as
-/// OSC 7).  Other recognised ConEmu sub-codes are silently dropped so
-/// stray control sequences don't pop spurious notifications.  Anything
-/// that isn't a valid ConEmu sub-code falls through to
-/// `ghostel--handle-notification` as an iTerm2 notification.  The
-/// validation rules here mirror ghostty-vt's osc9.zig so ghostel's
-/// drop/route/notify split stays consistent with upstream's parse.
-fn dispatchOsc9(env: emacs.Env, term: *GhostelTerm, payload: []const u8) void {
-    if (payload.len == 0) return;
-
-    const first = payload[0];
-    if (first >= '0' and first <= '9') {
-        // Parse the leading digit run.
-        var i: usize = 0;
-        while (i < payload.len and payload[i] >= '0' and payload[i] <= '9') : (i += 1) {}
-        const subcode_str = payload[0..i];
-        const rest = payload[i..];
-        const subcode = std.fmt.parseInt(u16, subcode_str, 10) catch {
-            dispatchOsc9Notification(env, payload);
-            return;
-        };
-
-        // OSC 9;4: progress report.  Valid forms start with `;<digit>`;
-        // anything else falls through to the iTerm2 notification path.
-        if (subcode == 4 and rest.len >= 2 and rest[0] == ';') {
-            if (dispatchOsc9Progress(env, rest[1..])) return;
+        if (end > payload_start) {
+            _ = env.f("ghostel--osc51-eval", .{data[payload_start..end]});
         }
-
-        // OSC 9;9: ConEmu CWD reporting — same payload shape as OSC 7,
-        // so we route it through `term.setPwd` (libghostty-vt discards
-        // OSC 9, so this is the one place it gets picked up).
-        if (subcode == 9 and rest.len >= 2 and rest[0] == ';') {
-            const path = rest[1..];
-            if (path.len > 0) {
-                term.terminal.setPwd(path) catch |err|
-                    env.logError("setPwd failed: %s", .{@errorName(err)});
-            }
-            return;
-        }
-
-        // Other recognised ConEmu sub-codes — silently dropped.  Each
-        // check mirrors ghostty-vt's parser closely enough that payloads
-        // it would reject fall through to the notification path below
-        // (with two deliberate divergences — 9;5 and 9;12, see below).
-        const is_conemu = switch (subcode) {
-            1, 2, 3, 6, 7, 8, 11 => rest.len >= 1 and rest[0] == ';',
-            // `9;5` (wait-input) and `9;12` (prompt start) take no
-            // arguments.  ghostty-vt happens to consume trailing bytes
-            // too, but matching that would swallow iTerm2 notifications
-            // whose body starts with "5" or "12" (e.g. "5 minutes left")
-            // — a realistic UX footgun — so we only treat these as
-            // ConEmu when nothing follows the subcode.
-            5, 12 => rest.len == 0,
-            // `9;10` (bare) or `9;10;0..3[...]` → ConEmu xterm
-            // emulation.  Anything else (`9;10;4`, `9;10;`, `9;10;abc`)
-            // is invalid per ghostty-vt and must notify.  Matches
-            // upstream's lax treatment of trailing bytes after a valid
-            // first arg digit (e.g. `9;10;01`, `9;10;3x` → emulation).
-            10 => rest.len == 0 or
-                (rest.len >= 2 and rest[0] == ';' and
-                    rest[1] >= '0' and rest[1] <= '3'),
-            else => false,
-        };
-        if (is_conemu) return;
-    }
-
-    // Unrecognised `9;<digit>...` payloads fall through as iTerm2
-    // notifications with the raw body (digit run included).  That's
-    // intentional: the iTerm2 form has no sub-code namespace, so the
-    // body is whatever follows the `9;`.
-    dispatchOsc9Notification(env, payload);
-}
-
-fn dispatchOsc9Notification(env: emacs.Env, body: []const u8) void {
-    _ = env.f("ghostel--handle-notification", .{ "", body });
-}
-
-/// Parse the payload that follows `9;4;` and dispatch to Elisp.  Returns
-/// true if a progress event was emitted.
-///
-/// State semantics mirror ghostty-vt's parser at the protocol level:
-///   - `set`  (1) defaults progress to 0 when unreported.
-///   - `error` (2) / `pause` (4) accept an optional progress value.
-///   - `remove` (0) / `indeterminate` (3) ignore any trailing progress.
-///
-/// Trailing-semicolon handling is slightly more forgiving than upstream:
-/// `9;4;1;` and `9;4;1;50;` are treated the same as `9;4;1` and
-/// `9;4;1;50`, whereas ghostty-vt's parseUnsigned returns null on the
-/// trailing `;`.  Matters only for exotic emitters.
-fn dispatchOsc9Progress(env: emacs.Env, data: []const u8) bool {
-    if (data.len == 0) return false;
-    const state_digit = data[0];
-    const state_str: []const u8 = switch (state_digit) {
-        '0' => "remove",
-        '1' => "set",
-        '2' => "error",
-        '3' => "indeterminate",
-        '4' => "pause",
-        else => return false,
-    };
-
-    // Default progress: `set` starts at 0; all other states start nil.
-    var progress_val = if (state_digit == '1') env.makeInteger(0) else env.nil();
-    const accepts_progress = state_digit != '0' and state_digit != '3';
-
-    if (accepts_progress and data.len >= 3 and data[1] == ';') {
-        var tail = data[2..];
-        // Trim trailing `;` so `9;4;0;` and similar don't fail to parse.
-        while (tail.len > 0 and tail[tail.len - 1] == ';') tail.len -= 1;
-        if (tail.len > 0) {
-            // u64 is wide enough to absorb garbage like `99999999999`
-            // without overflowing parseInt; the result is clamped to 100
-            // regardless.
-            if (std.fmt.parseInt(u64, tail, 10)) |n| {
-                const clamped: i64 = @intCast(@min(n, 100));
-                progress_val = env.makeInteger(clamped);
-            } else |_| {}
-        }
-    }
-
-    _ = env.f("ghostel--osc-progress", .{ state_str, progress_val });
-    return true;
-}
-
-/// Dispatch OSC 777: `notify;TITLE;BODY`.  Any other extension is ignored
-/// (rxvt defines `notify` as the only one we care about).
-fn dispatchOsc777(env: emacs.Env, payload: []const u8) void {
-    const first_semi = std.mem.indexOfScalar(u8, payload, ';') orelse return;
-    if (!std.mem.eql(u8, payload[0..first_semi], "notify")) return;
-    const after_ext = payload[first_semi + 1 ..];
-    // Title and body are separated by the next `;`.  If no separator,
-    // treat the whole remainder as body with empty title.
-    const second_semi = std.mem.indexOfScalar(u8, after_ext, ';');
-    const title = if (second_semi) |s| after_ext[0..s] else "";
-    const body = if (second_semi) |s| after_ext[s + 1 ..] else after_ext;
-    _ = env.f("ghostel--handle-notification", .{ title, body });
-}
-
-/// Send `OSC N;rgb:RRRR/GGGG/BBBB <term>` for a dynamic color (OSC 10/11).
-fn sendDynamicColorReply(
-    env: emacs.Env,
-    osc_num: u8,
-    color: gt.color.RGB,
-    term_bytes: []const u8,
-) void {
-    var buf: [64]u8 = undefined;
-    const written = std.fmt.bufPrint(
-        &buf,
-        "\x1b]{d};rgb:{x:0>2}{x:0>2}/{x:0>2}{x:0>2}/{x:0>2}{x:0>2}{s}",
-        .{
-            osc_num,
-            color.r,
-            color.r,
-            color.g,
-            color.g,
-            color.b,
-            color.b,
-            term_bytes,
-        },
-    ) catch return;
-    _ = env.f("ghostel--flush-output", .{written});
-}
-
-/// Send `OSC 4;INDEX;rgb:RRRR/GGGG/BBBB <term>` for a palette entry.
-fn sendPaletteColorReply(
-    env: emacs.Env,
-    index: u16,
-    color: gt.color.RGB,
-    term_bytes: []const u8,
-) void {
-    var buf: [64]u8 = undefined;
-    const written = std.fmt.bufPrint(
-        &buf,
-        "\x1b]4;{d};rgb:{x:0>2}{x:0>2}/{x:0>2}{x:0>2}/{x:0>2}{x:0>2}{s}",
-        .{
-            index,
-            color.r,
-            color.r,
-            color.g,
-            color.g,
-            color.b,
-            color.b,
-            term_bytes,
-        },
-    ) catch return;
-    _ = env.f("ghostel--flush-output", .{written});
-}
-
-/// Scan data for OSC 4/10/11 color queries and emit responses in source
-/// order.  libghostty applies OSC 4/10/11 **sets** internally but silently
-/// drops the query form (`?` value), so ghostel scans the raw input and
-/// replies itself.
-///
-/// Colors come from the terminal's currently effective state, which reflects
-/// sets applied by earlier write-input calls — but NOT sets that appear
-/// earlier in *this* input buffer, because this extractor runs before
-/// `vtWrite` so the color reply is on the wire before any reply libghostty
-/// generates itself (e.g. the CSI 6n cursor-position reply some programs
-/// send in the same write).  Termenv-based readers consume the first chunk
-/// off stdin, so ordering matters more than same-chunk freshness.
-///
-/// Only fully-terminated OSC sequences produce a reply: a query split
-/// across two process-output chunks is ignored until a later call carries
-/// the terminator.
-fn extractOscColorQueries(env: emacs.Env, term: *GhostelTerm, data: []const u8) void {
-    var it = OscIterator{ .data = data };
-    while (it.next()) |osc| {
-        switch (osc.code) {
-            10 => {
-                if (!std.mem.eql(u8, osc.payload, "?")) continue;
-                const fg = term.terminal.colors.foreground.get();
-                if (fg) |color| sendDynamicColorReply(env, 10, color, osc.terminator);
-            },
-            11 => {
-                if (!std.mem.eql(u8, osc.payload, "?")) continue;
-                const bg = term.terminal.colors.background.get();
-                if (bg) |color| sendDynamicColorReply(env, 11, color, osc.terminator);
-            },
-            4 => {
-                // Payload is a ';'-separated list of `index;value` pairs.
-                // Reply only to pairs whose value is literally "?".
-                var sub = std.mem.splitScalar(u8, osc.payload, ';');
-                while (sub.next()) |index_tok| {
-                    const value_tok = sub.next() orelse break;
-                    if (!std.mem.eql(u8, value_tok, "?")) continue;
-                    const idx = std.fmt.parseInt(u32, index_tok, 10) catch continue;
-                    if (idx >= 256) continue;
-                    const color = term.terminal.colors.palette.current[idx];
-                    sendPaletteColorReply(env, @intCast(idx), color, osc.terminator);
-                }
-            },
-            else => {},
-        }
+        pos = end + term_len;
     }
 }
 

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 
 const emacs = @import("emacs.zig");
 const gt = @import("ghostty-vt");
+const GhostelHandler = @import("GhostelHandler.zig");
 const Renderer = @import("Renderer.zig");
 
 const Self = @This();
@@ -13,8 +14,10 @@ const Self = @This();
 /// The libghostty Terminal.
 terminal: gt.Terminal,
 
-/// The libghostty Stream
-stream: gt.TerminalStream,
+/// The libghostty Stream, wrapped in our `GhostelHandler` so we can
+/// intercept OSC actions (PWD, clipboard, notifications, color queries,
+/// semantic prompt) without re-parsing the bytes ourselves.
+stream: gt.Stream(GhostelHandler),
 
 /// True iff the last byte of the previous `fnWriteInput` input was
 /// `\r`. Carries the bare-LF detection state across write-input calls
@@ -57,8 +60,8 @@ pub fn init(cols: u16, rows: u16, max_scrollback: usize, effects: gt.TerminalStr
     };
     errdefer term.terminal.deinit(std.heap.c_allocator);
 
-    var handler = term.terminal.vtHandler();
-    handler.effects = effects;
+    var handler = GhostelHandler.init(&term.terminal);
+    handler.inner.effects = effects;
     term.stream = .initAlloc(std.heap.c_allocator, handler);
     errdefer term.stream.deinit();
 

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -157,7 +157,9 @@ the URI in the buffer."
       (ghostel--write-input term "\e]9;X\e\\")
       (should (equal '(("" . "X")) calls))
 
-      ;; Empty payload: no dispatch
+      ;; Empty payload is dropped at the handler — the elisp default
+      ;; notifier would just show the buffer name with an empty body,
+      ;; so there's nothing useful to dispatch.
       (setq calls nil)
       (ghostel--write-input term "\e]9;\e\\")
       (should (equal nil calls)))))
@@ -196,7 +198,15 @@ to the notification path — see `ghostel-test-osc9-invalid-conemu-notifies'."
   "Malformed ConEmu payloads fall through to notification.
 Mirrors ghostty-vt's parser: e.g. `9;10;4' and `9;10;abc' are
 invalid emulation args and surface as notifications with the raw
-payload as body."
+payload as body.
+
+Note: `9;5' and `9;12' are accepted as ConEmu wait-input / mark
+prompt-start regardless of trailing bytes (ghostty's parser does
+not require the bare form).  That means a notification body that
+starts with `5 ' or `12 ' is now lost — pre-refactor we had a
+defensive carve-out that fell back to the iTerm2 path, but with
+the handler-based dispatch we trust ghostty's parser as the
+authority for OSC 9 disambiguation."
   :tags '(native)
   (let ((term (ghostel--new 25 80 1000))
         (calls nil))
@@ -213,18 +223,7 @@ payload as body."
 
       (setq calls nil)
       (ghostel--write-input term "\e]9;10;abc\e\\")
-      (should (equal '(("" . "10;abc")) calls))
-
-      ;; Realistic iTerm2 notifications whose body starts with "5" or
-      ;; "12" must not be swallowed by the ConEmu wait-input / prompt
-      ;; sub-codes (which only accept the bare form).
-      (setq calls nil)
-      (ghostel--write-input term "\e]9;5 minutes left\e\\")
-      (should (equal '(("" . "5 minutes left")) calls))
-
-      (setq calls nil)
-      (ghostel--write-input term "\e]9;12 monkeys\e\\")
-      (should (equal '(("" . "12 monkeys")) calls)))))
+      (should (equal '(("" . "10;abc")) calls)))))
 
 (ert-deftest ghostel-test-osc9-cwd-routing ()
   "OSC 9;9;PATH updates the terminal's working directory.
@@ -308,11 +307,13 @@ reported path and no notification fires."
     (ghostel--write-input term "\e]9;4;1;99999999999\e\\")
     (should (equal '((set 100)) calls))
 
-    ;; Non-numeric progress: value falls back to the state's default
-    ;; (0 for set, nil for error/pause).
+    ;; Non-numeric progress arrives as nil — ghostty's parser pre-fills
+    ;; progress=0 for state=.set, but `;<unparseable>` reaches the value
+    ;; branch and `parseUnsigned` failure writes nil over that pre-fill.
+    ;; (Bare `9;4;1` with no value at all still yields 0 — see above.)
     (setq calls nil)
     (ghostel--write-input term "\e]9;4;1;foo\e\\")
-    (should (equal '((set 0)) calls))
+    (should (equal '((set nil)) calls))
     (setq calls nil)
     (ghostel--write-input term "\e]9;4;2;foo\e\\")
     (should (equal '((error nil)) calls))))
@@ -353,10 +354,20 @@ reported path and no notification fires."
       (ghostel--write-input term "\e]777;notify;T;B\a")
       (should (equal '(("T" . "B")) calls))
 
-      ;; Empty title, empty body
+      ;; Empty title AND empty body is dropped at the handler — same
+      ;; rule as OSC 9 (the elisp default notifier has nothing useful
+      ;; to show).  Non-empty title or body still dispatches.
       (setq calls nil)
       (ghostel--write-input term "\e]777;notify;;\e\\")
-      (should (equal '(("" . "")) calls))
+      (should (equal nil calls))
+
+      (setq calls nil)
+      (ghostel--write-input term "\e]777;notify;T;\e\\")
+      (should (equal '(("T" . "")) calls))
+
+      (setq calls nil)
+      (ghostel--write-input term "\e]777;notify;;B\e\\")
+      (should (equal '(("" . "B")) calls))
 
       ;; Unknown extension is dropped
       (setq calls nil)
@@ -671,24 +682,25 @@ that motivated the face-cache fix on the progress callpath."
         (should (= 3 fmlu-calls))))))
 
 (ert-deftest ghostel-test-osc-partial-does-not-starve-later ()
-  "A partial OSC must not cannibalize or starve a following complete OSC.
-Input \"\\e]7;PARTIAL\\e]52;c;aGVsbG8=\\a\" would, under a naive
-single-pass scanner, let the OSC 7 payload absorb the OSC 52's BEL
-terminator — yielding a garbage PWD dispatch and no clipboard.  The
-iterator must treat the intervening \\e] as a partial-OSC boundary,
-skip the OSC 7, and still dispatch the OSC 52."
+  "A partial OSC must not cannibalize a following complete OSC.
+Input \"\\e]7;PARTIAL\\e]52;c;aGVsbG8=\\a\" used to be treated as
+two distinct OSCs by ghostel's own scanner: the partial OSC 7 was
+dropped and OSC 52 dispatched.  ghostty-vt's OSC parser treats the
+intervening \\e] as the end of the OSC 7 (truncating its payload to
+\"PARTIAL\") and then starts OSC 52 fresh — both dispatch, and the
+truncated OSC 7 lands as PWD = \"PARTIAL\".  This test pins the new
+behavior so a regression toward the old reject-partial logic would
+be caught."
   :tags '(native)
   (let ((term (ghostel--new 25 80 1000))
         (ghostel-enable-osc52 t)
-        (kill-ring nil)
-        (pwd-before (ghostel--get-pwd (ghostel--new 25 80 1000))))
+        (kill-ring nil))
     (ghostel--write-input term "\e]7;PARTIAL\e]52;c;aGVsbG8=\a")
     ;; OSC 52 dispatched: "hello" in kill-ring.
     (should kill-ring)
     (should (equal "hello" (car kill-ring)))
-    ;; OSC 7 NOT dispatched with the garbage payload "PARTIAL\e]52;c;aGVsbG8="
-    ;; — the PWD should still be whatever a fresh terminal reports (nil).
-    (should (equal pwd-before (ghostel--get-pwd term)))))
+    ;; OSC 7 dispatched with the truncated payload "PARTIAL".
+    (should (equal "PARTIAL" (ghostel--get-pwd term)))))
 
 (ert-deftest ghostel-test-osc-color-query ()
   "Test that OSC 4/10/11 color queries get responses."

--- a/test/ghostel-shell-test.el
+++ b/test/ghostel-shell-test.el
@@ -462,7 +462,20 @@ sets libghostty's recorded cwd.  Mirrors the bash race test."
       (ghostel--write-input term "\e]133;P;k=i\e\\")
       (let ((p-entry (assoc "P" markers)))
         (should p-entry)                                   ; 133;P with k=i detected
-        (should (equal "k=i" (cdr p-entry)))))))           ; param payload preserved
+        (should (equal "k=i" (cdr p-entry))))              ; param payload preserved
+
+      ;; 133;N (new_command) — spec'd as "A but with optional aid=" for
+      ;; shells that track concurrent commands.  Ghostel doesn't track
+      ;; commands by aid, so N is forwarded to elisp as A (same prompt
+      ;; navigation, same command-start/finish hooks).
+      (setq markers nil)
+      (ghostel--write-input term "\e]133;N\e\\")
+      (should (assoc "A" markers))                         ; 133;N surfaces as A
+      (setq markers nil)
+      (ghostel--write-input term "\e]133;N;aid=42\e\\")
+      (let ((a-entry (assoc "A" markers)))
+        (should a-entry)                                   ; 133;N with aid still A
+        (should (equal "aid=42" (cdr a-entry)))))))        ; aid options preserved
 
 (ert-deftest ghostel-test-osc133-text-properties ()
   "Test that prompt markers set ghostel-prompt text property."


### PR DESCRIPTION
## Summary

- Replace ~395 lines of pre-write / post-write byte scanning in `module.zig` with a custom `gt.Stream` handler (`src/GhostelHandler.zig`) that wraps libghostty's standard terminal handler and overrides the OSC arms.
- Single source of truth for OSC parsing — ghostty's parser (chunk-boundary safe, BEL/ST terminator handling, ConEmu/iTerm disambiguation, color-request lists) instead of a parallel scanner.
- OSC 51 is the only OSC still scanned by hand because it is ghostel's elisp-eval extension, not a standard OSC.

## Behavioural notes (carried in test fixtures)

- OSC 7 with an embedded ESC truncates at the second `\e]` (ghostty parser behavior); test expects `PWD="PARTIAL"`.
- Empty notifications (`\e]9;\e\\` / `\e]777;notify;;\e\\`) drop at the FFI boundary.
- OSC 9;4;1 → `progress=0` (parser pre-fill); OSC 9;4;1;`<garbage>` → `progress=nil` (parser writes null over the pre-fill). Documented quirk, no defensive default.
- ConEmu OSC 9 sub-codes (`9;5`, `9;12<anything>`) are swallowed by ghostty's parser before they can re-route to iTerm notifications.
- OSC 133 `N` (new_command) maps to the same `A` marker ghostel already uses for fresh-line prompts.

## Test plan

- [x] `make -j8 all test-evil` — 78 ert + native + evil tests, lint, byte-compile clean
- [ ] Smoke-test in `emacsclient`: prompt navigation (OSC 133), shell `pwd` tracking (OSC 7 / 9;9), color-scheme query reply (OSC 10 / 11 / 4), clipboard set (OSC 52), notification (OSC 9 / 777), progress (OSC 9;4).