### PR TITLE
Inject allocators via Zig best-practice pattern + DebugAllocator in debug builds

### DIFF
--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -5,6 +5,7 @@
 /// Emacs buffer.  See `redraw' below for the per-redraw algorithm
 /// (viewport parking, scrollback sync, dirty-row reuse).
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 const emacs = @import("emacs.zig");
 const gt = @import("ghostty-vt");
 const Terminal = @import("terminal.zig");
@@ -44,19 +45,19 @@ const FontInfo = struct {
     glyph_scale_floor: f64,
 };
 
-pub fn init(term: *gt.Terminal) !Self {
+pub fn init(alloc: Allocator, term: *gt.Terminal) !Self {
     var renderer = Self{
         .render_state = gt.RenderState.empty,
         .size = undefined,
         .pending_resize = .{ .cols = term.cols, .rows = term.rows, .cell_w = 1, .cell_h = 1 },
     };
-    try renderer.commitResize(term);
+    try renderer.commitResize(alloc, term);
     return renderer;
 }
 
-pub fn deinit(self: *Self) void {
-    self.render_state.deinit(std.heap.c_allocator);
-    self.row.deinit();
+pub fn deinit(self: *Self, alloc: Allocator) void {
+    self.render_state.deinit(alloc);
+    self.row.deinit(alloc);
 }
 
 pub fn resize(self: *Self, cols: u16, rows: u16, cell_w: u32, cell_h: u32) void {
@@ -135,7 +136,7 @@ pub fn redraw(self: *Self, env: emacs.Env, term: *Terminal, force_full_arg: bool
     if (force_full) {
         env.eraseBuffer();
         // Commit any pending resize since we're doing a rebuild anyway.
-        try self.commitResize(&term.terminal);
+        try self.commitResize(term.alloc, &term.terminal);
         self.rows_in_buffer = 0;
     }
 
@@ -167,7 +168,7 @@ pub fn redraw(self: *Self, env: emacs.Env, term: *Terminal, force_full_arg: bool
     // If we have a pending resize, commit it now and just rerender the active
     // since the scrollback is already up to date.
     if (self.pending_resize != null) {
-        try self.commitResize(&term.terminal);
+        try self.commitResize(term.alloc, &term.terminal);
         term.terminal.scrollViewport(.bottom);
         self.gotoActiveStart(env);
         try self.render(env, term, 0, false);
@@ -449,8 +450,6 @@ const CellPropKey = packed struct {
 };
 
 pub const RowContent = struct {
-    const allocator = std.heap.c_allocator;
-
     const Run = struct {
         start_char: usize,
         end_char: usize,
@@ -491,6 +490,7 @@ pub const RowContent = struct {
     /// styled blanks are preserved.
     pub fn build(
         self: *RowContent,
+        alloc: Allocator,
         term: *Terminal,
         row: *const gt.RenderState.Row,
         adjustment_threshold: u32,
@@ -515,7 +515,7 @@ pub const RowContent = struct {
             // in such a tight loop.
             const prop_key = CellPropKey.fromCell(cell.raw);
             if (prop_key != current_prop_key) {
-                try self.runs.append(RowContent.allocator, .{
+                try self.runs.append(alloc, .{
                     .start_char = self.char_len,
                     .end_char = self.char_len,
                     .props = readCellProps(&term.renderer, &cell),
@@ -527,16 +527,16 @@ pub const RowContent = struct {
             const char_start = self.char_len;
 
             const codepoint: u21 = if (cell.raw.hasText()) cell.raw.codepoint() else ' ';
-            try self.appendCodepoints(&[1]u21{codepoint});
+            try self.appendCodepoints(alloc, &[1]u21{codepoint});
             if (cell.raw.hasGrapheme()) {
-                try self.appendCodepoints(cell.grapheme);
+                try self.appendCodepoints(alloc, cell.grapheme);
             }
 
             // If this is a grapheme cluster, or if the char is not covered by
             // the default font, we register it as needing font glyph adjustment
             // to fit into the monospace grid.
             if (cell.raw.hasGrapheme() or codepoint >= adjustment_threshold) {
-                try self.adjust_cells.append(RowContent.allocator, .{
+                try self.adjust_cells.append(alloc, .{
                     .col = @intCast(col),
                     .byte_start = @intCast(byte_start),
                     .byte_end = @intCast(self.text.items.len),
@@ -566,13 +566,13 @@ pub const RowContent = struct {
             self.runs.items[self.runs.items.len - 1].end_char = trim_char_len;
         }
 
-        try self.text.append(RowContent.allocator, '\n');
+        try self.text.append(alloc, '\n');
     }
 
-    pub fn deinit(self: *RowContent) void {
-        self.text.deinit(allocator);
-        self.adjust_cells.deinit(allocator);
-        self.runs.deinit(allocator);
+    pub fn deinit(self: *RowContent, alloc: Allocator) void {
+        self.text.deinit(alloc);
+        self.adjust_cells.deinit(alloc);
+        self.runs.deinit(alloc);
     }
 
     fn clear(self: *RowContent) !void {
@@ -582,10 +582,10 @@ pub const RowContent = struct {
         self.char_len = 0;
     }
 
-    fn appendCodepoints(self: *RowContent, cluster: []const u21) !void {
+    fn appendCodepoints(self: *RowContent, alloc: Allocator, cluster: []const u21) !void {
         for (cluster) |cp| {
             const slice = try self.text.addManyAsSlice(
-                allocator,
+                alloc,
                 try std.unicode.utf8CodepointSequenceLength(cp),
             );
             _ = try std.unicode.utf8Encode(cp, slice);
@@ -694,6 +694,7 @@ fn insertRow(
     row: *const gt.RenderState.Row,
 ) !void {
     try self.row.build(
+        term.alloc,
         term,
         row,
         if (self.font_info) |f| f.coverage else std.math.maxInt(u32),
@@ -762,7 +763,7 @@ const BgFg = struct {
 };
 
 pub fn render(self: *Self, env: emacs.Env, term: *Terminal, skip: usize, force_full: bool) !void {
-    try self.render_state.update(std.heap.c_allocator, &term.terminal);
+    try self.render_state.update(term.alloc, &term.terminal);
 
     if (self.render_state.dirty != .false or force_full) {
         // Set buffer default face
@@ -865,9 +866,9 @@ fn renderToEnd(self: *Self, env: emacs.Env, term: *Terminal, force_full: bool) !
     return rendered_rows;
 }
 
-fn commitResize(self: *Self, term: *gt.Terminal) !void {
+fn commitResize(self: *Self, alloc: Allocator, term: *gt.Terminal) !void {
     if (self.pending_resize) |rz| {
-        try term.resize(std.heap.c_allocator, rz.cols, rz.rows);
+        try term.resize(alloc, rz.cols, rz.rows);
         term.width_px = std.math.mul(u32, rz.cols, rz.cell_w) catch std.math.maxInt(u32);
         term.height_px = std.math.mul(u32, rz.rows, rz.cell_h) catch std.math.maxInt(u32);
         self.size = rz;

--- a/src/kitty_graphics.zig
+++ b/src/kitty_graphics.zig
@@ -4,6 +4,7 @@
 /// each redraw cycle, converts pixel data to PPM for Emacs display,
 /// and calls into Elisp to apply image overlays.
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 const emacs = @import("emacs.zig");
 const Terminal = @import("terminal.zig");
 const gt = @import("ghostty-vt");
@@ -37,8 +38,8 @@ fn emitOnePlacement(
     const image = storage.images.getPtr(key.image_id) orelse return error.ImageNotFound;
     switch (placement.location) {
         .virtual => {
-            const emacs_data = try getImageData(image);
-            defer if (emacs_data.allocated) std.heap.c_allocator.free(emacs_data.data);
+            const emacs_data = try getImageData(term.alloc, image);
+            defer if (emacs_data.allocated) term.alloc.free(emacs_data.data);
 
             // Virtual placements (yazi-style U+10EEEE unicode placeholders).
             // The API doesn't provide viewport positions — Elisp searches
@@ -67,8 +68,8 @@ fn emitOnePlacement(
             // Non-virtual: get render info for viewport position.
             if (!visible) return error.NotVisible;
 
-            const emacs_data = try getImageData(image);
-            defer if (emacs_data.allocated) std.heap.c_allocator.free(emacs_data.data);
+            const emacs_data = try getImageData(term.alloc, image);
+            defer if (emacs_data.allocated) term.alloc.free(emacs_data.data);
 
             const img_val = env.makeUnibyteString(emacs_data.data) orelse return error.MakeString;
             // viewport_row is relative to the visible viewport; ghostel materializes
@@ -102,15 +103,15 @@ fn emitOnePlacement(
 /// (e.g. an evicting transmit, a delete command, or storage trimming).
 /// Use it synchronously — copy via `makeUnibyteString` and drop the
 /// reference before yielding control back to libghostty.  When
-/// `allocated` is true, `data` is owned by `c_allocator` and the caller
-/// must free it.
+/// `allocated` is true, `data` is owned by the caller's allocator and the
+/// caller must free it.
 const ImageData = struct {
     data: []const u8,
     is_png: bool,
     allocated: bool,
 };
 
-fn getImageData(image: *const gt.kitty.graphics.Image) !ImageData {
+fn getImageData(alloc: Allocator, image: *const gt.kitty.graphics.Image) !ImageData {
     // libghostty decompresses images at transmit time, so by the time
     // we read out the data here it should always be in the .none state.
     // Refuse explicitly so a future libghostty change that defers
@@ -125,26 +126,25 @@ fn getImageData(image: *const gt.kitty.graphics.Image) !ImageData {
     // transmit time, so format arrives as RGBA and we go through the
     // PPM path with channels=4.  The PNG branch stays for the case
     // where the decode hook is uninstalled or rejected the payload.
-    const ppm_alloc = std.heap.c_allocator;
     return switch (image.format) {
         .png => .{ .data = image.data, .is_png = true, .allocated = false },
         .rgba => .{
-            .data = ppm.createPpm(ppm_alloc, image.data, image.width, image.height, 4) orelse return error.PpmConvert,
+            .data = ppm.createPpm(alloc, image.data, image.width, image.height, 4) orelse return error.PpmConvert,
             .is_png = false,
             .allocated = true,
         },
         .rgb => .{
-            .data = ppm.createPpm(ppm_alloc, image.data, image.width, image.height, 3) orelse return error.PpmConvert,
+            .data = ppm.createPpm(alloc, image.data, image.width, image.height, 3) orelse return error.PpmConvert,
             .is_png = false,
             .allocated = true,
         },
         .gray_alpha => .{
-            .data = ppm.createPpm(ppm_alloc, image.data, image.width, image.height, 2) orelse return error.PpmConvert,
+            .data = ppm.createPpm(alloc, image.data, image.width, image.height, 2) orelse return error.PpmConvert,
             .is_png = false,
             .allocated = true,
         },
         .gray => .{
-            .data = ppm.createPpm(ppm_alloc, image.data, image.width, image.height, 1) orelse return error.PpmConvert,
+            .data = ppm.createPpm(alloc, image.data, image.width, image.height, 1) orelse return error.PpmConvert,
             .is_png = false,
             .allocated = true,
         },

--- a/src/module.zig
+++ b/src/module.zig
@@ -4,6 +4,7 @@
 /// It exports emacs_module_init (the C entry point Emacs calls on load)
 /// and registers all Elisp-callable functions.
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 const emacs = @import("emacs.zig");
 const GhostelTerm = @import("terminal.zig");
 const gt = @import("ghostty-vt");
@@ -13,6 +14,12 @@ const sys = @import("sys.zig");
 const pty = @import("pty.zig");
 
 const c = emacs.c;
+
+/// Allocator for all module-owned allocations (string extraction, formatting
+/// scratch buffers, and Terminal instances).  c_allocator is the right choice
+/// for a C-ABI .dylib: it wraps libc malloc/free, which is stable across the
+/// Emacs ↔ module boundary and appropriate for long-lived objects.
+const alloc: Allocator = std.heap.c_allocator;
 
 /// Module version — see src/version.zig.  Keep in sync with ghostel.el
 /// and build.zig.zon.
@@ -205,7 +212,7 @@ fn fnNew(raw_env: ?*c.emacs_env, nargs: isize, args: [*c]c.emacs_value, _: ?*any
     effects.title_changed = &titleChangedCallback;
     effects.size = &sizeCallback;
 
-    const term = GhostelTerm.init(cols, rows, max_scrollback, effects) catch {
+    const term = GhostelTerm.init(alloc, cols, rows, max_scrollback, effects) catch {
         env.signalError("failed to create terminal", .{});
         return env.nil();
     };
@@ -239,10 +246,10 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
     // Extract string data — try stack buffer first, fall back to alloc
     var stack_buf: [65536]u8 = undefined;
     var heap_buf: ?[]const u8 = null;
-    defer if (heap_buf) |hb| std.heap.c_allocator.free(hb);
+    defer if (heap_buf) |hb| alloc.free(hb);
 
     const data = env.extractString(args[1], &stack_buf) orelse blk: {
-        heap_buf = env.extractStringAlloc(args[1], std.heap.c_allocator);
+        heap_buf = env.extractStringAlloc(args[1], alloc);
         break :blk heap_buf;
     };
 
@@ -733,7 +740,7 @@ fn fnCopyAllText(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?
     };
 
     var formatter = gt.formatter.TerminalFormatter.init(&term.terminal, options);
-    var writer = std.io.Writer.Allocating.init(std.heap.c_allocator);
+    var writer = std.io.Writer.Allocating.init(alloc);
     defer writer.deinit();
     formatter.format(&writer.writer) catch {
         env.signalError("formatter failed", .{});

--- a/src/module.zig
+++ b/src/module.zig
@@ -4,6 +4,7 @@
 /// It exports emacs_module_init (the C entry point Emacs calls on load)
 /// and registers all Elisp-callable functions.
 const std = @import("std");
+const builtin = @import("builtin");
 const Allocator = std.mem.Allocator;
 const emacs = @import("emacs.zig");
 const GhostelTerm = @import("terminal.zig");
@@ -15,11 +16,13 @@ const pty = @import("pty.zig");
 
 const c = emacs.c;
 
-/// Allocator for all module-owned allocations (string extraction, formatting
-/// scratch buffers, and Terminal instances).  c_allocator is the right choice
-/// for a C-ABI .dylib: it wraps libc malloc/free, which is stable across the
-/// Emacs ↔ module boundary and appropriate for long-lived objects.
-const alloc: Allocator = std.heap.c_allocator;
+/// In debug builds, all allocations go through DebugAllocator for corruption
+/// detection (double-free, use-after-free, overflow canaries).  An atexit
+/// handler calls deinit() on process exit, which fires on both Linux and macOS
+/// when Emacs calls exit().  Reports may include false positives if Emacs has
+/// not finalized all user-ptrs (terminals) before exit().
+var debug_alloc: std.heap.DebugAllocator(.{}) = .init;
+var alloc: Allocator = std.heap.c_allocator;
 
 /// Module version — see src/version.zig.  Keep in sync with ghostel.el
 /// and build.zig.zon.
@@ -34,6 +37,8 @@ export fn emacs_module_init(runtime: *c.struct_emacs_runtime) callconv(.c) c_int
     if (runtime.size < @sizeOf(c.struct_emacs_runtime)) {
         return 1; // ABI mismatch
     }
+
+    if (builtin.mode == .Debug) alloc = debug_alloc.allocator();
 
     const raw_env = runtime.get_environment.?(runtime);
     const env = emacs.Env.init(raw_env);
@@ -152,8 +157,18 @@ export fn emacs_module_init(runtime: *c.struct_emacs_runtime) callconv(.c) c_int
     // Install system callbacks (PNG decoder for kitty graphics, logging).
     sys.init();
 
+    if (builtin.mode == .Debug) _ = atexit(&debugAtExit);
+
     env.provide("ghostel-module");
     return 0;
+}
+
+extern fn atexit(func: *const fn () callconv(.c) void) c_int;
+
+fn debugAtExit() callconv(.c) void {
+    if (debug_alloc.deinit() == .leak) {
+        std.debug.print("ghostel: memory leak detected at exit\n", .{});
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/terminal.zig
+++ b/src/terminal.zig
@@ -3,6 +3,7 @@
 /// Holds the resources for a single instance of a Ghostel terminal
 ///
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 
 const emacs = @import("emacs.zig");
 const gt = @import("ghostty-vt");
@@ -10,6 +11,9 @@ const GhostelHandler = @import("GhostelHandler.zig");
 const Renderer = @import("Renderer.zig");
 
 const Self = @This();
+
+/// Allocator used for all owned allocations; injected at init time.
+alloc: Allocator,
 
 /// The libghostty Terminal.
 terminal: gt.Terminal,
@@ -37,7 +41,7 @@ renderer: Renderer,
 env: ?emacs.Env = null,
 
 /// Create a new terminal with the given dimensions and scrollback.
-pub fn init(cols: u16, rows: u16, max_scrollback: usize, effects: gt.TerminalStream.Handler.Effects) !*Self {
+pub fn init(alloc: Allocator, cols: u16, rows: u16, max_scrollback: usize, effects: gt.TerminalStream.Handler.Effects) !*Self {
     if (cols == 0 or rows == 0) return error.InvalidSize;
 
     const opts = gt.Terminal.Options{
@@ -50,32 +54,33 @@ pub fn init(cols: u16, rows: u16, max_scrollback: usize, effects: gt.TerminalStr
         },
     };
 
-    const term = try std.heap.c_allocator.create(Self);
-    errdefer std.heap.c_allocator.destroy(term);
+    const term = try alloc.create(Self);
+    errdefer alloc.destroy(term);
 
     term.* = Self{
-        .terminal = try .init(std.heap.c_allocator, opts),
+        .alloc = alloc,
+        .terminal = try .init(alloc, opts),
         .renderer = undefined,
         .stream = undefined,
     };
-    errdefer term.terminal.deinit(std.heap.c_allocator);
+    errdefer term.terminal.deinit(alloc);
 
     var handler = GhostelHandler.init(&term.terminal);
     handler.inner.effects = effects;
-    term.stream = .initAlloc(std.heap.c_allocator, handler);
+    term.stream = .initAlloc(alloc, handler);
     errdefer term.stream.deinit();
 
-    term.renderer = try .init(&term.terminal);
+    term.renderer = try .init(alloc, &term.terminal);
 
     return term;
 }
 
 /// Free all ghostty resources.
 pub fn deinit(self: *Self) void {
-    self.renderer.deinit();
+    self.renderer.deinit(self.alloc);
     self.stream.deinit();
-    self.terminal.deinit(std.heap.c_allocator);
-    std.heap.c_allocator.destroy(self);
+    self.terminal.deinit(self.alloc);
+    self.alloc.destroy(self);
 }
 
 /// Set default foreground color.


### PR DESCRIPTION
## Summary

- **Allocator injection**: `Terminal` now stores an `alloc: Allocator` field injected at `init` time. `Renderer`, `RowContent`, and `kitty_graphics` follow the unmanaged pattern — they receive the allocator as a parameter rather than storing a redundant copy, since they are embedded in or owned by `Terminal`. `module.zig` has a single `alloc` constant at the top replacing scattered `std.heap.c_allocator` references.
- **Type alias + naming**: `const Allocator = std.mem.Allocator` in each file; parameters and fields named `alloc`.
- **DebugAllocator in debug builds**: In debug builds `alloc` is backed by `std.heap.DebugAllocator` for corruption detection (double-free, use-after-free, overflow canaries). An `atexit` handler calls `deinit()` on process exit for a best-effort leak report (may include false positives from terminals not yet finalized by Emacs GC before `exit()`). Release builds use `c_allocator` with zero overhead.

## Test plan

- `zig build` passes on both debug and release (`-Doptimize=ReleaseFast`)
- Load the module in Emacs and exercise normal terminal usage — no regressions expected
- In a debug build, verify that double-free or use-after-free triggers a DebugAllocator panic with a useful trace