### PR TITLE
Make mouse double/triple-click select word/line and protect the region

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -777,7 +777,7 @@ Customize the faces `ghostel-fake-cursor' and
   :type 'boolean)
 
 (defcustom ghostel-mouse-drag-input-mode 'copy
-  "Input mode to switch to after a left-button drag selects a region.
+  "Input mode to switch to after a left-button drag or multi-click selects text.
 
 - `copy' (default): enter `ghostel-copy-mode'.  Pauses redraws -
   the selection is stable and the buffer is read-only.
@@ -2615,15 +2615,22 @@ is set so subsequent terminal output cannot clobber the selection."
       (ghostel--mouse-press event)
     (mouse-drag-region event)))
 
-(defun ghostel-mouse-release-or-set-point (event)
+(defun ghostel-mouse-release-or-set-point (event &optional promote-to-region)
   "Forward EVENT to the terminal, or hand off to `mouse-set-point'.
 Companion to `ghostel-mouse-press-or-copy-mode' for the left-button
 release event.  With tracking off, defers to Emacs's standard
-click handler so the release of a non-drag click sets point normally."
-  (interactive "e")
+click handler so the release of a non-drag click sets point normally.
+PROMOTE-TO-REGION is passed through to `mouse-set-point' so that
+double-click and triple-click events keep the word/line selection."
+  (interactive "e\np")
   (if (ghostel--mouse-tracking-active-p)
       (ghostel--mouse-release event)
-    (mouse-set-point event)))
+    (mouse-set-point event promote-to-region)
+    (when (and (eq ghostel--input-mode 'semi-char)
+               (> (event-click-count event) 1))
+      (pcase ghostel-mouse-drag-input-mode
+        ('copy  (ghostel-copy-mode))
+        ('emacs (ghostel-emacs-mode))))))
 
 (defun ghostel-mouse-drag-or-set-region (event)
   "Forward EVENT to the terminal, or hand off to `mouse-set-region'.

--- a/test/ghostel-mouse-paste-test.el
+++ b/test/ghostel-mouse-paste-test.el
@@ -437,12 +437,62 @@ mode or otherwise interfere."
       (cl-letf (((symbol-function 'ghostel--mode-enabled)
                  (lambda (_term _mode) nil))
                 ((symbol-function 'mouse-set-point)
-                 (lambda (event) (setq set-point-arg event)))
+                 (lambda (event &optional _promote) (setq set-point-arg event)))
                 ((symbol-function 'ghostel--mouse-event)
                  (lambda (&rest _) (setq mouse-event-called t) t)))
         (ghostel-mouse-release-or-set-point fake-event))
       (should (equal fake-event set-point-arg))
       (should-not mouse-event-called))))
+
+(ert-deftest ghostel-test-mouse-1-release-no-tracking-promotes-multi-click ()
+  "Release forwards PROMOTE-TO-REGION so double/triple-click selects.
+A double-click release falls back to the single-click binding;
+without forwarding the second arg, `mouse-set-point' would just
+move point and clobber the word selection set by `mouse-drag-region'."
+  :tags '(native)
+  (let ((fake-event `(double-mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (set-point-promote nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-point)
+                 (lambda (_event &optional promote) (setq set-point-promote promote))))
+        (ghostel-mouse-release-or-set-point fake-event 1))
+      (should (equal 1 set-point-promote)))))
+
+(ert-deftest ghostel-test-mouse-1-release-multi-click-semi-char-enters-copy-mode ()
+  "Multi-click release in semi-char enters copy mode after the region is set.
+Mirrors the drag handler: terminal output that arrives after a
+double/triple-click would otherwise overwrite the highlighted cells
+and the live cursor advancing would extend the region."
+  :tags '(native)
+  (let ((fake-event `(double-mouse-1 (,(selected-window) 1 (10 . 5) 0) 2))
+        (ghostel-mouse-drag-input-mode 'copy)
+        (set-point-event nil)
+        (copy-mode-called nil)
+        (emacs-mode-called nil)
+        (call-order nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-point)
+                 (lambda (event &optional _promote)
+                   (setq set-point-event event)
+                   (push 'set-point call-order)))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda ()
+                   (setq copy-mode-called t)
+                   (push 'copy-mode call-order)))
+                ((symbol-function 'ghostel-emacs-mode)
+                 (lambda () (setq emacs-mode-called t))))
+        (ghostel-mouse-release-or-set-point fake-event 1))
+      (should (equal fake-event set-point-event))
+      (should copy-mode-called)
+      (should-not emacs-mode-called)
+      (should (equal '(set-point copy-mode) (nreverse call-order))))))
 
 (ert-deftest ghostel-test-mouse-1-release-tracking-forwards ()
   "Release with active tracking forwards via `ghostel--mouse-release'."
@@ -456,7 +506,7 @@ mode or otherwise interfere."
       (cl-letf (((symbol-function 'ghostel--mode-enabled)
                  (lambda (_term mode) (eq mode 1000)))
                 ((symbol-function 'mouse-set-point)
-                 (lambda (_e) (setq set-point-called t)))
+                 (lambda (_e &optional _promote) (setq set-point-called t)))
                 ((symbol-function 'ghostel--mouse-event)
                  (lambda (_term action button row col mods)
                    (setq mouse-event-args (list action button row col mods))


### PR DESCRIPTION
## Summary

Two related fixes to the left-button release handler so multi-click selection works the way users expect in semi-char, line, emacs, and copy modes.

- `ghostel-mouse-release-or-set-point` now forwards `PROMOTE-TO-REGION` to `mouse-set-point`. `<double-mouse-1>` / `<triple-mouse-1>` fall back to the `<mouse-1>` binding, and without the second arg `mouse-set-point` would just move point and clobber the word/line selection that `mouse-drag-region` set on the preceding down-event.
- When that multi-click sets a region in semi-char mode, switch to the input mode configured by `ghostel-mouse-drag-input-mode` (copy by default). Mirrors the drag handler: without the switch, the buffer stays live and the next terminal redraw advances point with the mark still active, visually extending the highlight down to the cursor.

## Test plan

- [x] `make -j8 all` (build, all elisp + native tests, lint)
- [x] New ERT test `ghostel-test-mouse-1-release-no-tracking-promotes-multi-click` guards the prefix-arg forwarding
- [x] New ERT test `ghostel-test-mouse-1-release-multi-click-semi-char-enters-copy-mode` guards the copy-mode entry on multi-click
- [x] Manual: double-click a word in semi-char mode → word highlights, buffer enters copy mode; `q` returns to live input
- [x] Manual: triple-click a line → whole line highlights, copy mode entered
- [x] Manual: double-click in emacs/copy mode → word highlights without re-toggling the mode
- [x] Manual: with a DEC mouse-tracking app (vim/htop), clicks still forward to the program