### PR TITLE
Skip rows-only resize while a minibuffer is active

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -6660,6 +6660,15 @@ PROCESS is the shell process, WINDOWS is the list of windows."
            ((and (eql height ghostel--term-rows)
                  (eql width ghostel--term-cols))
             (setq size nil))
+           ;; Don't resize on minibuffer-induced rows-only change.
+           ;; E.g. fish clears and re-emits its prompt on every SIGWINCH;
+           ;; a `consult-buffer'/`M-x' cycle that grows then shrinks the body
+           ;; would otherwise produce two prompt repaints in quick succession.
+           ;; Skip the deferral on the alt screen TUIs.
+           ((and (active-minibuffer-window)
+                 (eql width ghostel--term-cols)
+                 (not (ghostel--alt-screen-p ghostel--term)))
+            (setq size nil))
            ;; Real resize — update the terminal model and redraw.
            (t
             (ghostel--set-size-with-cell-dims

--- a/test/ghostel-terminal-test.el
+++ b/test/ghostel-terminal-test.el
@@ -168,6 +168,194 @@ modes (47 / 1047 / 1049) are handled uniformly."
     (let ((state (ghostel--copy-all-text term)))
       (should (string-match-p "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" state))))) ; 40 x's on row
 
+(ert-deftest ghostel-test-resize-window-adjust ()
+  "Window adjust resizes the VT, marks redraw state, and returns dimensions."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--force-next-redraw nil)
+          (set-size-args nil)
+          (redraw-called nil))
+      (let ((cur-buf (current-buffer)))
+        (cl-letf (((symbol-function 'ghostel--set-size-with-cell-dims)
+                   (lambda (_term h w) (setq set-size-args (list h w))))
+                  ((symbol-function 'ghostel--delayed-redraw)
+                   (lambda (_buf) (setq redraw-called t)))
+                  ((symbol-function 'process-buffer)
+                   (lambda (_proc) cur-buf))
+                  ((default-value 'window-adjust-process-window-size-function)
+                   (lambda (_proc _wins) '(120 . 40))))
+          (let ((result (ghostel--window-adjust-process-window-size
+                         'fake-proc '(fake-win))))
+            (should (equal '(120 . 40) result))
+            (should (equal '(40 120) set-size-args))
+            (should ghostel--force-next-redraw)
+            (should redraw-called)))))))
+
+(ert-deftest ghostel-test-resize-nil-size ()
+  "When default function returns nil, no resize happens."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (set-size-called nil))
+      (cl-letf (((symbol-function 'ghostel--set-size-with-cell-dims)
+                 (lambda (_term _h _w) (setq set-size-called t)))
+                ((symbol-function 'process-buffer)
+                 (lambda (_proc) nil))
+                ((default-value 'window-adjust-process-window-size-function)
+                 (lambda (_proc _wins) nil)))
+        (let ((result (ghostel--window-adjust-process-window-size
+                       'fake-proc nil)))
+          (should (null result))
+          (should-not set-size-called))))))
+
+(ert-deftest ghostel-test-resize-noop-same-dims ()
+  "Resize to identical dims returns nil and skips set-size."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--term-rows 40)
+          (ghostel--term-cols 120)
+          (set-size-called nil))
+      (let ((cur-buf (current-buffer)))
+        (cl-letf (((symbol-function 'ghostel--set-size-with-cell-dims)
+                   (lambda (_term _h _w) (setq set-size-called t)))
+                  ((symbol-function 'ghostel--delayed-redraw) #'ignore)
+                  ((symbol-function 'process-buffer)
+                   (lambda (_proc) cur-buf))
+                  ((default-value 'window-adjust-process-window-size-function)
+                   (lambda (_proc _wins) '(120 . 40))))
+          (let ((result (ghostel--window-adjust-process-window-size
+                         'fake-proc '(fake-win))))
+            (should (null result))
+            (should-not set-size-called)))))))
+
+(ert-deftest ghostel-test-resize-rows-only-during-minibuffer-suppressed ()
+  "Rows-only resize while a minibuffer is active is deferred (#268).
+fish (and other shells with `fish_handle_reflow' on) clears and
+re-emits its prompt on every SIGWINCH.  A `consult-buffer'/`M-x'
+cycle shrinks then re-grows the body and would otherwise produce
+two prompt repaints in quick succession — visible as flicker."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--term-rows 40)
+          (ghostel--term-cols 120)
+          (set-size-called nil)
+          (redraw-called nil))
+      (let ((cur-buf (current-buffer)))
+        (cl-letf (((symbol-function 'ghostel--set-size-with-cell-dims)
+                   (lambda (_term _h _w) (setq set-size-called t)))
+                  ((symbol-function 'ghostel--delayed-redraw)
+                   (lambda (_buf) (setq redraw-called t)))
+                  ((symbol-function 'process-buffer)
+                   (lambda (_proc) cur-buf))
+                  ((symbol-function 'active-minibuffer-window)
+                   (lambda () 'fake-mini-win))
+                  ((symbol-function 'ghostel--alt-screen-p)
+                   (lambda (_term) nil))
+                  ((default-value 'window-adjust-process-window-size-function)
+                   (lambda (_proc _wins) '(120 . 32))))
+          (let ((result (ghostel--window-adjust-process-window-size
+                         'fake-proc '(fake-win))))
+            (should (null result))
+            (should-not set-size-called)
+            (should-not redraw-called)
+            (should (= 40 ghostel--term-rows))
+            (should (= 120 ghostel--term-cols))))))))
+
+(ert-deftest ghostel-test-resize-rows-only-during-minibuffer-on-alt-screen-still-resizes ()
+  "Alt-screen TUIs bypass the minibuffer deferral and resize normally.
+vim/htop/less re-render against $LINES and would draw with stale
+dimensions otherwise."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--term-rows 40)
+          (ghostel--term-cols 120)
+          (ghostel--force-next-redraw nil)
+          (set-size-args nil)
+          (redraw-called nil))
+      (let ((cur-buf (current-buffer)))
+        (cl-letf (((symbol-function 'ghostel--set-size-with-cell-dims)
+                   (lambda (_term h w) (setq set-size-args (list h w))))
+                  ((symbol-function 'ghostel--delayed-redraw)
+                   (lambda (_buf) (setq redraw-called t)))
+                  ((symbol-function 'process-buffer)
+                   (lambda (_proc) cur-buf))
+                  ((symbol-function 'active-minibuffer-window)
+                   (lambda () 'fake-mini-win))
+                  ((symbol-function 'ghostel--alt-screen-p)
+                   (lambda (_term) t))
+                  ((default-value 'window-adjust-process-window-size-function)
+                   (lambda (_proc _wins) '(120 . 32))))
+          (let ((result (ghostel--window-adjust-process-window-size
+                         'fake-proc '(fake-win))))
+            (should (equal '(120 . 32) result))
+            (should (equal '(32 120) set-size-args))
+            (should ghostel--force-next-redraw)
+            (should redraw-called)
+            (should (= 32 ghostel--term-rows))
+            (should (= 120 ghostel--term-cols))))))))
+
+(ert-deftest ghostel-test-resize-rows-only-outside-minibuffer-still-resizes ()
+  "Rows-only resize with no minibuffer active goes through the normal path.
+Genuine vertical resizes like `C-x 2' must still propagate to the
+shell so $LINES stays accurate."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--term-rows 40)
+          (ghostel--term-cols 120)
+          (ghostel--force-next-redraw nil)
+          (set-size-args nil)
+          (redraw-called nil))
+      (let ((cur-buf (current-buffer)))
+        (cl-letf (((symbol-function 'ghostel--set-size-with-cell-dims)
+                   (lambda (_term h w) (setq set-size-args (list h w))))
+                  ((symbol-function 'ghostel--delayed-redraw)
+                   (lambda (_buf) (setq redraw-called t)))
+                  ((symbol-function 'process-buffer)
+                   (lambda (_proc) cur-buf))
+                  ((symbol-function 'active-minibuffer-window)
+                   (lambda () nil))
+                  ((default-value 'window-adjust-process-window-size-function)
+                   (lambda (_proc _wins) '(120 . 32))))
+          (let ((result (ghostel--window-adjust-process-window-size
+                         'fake-proc '(fake-win))))
+            (should (equal '(120 . 32) result))
+            (should (equal '(32 120) set-size-args))
+            (should ghostel--force-next-redraw)
+            (should redraw-called)
+            (should (= 32 ghostel--term-rows))
+            (should (= 120 ghostel--term-cols))))))))
+
+(ert-deftest ghostel-test-resize-cols-change-during-minibuffer-still-resizes ()
+  "Cols change during a minibuffer still goes through the normal path.
+The deferral only applies to rows-only deltas; a column change means
+real reflow that the shell needs to know about regardless of
+minibuffer state."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--term-rows 40)
+          (ghostel--term-cols 120)
+          (ghostel--force-next-redraw nil)
+          (set-size-args nil)
+          (redraw-called nil))
+      (let ((cur-buf (current-buffer)))
+        (cl-letf (((symbol-function 'ghostel--set-size-with-cell-dims)
+                   (lambda (_term h w) (setq set-size-args (list h w))))
+                  ((symbol-function 'ghostel--delayed-redraw)
+                   (lambda (_buf) (setq redraw-called t)))
+                  ((symbol-function 'process-buffer)
+                   (lambda (_proc) cur-buf))
+                  ((symbol-function 'active-minibuffer-window)
+                   (lambda () 'fake-mini-win))
+                  ((default-value 'window-adjust-process-window-size-function)
+                   (lambda (_proc _wins) '(100 . 40))))
+          (let ((result (ghostel--window-adjust-process-window-size
+                         'fake-proc '(fake-win))))
+            (should (equal '(100 . 40) result))
+            (should (equal '(40 100) set-size-args))
+            (should ghostel--force-next-redraw)
+            (should redraw-called)
+            (should (= 40 ghostel--term-rows))
+            (should (= 100 ghostel--term-cols))))))))
+
 (ert-deftest ghostel-test-cleanup-temp-paths-handles-files-and-dirs ()
   "`ghostel--cleanup-temp-paths' deletes files and recursively deletes dirs.
 Mirrors the real zsh case where the directory still contains a

--- a/test/ghostel-tramp-test.el
+++ b/test/ghostel-tramp-test.el
@@ -929,65 +929,6 @@ former defaulted to t and throttled bursty TUI redraws."
             (when (process-live-p proc)
               (delete-process proc))))))))
 
-(ert-deftest ghostel-test-resize-window-adjust ()
-  "Window adjust resizes the VT, marks redraw state, and returns dimensions."
-  (with-temp-buffer
-    (let ((ghostel--term 'fake)
-          (ghostel--force-next-redraw nil)
-          (set-size-args nil)
-          (redraw-called nil))
-      (let ((cur-buf (current-buffer)))
-        (cl-letf (((symbol-function 'ghostel--set-size-with-cell-dims)
-                   (lambda (_term h w) (setq set-size-args (list h w))))
-                  ((symbol-function 'ghostel--delayed-redraw)
-                   (lambda (_buf) (setq redraw-called t)))
-                  ((symbol-function 'process-buffer)
-                   (lambda (_proc) cur-buf))
-                  ((default-value 'window-adjust-process-window-size-function)
-                   (lambda (_proc _wins) '(120 . 40))))
-          (let ((result (ghostel--window-adjust-process-window-size
-                         'fake-proc '(fake-win))))
-            (should (equal '(120 . 40) result))
-            (should (equal '(40 120) set-size-args))
-            (should ghostel--force-next-redraw)
-            (should redraw-called)))))))
-
-(ert-deftest ghostel-test-resize-nil-size ()
-  "When default function returns nil, no resize happens."
-  (with-temp-buffer
-    (let ((ghostel--term 'fake)
-          (set-size-called nil))
-      (cl-letf (((symbol-function 'ghostel--set-size-with-cell-dims)
-                 (lambda (_term _h _w) (setq set-size-called t)))
-                ((symbol-function 'process-buffer)
-                 (lambda (_proc) nil))
-                ((default-value 'window-adjust-process-window-size-function)
-                 (lambda (_proc _wins) nil)))
-        (let ((result (ghostel--window-adjust-process-window-size
-                       'fake-proc nil)))
-          (should (null result))
-          (should-not set-size-called))))))
-
-(ert-deftest ghostel-test-resize-noop-same-dims ()
-  "Resize to identical dims returns nil and skips set-size."
-  (with-temp-buffer
-    (let ((ghostel--term 'fake)
-          (ghostel--term-rows 40)
-          (ghostel--term-cols 120)
-          (set-size-called nil))
-      (let ((cur-buf (current-buffer)))
-        (cl-letf (((symbol-function 'ghostel--set-size-with-cell-dims)
-                   (lambda (_term _h _w) (setq set-size-called t)))
-                  ((symbol-function 'ghostel--delayed-redraw) #'ignore)
-                  ((symbol-function 'process-buffer)
-                   (lambda (_proc) cur-buf))
-                  ((default-value 'window-adjust-process-window-size-function)
-                   (lambda (_proc _wins) '(120 . 40))))
-          (let ((result (ghostel--window-adjust-process-window-size
-                         'fake-proc '(fake-win))))
-            (should (null result))
-            (should-not set-size-called)))))))
-
 (ert-deftest ghostel-test-sigwinch-reaches-shell-basic ()
   "Verify `set-process-window-size' delivers SIGWINCH to a PTY shell.
 This is the baseline: if this fails, the Emacs PTY mechanism itself


### PR DESCRIPTION
## Summary
- `consult-buffer`/`M-x` etc. open and then close the minibuffer, transiently shrinking and re-growing the body of the window showing a ghostel buffer. The previous code propagated each transition as a real resize, producing two SIGWINCHes per cycle.
- fish (and any shell with `fish_handle_reflow` enabled, the default) clears and re-emits its prompt on every SIGWINCH, so the user saw two prompt repaints in quick succession — the visible flicker reported in #268.
- Fix: when `(active-minibuffer-window)` is non-nil and only the row count changed, defer the resize. `ghostel--term-rows` is intentionally left at its pre-minibuffer value, so the post-minibuffer adjust-fn pass hits the existing no-change branch.
- Genuine vertical resizes (`C-x 2`, frame-edge drag) and any cols change still go through the normal path, so `$LINES` stays accurate for layout changes the user actually committed to.

The existing `ghostel--redraw-resize-active` / `ghostel--correct-mangled-scroll-positions` machinery — which only defended the scroll/anchor state across the same scenario — stays in place as belt-and-braces.

## Test plan
- [x] `make test` (all elisp tests pass)
- [x] `make lint` (clean)
- [x] Three new tests in `ghostel-terminal-test.el`:
  - `ghostel-test-resize-rows-only-during-minibuffer-suppressed`
  - `ghostel-test-resize-rows-only-outside-minibuffer-still-resizes`
  - `ghostel-test-resize-cols-change-during-minibuffer-still-resizes`
- [x] Moved the three existing elisp-level adjust-fn tests out of `ghostel-tramp-test.el` (they had nothing to do with TRAMP) into `ghostel-terminal-test.el` alongside the VT-level resize test
- [x] Live verify in emacsclient with fish: `C-x b` / `consult-buffer` / `M-x` cycles no longer flicker the prompt
- [x] Live regression check in zsh: behavior unchanged
- [x] Live regression check with an alt-screen TUI (vim/htop): re-flows correctly when the minibuffer-induced resize ends

Fixes #268.