### PR TITLE
Dedupe hyperlink navigation by OSC 8 id

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4007,23 +4007,47 @@ a line suffix opens at the start of the file or directory."
   (interactive)
   (ghostel--open-link (ghostel--uri-at-pos (point))))
 
+(defun ghostel--find-link-1 (direction from)
+  "Return the start of the next/previous hyperlink from FROM, or nil.
+DIRECTION is `next' or `previous'.
+
+Treats runs sharing a `ghostel-link-id' as one logical link: if FROM is
+inside such a run, other runs with that id are skipped; for `previous',
+the result is walked back to the earliest same-id run so a wrapped URL
+lands at its start, not its last chunk."
+  (let ((search-fn (if (eq direction 'next)
+                       #'text-property-search-forward
+                     #'text-property-search-backward))
+        (skip-id (get-text-property from 'ghostel-link-id)))
+    (save-excursion
+      (goto-char from)
+      (catch 'found
+        (while-let ((match (funcall search-fn 'help-echo nil
+                                    (lambda (_ v) v) t)))
+          (let* ((pos (prop-match-beginning match))
+                 (id (get-text-property pos 'ghostel-link-id)))
+            (unless (and skip-id (equal skip-id id))
+              (when (and (eq direction 'previous) id)
+                (catch 'walked
+                  (while-let ((earlier (text-property-search-backward
+                                        'help-echo nil
+                                        (lambda (_ v) v) t)))
+                    (let ((earlier-pos (prop-match-beginning earlier)))
+                      (if (equal id (get-text-property
+                                     earlier-pos 'ghostel-link-id))
+                          (setq pos earlier-pos)
+                        (throw 'walked nil))))))
+              (throw 'found pos))))))))
+
 (defun ghostel--find-next-link (from)
   "Return start position of the first hyperlink after FROM, or nil.
-A hyperlink is any region with a non-nil `help-echo' property —
-covers OSC 8 links, auto-detected URLs, and `fileref:' references."
-  (save-excursion
-    (goto-char from)
-    (when-let* ((match (text-property-search-forward
-                        'help-echo nil (lambda (_ v) v) t)))
-      (prop-match-beginning match))))
+A hyperlink is any region with a non-nil `help-echo' property.
+Covers OSC 8 links, auto-detected URLs, and `fileref:' references."
+  (ghostel--find-link-1 'next from))
 
 (defun ghostel--find-previous-link (from)
   "Return start position of the first hyperlink before FROM, or nil."
-  (save-excursion
-    (goto-char from)
-    (when-let* ((match (text-property-search-backward
-                        'help-echo nil (lambda (_ v) v) t)))
-      (prop-match-beginning match))))
+  (ghostel--find-link-1 'previous from))
 
 (defun ghostel--goto-hyperlink (direction)
   "Jump to the next/previous hyperlink.  DIRECTION is `next' or `previous'.

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -13,6 +13,7 @@ const GhostelTerm = @import("GhostelTerm.zig");
 const style_face = @import("style_face.zig");
 
 pub const CellProps = style_face.CellProps;
+pub const LinkId = style_face.LinkId;
 const formatColor = style_face.formatColor;
 
 const Self = @This();
@@ -270,9 +271,25 @@ fn readCellProps(self: *Self, cell: *const gt.RenderState.Cell) ?CellProps {
     )) null else props;
 }
 
+/// Resolve a page-local hyperlink id to a `LinkId` that compares equal
+/// across pages for the same logical OSC 8 link.  `PageEntry.dupe`
+/// preserves `.explicit` byte strings verbatim and `.implicit` counters
+/// as-is, so byte- and numeric-equality both work cross-page.
+///
+/// The `.explicit` slice borrows from `page` memory and is invalidated
+/// by the next `render_state.update`; callers must copy it (e.g. via
+/// `env.makeString`) within the current `insertRow`.
+fn resolveLinkId(page: *const gt.page.Page, local_id: gt.size.HyperlinkCountInt) LinkId {
+    const entry = page.hyperlink_set.get(page.memory, local_id);
+    return switch (entry.id) {
+        .explicit => |slice| .{ .explicit = slice.slice(page.memory) },
+        .implicit => |v| .{ .implicit = @intCast(v) },
+    };
+}
+
 /// Apply face properties to a region of the buffer.
 /// Uses (put-text-property START END 'face PLIST).
-fn applyProps(env: emacs.Env, start: i64, end: i64, props: CellProps) !void {
+fn applyProps(env: emacs.Env, start: i64, end: i64, props: CellProps, link_id: ?LinkId) !void {
     if (start >= end) return;
 
     const start_val = env.makeInteger(start);
@@ -287,6 +304,16 @@ fn applyProps(env: emacs.Env, start: i64, end: i64, props: CellProps) !void {
         env.putTextProperty(start_val, end_val, "help-echo", s.@"ghostel--native-link-help-echo");
         env.putTextProperty(start_val, end_val, "mouse-face", s.highlight);
         env.putTextProperty(start_val, end_val, "keymap", env.symbolValue("ghostel-link-map"));
+        if (link_id) |id| {
+            // Stored as a string (explicit) or integer (implicit), so elisp `equal' returns true
+            // only when both kind and value match. A user-supplied explicit id like "42" never
+            // collides with an implicit counter of 42.
+            const id_val: emacs.Value = switch (id) {
+                .explicit => |str| env.makeString(str),
+                .implicit => |n| env.makeInteger(@intCast(n)),
+            };
+            env.putTextProperty(start_val, end_val, "ghostel-link-id", id_val);
+        }
     }
 
     switch (props.semantic_content) {
@@ -299,17 +326,22 @@ fn applyProps(env: emacs.Env, start: i64, end: i64, props: CellProps) !void {
 /// Unique identifier that is cheaper to read and compare relative to `CellProps`.
 /// We read this first and if it differs from the previous cell, we read the full
 /// `CellProps`.
+///
+/// `hyperlink_id` carries the page-local hyperlink id (0 = no hyperlink) so two
+/// adjacent cells pointing to different hyperlinks split into separate runs and
+/// each gets its own `ghostel-link-id` text property.  Page-local is sufficient
+/// because all cells in a single row live on the same page.
 const CellPropKey = packed struct {
     // TODO: Style ID type is not exported from ghostty-vt for some reason.
     //       We should file an issue.
     style_id: @FieldType(gt.page.Cell, "style_id"),
-    hyperlink: bool,
+    hyperlink_id: gt.size.HyperlinkCountInt,
     semantic_content: gt.page.Cell.SemanticContent,
 
-    fn fromCell(cell: gt.page.Cell) CellPropKey {
+    fn fromCell(cell: gt.page.Cell, hyperlink_id: gt.size.HyperlinkCountInt) CellPropKey {
         return .{
             .style_id = cell.style_id,
-            .hyperlink = cell.hyperlink,
+            .hyperlink_id = hyperlink_id,
             .semantic_content = cell.semantic_content,
         };
     }
@@ -320,6 +352,7 @@ pub const RowContent = struct {
         start_char: usize,
         end_char: usize,
         props: ?CellProps,
+        link_id: ?LinkId,
     };
 
     const CellInfo = struct {
@@ -369,22 +402,36 @@ pub const RowContent = struct {
         var trim_byte_len: usize = 0;
         var trim_char_len: usize = 0;
 
+        // `RenderState.Cell.raw` is a copy; the page-memory cell pointer is
+        // needed for `Page.lookupHyperlink` (which uses offset arithmetic).
+        const page = &row.pin.node.data;
+
         var current_prop_key: ?CellPropKey = null;
         var col: usize = 0;
         while (col < row.cells.len) : (col += 1) {
             const cell = row.cells.get(col);
             if (cell.raw.wide == .spacer_tail or cell.raw.wide == .spacer_head) continue;
 
+            // Resolve the page-local hyperlink id (0 = no link) so adjacent
+            // cells pointing to *different* hyperlinks split into separate
+            // runs.  Without this, two different links touching would share
+            // one run and one `ghostel-link-id' text property.
+            const hyperlink_id: gt.size.HyperlinkCountInt = if (cell.raw.hyperlink) blk: {
+                const real_cell = page.getRowAndCell(col, row.pin.y).cell;
+                break :blk page.lookupHyperlink(real_cell) orelse 0;
+            } else 0;
+
             // We use a "key" that holds a minimum set of values that are cheap to
             // read and compare to detect style run breaks. Only when we detect a
             // break do we read the cell style, which is a more expensive operation
             // in such a tight loop.
-            const prop_key = CellPropKey.fromCell(cell.raw);
+            const prop_key = CellPropKey.fromCell(cell.raw, hyperlink_id);
             if (prop_key != current_prop_key) {
                 try self.runs.append(alloc, .{
                     .start_char = self.char_len,
                     .end_char = self.char_len,
                     .props = readCellProps(renderer, &cell),
+                    .link_id = if (hyperlink_id != 0) resolveLinkId(page, hyperlink_id) else null,
                 });
                 current_prop_key = prop_key;
             }
@@ -571,7 +618,7 @@ fn insertRow(self: *Self, alloc: Allocator, env: emacs.Env, row: *const gt.Rende
         const prop_start = row_start + @as(i64, @intCast(run.start_char));
         const prop_end = row_start + @as(i64, @intCast(run.end_char));
         if (run.props) |props| {
-            try applyProps(env, prop_start, prop_end, props);
+            try applyProps(env, prop_start, prop_end, props, run.link_id);
         }
     }
 

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -241,8 +241,31 @@ fn probeCoverage(env: emacs.Env, font: emacs.Value) u32 {
 
 const ViewportSize = struct { cols: u16, rows: u16, cell_w: u32, cell_h: u32 };
 
+/// Resolve a page-local hyperlink id to a `LinkId` that compares equal
+/// across pages for the same logical OSC 8 link.  `PageEntry.dupe`
+/// preserves `.explicit` byte strings verbatim and `.implicit` counters
+/// as-is, so byte- and numeric-equality both work cross-page.
+///
+/// The `.explicit` slice borrows from `page` memory and is invalidated
+/// by the next `render_state.update`; callers must copy it (e.g. via
+/// `env.makeString`) within the current `insertRow`.
+fn resolveLinkId(page: *const gt.page.Page, local_id: gt.size.HyperlinkCountInt) ?LinkId {
+    if (local_id == 0) return null;
+
+    const entry = page.hyperlink_set.get(page.memory, local_id);
+    return switch (entry.id) {
+        .explicit => |slice| .{ .explicit = slice.slice(page.memory) },
+        .implicit => |v| .{ .implicit = @intCast(v) },
+    };
+}
+
 /// Read the style for the current cell from the render state.
-fn readCellProps(self: *Self, cell: *const gt.RenderState.Cell) ?CellProps {
+fn createCellProps(
+    self: *Self,
+    page: *const gt.Page,
+    key: CellPropKey,
+    cell: *const gt.RenderState.Cell,
+) ?CellProps {
     var props: CellProps = .{};
 
     const style: gt.Style = if (cell.raw.hasStyling()) cell.style else .{};
@@ -262,7 +285,7 @@ fn readCellProps(self: *Self, cell: *const gt.RenderState.Cell) ?CellProps {
     props.overline = style.flags.overline;
     props.inverse = style.flags.inverse;
     props.underline_color = style.underlineColor(&self.render_state.colors.palette);
-    props.hyperlink = cell.raw.hyperlink;
+    props.link_id = resolveLinkId(page, key.hyperlink_id);
     props.semantic_content = cell.raw.semantic_content;
 
     return if (props.isDefault(
@@ -271,25 +294,9 @@ fn readCellProps(self: *Self, cell: *const gt.RenderState.Cell) ?CellProps {
     )) null else props;
 }
 
-/// Resolve a page-local hyperlink id to a `LinkId` that compares equal
-/// across pages for the same logical OSC 8 link.  `PageEntry.dupe`
-/// preserves `.explicit` byte strings verbatim and `.implicit` counters
-/// as-is, so byte- and numeric-equality both work cross-page.
-///
-/// The `.explicit` slice borrows from `page` memory and is invalidated
-/// by the next `render_state.update`; callers must copy it (e.g. via
-/// `env.makeString`) within the current `insertRow`.
-fn resolveLinkId(page: *const gt.page.Page, local_id: gt.size.HyperlinkCountInt) LinkId {
-    const entry = page.hyperlink_set.get(page.memory, local_id);
-    return switch (entry.id) {
-        .explicit => |slice| .{ .explicit = slice.slice(page.memory) },
-        .implicit => |v| .{ .implicit = @intCast(v) },
-    };
-}
-
 /// Apply face properties to a region of the buffer.
 /// Uses (put-text-property START END 'face PLIST).
-fn applyProps(env: emacs.Env, start: i64, end: i64, props: CellProps, link_id: ?LinkId) !void {
+fn applyProps(env: emacs.Env, start: i64, end: i64, props: CellProps) !void {
     if (start >= end) return;
 
     const start_val = env.makeInteger(start);
@@ -300,20 +307,19 @@ fn applyProps(env: emacs.Env, start: i64, end: i64, props: CellProps, link_id: ?
         env.putTextProperty(start_val, end_val, "face", face);
     }
 
-    if (props.hyperlink) {
+    if (props.link_id) |id| {
         env.putTextProperty(start_val, end_val, "help-echo", s.@"ghostel--native-link-help-echo");
         env.putTextProperty(start_val, end_val, "mouse-face", s.highlight);
         env.putTextProperty(start_val, end_val, "keymap", env.symbolValue("ghostel-link-map"));
-        if (link_id) |id| {
-            // Stored as a string (explicit) or integer (implicit), so elisp `equal' returns true
-            // only when both kind and value match. A user-supplied explicit id like "42" never
-            // collides with an implicit counter of 42.
-            const id_val: emacs.Value = switch (id) {
-                .explicit => |str| env.makeString(str),
-                .implicit => |n| env.makeInteger(@intCast(n)),
-            };
-            env.putTextProperty(start_val, end_val, "ghostel-link-id", id_val);
-        }
+
+        // Stored as a string (explicit) or integer (implicit), so elisp `equal' returns true
+        // only when both kind and value match. A user-supplied explicit id like "42" never
+        // collides with an implicit counter of 42.
+        const id_val: emacs.Value = switch (id) {
+            .explicit => |str| env.makeString(str),
+            .implicit => |n| env.makeInteger(@intCast(n)),
+        };
+        env.putTextProperty(start_val, end_val, "ghostel-link-id", id_val);
     }
 
     switch (props.semantic_content) {
@@ -326,11 +332,6 @@ fn applyProps(env: emacs.Env, start: i64, end: i64, props: CellProps, link_id: ?
 /// Unique identifier that is cheaper to read and compare relative to `CellProps`.
 /// We read this first and if it differs from the previous cell, we read the full
 /// `CellProps`.
-///
-/// `hyperlink_id` carries the page-local hyperlink id (0 = no hyperlink) so two
-/// adjacent cells pointing to different hyperlinks split into separate runs and
-/// each gets its own `ghostel-link-id` text property.  Page-local is sufficient
-/// because all cells in a single row live on the same page.
 const CellPropKey = packed struct {
     // TODO: Style ID type is not exported from ghostty-vt for some reason.
     //       We should file an issue.
@@ -338,10 +339,13 @@ const CellPropKey = packed struct {
     hyperlink_id: gt.size.HyperlinkCountInt,
     semantic_content: gt.page.Cell.SemanticContent,
 
-    fn fromCell(cell: gt.page.Cell, hyperlink_id: gt.size.HyperlinkCountInt) CellPropKey {
+    fn create(page: *const gt.Page, cell: *const gt.page.Cell) CellPropKey {
         return .{
             .style_id = cell.style_id,
-            .hyperlink_id = hyperlink_id,
+            .hyperlink_id = if (cell.hyperlink)
+                page.lookupHyperlink(cell) orelse 0
+            else
+                0,
             .semantic_content = cell.semantic_content,
         };
     }
@@ -352,7 +356,6 @@ pub const RowContent = struct {
         start_char: usize,
         end_char: usize,
         props: ?CellProps,
-        link_id: ?LinkId,
     };
 
     const CellInfo = struct {
@@ -402,36 +405,22 @@ pub const RowContent = struct {
         var trim_byte_len: usize = 0;
         var trim_char_len: usize = 0;
 
-        // `RenderState.Cell.raw` is a copy; the page-memory cell pointer is
-        // needed for `Page.lookupHyperlink` (which uses offset arithmetic).
         const page = &row.pin.node.data;
-
         var current_prop_key: ?CellPropKey = null;
         var col: usize = 0;
         while (col < row.cells.len) : (col += 1) {
             const cell = row.cells.get(col);
+            const raw_cell = page.getRowAndCell(col, row.pin.y).cell;
             if (cell.raw.wide == .spacer_tail or cell.raw.wide == .spacer_head) continue;
 
-            // Resolve the page-local hyperlink id (0 = no link) so adjacent
-            // cells pointing to *different* hyperlinks split into separate
-            // runs.  Without this, two different links touching would share
-            // one run and one `ghostel-link-id' text property.
-            const hyperlink_id: gt.size.HyperlinkCountInt = if (cell.raw.hyperlink) blk: {
-                const real_cell = page.getRowAndCell(col, row.pin.y).cell;
-                break :blk page.lookupHyperlink(real_cell) orelse 0;
-            } else 0;
-
             // We use a "key" that holds a minimum set of values that are cheap to
-            // read and compare to detect style run breaks. Only when we detect a
-            // break do we read the cell style, which is a more expensive operation
-            // in such a tight loop.
-            const prop_key = CellPropKey.fromCell(cell.raw, hyperlink_id);
+            // compare to detect style run breaks.
+            const prop_key = CellPropKey.create(&row.pin.node.data, raw_cell);
             if (prop_key != current_prop_key) {
                 try self.runs.append(alloc, .{
                     .start_char = self.char_len,
                     .end_char = self.char_len,
-                    .props = readCellProps(renderer, &cell),
-                    .link_id = if (hyperlink_id != 0) resolveLinkId(page, hyperlink_id) else null,
+                    .props = createCellProps(renderer, page, prop_key, &cell),
                 });
                 current_prop_key = prop_key;
             }
@@ -439,23 +428,23 @@ pub const RowContent = struct {
             const byte_start = self.text.items.len;
             const char_start = self.char_len;
 
-            const codepoint: u21 = if (cell.raw.hasText()) cell.raw.codepoint() else ' ';
+            const codepoint: u21 = if (raw_cell.hasText()) raw_cell.codepoint() else ' ';
             try self.appendCodepoints(alloc, &[1]u21{codepoint});
-            if (cell.raw.hasGrapheme()) {
+            if (raw_cell.hasGrapheme()) {
                 try self.appendCodepoints(alloc, cell.grapheme);
             }
 
             // If this is a grapheme cluster, or if the char is not covered by
             // the default font, we register it as needing font glyph adjustment
             // to fit into the monospace grid.
-            if (cell.raw.hasGrapheme() or codepoint >= adjustment_threshold) {
+            if (raw_cell.hasGrapheme() or codepoint >= adjustment_threshold) {
                 try self.adjust_cells.append(alloc, .{
                     .col = @intCast(col),
                     .byte_start = @intCast(byte_start),
                     .byte_end = @intCast(self.text.items.len),
                     .char_start = @intCast(char_start),
                     .char_end = @intCast(self.char_len),
-                    .wide = cell.raw.wide == .wide,
+                    .wide = raw_cell.wide == .wide,
                 });
             }
 
@@ -463,7 +452,7 @@ pub const RowContent = struct {
             last_run.end_char = self.char_len;
 
             // We trim cells that neither have content nor styling
-            if (cell.raw.hasText() or last_run.props != null) {
+            if (raw_cell.hasText() or last_run.props != null) {
                 trim_byte_len = self.text.items.len;
                 trim_char_len = self.char_len;
             }
@@ -618,7 +607,7 @@ fn insertRow(self: *Self, alloc: Allocator, env: emacs.Env, row: *const gt.Rende
         const prop_start = row_start + @as(i64, @intCast(run.start_char));
         const prop_end = row_start + @as(i64, @intCast(run.end_char));
         if (run.props) |props| {
-            try applyProps(env, prop_start, prop_end, props, run.link_id);
+            try applyProps(env, prop_start, prop_end, props);
         }
     }
 

--- a/src/comint_filter.zig
+++ b/src/comint_filter.zig
@@ -129,7 +129,7 @@ const Handler = struct {
             .overline = self.style.flags.overline,
             .inverse = self.style.flags.inverse,
             .underline_color = self.style.underlineColor(&self.palette),
-            .hyperlink = self.link_uri != null,
+            .link_id = if (self.link_uri != null) .{ .implicit = 0 } else null,
             // semantic_content stays default — comint has no notion of prompts here
         };
     }
@@ -139,7 +139,7 @@ const Handler = struct {
     /// current `link_uri` into `pending_link_uri` so the run sees the
     /// URI that was active when it started.
     fn switchProps(self: *Handler, props: style_face.CellProps) !void {
-        const new_link: ?[]u8 = if (props.hyperlink and self.link_uri != null)
+        const new_link: ?[]u8 = if (self.link_uri != null)
             try self.alloc.dupe(u8, self.link_uri.?)
         else
             null;
@@ -357,7 +357,7 @@ pub fn feed(self: *Self, env: emacs.Env, data: []const u8) !emacs.Value {
         h.pending_link_uri = null;
         h.alloc.free(uri);
     }
-    h.pending_link_uri = if (h.pending_props.hyperlink and h.link_uri != null)
+    h.pending_link_uri = if (h.link_uri != null)
         try h.alloc.dupe(u8, h.link_uri.?)
     else
         null;

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -526,6 +526,7 @@ const interned_symbols = [_][:0]const u8{
     "ghostel-comint--update-dir",
     "ghostel-glyph-scale-floor",
     "ghostel-input",
+    "ghostel-link-id",
     "ghostel-link-map",
     "ghostel-prompt",
     "ghostel-wrap",

--- a/src/style_face.zig
+++ b/src/style_face.zig
@@ -10,6 +10,15 @@ const emacs = @import("emacs.zig");
 const gt = @import("ghostty-vt");
 const FixedArrayList = @import("fixed_array_list.zig").FixedArrayList;
 
+/// Globally-stable identity for an OSC 8 hyperlink span.  `.explicit`
+/// holds the user-supplied `id=...`; `.implicit` is ghostty's auto-counter
+/// for links emitted without one.  Both survive page dupes, so equality
+/// is meaningful across the whole buffer.
+pub const LinkId = union(enum) {
+    explicit: []const u8,
+    implicit: u32,
+};
+
 /// Resolved style attributes for a run of cells.
 pub const CellProps = struct {
     fg: gt.color.RGB = .{},

--- a/src/style_face.zig
+++ b/src/style_face.zig
@@ -37,7 +37,7 @@ pub const CellProps = struct {
     strikethrough: bool = false,
     overline: bool = false,
     inverse: bool = false,
-    hyperlink: bool = false,
+    link_id: ?LinkId = null,
     semantic_content: gt.page.Cell.SemanticContent = .output,
 
     /// True if these props match the default style for the given palette

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -73,6 +73,90 @@ the URI in the buffer."
               (should (or (null uri) (string= "" uri))))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-osc8-shared-id-emits-link-id-property ()
+  "OSC 8 chunks sharing `id=foo' carry equal `ghostel-link-id' text properties.
+Distinct ids and implicit (no-id) links each get unique values, so elisp
+`equal' can dedupe only the matching chunks."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-osc8-link-id*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 5 80 1000))
+                 (ghostel--term term)
+                 (ghostel--term-rows 5)
+                 (inhibit-read-only t))
+            (ghostel--write-input
+             term
+             (concat
+              "\e]8;id=A;https://shared.example\e\\foo\e]8;;\e\\ "
+              "\e]8;id=B;https://other.example\e\\bar\e]8;;\e\\ "
+              "\e]8;id=A;https://shared.example\e\\baz\e]8;;\e\\ "
+              "\e]8;;https://implicit.example\e\\qux\e]8;;\e\\ "
+              "\e]8;;https://implicit.example\e\\zot\e]8;;\e\\"))
+            (ghostel--redraw term t)
+            (goto-char (point-min))
+            (let ((foo (progn (search-forward "foo") (- (point) 3)))
+                  (bar (progn (search-forward "bar") (- (point) 3)))
+                  (baz (progn (search-forward "baz") (- (point) 3)))
+                  (qux (progn (search-forward "qux") (- (point) 3)))
+                  (zot (progn (search-forward "zot") (- (point) 3))))
+              ;; Same explicit id → equal property value.
+              (should (equal "A" (get-text-property foo 'ghostel-link-id)))
+              (should (equal "A" (get-text-property baz 'ghostel-link-id)))
+              (should (equal "B" (get-text-property bar 'ghostel-link-id)))
+              ;; Implicit links are integers; two separate OSC 8 sequences
+              ;; without `id=' get distinct counters (ghostty bumps the
+              ;; implicit counter on every startHyperlink), so they never
+              ;; equal each other and dedupe never kicks in for them.
+              (should (integerp (get-text-property qux 'ghostel-link-id)))
+              (should (integerp (get-text-property zot 'ghostel-link-id)))
+              (should-not (equal (get-text-property qux 'ghostel-link-id)
+                                 (get-text-property zot 'ghostel-link-id))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-osc8-shared-id-navigation-dedupes ()
+  "`ghostel-next/previous-hyperlink' stop once per OSC 8 id (issue #125).
+Feeds the scenario from the issue: a single logical URL emitted as two
+OSC 8 chunks with `id=wrap', separated by intervening text on a new
+row.  Navigation should land on the link only once, not on each chunk."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-osc8-nav-dedupe*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let* ((term (ghostel--new 5 80 1000))
+                 (ghostel--term term)
+                 (ghostel--term-rows 5)
+                 (inhibit-read-only t))
+            (ghostel--write-input
+             term
+             (concat
+              "\e]8;id=wrap;https://wrapped.example\e\\http://exa\e]8;;\e\\\r\n"
+              "│ middle text │\r\n"
+              "\e]8;id=wrap;https://wrapped.example\e\\mple.com\e]8;;\e\\\r\n"
+              "\e]8;id=other;https://other.example\e\\next\e]8;;\e\\"))
+            (ghostel--redraw term t)
+            (goto-char (point-min))
+            (let ((chunk1 (progn (search-forward "http://exa") (- (point) 10)))
+                  (chunk2 (progn (search-forward "mple.com") (- (point) 8)))
+                  (other (progn (search-forward "next") (- (point) 4))))
+              ;; Same id on both chunks.
+              (should (equal "wrap" (get-text-property chunk1 'ghostel-link-id)))
+              (should (equal "wrap" (get-text-property chunk2 'ghostel-link-id)))
+              (should (equal "other" (get-text-property other 'ghostel-link-id)))
+              ;; From inside chunk1, forward skips chunk2 (same id), lands on `next'.
+              (should (equal other (ghostel--find-next-link chunk1)))
+              ;; From inside chunk2, forward also lands on `next' (no skip,
+              ;; since `other' has a different id).
+              (should (equal other (ghostel--find-next-link chunk2)))
+              ;; From inside chunk2, backward skips chunk1 (same id), no link left.
+              (should (null (ghostel--find-previous-link chunk2)))
+              ;; From inside `next', backward walks back over chunk2 (same id)
+              ;; and lands on chunk1, the URL's first chunk.
+              (should (equal chunk1 (ghostel--find-previous-link other))))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-osc8-uri-at-pos-two-links ()
   "`ghostel--native-uri-at-pos' returns the correct URI for each of two links."
   :tags '(native)

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -1174,6 +1174,99 @@ native URI lookup when Emacs invokes it for tooltip display or clicking."
     (should (commandp #'ghostel-next-hyperlink))
     (should (commandp #'ghostel-previous-hyperlink))))
 
+(ert-deftest ghostel-test-hyperlink-navigation-skips-shared-id ()
+  "Multiple help-echo runs sharing `ghostel-link-id' navigate as one logical link.
+Reproduces the wrapped-OSC8-in-a-box case from issue #125 at the elisp
+helper layer (no native module needed).  Layout puts two same-id runs
+back-to-back (no different-id link between them) so the dedup loop has
+to step past more than one run before landing on a different id."
+  ;; Buffer (1-indexed):
+  ;;   "AAA A1 BBB A2 CCC other DDD"
+  ;;        ^5..6  ^12..13  ^19..23
+  ;; A1 and A2 carry id "shared"; `other' carries id "other".
+  (let ((buf (generate-new-buffer " *hyperlink-shared-id*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (insert "AAA ")                ; 1..4
+          (let ((p (point)))             ; 5
+            (insert "A1")                ; 5..6
+            (put-text-property p (point) 'help-echo "https://shared")
+            (put-text-property p (point) 'ghostel-link-id "shared"))
+          (insert " BBB ")               ; 7..11
+          (let ((p (point)))             ; 12
+            (insert "A2")                ; 12..13
+            (put-text-property p (point) 'help-echo "https://shared")
+            (put-text-property p (point) 'ghostel-link-id "shared"))
+          (insert " CCC ")               ; 14..18
+          (let ((p (point)))             ; 19
+            (insert "other")             ; 19..23
+            (put-text-property p (point) 'help-echo "https://other")
+            (put-text-property p (point) 'ghostel-link-id "other"))
+          (insert " DDD")                ; 24..27
+
+          ;; Forward from inside A1: dedup loop must step PAST A2 (shared id)
+          ;; before landing on `other'.  This is the path that proves the
+          ;; loop actually iterates more than once.
+          (should (equal 19 (ghostel--find-next-link 5)))
+          ;; Forward from inside A2 also dedupes; lands on `other'.
+          (should (equal 19 (ghostel--find-next-link 12)))
+          ;; Outside any link, skip-id is nil → no dedup, lands on A1.
+          (should (equal 5 (ghostel--find-next-link (point-min))))
+          ;; Between A1 and A2 (no link), skip-id is nil → lands on A2.
+          (should (equal 12 (ghostel--find-next-link 8)))
+          ;; Forward from inside `other' has nothing left.
+          (should (null (ghostel--find-next-link 19)))
+
+          ;; Backward from inside A2: must step PAST A1 (shared id) → nil.
+          (should (null (ghostel--find-previous-link 12)))
+          ;; Backward from inside `other': lands on A1 (the URL's first chunk,
+          ;; not A2 the last chunk) by walking back over same-id runs.
+          (should (equal 5 (ghostel--find-previous-link 19)))
+          ;; Outside any link, skip-id is nil → lands on the last link.
+          (should (equal 19 (ghostel--find-previous-link (point-max)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-hyperlink-navigation-previous-lands-at-url-start ()
+  "`ghostel--find-previous-link' lands at the URL's first chunk, not its last.
+For a wrapped OSC 8 URL emitted as two chunks sharing `ghostel-link-id',
+backward navigation from below the URL should skip the second chunk and
+land on the start of the first chunk."
+  ;; Buffer:
+  ;;   "AAA U1 BBB U2 CCC DDD"
+  ;;        ^5..6 ^12..13
+  ;; U1 and U2 carry id "wrapped"; nothing else carries a link-id.
+  (let ((buf (generate-new-buffer " *hyperlink-url-start*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (insert "AAA ")                ; 1..4
+          (let ((p (point)))             ; 5
+            (insert "U1")
+            (put-text-property p (point) 'help-echo "https://wrapped")
+            (put-text-property p (point) 'ghostel-link-id "wrapped"))
+          (insert " BBB ")
+          (let ((p (point)))             ; 12
+            (insert "U2")
+            (put-text-property p (point) 'help-echo "https://wrapped")
+            (put-text-property p (point) 'ghostel-link-id "wrapped"))
+          (insert " CCC DDD")
+          ;; From past the URL, backward lands on U1 (not U2).
+          (should (equal 5 (ghostel--find-previous-link (point-max))))
+          ;; Forward still lands on U1 naturally (URL start).
+          (should (equal 5 (ghostel--find-next-link (point-min)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-hyperlink-navigation-shared-id-no-link-id-property ()
+  "Runs without `ghostel-link-id' (auto-detected URL, fileref) are never deduped.
+The dedup must only kick in when both ends carry a non-nil link id."
+  (with-temp-buffer
+    (insert "AAA URL1 BBB URL2 CCC")
+    ;; Plain-text URL detection sets only help-echo, no link-id.
+    (put-text-property 5 9 'help-echo "https://one")
+    (put-text-property 14 18 'help-echo "https://two")
+    ;; From inside URL1, URL2 is still found (no skip).
+    (should (equal 14 (ghostel--find-next-link 5)))
+    (should (equal 5 (ghostel--find-previous-link 14)))))
+
 (ert-deftest ghostel-test-hyperlink-navigation-wrap ()
   "Test that `ghostel--goto-hyperlink' wraps and errors cleanly."
   :tags '(native)

--- a/tools/test-osc8.sh
+++ b/tools/test-osc8.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 # Test OSC8 hyperlinks in the terminal
-# Format: \e]8;;URI\aLABEL\e]8;;\a
+# Format: \e]8;PARAMS;URI\aLABEL\e]8;;\a
+#   PARAMS is empty for no params, "id=FOO" for an explicit OSC 8 id.
 
 link() {
   local uri="$1" label="$2"
   printf '\e]8;;%s\a%s\e]8;;\a' "$uri" "$label"
+}
+
+link_id() {
+  local id="$1" uri="$2" label="$3"
+  printf '\e]8;id=%s;%s\a%s\e]8;;\a' "$id" "$uri" "$label"
 }
 
 echo "Plain text (no link)"
@@ -25,4 +31,76 @@ echo -n "  "; link "https://emacs.org" "Emacs"; echo -n "  "; link "https://gith
 echo ""
 echo "Link with special chars:"
 echo -n "  "; link "https://example.com/path?foo=bar&baz=qux" "Query params"
+echo ""
+echo ""
+
+# --- OSC 8 id-based dedup -----------------------------------------------
+# These exercise `ghostel-next-hyperlink' / `ghostel-previous-hyperlink'
+# (C-c C-n / C-c C-p).  With OSC 8 id dedup, chunks that share the same
+# id=... parameter are visited only once.  Chunks emitted without an id
+# get distinct implicit ids and are visited individually.
+
+echo "OSC 8 id dedup — try C-c C-n / C-c C-p over the next blocks:"
+echo ""
+
+echo "1) Wrapped URL with shared id=wrap (should stop ONCE on the whole link):"
+echo -n "   "
+link_id "wrap" "https://wrapped.example" "http://exa"
+echo ""
+echo -n "           middle text "
+echo ""
+echo -n "   "
+link_id "wrap" "https://wrapped.example" "mple.com"
+echo ""
+echo ""
+
+echo "2) Imaginary text editor box (verbatim from the issue):"
+echo "   Both halves of http://example.com share id=ed1."
+cat <<EOF
+   ╔═ file1 ════╗
+   ║          ╔═ file2 ═══╗
+   ║$(link_id ed1 'http://example.com' 'http://exa')║Lorem ipsum║
+   ║$(link_id ed1 'http://example.com' 'le.com    ')║ dolor sit ║
+   ║          ║amet, conse║
+   ╚══════════║ctetur adip║
+              ╚═══════════╝
+EOF
+echo ""
+
+echo "3) Same URL, DIFFERENT explicit ids (should stop on EACH — they are"
+echo "   semantically distinct links):"
+echo -n "   "
+link_id "a" "https://example.com" "first"
+echo -n " ... "
+link_id "b" "https://example.com" "second"
+echo ""
+echo ""
+
+echo "4) Two OSC 8 sequences with NO id at all (each gets a fresh implicit"
+echo "   counter — should stop on each):"
+echo -n "   "
+link "https://implicit.example" "alpha"
+echo -n " ... "
+link "https://implicit.example" "beta"
+echo ""
+echo ""
+
+echo "5) Single OSC 8 begin/end spanning multiple visual rows via wrap"
+echo "   (one logical region, no id needed — Emacs treats each row as a"
+echo "   separate help-echo run, so dedup falls back to the old behavior"
+echo "   of stopping on each row):"
+printf '   \e]8;;https://example.com/long\a'
+printf 'Cursor movement within the same OSC 8 run: move   right'
+printf '\e]8;;\a\n'
+echo ""
+
+echo "6) Common case: long URL wrapped in a rounded box (as Claude Code,"
+echo "   gh, etc. render plan/output panels).  Both halves share id=box1"
+echo "   so C-c C-n should stop on the URL exactly once:"
+cat <<EOF
+   ╭───────────────────────────────────────────────────────────╮
+   │ See $(link_id box1 'https://github.com/dakra/ghostel/blob/main/lisp/ghostel.el' 'https://github.com/dakra/ghostel/blob/main/lisp/ghos')  │
+   │ $(link_id box1 'https://github.com/dakra/ghostel/blob/main/lisp/ghostel.el' 'tel.el') for the source.                                    │
+   ╰───────────────────────────────────────────────────────────╯
+EOF
 echo ""


### PR DESCRIPTION
## Summary
- `ghostel-next/previous-hyperlink` now treat OSC 8 chunks sharing the same `id=...` parameter as one logical link, so a URL wrapped across rows (e.g. inside a Claude Code plan box) lands the user exactly once.
- `previous-hyperlink` walks back over same-id chunks and lands on the URL's *first* chunk, not its last, so multi-line URLs are reached at their start.
- `CellPropKey` now carries the page-local hyperlink id, which incidentally fixes a latent bug where two adjacent cells pointing to different OSC 8 hyperlinks merged into one style run and clobbered the second link's text properties.

The id is exposed via a new `ghostel-link-id` text property emitted by the renderer (`.explicit` byte strings for `id=...`, `.implicit` counters for OSC 8 without an id). Auto-detected URLs and fileref refs carry no id and are never deduped.

Fixes #125

## Test plan
- [x] `make -j8 all` passes
- [x] `tools/test-osc8.sh` examples 1, 2, 6: `C-c C-n` / `C-c C-p` stop on each wrapped URL exactly once
- [x] `tools/test-osc8.sh` example 3 (same URL, different ids): stops on each
- [x] `tools/test-osc8.sh` example 4 (two no-id sequences): stops on each
- [x] From below a multi-line URL in a box: `C-c C-p` lands on the URL's first character, not the second-line chunk