### PR TITLE
Skip CRLF normalization on alt screen

### DIFF
--- a/src/module.zig
+++ b/src/module.zig
@@ -327,6 +327,11 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
     // chunking (that's how the process filter already works), so no
     // scratch buffer, no allocation, no truncation fallback.
     //
+    // Skip normalization on the alternate screen.  Apps that use the
+    // alt screen (tmux, vim, less) send VT-correct sequences where bare
+    // \n is LF (cursor down, column preserved); normalizing to \r\n
+    // breaks their layout.
+    //
     // `prev_was_cr` is seeded from `term.last_input_was_cr` so a CRLF
     // pair split across two writes — chunk A ending with \r, chunk B
     // starting with \n — is not mis-normalized into \r\r\n.  The final
@@ -336,22 +341,27 @@ fn fnWriteInput(raw_env: ?*c.emacs_env, _: isize, args: [*c]c.emacs_value, _: ?*
     // All standard OSC sequences (4, 7, 9, 10, 11, 52, 133, 777) are
     // intercepted by `GhostelHandler` inside the stream itself — no
     // post-write byte scan is needed for them.
-    var seg_start: usize = 0;
-    var prev_was_cr: bool = term.last_input_was_cr;
-    for (raw, 0..) |ch, i| {
-        if (ch == '\n' and !prev_was_cr) {
-            if (i > seg_start) term.vtWrite(raw[seg_start..i]);
-            term.vtWrite("\r\n");
-            seg_start = i + 1;
-            prev_was_cr = false;
-        } else {
-            prev_was_cr = (ch == '\r');
+    if (term.terminal.screens.active_key == .alternate) {
+        term.vtWrite(raw);
+        if (raw.len > 0) term.last_input_was_cr = raw[raw.len - 1] == '\r';
+    } else {
+        var seg_start: usize = 0;
+        var prev_was_cr: bool = term.last_input_was_cr;
+        for (raw, 0..) |ch, i| {
+            if (ch == '\n' and !prev_was_cr) {
+                if (i > seg_start) term.vtWrite(raw[seg_start..i]);
+                term.vtWrite("\r\n");
+                seg_start = i + 1;
+                prev_was_cr = false;
+            } else {
+                prev_was_cr = (ch == '\r');
+            }
         }
+        if (seg_start < raw.len) {
+            term.vtWrite(raw[seg_start..]);
+        }
+        term.last_input_was_cr = prev_was_cr;
     }
-    if (seg_start < raw.len) {
-        term.vtWrite(raw[seg_start..]);
-    }
-    term.last_input_was_cr = prev_was_cr;
 
     // OSC 51;E (ghostel's elisp-eval extension) is not a standard OSC,
     // so ghostty's parser drops it without firing an action.  Scan the

--- a/test/ghostel-terminal-test.el
+++ b/test/ghostel-terminal-test.el
@@ -31,6 +31,55 @@
       (should (string-match-p "hello world" state))  ; row0 has full first line
       (should (string-match-p "line2" state)))))      ; row1 has line2
 
+(ert-deftest ghostel-test-write-input-normalizes-bare-lf-on-primary ()
+  "On the primary screen, bare LF is normalized to CRLF.
+Emacs PTYs lack ONLCR, so a bare \\n from subprocess output needs an
+inserted \\r to land at column 0 of the next row."
+  :tags '(native)
+  (let ((term (ghostel--new 25 80 1000)))
+    (ghostel--write-input term "abc\ndef")
+    ;; Inserted \r resets the column; "def" lands at (3 . 1), not (6 . 1).
+    (should (equal '(3 . 1) (ghostel-test--cursor term)))))
+
+(ert-deftest ghostel-test-write-input-preserves-bare-lf-on-alt-screen-1049 ()
+  "On the alternate screen (DECSET 1049), bare LF preserves the column.
+Apps that target the alt screen (tmux, vim, less) emit VT-correct LF
+that moves the cursor down with the column preserved; prepending CR
+would corrupt their layout, e.g. tmux pane border erasure misfires."
+  :tags '(native)
+  (let ((term (ghostel--new 25 80 1000)))
+    (ghostel--write-input term "\e[?1049h")
+    (ghostel--write-input term "abc\ndef")
+    ;; Bare LF: column preserved, so "def" lands at (6 . 1).
+    (should (equal '(6 . 1) (ghostel-test--cursor term)))))
+
+(ert-deftest ghostel-test-write-input-preserves-bare-lf-on-alt-screen-1047 ()
+  "Alt-screen detection covers DECSET 1047 as well as 1049."
+  :tags '(native)
+  (let ((term (ghostel--new 25 80 1000)))
+    (ghostel--write-input term "\e[?1047h")
+    (ghostel--write-input term "abc\ndef")
+    (should (equal '(6 . 1) (ghostel-test--cursor term)))))
+
+(ert-deftest ghostel-test-write-input-preserves-bare-lf-on-alt-screen-47 ()
+  "Alt-screen detection covers the legacy DECSET 47 mode.
+Detection is via `screens.active_key', so the three alt-screen entry
+modes (47 / 1047 / 1049) are handled uniformly."
+  :tags '(native)
+  (let ((term (ghostel--new 25 80 1000)))
+    (ghostel--write-input term "\e[?47h")
+    (ghostel--write-input term "abc\ndef")
+    (should (equal '(6 . 1) (ghostel-test--cursor term)))))
+
+(ert-deftest ghostel-test-write-input-renormalizes-after-leaving-alt-screen ()
+  "Leaving the alternate screen restores CRLF normalization on primary."
+  :tags '(native)
+  (let ((term (ghostel--new 25 80 1000)))
+    (ghostel--write-input term "\e[?1049h")
+    (ghostel--write-input term "\e[?1049l") ; back to primary
+    (ghostel--write-input term "abc\ndef")
+    (should (equal '(3 . 1) (ghostel-test--cursor term)))))
+
 (ert-deftest ghostel-test-backspace ()
   "Test backspace (BS) processing by the terminal."
   :tags '(native)


### PR DESCRIPTION
## Summary

Skip bare-LF -> CRLF normalization while the terminal is on the alternate screen.

## Why

Emacs PTYs lack `ONLCR`, so the module inserts `\r` before each bare `\n` - correct for line-oriented output on the primary screen. But alt-screen apps (tmux, vim, less) emit VT-correct LF (cursor down, **column preserved**); normalizing those to `\r\n` corrupts their layout.

## Fix

Skip the conversion when the active screen is the alternate one:

```zig
if (term.terminal.screens.active_key == .alternate) {
    term.vtWrite(raw);
    ...
}
```

Detection via `screens.active_key` covers all three alt-screen entry modes (DECSET 47 / 1047 / 1049) uniformly. `last_input_was_cr` is still maintained so a CRLF pair split across writes isn't mis-normalized into `\r\r\n`.

## Demo

### Before

https://github.com/user-attachments/assets/d258aaf9-c7ba-4d29-81bf-b56976f4ba44

### After

https://github.com/user-attachments/assets/4fd2f858-0f23-47a5-b4e5-ddceb57b49e4