### PR TITLE
Preserve ghostel identity on buffer init

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -6908,9 +6908,10 @@ prevent redraw flicker."
 (defun ghostel--init-buffer (buffer &optional rows cols)
   "Initialize BUFFER as a ghostel terminal.
 This is the invariant boundary between an Emacs buffer and its native
-terminal handle: BUFFER is made empty, stale terminal state is cleared,
-and the newly created terminal is attached immediately as BUFFER's
-buffer-local `ghostel--term'.
+terminal handle: BUFFER is made empty, renderer-coupled buffer-local
+state is reset, and the newly created terminal is attached immediately
+as BUFFER's buffer-local `ghostel--term'.  It intentionally does not
+reset unrelated buffer-local state such as title/identity bookkeeping.
 
 Optional ROWS and COLS override size detection.  Otherwise terminal
 dimensions come from BUFFER's displayed window when one exists,
@@ -6956,9 +6957,7 @@ spawn after initialization."
           ghostel--force-next-redraw nil
           ghostel--cursor-pos nil
           ghostel--cursor-char-pos nil
-          ghostel--rendered-font nil
-          ghostel--managed-buffer-name nil
-          ghostel--buffer-identity nil)
+          ghostel--rendered-font nil)
     (let* ((w (or (get-buffer-window buffer t) (selected-window)))
            (height (max 1 (or rows
                               (if (window-live-p w)
@@ -7082,10 +7081,6 @@ Signals `user-error' if BUFFER already has a live ghostel process."
                   80)))
     (with-current-buffer buffer
       (ghostel--init-buffer buffer height width)
-      ;; `ghostel--init-buffer' clears identity bookkeeping; restore it so
-      ;; OSC 2 title sequences don't auto-rename a user-renamed buffer
-      (setq ghostel--managed-buffer-name (buffer-name))
-      (setq ghostel--buffer-identity (buffer-name))
       (let ((remote-p (file-remote-p default-directory)))
         (ghostel--spawn-pty program args ghostel--term-rows ghostel--term-cols
                             ghostel--default-stty nil remote-p)))))

--- a/test/ghostel-exec-test.el
+++ b/test/ghostel-exec-test.el
@@ -68,27 +68,27 @@ buffer eventually shows up."
                                  (ghostel--kitty-mediums-bits))))))
       (kill-buffer buf))))
 
-(ert-deftest ghostel-test-exec-sets-identity-bookkeeping ()
-  "`ghostel-exec' restores the buffer identity bookkeeping vars.
-`ghostel--init-buffer' clears `ghostel--managed-buffer-name' and
-`ghostel--buffer-identity'; without restoring them, an OSC 2 title
-sequence would auto-rename the buffer even after the user manually
-renamed it (the rename guard in `ghostel--set-title-default' triggers
-when `managed-buffer-name' is nil)."
+(ert-deftest ghostel-test-exec-preserves-identity-bookkeeping ()
+  "`ghostel-exec' does not clobber buffer identity bookkeeping vars."
   (let ((buf (generate-new-buffer " *ghostel-exec-identity*")))
     (unwind-protect
-        (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
-                  ((symbol-function 'ghostel--new)
-                   (lambda (&rest _) 'fake-term))
-                  ((symbol-function 'ghostel--set-size-with-cell-dims) #'ignore)
-                  ((symbol-function 'ghostel--apply-palette) #'ignore)
-                  ((symbol-function 'ghostel--apply-bold-config) #'ignore)
-                  ((symbol-function 'ghostel--spawn-pty)
-                   (lambda (&rest _) 'fake-proc)))
-          (ghostel-exec buf "ls" nil)
+        (progn
           (with-current-buffer buf
-            (should (equal ghostel--managed-buffer-name (buffer-name)))
-            (should (equal ghostel--buffer-identity (buffer-name)))))
+            (ghostel-mode)
+            (setq-local ghostel--managed-buffer-name "managed")
+            (setq-local ghostel--buffer-identity "identity"))
+          (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                    ((symbol-function 'ghostel--new)
+                     (lambda (&rest _) 'fake-term))
+                    ((symbol-function 'ghostel--set-size-with-cell-dims) #'ignore)
+                    ((symbol-function 'ghostel--apply-palette) #'ignore)
+                    ((symbol-function 'ghostel--apply-bold-config) #'ignore)
+                    ((symbol-function 'ghostel--spawn-pty)
+                     (lambda (&rest _) 'fake-proc)))
+            (ghostel-exec buf "ls" nil)
+            (with-current-buffer buf
+              (should (equal ghostel--managed-buffer-name "managed"))
+              (should (equal ghostel--buffer-identity "identity")))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-eshell-visual-command-mode-toggles-advice ()

--- a/test/ghostel-project-test.el
+++ b/test/ghostel-project-test.el
@@ -149,14 +149,17 @@ proves the project-prefixed binding actually took effect."
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-init-buffer-replaces-stale-terminal ()
-  "`ghostel--init-buffer' supports reusing a buffer with stale terminal state."
+  "`ghostel--init-buffer' preserves identity while replacing stale terminal state."
   (let ((buf (generate-new-buffer " *ghostel-test-reinit*")))
     (unwind-protect
         (progn
           (with-current-buffer buf
+            (ghostel-mode)
             (setq-local ghostel--term 'old-term)
             (setq-local ghostel--term-rows 1)
-            (setq-local ghostel--term-cols 2))
+            (setq-local ghostel--term-cols 2)
+            (setq-local ghostel--managed-buffer-name "managed")
+            (setq-local ghostel--buffer-identity "identity"))
           (cl-letf (((symbol-function 'ghostel--new) (lambda (&rest _) 'new-term))
                     ((symbol-function 'ghostel--set-size) #'ignore)
                     ((symbol-function 'ghostel--apply-palette) #'ignore))
@@ -164,7 +167,9 @@ proves the project-prefixed binding actually took effect."
           (with-current-buffer buf
             (should (eq ghostel--term 'new-term))
             (should (= ghostel--term-rows 7))
-            (should (= ghostel--term-cols 33))))
+            (should (= ghostel--term-cols 33))
+            (should (equal ghostel--managed-buffer-name "managed"))
+            (should (equal ghostel--buffer-identity "identity"))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-create-initializes-buffer ()


### PR DESCRIPTION
## Summary
- keep `ghostel--managed-buffer-name` and `ghostel--buffer-identity` intact when reinitializing a buffer
- remove the `ghostel-exec` restore path that was only needed because init clobbered those locals
- update tests to assert identity bookkeeping survives reinit/exec

## Tests
- `make .build/tests/elisp-ghostel-exec-test.ok .build/tests/elisp-ghostel-project-test.ok`