### PR TITLE
Add tooltip and mouse-1 exit to input-mode mode-line tag

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2690,6 +2690,46 @@ Set by `ghostel-default-progress' / `ghostel-spinner-progress'.
 Composed with `ghostel--mode-line-tag' (and the spinner
 construct, when active) by `ghostel--mode-line-refresh'.")
 
+(defun ghostel--mode-line-tag-mouse-exit (event)
+  "Mouse-1 handler on the input-mode mode-line tag.
+EVENT is the mouse event that triggered the click.  Read-only modes return
+to the pre-readonly mode; char and line modes return to semi-char."
+  (interactive "e")
+  (with-selected-window (posn-window (event-start event))
+    (pcase ghostel--input-mode
+      ((or 'copy 'emacs) (ghostel-readonly-exit))
+      ((or 'char 'line)  (ghostel-semi-char-mode)))))
+
+(defvar ghostel--mode-line-tag-mouse-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map [mode-line mouse-1] #'ghostel--mode-line-tag-mouse-exit)
+    map)
+  "Keymap attached to the input-mode tag in `mode-line-process'.")
+
+(defun ghostel--mode-line-tag-help-echo-text (mode)
+  "Return current help-echo text for the input MODE mode-line tag.
+MODE is one of `char', `line', `copy', `emacs'."
+  (substitute-command-keys
+   (pcase mode
+     ('char
+      "Ghostel char-mode: \\<ghostel-char-mode-map>\\[ghostel-semi-char-mode] or mouse-1 to exit")
+     ('line
+      "Ghostel line-mode: \\<ghostel-line-mode-map>\\[ghostel-semi-char-mode] or mouse-1 to exit")
+     ((or 'copy 'emacs)
+      (let ((name (if (eq mode 'copy) "copy" "emacs"))
+            (exit (if ghostel-readonly-fast-exit
+                      "\\`q' / \\`C-g' / mouse-1 to exit"
+                    "\\<ghostel-mode-map>\\[ghostel-semi-char-mode] or mouse-1 to exit")))
+        (format "Ghostel %s-mode: %s" name exit))))))
+
+(defun ghostel--mode-line-tag-make (mode label)
+  "Return LABEL propertized as a clickable mode-line tag for MODE."
+  (propertize label
+              'help-echo (lambda (&rest _)
+                           (ghostel--mode-line-tag-help-echo-text mode))
+              'mouse-face 'mode-line-highlight
+              'local-map ghostel--mode-line-tag-mouse-map))
+
 (defun ghostel--mode-line-refresh ()
   "Recompute `mode-line-process' from tag + spinner + progress.
 Composes `ghostel--mode-line-tag', the spinner construct (when
@@ -2863,7 +2903,7 @@ Even keys listed in `ghostel-keymap-exceptions' (\\`C-c', \\`C-x',
     ;; `ghostel-char-mode-map' got a chance).
     (setq ghostel--char-mode-override-active t)
     (use-local-map ghostel-char-mode-map)
-    (setq ghostel--mode-line-tag ":Char")
+    (setq ghostel--mode-line-tag (ghostel--mode-line-tag-make 'char ":Char"))
     (ghostel--mode-line-refresh)
     (when ghostel--term
       (setq ghostel--snap-requested t)
@@ -2924,7 +2964,7 @@ a non-read-only mode."
         (ghostel--invalidate)))
     (setq ghostel--input-mode mode)
     (use-local-map (ghostel--readonly-keymap))
-    (setq ghostel--mode-line-tag label)
+    (setq ghostel--mode-line-tag (ghostel--mode-line-tag-make mode label))
     (ghostel--mode-line-refresh)
     (ghostel--fake-cursor-update)))
 
@@ -3420,7 +3460,7 @@ in line mode (the interactive entry validates these)."
       (setq ghostel--char-mode-override-active nil)
       (setq ghostel--input-mode 'line)
       (use-local-map ghostel-line-mode-map)
-      (setq ghostel--mode-line-tag ":Line")
+      (setq ghostel--mode-line-tag (ghostel--mode-line-tag-make 'line ":Line"))
       (ghostel--mode-line-refresh)
       ;; Protect everything before the input marker with a read-only
       ;; text property so commands that would modify the buffer

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -471,6 +471,93 @@ unlike semi-char mode where it tracks the terminal cursor."
               (should (null mode-line-process)))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-mode-line-tag-make ()
+  "`ghostel--mode-line-tag-make' propertizes the tag for every input mode."
+  (dolist (case '((char  ":Char"  "char-mode")
+                  (line  ":Line"  "line-mode")
+                  (copy  ":Copy"  "copy-mode")
+                  (emacs ":Emacs" "emacs-mode")))
+    (pcase-let* ((`(,mode ,label ,needle) case)
+                 (tag (ghostel--mode-line-tag-make mode label)))
+      ;; `equal' is property-blind, so existing string assertions still hold.
+      (should (equal tag label))
+      ;; mouse-face + local-map are static properties.
+      (should (eq (get-text-property 0 'mouse-face tag) 'mode-line-highlight))
+      (should (eq (get-text-property 0 'local-map tag)
+                  ghostel--mode-line-tag-mouse-map))
+      ;; help-echo is a function (re-renders on each hover).
+      (let* ((he (get-text-property 0 'help-echo tag))
+             (text (funcall he nil tag 0)))
+        (should (functionp he))
+        (should (stringp text))
+        (should (string-match-p (regexp-quote needle) text))
+        (should (string-match-p "mouse-1" text))))))
+
+(ert-deftest ghostel-test-mode-line-tag-help-echo-respects-fast-exit ()
+  "Copy/Emacs tooltips list `q'/`C-g' only when `ghostel-readonly-fast-exit' is on."
+  (let ((ghostel-readonly-fast-exit t))
+    (dolist (mode '(copy emacs))
+      (let ((text (ghostel--mode-line-tag-help-echo-text mode)))
+        (should (string-match-p "\\bq\\b" text))
+        (should (string-match-p "C-g" text)))))
+  (let ((ghostel-readonly-fast-exit nil))
+    (dolist (mode '(copy emacs))
+      (let ((text (ghostel--mode-line-tag-help-echo-text mode)))
+        ;; Without fast-exit, q is not an exit key — must not appear.
+        (should-not (string-match-p "\\bq\\b" text))
+        ;; The way out is the semi-char-mode binding (C-c C-j by default).
+        (should (string-match-p "C-c C-j" text))))))
+
+(ert-deftest ghostel-test-mode-line-tag-integration ()
+  "Entering char/copy/emacs sets `mode-line-process' to the propertized tag."
+  (let ((buf (generate-new-buffer " *ghostel-test-mode-line-tag*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              (dolist (case '((ghostel-char-mode  . ":Char")
+                              (ghostel-emacs-mode . ":Emacs")
+                              (ghostel-copy-mode  . ":Copy")))
+                (funcall (car case))
+                (should (equal mode-line-process (cdr case)))
+                (should (functionp (get-text-property 0 'help-echo
+                                                     mode-line-process)))
+                (ghostel-semi-char-mode)
+                (should (null mode-line-process))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-mode-line-tag-mouse-exit ()
+  "`mouse-1' on the tag exits char/line to semi-char and copy/emacs to previous."
+  (let ((buf (generate-new-buffer " *ghostel-test-mode-line-tag-mouse*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (set-window-buffer (selected-window) buf)
+          (let ((ghostel--term 'fake)
+                (event `(mouse-1 (,(selected-window) mode-line (0 . 0) 0))))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore)
+                      ((symbol-function 'ghostel-force-redraw) #'ignore))
+              ;; Char mode → semi-char on click.
+              (ghostel-char-mode)
+              (should (eq ghostel--input-mode 'char))
+              (ghostel--mode-line-tag-mouse-exit event)
+              (should (eq ghostel--input-mode 'semi-char))
+              ;; Emacs mode → semi-char (its previous mode) on click.
+              (ghostel-emacs-mode)
+              (should (eq ghostel--input-mode 'emacs))
+              (ghostel--mode-line-tag-mouse-exit event)
+              (should (eq ghostel--input-mode 'semi-char))
+              ;; Copy mode → semi-char on click.  Freezes the terminal,
+              ;; so the readonly exit path resumes redraws (stubbed).
+              (ghostel-copy-mode)
+              (should (eq ghostel--input-mode 'copy))
+              (ghostel--mode-line-tag-mouse-exit event)
+              (should (eq ghostel--input-mode 'semi-char)))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-emacs-mode-is-unfrozen ()
   "Emacs mode leaves the terminal live so redraws keep running."
   (let ((buf (generate-new-buffer " *ghostel-test-emacs-live*")))


### PR DESCRIPTION
Closes #329.

## Summary
- The `:Char` / `:Line` / `:Copy` / `:Emacs` lighters in `mode-line-process` are now propertized with `help-echo`, `mouse-face`, and a `local-map`.
- Hovering shows a one-line tooltip that names the mode and the exit key(s).
- `mouse-1` on the tag exits — back to semi-char for char/line, back to the pre-readonly mode for copy/emacs.
- Tooltip is a function-form `help-echo` so it re-renders on each hover and stays accurate when the user rebinds keys or toggles `ghostel-readonly-fast-exit`.

Example renderings (defaults):
- `Ghostel char-mode: M-RET or mouse-1 to exit`
- `Ghostel line-mode: C-c C-j or mouse-1 to exit`
- `Ghostel Copy-mode: q / C-g / mouse-1 to exit` (fast-exit on)
- `Ghostel Copy-mode: C-c C-j or mouse-1 to exit` (fast-exit off)

## Test plan
- [x] `make -j8 all` green
- [x] Unit test covers all four modes via `ghostel--mode-line-tag-make`
- [x] Fast-exit on / off branching of the copy/emacs help-echo
- [x] `mouse-1` integration test for char, emacs, copy
- [x] Manual hover in a live `emacsclient` Ghostel buffer to confirm the tooltip appears