### PR TITLE
Add some utilities for development

### DIFF
--- a/tools/ghostel-dape.el
+++ b/tools/ghostel-dape.el
@@ -1,0 +1,109 @@
+;;; ghostel-dape.el --- Dape launch helpers for ghostel tests -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Project-local Dape helpers for debugging Ghostel's native module under
+;; test.  Load this file, then use:
+;;
+;;   M-x ghostel-dape-ert-test-at-point
+;;   M-x ghostel-dape-ert-file
+;;
+;; The commands launch a fresh batch Emacs under codelldb, matching the
+;; existing manual Dape workflow but without typing the long config blob.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'subr-x)
+(require 'dape)
+
+(defgroup ghostel-dape nil
+  "Dape helpers for Ghostel tests."
+  :group 'ghostel)
+
+(defcustom ghostel-dape-build-command
+  "zig build -Doptimize=Debug -Dcpu=baseline"
+  "Build command run before launching Dape.
+Set to nil to skip automatic compilation."
+  :type '(choice (const :tag "Do not build" nil) string)
+  :group 'ghostel-dape)
+
+(defun ghostel-dape--root ()
+  "Return the Ghostel project root."
+  (or (locate-dominating-file default-directory "build.zig")
+      (user-error "Could not find Ghostel project root")))
+
+(defun ghostel-dape--relative-file (file)
+  "Return FILE relative to the Ghostel project root."
+  (file-relative-name (expand-file-name file) (ghostel-dape--root)))
+
+(defun ghostel-dape--vector (&rest args)
+  "Return ARGS as a vector, dropping nil elements."
+  (vconcat (delq nil args)))
+
+(defun ghostel-dape--launch-emacs (&rest args)
+  "Launch batch Emacs with ARGS under Dape/codelldb."
+  (let* ((root (file-name-as-directory (expand-file-name (ghostel-dape--root))))
+         (base (or (cdr (assoc 'codelldb-cc dape-configs))
+                   (user-error "No `codelldb-cc' entry in `dape-configs'")))
+         (config (copy-sequence base)))
+    (setq config (plist-put config 'command-cwd root))
+    (setq config (plist-put config :program (expand-file-name invocation-name invocation-directory)))
+    (setq config (plist-put config :cwd root))
+    (setq config (plist-put config :args (apply #'ghostel-dape--vector args)))
+    (setq config (plist-put config :stopOnEntry nil))
+    (if ghostel-dape-build-command
+        (setq config (plist-put config 'compile ghostel-dape-build-command))
+      (cl-remf config 'compile))
+    (dape config)))
+
+(defun ghostel-dape--current-ert-test ()
+  "Return the `ert-deftest' name around point, or nil."
+  (save-excursion
+    (end-of-line)
+    (when (re-search-backward "^(ert-deftest[[:space:]]+\\([^[:space:]]+\\)" nil t)
+      (match-string-no-properties 1))))
+
+(defun ghostel-dape--ert-eval (test-regexp)
+  "Return Elisp form string that runs ERT tests matching TEST-REGEXP."
+  (format "(ert-run-tests-batch-and-exit %S)" test-regexp))
+
+;;;###autoload
+(defun ghostel-dape-ert-test-at-point (&optional test-name)
+  "Debug the ERT TEST-NAME at point under Dape.
+When called interactively outside an `ert-deftest', prompt for the test
+name.  The current buffer's test file is loaded into a fresh batch Emacs."
+  (interactive)
+  (let* ((file (buffer-file-name))
+         (_ (unless file (user-error "Current buffer is not visiting a file")))
+         (test (or test-name
+                   (ghostel-dape--current-ert-test)
+                   (read-string "ERT test name: ")))
+         (regexp (concat "^" (regexp-quote test) "$")))
+    (ghostel-dape--launch-emacs
+     "--batch" "-Q"
+     "-L" "lisp"
+     "-L" "test"
+     "-l" "ert"
+     "-l" "test/ghostel-test-helpers.el"
+     "-l" (ghostel-dape--relative-file file)
+     "--eval" (ghostel-dape--ert-eval regexp))))
+
+;;;###autoload
+(defun ghostel-dape-ert-file ()
+  "Debug all ERT tests in the current file under Dape."
+  (interactive)
+  (let ((file (buffer-file-name)))
+    (unless file
+      (user-error "Current buffer is not visiting a file"))
+    (ghostel-dape--launch-emacs
+     "--batch" "-Q"
+     "-L" "lisp"
+     "-L" "test"
+     "-l" "ert"
+     "-l" "test/ghostel-test-helpers.el"
+     "-l" (ghostel-dape--relative-file file)
+     "--eval" "(ert-run-tests-batch-and-exit t)")))
+
+(provide 'ghostel-dape)
+;;; ghostel-dape.el ends here

--- a/tools/test-charwidth.sh
+++ b/tools/test-charwidth.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Visual double-width character verification.
+#
+# For each character type, a line of N chars is printed directly above
+# a baseline of 2N ASCII dots.  If the terminal renders each char at
+# exactly 2 columns the trailing | markers will be vertically aligned.
+#
+# Look at the output — nothing here can be verified programmatically.
+
+RULER='+----+----+----+----+----+----+----+----+----+----+'
+NUMS='1    5    10   15   20   25   30   35   40   45   50'
+
+section() {
+  printf '\n\e[1m%s\e[0m\n' "=== $1 ==="
+  printf '%s\n' "$RULER"
+  printf '%s\n' "$NUMS"
+  echo
+}
+
+# pair LABEL CHARS DOTS
+# Prints LABEL, then CHARS|, then DOTS| on the next line.
+# DOTS should be exactly 2× as many characters as CHARS.
+pair() {
+  local label="$1" chars="$2" dots="$3"
+  printf '  %-22s %s|\n' "$label" "$chars"
+  printf '  %-22s %s|\n' "(ASCII baseline)" "$dots"
+  echo
+}
+
+echo
+echo 'Each test char type is shown above an ASCII dot baseline.'
+echo 'The | at the end of each pair MUST be vertically aligned.'
+echo 'Misalignment means that character type renders at the wrong width.'
+echo
+
+section "CJK ideographs  (10 chars → 20 cols)"
+pair "10 CJK"       "的一了是我不在人们有"   "...................."
+pair "10 hiragana"  "あいうえおかきくけこ"   "...................."
+pair "10 katakana"  "アイウエオカキクケコ"   "...................."
+pair "10 hangul"    "가나다라마바사아자차"   "...................."
+
+section "Full-width Latin  (10 chars → 20 cols)"
+pair "10 fw-Latin"  "ＡＢＣＤＥＦＧＨＩＪ"  "...................."
+pair "10 fw-digits" "０１２３４５６７８９"   "...................."
+
+section "Emoji  (10 chars → 20 cols)"
+pair "10 faces"     "😀😃😄😁😆😅🤣😂🙂😉"   "...................."
+pair "10 objects"   "🍎🍊🍋🍌🍇🍓🍒🍑🥭🍍"   "...................."
+pair "10 symbols"   "⚽️🏀🏈⚾️🎾🏐🏉🎱🏓🏸"   "...................."
+
+section "Emoji flags  (10 pairs of regional indicators → 20 cols)"
+pair "10 flags"     "🇺🇸🇬🇧🇫🇷🇩🇪🇯🇵🇨🇳🇰🇷🇧🇷🇮🇳🇮🇹"   "...................."
+
+section "Half-width katakana  (10 chars → 10 cols, single-width)"
+pair "10 hw-kana"   "ｱｲｳｴｵｶｷｸｹｺ"              ".........."
+
+section "ZWJ sequences  (each sequence = 1 glyph, typically 2 cols)"
+echo '  These are renderer-defined — width varies. No fixed baseline.'
+echo '  Check visually whether each glyph occupies ~2 columns.'
+echo
+printf '  👨‍💻 👩‍🔬 👨‍🍳 👩‍🎨 👨‍✈️\n'
+printf '  👨‍👩‍👧  👨‍👩‍👧‍👦  👩‍👩‍👦  👨‍👨‍👧\n'
+echo
+
+section "Skin-tone modifier sequences  (10 chars → 20 cols)"
+pair "10 skin-tone" "👋🏻👋🏼👋🏽👋🏾👋🏿👍🏻👍🏼👍🏽👍🏾👍🏿" "...................."
+
+section "Combining diacritics  (10 base+combining → 10 cols, single-width)"
+pair "10 combined"  "àèìòùáéíóú"                ".........."
+
+printf '%s\n' "$RULER"
+printf '%s\n' "$NUMS"
+echo

--- a/tools/test-osc8.sh
+++ b/tools/test-osc8.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Test OSC8 hyperlinks in the terminal
+# Format: \e]8;;URI\aLABEL\e]8;;\a
+
+link() {
+  local uri="$1" label="$2"
+  printf '\e]8;;%s\a%s\e]8;;\a' "$uri" "$label"
+}
+
+echo "Plain text (no link)"
+echo -n "Basic link: "
+link "https://example.com" "Example"
+echo ""
+echo ""
+echo -n "Email link: "
+link "mailto:test@example.com" "Email"
+echo ""
+echo ""
+echo -n "File link: "
+link "file:///etc/hosts" "/etc/hosts"
+echo ""
+echo ""
+echo "Multiple links on one line:"
+echo -n "  "; link "https://emacs.org" "Emacs"; echo -n "  "; link "https://github.com" "GitHub"; echo ""
+echo ""
+echo "Link with special chars:"
+echo -n "  "; link "https://example.com/path?foo=bar&baz=qux" "Query params"
+echo ""


### PR DESCRIPTION
This adds three things:
- A shell script to test OSC8 handling
- A shell script to test rendering widths
- An Elisp file that can be loaded to aid in debugging Zig code. It makes it easy to start a unit test under Dape for debugging Zig code with LLDB and CodeLLDB, something I frequently have to do.