### PR TITLE
Improve extractString and extractStringAlloc

### DIFF
--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -28,6 +28,9 @@ terminal: gt.Terminal,
 /// semantic prompt) without re-parsing the bytes ourselves.
 stream: gt.Stream(GhostelHandler),
 
+/// Reusable and dynamically growing buffer for VT writes.
+buffer: ?[]u8 = null,
+
 /// True iff the last byte of the previous `fnWriteInput` input was
 /// `\r`. Carries the bare-LF detection state across write-input calls
 /// so that a CR at the tail of one write and an LF at the head of the
@@ -82,6 +85,7 @@ pub fn deinit(self: *Self) void {
     self.renderer.deinit(self.alloc);
     self.stream.deinit();
     self.terminal.deinit(self.alloc);
+    if (self.buffer) |buf| self.alloc.free(buf);
     self.alloc.destroy(self);
 }
 
@@ -317,18 +321,10 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                     env.signalError("invalid terminal handle", .{});
                     return env.nil();
                 };
-                // Extract string data — try stack buffer first, fall back to alloc
-                var stack_buf: [65536]u8 = undefined;
-                var heap_buf: ?[]const u8 = null;
-                defer if (heap_buf) |hb| module_alloc.free(hb);
-                const data = env.extractString(args[1], &stack_buf) orelse blk: {
-                    heap_buf = env.extractStringAlloc(args[1], module_alloc);
-                    break :blk heap_buf;
-                };
-                if (data == null) {
+                const raw = env.extractStringAlloc(module_alloc, args[1], &term.buffer) catch |err| {
+                    env.signalError("Failed to extract string: %s", .{@errorName(err)});
                     return env.nil();
-                }
-                const raw = data.?;
+                };
                 if (term.terminal.screens.active_key == .alternate) {
                     term.vtWrite(raw);
                     if (raw.len > 0) term.last_input_was_cr = raw[raw.len - 1] == '\r';
@@ -475,12 +471,12 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
             pub fn call(env: emacs.Env, nargs: isize, args: [*c]emacs.Value) emacs.Value {
                 const term = env.getUserPtr(Self, args[0]) orelse return env.nil();
                 var key_buf: [64]u8 = undefined;
-                const key_name = env.extractString(args[1], &key_buf) orelse return env.nil();
+                const key_name = env.extractString(args[1], &key_buf) catch return env.nil();
                 var mod_buf: [64]u8 = undefined;
-                const mod_str = env.extractString(args[2], &mod_buf) orelse "";
+                const mod_str = env.extractString(args[2], &mod_buf) catch "";
                 var utf8_buf: [32]u8 = undefined;
                 const utf8: ?[]const u8 = if (nargs > 3 and env.isNotNil(args[3]))
-                    env.extractString(args[3], &utf8_buf)
+                    env.extractString(args[3], &utf8_buf) catch null
                 else
                     null;
                 const key = input.mapKey(key_name);
@@ -562,8 +558,8 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                     return env.nil();
                 };
                 var str_buf: [2048]u8 = undefined;
-                const colors_str = env.extractString(args[1], &str_buf) orelse {
-                    env.signalError("invalid palette string", .{});
+                const colors_str = env.extractString(args[1], &str_buf) catch |err| {
+                    env.signalError("invalid palette string: %s", .{@errorName(err)});
                     return env.nil();
                 };
                 var palette = term.terminal.colors.palette.current;
@@ -614,12 +610,12 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 };
                 var fg_buf: [16]u8 = undefined;
                 var bg_buf: [16]u8 = undefined;
-                const fg_str = env.extractString(args[1], &fg_buf) orelse {
-                    env.signalError("invalid foreground color", .{});
+                const fg_str = env.extractString(args[1], &fg_buf) catch |err| {
+                    env.signalError("invalid foreground color: %s", .{@errorName(err)});
                     return env.nil();
                 };
-                const bg_str = env.extractString(args[2], &bg_buf) orelse {
-                    env.signalError("invalid background color", .{});
+                const bg_str = env.extractString(args[2], &bg_buf) catch |err| {
+                    env.signalError("invalid background color: %s", .{@errorName(err)});
                     return env.nil();
                 };
                 const fg = parseHexColor(fg_str) orelse {
@@ -656,8 +652,8 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                     term.renderer.bold_config = .bright;
                 } else {
                     var hex_buf: [16]u8 = undefined;
-                    const hex = env.extractString(val, &hex_buf) orelse {
-                        env.signalError("invalid bold config value", .{});
+                    const hex = env.extractString(val, &hex_buf) catch |err| {
+                        env.signalError("invalid bold config value: %s", .{@errorName(err)});
                         return env.nil();
                     };
                     if (parseHexColor(hex)) |color| {

--- a/src/comint_filter.zig
+++ b/src/comint_filter.zig
@@ -313,6 +313,7 @@ const Handler = struct {
 
 alloc: Allocator,
 stream: gt.Stream(Handler),
+buffer: ?[]u8 = null,
 
 pub fn create(alloc: Allocator) !*Self {
     const self = try alloc.create(Self);
@@ -325,6 +326,7 @@ pub fn create(alloc: Allocator) !*Self {
 }
 
 pub fn deinit(self: *Self) void {
+    if (self.buffer) |buf| self.alloc.free(buf);
     self.stream.deinit();
     self.alloc.destroy(self);
 }
@@ -459,15 +461,11 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                     env.signalError("invalid comint filter state", .{});
                     return env.nil();
                 };
-                var stack_buf: [65536]u8 = undefined;
-                var heap_buf: ?[]const u8 = null;
-                defer if (heap_buf) |hb| module_alloc.free(hb);
-                const data = env.extractString(args[1], &stack_buf) orelse blk: {
-                    heap_buf = env.extractStringAlloc(args[1], module_alloc);
-                    break :blk heap_buf;
+                const data = env.extractStringAlloc(module_alloc, args[1], &filter.buffer) catch |err| {
+                    env.signalError("Failed to extract string: %s", .{@errorName(err)});
+                    return env.nil();
                 };
-                if (data == null) return env.nil();
-                return filter.feed(env, data.?) catch |err| {
+                return filter.feed(env, data) catch |err| {
                     env.signalError("comint filter failed: %s", .{@errorName(err)});
                     return env.nil();
                 };
@@ -493,8 +491,8 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                     return env.nil();
                 };
                 var str_buf: [2048]u8 = undefined;
-                const colors_str = env.extractString(args[1], &str_buf) orelse {
-                    env.signalError("invalid palette string", .{});
+                const colors_str = env.extractString(args[1], &str_buf) catch |err| {
+                    env.signalError("invalid palette string: %s", .{@errorName(err)});
                     return env.nil();
                 };
                 var palette16: [16]gt.color.RGB = @splat(.{});
@@ -532,12 +530,12 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 };
                 var fg_buf: [16]u8 = undefined;
                 var bg_buf: [16]u8 = undefined;
-                const fg_str = env.extractString(args[1], &fg_buf) orelse {
-                    env.signalError("invalid foreground color", .{});
+                const fg_str = env.extractString(args[1], &fg_buf) catch |err| {
+                    env.signalError("invalid foreground color: %s", .{@errorName(err)});
                     return env.nil();
                 };
-                const bg_str = env.extractString(args[2], &bg_buf) orelse {
-                    env.signalError("invalid background color", .{});
+                const bg_str = env.extractString(args[2], &bg_buf) catch |err| {
+                    env.signalError("invalid background color: %s", .{@errorName(err)});
                     return env.nil();
                 };
                 const fg = parseHexColor(fg_str) orelse {

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -25,7 +25,7 @@ pub const FuncallExit = enum(c_int) {
     throw = 2,
 };
 
-var alloc: Allocator = undefined;
+var module_alloc: Allocator = undefined;
 
 const DebugUserPtr = struct {
     ptr: UserPtr,
@@ -100,7 +100,7 @@ pub const Env = struct {
 
     pub fn makeUserPtr(self: Env, finalizer: Finalizer, ptr: UserPtr) Value {
         if (builtin.mode == .Debug) {
-            if (debug_userptrs.append(alloc, .{ .ptr = ptr, .finalizer = &finalizer })) |_| {
+            if (debug_userptrs.append(module_alloc, .{ .ptr = ptr, .finalizer = &finalizer })) |_| {
                 const debugFinalizer = struct {
                     fn debugFinalize(p: ?*anyopaque) callconv(.c) void {
                         for (debug_userptrs.items, 0..) |item, i| {
@@ -175,42 +175,33 @@ pub const Env = struct {
         return self.extractFloat(self.f("float", .{val}));
     }
 
-    pub fn extractString(self: Env, val: Value, buf: []u8) ?[]const u8 {
+    pub fn extractString(self: Env, val: Value, buf: []u8) ![]const u8 {
         var len: isize = @intCast(buf.len);
         if (self.raw.copy_string_contents.?(self.raw, val, buf.ptr, &len)) {
             // len includes the null terminator
-            const actual_len: usize = @intCast(len);
-            if (actual_len > 0) {
-                return buf[0 .. actual_len - 1];
-            }
-            return buf[0..0];
+            return buf[0..(@as(usize, @intCast(len)) - 1)];
         }
         // Clear the non-local exit so callers (e.g. extractStringAlloc
         // fallback) can make further API calls.
-        self.raw.non_local_exit_clear.?(self.raw);
-        return null;
+        self.nonLocalExitClear();
+        return error.ExtractStringFailed;
     }
 
-    pub fn extractStringAlloc(self: Env, val: Value, allocator: std.mem.Allocator) ?[]const u8 {
-        // First call to get required size
-        var len: isize = 0;
-        _ = self.raw.copy_string_contents.?(self.raw, val, null, &len);
-        self.raw.non_local_exit_clear.?(self.raw);
-
-        if (len <= 0) return null;
-        const size: usize = @intCast(len);
-
-        const buf = allocator.alloc(u8, size) catch return null;
-        var actual_len: isize = @intCast(size);
-        if (self.raw.copy_string_contents.?(self.raw, val, buf.ptr, &actual_len)) {
-            const actual: usize = @intCast(actual_len);
-            if (actual > 0) {
-                return buf[0 .. actual - 1];
+    pub fn extractStringAlloc(self: Env, alloc: Allocator, val: Value, buf: *?[]u8) ![]u8 {
+        const ptr = if (buf.*) |b| b.ptr else null;
+        var len: isize = if (buf.*) |b| @intCast(b.len) else 0;
+        if (!self.raw.copy_string_contents.?(self.raw, val, ptr, &len) or ptr == null) {
+            self.nonLocalExitClear();
+            if (buf.*) |b| alloc.free(b);
+            buf.* = try alloc.alloc(u8, @intCast(len));
+            if (!self.raw.copy_string_contents.?(self.raw, val, buf.*.?.ptr, &len)) {
+                self.nonLocalExitClear();
+                return error.ExtractStringFailed;
             }
-            return buf[0..0];
         }
-        allocator.free(buf);
-        return null;
+
+        // len includes the null terminator
+        return buf.*.?[0..(@as(usize, @intCast(len)) - 1)];
     }
 
     // --- Type checking ---
@@ -588,8 +579,8 @@ pub var sym: SymbolCache(&interned_symbols) = undefined;
 
 /// Initialize the global symbol cache.  Must be called once from
 /// emacs_module_init with the environment provided by Emacs.
-pub fn initModule(allocator: Allocator, raw: *c.emacs_env) void {
-    alloc = allocator;
+pub fn initModule(alloc: Allocator, raw: *c.emacs_env) void {
+    module_alloc = alloc;
 
     const env = Env.init(raw);
     inline for (std.meta.fields(@TypeOf(sym))) |field| {
@@ -612,6 +603,6 @@ fn debugKillEmacsHook(_: ?*c.emacs_env, _: isize, _: [*c]c.emacs_value, _: ?*any
     for (debug_userptrs.items) |user_ptr| {
         user_ptr.finalizer(user_ptr.ptr);
     }
-    debug_userptrs.deinit(alloc);
+    debug_userptrs.deinit(module_alloc);
     return sym.nil;
 }

--- a/src/module.zig
+++ b/src/module.zig
@@ -133,7 +133,7 @@ const emacs_functions = [_]emacs.FunctionEntry{
         .impl = struct {
             pub fn call(env: emacs.Env, _: isize, args: [*c]emacs.Value) emacs.Value {
                 var stack_buf: [1024]u8 = undefined;
-                const path = env.extractString(args[0], &stack_buf) orelse return env.nil();
+                const path = env.extractString(args[0], &stack_buf) catch return env.nil();
                 return if (pty.isPasswordMode(path)) env.t() else env.nil();
             }
         },


### PR DESCRIPTION
Both now return errors instead of null. This usage of extractStringAlloc also doesn't give errors in debug mode due to freeing a slice of a different length that the one allocated.