### PR TITLE
Fix raw fallback for M-. and other meta-modified printable keys

### DIFF
--- a/lisp/ghostel-debug.el
+++ b/lisp/ghostel-debug.el
@@ -913,6 +913,7 @@ omit it when the connection itself is the suspected fault."
                                  ("backspace" "meta"      "M-Backspace")
                                  ("f"         "meta"      "M-f")
                                  ("b"         "meta"      "M-b")
+                                 ("."         "meta"      "M-.")
                                  ("f"         "ctrl,meta" "C-M-f")
                                  ("v"         "ctrl,meta" "C-M-v")
                                  ("h"         "ctrl"      "C-h")))

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2128,9 +2128,10 @@ Returns the sequence string, or nil for unknown keys."
            (<= ?a (aref key-name 0)) (<= (aref key-name 0) ?z)
            (> (logand mod-num 4) 0))        ; ctrl bit
       (string (- (aref key-name 0) 96)))    ; ctrl-a=1, ctrl-z=26
-     ;; Meta + single letter → ESC + char
+     ;; Meta + printable ASCII → ESC + char (legacy alt encoding)
      ((and (= (length key-name) 1)
-           (<= ?a (aref key-name 0)) (<= (aref key-name 0) ?z)
+           (let ((c (aref key-name 0)))
+             (and (>= c 32) (<= c 126)))
            (> (logand mod-num 2) 0))        ; alt/meta bit
       (format "\e%c" (aref key-name 0)))
      ;; Simple special keys (CSI u encoding for modified variants)

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -39,6 +39,17 @@
   ;; Unknown key
   (should (equal nil (ghostel--raw-key-sequence "xyzzy" ""))))        ; unknown
 
+(ert-deftest ghostel-test-raw-key-meta-printable ()
+  "Meta + any printable ASCII char encodes as ESC followed by that char.
+Covers punctuation, digits, uppercase, space, and lowercase letters."
+  (should (equal "\e." (ghostel--raw-key-sequence "." "meta")))
+  (should (equal "\e," (ghostel--raw-key-sequence "," "meta")))
+  (should (equal "\e1" (ghostel--raw-key-sequence "1" "meta")))
+  (should (equal "\eA" (ghostel--raw-key-sequence "A" "meta")))
+  (should (equal "\e " (ghostel--raw-key-sequence " " "meta")))
+  ;; Lowercase letters still work (existing behavior)
+  (should (equal "\eb" (ghostel--raw-key-sequence "b" "meta"))))
+
 (ert-deftest ghostel-test-modifier-number ()
   "Test modifier bitmask parsing."
   (should (equal 0 (ghostel--modifier-number "")))            ; no mods
@@ -79,6 +90,8 @@
         (sim (aref (kbd "M-<left>") 0)    "left"      "meta")
         (sim (aref (kbd "S-<f5>") 0)      "f5"        "shift")
         (sim (aref (kbd "C-S-<return>") 0) "return"   "ctrl,shift")
+        (sim (aref (kbd "M-.") 0)  "."  "meta")
+        (sim (aref (kbd "M-1") 0)  "1"  "meta")
         ;; backtab (Emacs's name for S-TAB)
         (sim (aref (kbd "<backtab>") 0)   "tab"       "shift")))))
 
@@ -483,6 +496,19 @@ Regression test for issue #239: these byte sequences match readline
       (should (ghostel--encode-key term "v" "ctrl,meta" nil))
       (should (equal "\e\x16" sent)))))
 
