### PR TITLE
Forward M-<digit>, M-<punct>, M-<uppercase> in semi-char mode

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -721,7 +721,7 @@ When nil, falls back to `tramp-default-method'."
                  string))
 
 (defcustom ghostel-keymap-exceptions
-  '("C-c" "C-x" "C-u" "C-h" "M-x" "M-o" "M-:" "C-\\")
+  '("C-c" "C-x" "C-u" "C-h" "M-x" "M-:" "C-\\")
   "Key sequences that should not be sent to the terminal.
 These keys pass through to Emacs instead."
   :type '(repeat string))
@@ -1781,7 +1781,7 @@ When NO-EXCEPTIONS is non-nil, also bind the keys in
   (define-key map (kbd "DEL") #'ghostel--send-event)
   ;; Emacs reports S-TAB as <backtab>
   (define-key map (kbd "<backtab>") #'ghostel--send-event)
-  ;; Control keys — bind all C-<letter> to send ASCII control codes.
+  ;; Control keys - bind all C-<letter> to send ASCII control codes.
   ;; C-i = TAB and C-m = RET are equivalent to <tab>/<return> (bound above).
   ;; C-y is reserved for ghostel-yank in semi-char mode.
   ;; C-g is always handled by `ghostel-send-C-g' so the mark and
@@ -1796,13 +1796,24 @@ When NO-EXCEPTIONS is non-nil, also bind the keys in
                       (let ((code (- c 96)))
                         (lambda () (interactive)
                           (ghostel--send-string (string code)))))))))
-  ;; Meta and Control-Meta keys - bind all (C-)M-<letter> so they reach
-  ;; the terminal instead of running Emacs commands like forward-word.
+  ;; Meta keys - bind M-<printable ASCII> so the full set reaches the terminal.
+  ;; Skip ?\[ and ?O: those are escape-sequence prefixes (CSI / SS3)
+  ;; used by Emacs input decoding for arrow/function keys in TTY mode.
+  (dolist (c (number-sequence ?! ?~))
+    (unless (memq c '(?\[ ?O))
+      (let ((key-str (format "M-%c" c)))
+        (when (or no-exceptions
+                  (not (member key-str ghostel-keymap-exceptions)))
+          (ignore-errors
+            (define-key map (kbd key-str) #'ghostel--send-event))))))
+  ;; M-SPC: `(format "M-%c" ?\s)' yields "M- ", which `kbd' rejects.
+  (let ((key-str "M-SPC"))
+    (when (or no-exceptions
+              (not (member key-str ghostel-keymap-exceptions)))
+      (define-key map (kbd key-str) #'ghostel--send-event)))
+  ;; Control-Meta keys - C-M-<letter> only; C-M-<punct>/<digit> aren't
+  ;; widely supported by terminal apps.
   (dolist (c (number-sequence ?a ?z))
-    (let ((key-str (format "M-%c" c)))
-      (when (or no-exceptions
-                (not (member key-str ghostel-keymap-exceptions)))
-        (define-key map (kbd key-str) #'ghostel--send-event)))
     (let ((key-str (format "C-M-%c" c)))
       (when (or no-exceptions
                 (not (member key-str ghostel-keymap-exceptions)))

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -422,15 +422,34 @@ by the input-mode refactor)."
               #'ghostel-send-C-g)))
 
 (ert-deftest ghostel-test-meta-key-bindings ()
-  "All non-exception M-<letter> keys should be bound in semi-char-mode-map."
-  (dolist (c (number-sequence ?a ?z))
-    (let* ((key-str (format "M-%c" c))
-           (key-vec (kbd key-str))
-           (binding (lookup-key ghostel-semi-char-mode-map key-vec)))
-      (unless (eq c ?y)  ; M-y is ghostel-yank-pop
-        (if (member key-str ghostel-keymap-exceptions)
-            (should-not (eq binding #'ghostel--send-event))
-          (should (eq binding #'ghostel--send-event))))))
+  "All non-exception M-<printable ASCII> keys should be bound in semi-char-mode.
+Covers digits (M-1..M-9), punctuation (M-., M-,, M-/, ...), uppercase, and
+lowercase letters.  Regression test for issue #314: only M-<a-z> was bound,
+so M-<punct>/M-<digit> fell through to Emacs commands like
+`xref-find-definitions'."
+  (dolist (c (number-sequence ?! ?~))
+    ;; ?y = ghostel-yank-pop; ?\[ and ?O are escape-sequence prefixes
+    ;; intentionally not bound (would clobber TTY input decoding).
+    (unless (memq c '(?y ?\[ ?O))
+      (let* ((key-str (format "M-%c" c))
+             (key-vec (ignore-errors (kbd key-str)))
+             (binding (and key-vec
+                           (lookup-key ghostel-semi-char-mode-map key-vec))))
+        (when key-vec
+          (if (member key-str ghostel-keymap-exceptions)
+              (should-not (eq binding #'ghostel--send-event))
+            (should (eq binding #'ghostel--send-event)))))))
+  ;; Explicit regression guards for the keys called out in issue #314.
+  (dolist (key-str '("M-." "M-," "M-/" "M-;" "M-1" "M-9" "M-!" "M-A" "M-Z"))
+    (should (eq (lookup-key ghostel-semi-char-mode-map (kbd key-str))
+                #'ghostel--send-event)))
+  ;; M-SPC: source binds this explicitly because `(kbd "M- ")' won't parse.
+  (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "M-SPC"))
+              #'ghostel--send-event))
+  ;; Default exceptions (M-x, M-o, M-:) must still fall through to Emacs.
+  (dolist (key-str '("M-x" "M-:"))
+    (should-not (eq (lookup-key ghostel-semi-char-mode-map (kbd key-str))
+                    #'ghostel--send-event)))
   (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "M-y")) #'ghostel-yank-pop))
   ;; M-DEL must be bound so TTY Alt-Backspace ([27 127]) routes through
   ;; ghostel--send-event instead of global backward-kill-word.


### PR DESCRIPTION
## Summary

- The M- binding loop in `ghostel--define-terminal-keys` only covered `?a..?z`, so `M-.`, `M-1`, `M-/`, `M-;`, `M-A`, etc. fell through to Emacs global commands (`xref-find-definitions`, `digit-argument`, …) instead of reaching the shell. README promises *"most keys are sent to the terminal"* — this closes the gap.
- Iterate printable ASCII (33..126) for `M-<c>`, skip `?\[` and `?O` (CSI / SS3 escape-sequence prefixes used by TTY input decoding), and bind `M-SPC` explicitly since `(kbd "M- ")` won't parse. `C-M-` loop unchanged (letters only — `C-M-<punct>` isn't widely supported by terminal apps).
- Extends `ghostel-test-meta-key-bindings` to cover the new range, with explicit regression asserts for `M-.`, `M-,`, `M-/`, `M-;`, `M-1`, `M-9`, `M-!`, `M-A`, `M-Z`, `M-SPC`, plus negative asserts that the default exceptions (`M-x`, `M-:`) still fall through.

Fixes #314.

## Test plan

- [x] `make -j8 all` clean
- [x] Targeted `ghostel-test-meta-key-bindings` passes
- [x] Live: `bindkey -s '\e.' 'test'` in zsh, press `M-.`, confirm `test` is inserted (instead of `xref-find-definitions` firing)
- [x] Live: `M-1`, `M-9`, `M-/`, `M-;` reach the shell as expected
- [x] Live: `M-x`, `M-:` still open their Emacs commands (exception list honored)