### PR TITLE
Rebuild semi-char keymap when ghostel-keymap-exceptions changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ and watch `mode-line-process` for the current mode indicator.
 
 Most keys are sent to the terminal.  Keys in
 `ghostel-keymap-exceptions` (default: `C-c`, `C-x`, `C-u`, `C-h`,
-`C-g`, `M-x`, `M-o`, `M-:`, `C-\`) pass through to Emacs.
+`M-x`, `M-:`, `C-\`) pass through to Emacs.
 
 | Key         | Action                                 |
 |-------------|----------------------------------------|

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -724,7 +724,11 @@ When nil, falls back to `tramp-default-method'."
   '("C-c" "C-x" "C-u" "C-h" "M-x" "M-:" "C-\\")
   "Key sequences that should not be sent to the terminal.
 These keys pass through to Emacs instead."
-  :type '(repeat string))
+  :type '(repeat string)
+  :initialize #'custom-initialize-default
+  :set (lambda (sym newval)
+         (set-default sym newval)
+         (ghostel--rebuild-semi-char-keymap)))
 
 (defcustom ghostel-ignore-cursor-change nil
   "When non-nil, ignore terminal requests to change cursor shape or visibility.
@@ -1907,16 +1911,28 @@ bare \\`n'/\\`p' or \\`M-n'/\\`M-p' keeps navigating."
   :doc "Keymap for semi-char mode (the default input mode).
 Most keys are sent to the terminal.  Keys in
 `ghostel-keymap-exceptions' pass through to Emacs.  Inherits the
-\\`C-c' prefix from `ghostel-mode-map'."
-  :parent ghostel-mode-map)
-(ghostel--define-terminal-keys ghostel-semi-char-mode-map)
-;; Yank bindings layer on top of the helper's defaults so the kill
-;; ring wins over `ghostel--send-event' for `M-y', `S-<insert>', etc.
-(define-keymap :keymap ghostel-semi-char-mode-map
-  "C-y"            #'ghostel-yank
-  "S-<insert>"     #'ghostel-yank
-  "<remap> <yank>" #'ghostel-yank
-  "M-y"            #'ghostel-yank-pop)
+\\`C-c' prefix from `ghostel-mode-map'.
+
+Populated by `ghostel--rebuild-semi-char-keymap'.")
+
+(defun ghostel--rebuild-semi-char-keymap ()
+  "Rebuild `ghostel-semi-char-mode-map' from `ghostel-keymap-exceptions'.
+Mutates the existing keymap object in place so any buffer-local
+reference to it picks up the new bindings."
+  (let ((fresh (make-sparse-keymap)))
+    (set-keymap-parent fresh ghostel-mode-map)
+    (ghostel--define-terminal-keys fresh)
+    ;; Yank bindings layer on top of the helper's defaults so the
+    ;; kill ring wins over `ghostel--send-event' for `M-y',
+    ;; `S-<insert>', etc.
+    (define-keymap :keymap fresh
+      "C-y"            #'ghostel-yank
+      "S-<insert>"     #'ghostel-yank
+      "<remap> <yank>" #'ghostel-yank
+      "M-y"            #'ghostel-yank-pop)
+    (setcdr ghostel-semi-char-mode-map (cdr fresh))))
+
+(ghostel--rebuild-semi-char-keymap)
 
 ;; No parent — char mode captures everything, including C-c.
 (defvar-keymap ghostel-char-mode-map

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -601,6 +601,38 @@ but `this-command-keys-vector' retains the ESC prefix."
   (should (eq (lookup-key ghostel-char-mode-map (kbd "C-M-m"))
               #'ghostel-semi-char-mode)))
 
+(ert-deftest ghostel-test-keymap-rebuild-on-exception-change ()
+  "The custom setter for `ghostel-keymap-exceptions' rebuilds input maps.
+Adding a key removes it from `ghostel-semi-char-mode-map' so the
+global Emacs binding takes over; char mode binds every key
+regardless of exceptions."
+  (let ((orig (default-value 'ghostel-keymap-exceptions)))
+    (unwind-protect
+        (progn
+          ;; Baseline: M-o is bound in semi-char (not an exception).
+          (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "M-o"))
+                      #'ghostel--send-event))
+          (customize-set-variable 'ghostel-keymap-exceptions
+                                  (append orig '("M-o")))
+          (should-not (lookup-key ghostel-semi-char-mode-map (kbd "M-o")))
+          ;; Char mode is unaffected — it captures everything.
+          (should (eq (lookup-key ghostel-char-mode-map (kbd "M-o"))
+                      #'ghostel--send-event)))
+      (customize-set-variable 'ghostel-keymap-exceptions orig))))
+
+(ert-deftest ghostel-test-keymap-rebuild-preserves-object-identity ()
+  "Rebuilding mutates `ghostel-semi-char-mode-map' in place.
+Buffer-local references to the keymap need `eq'-identity to
+survive a rebuild."
+  (let ((orig (default-value 'ghostel-keymap-exceptions))
+        (semi-id ghostel-semi-char-mode-map))
+    (unwind-protect
+        (progn
+          (customize-set-variable 'ghostel-keymap-exceptions
+                                  (append orig '("M-o")))
+          (should (eq ghostel-semi-char-mode-map semi-id)))
+      (customize-set-variable 'ghostel-keymap-exceptions orig))))
+
 (ert-deftest ghostel-test-send-next-key-control-x ()
   "Send-next-key sends the prefix key as raw byte 24 (not intercepted by Emacs)."
   (let (sent-key)


### PR DESCRIPTION
## Summary

- `ghostel-semi-char-mode-map` was populated once at load time, so customizing `ghostel-keymap-exceptions` after the package loaded (e.g. via use-package `:config` + `add-to-list`) had no effect on the actual bindings.
- Add a `:set` handler that rebuilds the semi-char keymap in place via `setcdr`, preserving keymap object identity so buffer-local references stay valid.
- `setopt`, `customize-set-variable`, and use-package `:custom` all trigger the rebuild. `setq` / `add-to-list` still bypass `:set` — that's the Emacs custom-system contract, and the docstring change is intentionally minimal.
- Char-mode keymap is unaffected by exceptions and stays a one-shot at load time — only semi-char rebuilds.
- Drop stale `C-g` and `M-o` entries from the README's default exception list (neither was actually in the defcustom default).

## Test plan

- [x] `make -j8 all` green
- [x] Live verification: `setopt ghostel-keymap-exceptions (append … '("M-o"))` → `M-o` becomes nil in semi-char, stays `ghostel--send-event` in char-mode, both keymap objects keep `eq`-identity
- [x] Two new ERT tests in `test/ghostel-keys-test.el`: rebuild-on-exception-change and rebuild-preserves-object-identity