+(ert-deftest ghostel-test-send-encoded-meta-period ()
+  "M-. sends ESC + period via raw fallback (legacy alt encoding)."
+  :tags '(native)
+  (let* ((term (ghostel--new 25 80 1000))
+         (sent nil))
+    (cl-letf (((symbol-function 'process-live-p) (lambda (_) t))
+              ((symbol-function 'process-send-string)
+               (lambda (_proc str) (setq sent str))))
+      (setq ghostel--term term
+            ghostel--process 'fake)
+      (ghostel--send-encoded "." "meta")
+      (should (equal "\e." sent)))))
+
 (ert-deftest ghostel-test-special-key-modifier-bindings ()
   "Modified special keys are bound unless in `ghostel-keymap-exceptions'.
 Covers e.g. C-<return>, C-M-<down>, S-<f1>.
@@ -550,6 +576,8 @@ but `this-command-keys-vector' retains the ESC prefix."
         (sim-tty (vector 27 ?b)   ?b  "b" "meta")
         (sim-tty (vector 27 ?f)   ?f  "f" "meta")
         (sim-tty (vector 27 ?d)   ?d  "d" "meta")
+        (sim-tty (vector 27 ?.)  ?.  "." "meta")
+        (sim-tty (vector 27 ?1)  ?1  "1" "meta")
         ;; M-DEL in TTY: ESC then 127 → backspace + meta
         (sim-tty (vector 27 127)  127 "backspace" "meta")
         ;; Already-meta event (shouldn't double-add meta)


### PR DESCRIPTION
PR #315 bound `M-<digit>` and `M-<punct>` to `ghostel--send-event`, but when libghostty's encoder returns no output the raw fallback in `ghostel--raw-key-sequence` only handled meta + lowercase a-z. Keys like `M-.` were dropped silently. Extend the meta branch to printable ASCII (32–126) so the encoder fallback emits ESC + char, matching legacy alt encoding and what zsh/readline expect (e.g. `M-.` → insert-last-word). Add regression tests and an `M-.` entry to the debug encoding probe.

Related issue: https://github.com/dakra/ghostel/issues/314

## Output from `ghostel-debug-keypress`
### v0.29, M-.
```
=== ghostel-debug-keypress ===

--- Event ---
Buffer:              *ghostel*
last-input-event:    134217774
Keys vector:         [134217774]
Key description:     M-.
this-command:        ghostel--send-event
Resolved binding:    ghostel--send-event

--- Sends during this command ---
(no calls to ghostel--send-string or ghostel--flush-output)

--- Terminal modes ---
DECCKM (cursor keys app) (1): ON
DECKPAM (keypad app) (66): ON
Mouse X10 (1000):          off
Mouse button-event (1002): off
Mouse any-event (1003):    off
Focus events (1004):       off
Mouse SGR (1006):          off
Mouse urxvt (1015):        off
Alt screen (alt buffer) (1047): off
Alt screen (cursor save) (1049): off
Bracketed paste (2004):    ON
DEC 2026 sync (2026):      off

--- Coalesce buffer ---
Pending bytes:       0
Coalesce timer:      none

--- Process ---
PID:                 1643
Status:              run
TTY:                 /dev/ttys001
```

### v0.29, M-b (for reference)
```
=== ghostel-debug-keypress ===

--- Event ---
Buffer:              *ghostel*
last-input-event:    134217826
Keys vector:         [134217826]
Key description:     M-b
this-command:        ghostel--send-event
Resolved binding:    ghostel--send-event

--- Sends during this command ---
1. send-string: "\33b"  (2 bytes, hex: 1b 62)

--- Terminal modes ---
DECCKM (cursor keys app) (1): ON
DECKPAM (keypad app) (66): ON
Mouse X10 (1000):          off
Mouse button-event (1002): off
Mouse any-event (1003):    off
Focus events (1004):       off
Mouse SGR (1006):          off
Mouse urxvt (1015):        off
Alt screen (alt buffer) (1047): off
Alt screen (cursor save) (1049): off
Bracketed paste (2004):    ON
DEC 2026 sync (2026):      off

--- Coalesce buffer ---
Pending bytes:       0
Coalesce timer:      none

--- Process ---
PID:                 1643
Status:              run
TTY:                 /dev/ttys001
```

### with this patch, M-.
```
=== ghostel-debug-keypress ===

--- Event ---
Buffer:              *ghostel*
last-input-event:    134217774
Keys vector:         [134217774]
Key description:     M-.
this-command:        ghostel--send-event
Resolved binding:    ghostel--send-event

--- Sends during this command ---
1. send-string: "\33."  (2 bytes, hex: 1b 2e)

--- Terminal modes ---
DECCKM (cursor keys app) (1): ON
DECKPAM (keypad app) (66): ON
Mouse X10 (1000):          off
Mouse button-event (1002): off
Mouse any-event (1003):    off
Focus events (1004):       off
Mouse SGR (1006):          off
Mouse urxvt (1015):        off
Alt screen (alt buffer) (1047): off
Alt screen (cursor save) (1049): off
Bracketed paste (2004):    ON
DEC 2026 sync (2026):      off

--- Coalesce buffer ---
Pending bytes:       0
Coalesce timer:      none

--- Process ---
PID:                 4182
Status:              run
TTY:                 /dev/ttys001
```