### PR TITLE
Forward IME-committed text and guard redraws during composition (CJK lisp IME)

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,6 +885,32 @@ When `evil-ghostel-mode` is active:
 - Cursor shape follows evil state (block for normal, bar for insert)
 - Alt-screen programs (vim, less, htop) are unaffected
 
+## Emacs Lisp input methods
+
+Some Emacs Lisp input methods — `hangul-input-method` is the common
+example — commit text by inserting it into the current buffer instead
+of returning key events.  Inside a ghostel buffer that insert lands in
+the buffer but is never sent to the PTY, so the next redraw erases it.
+
+`ghostel-ime-mode` is an optional minor mode that wraps
+`input-method-function` locally.  When the input method commits by
+buffer insertion it forwards the committed text to the PTY as UTF-8 and
+lets the shell echo it back through the normal redraw path.  While a
+Quail-style composition is in flight it also asks ghostel to defer
+redraws (via `ghostel-inhibit-redraw-functions`) so the renderer does
+not rewrite the buffer mid-composition.  GUI native preedit handling is
+unaffected.
+
+```elisp
+(use-package ghostel-ime
+  :ensure nil
+  :after ghostel
+  :hook (ghostel-mode . ghostel-ime-mode))
+```
+
+This generalizes to any Lisp input method that uses `quail-overlay`
+(Korean Hangul, Japanese, Chinese, …).
+
 ## Commands
 
 | Command                        | Description                                  |

--- a/lisp/ghostel-ime.el
+++ b/lisp/ghostel-ime.el
@@ -1,0 +1,170 @@
+;;; ghostel-ime.el --- Emacs Lisp IME integration for ghostel -*- lexical-binding: t; -*-
+
+;; Copyright (c) 2026 Daniel Kraus <daniel@kraus.my>
+
+;; Author: Daniel Kraus <daniel@kraus.my>
+;; URL: https://github.com/dakra/ghostel
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Optional integration for Emacs Lisp input methods that commit text by
+;; inserting into the current buffer.  `hangul-input-method' is the common
+;; example: it calls `self-insert-command' directly for the composed syllable,
+;; bypassing ghostel's key remapping, so the commit lands in the buffer but is
+;; not sent to the PTY.
+;;
+;; `ghostel-ime-mode' wraps the buffer-local `input-method-function'.  If the
+;; input method inserts committed text into the ghostel buffer, the wrapper
+;; captures that text, deletes the local insert, and forwards the UTF-8 bytes to
+;; the PTY.  The shell then echoes the text through ghostel's normal redraw path.
+;;
+;; During an in-flight Lisp IME composition, the mode also asks core ghostel to
+;; defer redraws via `ghostel-inhibit-redraw-functions'.  This keeps the native
+;; redrawer from rewriting the buffer while Quail-style overlays use it as
+;; scratch state.  GUI preedit overlays are left to ghostel.el's native preedit
+;; preservation path.
+
+;;; Code:
+
+(require 'ghostel)
+
+(declare-function ghostel--buffer-editable-p "ghostel")
+(declare-function ghostel--send-string "ghostel" (string))
+
+(defvar ghostel-ime-mode)
+
+(defgroup ghostel-ime nil
+  "Emacs Lisp input-method integration for ghostel."
+  :group 'ghostel
+  :prefix "ghostel-ime-")
+
+(defvar-local ghostel-ime--original-input-method-function nil
+  "Original buffer-local `input-method-function' before ghostel-ime wrapped it.")
+
+(defvar ghostel-ime--composition-buffer nil
+  "Buffer where a Lisp input-method composition is currently in flight.")
+
+(defun ghostel-ime--active-quail-overlay-p (buffer)
+  "Return non-nil if BUFFER has a live non-empty `quail-overlay'."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let ((overlay (and (boundp 'quail-overlay)
+                          (symbol-value 'quail-overlay))))
+        (and (overlayp overlay)
+             (eq (overlay-buffer overlay) buffer)
+             (let ((start (overlay-start overlay))
+                   (end (overlay-end overlay)))
+               (and start end (< start end))))))))
+
+(defun ghostel-ime-lisp-composing-p (&optional buffer)
+  "Return non-nil when a Lisp IME composition is active in BUFFER.
+BUFFER defaults to the current buffer.  This detects the dynamic
+wrapper state and Quail-style `quail-overlay' state.  It intentionally
+ignores GUI preedit overlays, which core ghostel handles separately."
+  (let ((buffer (or buffer (current-buffer))))
+    (or (eq ghostel-ime--composition-buffer buffer)
+        (ghostel-ime--active-quail-overlay-p buffer))))
+
+(defun ghostel-ime--wrap-input-method (key)
+  "Translate KEY through the original input method.
+If the input method commits text by inserting into the current ghostel
+buffer, delete that transient insertion and forward the committed text
+to the PTY as UTF-8."
+  (let ((ghostel-ime--composition-buffer (current-buffer))
+        (original ghostel-ime--original-input-method-function)
+        (before-point (point)))
+    (if (or (null original)
+            ;; `list' is the framework's pass-through sentinel, not a real
+            ;; translator; calling it would silently skip composition.
+            (eq original #'list))
+        (list key)
+      (let ((events (funcall original key)))
+        (let ((after-point (point)))
+          (when (and (> after-point before-point)
+                     (ghostel--buffer-editable-p))
+            (let ((inserted (buffer-substring-no-properties
+                             before-point after-point)))
+              (let ((inhibit-read-only t))
+                (delete-region before-point after-point))
+              (ghostel--send-string
+               (encode-coding-string inserted 'utf-8)))))
+        events))))
+
+(defun ghostel-ime--install ()
+  "Wrap `input-method-function' in the current ghostel buffer."
+  (when (and ghostel-ime-mode
+             (derived-mode-p 'ghostel-mode)
+             input-method-function
+             ;; Never capture the `list' pass-through sentinel as the
+             ;; original; it appears when no real input method is active,
+             ;; and wrapping it would bypass composition.  Wait for the
+             ;; activation hook to fire with a genuine translator.
+             (not (eq input-method-function #'list))
+             (not (eq input-method-function
+                      #'ghostel-ime--wrap-input-method)))
+    (setq-local ghostel-ime--original-input-method-function
+                input-method-function)
+    (setq-local input-method-function
+                #'ghostel-ime--wrap-input-method)))
+
+(defun ghostel-ime--reassert ()
+  "Reinstall the wrapper if an active input method left it unwrapped.
+An external input-method or editing-state manager can restore the raw
+translator into `input-method-function' without going through
+`input-method-activate-hook'.  Run late from `post-command-hook' so the
+wrapper is back in place before the next key is read."
+  (when current-input-method
+    (ghostel-ime--install)))
+
+(defun ghostel-ime--uninstall ()
+  "Restore the original `input-method-function' in the current buffer."
+  (when (and (eq input-method-function
+                 #'ghostel-ime--wrap-input-method)
+             ghostel-ime--original-input-method-function)
+    (setq-local input-method-function
+                ghostel-ime--original-input-method-function))
+  (setq-local ghostel-ime--original-input-method-function nil))
+
+;;;###autoload
+(define-minor-mode ghostel-ime-mode
+  "Toggle Emacs Lisp input-method integration in this ghostel buffer.
+
+When enabled, ghostel forwards committed text from Lisp input methods
+that insert directly into the buffer, and defers redraws while a
+Quail-style composition is in flight.  A typical setup is:
+
+  (add-hook \='ghostel-mode-hook #\='ghostel-ime-mode)"
+  :lighter nil
+  (if ghostel-ime-mode
+      (progn
+        (add-hook 'input-method-activate-hook #'ghostel-ime--install nil t)
+        (add-hook 'input-method-deactivate-hook #'ghostel-ime--uninstall nil t)
+        (add-hook 'ghostel-inhibit-redraw-functions
+                  #'ghostel-ime-lisp-composing-p nil t)
+        (add-hook 'post-command-hook #'ghostel-ime--reassert 90 t)
+        (ghostel-ime--install))
+    (remove-hook 'input-method-activate-hook #'ghostel-ime--install t)
+    (remove-hook 'input-method-deactivate-hook #'ghostel-ime--uninstall t)
+    (remove-hook 'ghostel-inhibit-redraw-functions
+                 #'ghostel-ime-lisp-composing-p t)
+    (remove-hook 'post-command-hook #'ghostel-ime--reassert t)
+    (ghostel-ime--uninstall)))
+
+(provide 'ghostel-ime)
+;;; ghostel-ime.el ends here

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -293,6 +293,16 @@ When `ghostel-adaptive-fps' is non-nil, this serves as the base
 delay between frames during sustained output."
   :type 'number)
 
+(defcustom ghostel-inhibit-redraw-functions nil
+  "Abnormal hook run before a ghostel buffer redraw.
+Each function is called with the buffer as its sole argument, with
+that buffer current.  If any function returns non-nil, the redraw
+is deferred and rescheduled.  Errors are demoted and treated as nil.
+Add-on features can use this to keep core ghostel from rewriting the
+buffer during transient states such as Emacs Lisp input-method
+composition."
+  :type 'hook)
+
 (defcustom ghostel-adaptive-fps t
   "Use adaptive frame rate for terminal redraw.
 When non-nil, use a shorter initial delay for responsive interactive
@@ -5996,6 +6006,18 @@ vscroll if there are more rows than can fit into the window."
         (set-window-point window (or ghostel--cursor-char-pos
                                      (point-max)))))))
 
+(defun ghostel--maybe-defer-redraw (buffer)
+  "Defer BUFFER's redraw if a `ghostel-inhibit-redraw-functions' hook asks.
+Return non-nil when deferred, after rescheduling `ghostel--redraw-now'
+for BUFFER; return nil to let the redraw proceed."
+  (when (with-demoted-errors "ghostel-inhibit-redraw-functions error: %S"
+          (run-hook-with-args-until-success
+           'ghostel-inhibit-redraw-functions buffer))
+    (setq ghostel--redraw-timer
+          (run-with-timer ghostel-timer-delay nil
+                          #'ghostel--redraw-now buffer))
+    t))
+
 (defun ghostel--redraw-now (buffer)
   "Perform the actual redraw in BUFFER.
 Flushes pending PTY output and runs the native renderer.  The
@@ -6007,7 +6029,9 @@ live viewport."
       (when ghostel--redraw-timer
         (cancel-timer ghostel--redraw-timer)
         (setq ghostel--redraw-timer nil))
-      (when (and ghostel--term (ghostel--terminal-live-p))
+      (when (and ghostel--term
+                 (ghostel--terminal-live-p)
+                 (not (ghostel--maybe-defer-redraw buffer)))
         ;; Skip during synchronized output unless forced by scroll/resize.
         (unless (and (not ghostel--force-next-redraw)
                      (ghostel--mode-enabled ghostel--term 2026))

--- a/test/ghostel-ime-test.el
+++ b/test/ghostel-ime-test.el
@@ -1,0 +1,214 @@
+;;; ghostel-ime-test.el --- Tests for ghostel-ime -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Pure-Elisp unit tests for `ghostel-ime': the redraw-inhibit hook,
+;; the buffer-local minor-mode wiring, the IME commit-forward wrapper
+;; (Korean/Japanese/Chinese), and the Quail-overlay composition probe.
+;; None require the native module; the renderer and PTY send are mocked.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'ghostel-test-helpers)
+(require 'ghostel-ime)
+
+(declare-function ghostel--redraw-now "ghostel" (buffer))
+(declare-function ghostel--redraw "ghostel" (term &optional full))
+(declare-function ghostel--buffer-editable-p "ghostel")
+(declare-function ghostel--send-string "ghostel" (string))
+
+;; `quail-overlay' is defined by quail.el, which is not loaded in batch.
+(defvar quail-overlay)
+
+(ert-deftest ghostel-test-ime-inhibit-hook-defers-redraw ()
+  "A non-nil `ghostel-inhibit-redraw-functions' reschedules the redraw.
+The buffer must not be redrawn while a feature inhibits it."
+  (ghostel-test--with-compile-buffer buf
+    (let ((old-timer (run-with-timer 1000 nil #'ignore))
+          timer-delay timer-repeat timer-fn timer-args)
+      (setq-local ghostel--redraw-timer old-timer)
+      (setq-local ghostel--term 'fake-term)
+      (add-hook 'ghostel-inhibit-redraw-functions
+                (lambda (buffer)
+                  (should (eq buffer buf))
+                  (should (eq (current-buffer) buf))
+                  t)
+                nil t)
+      (cl-letf (((symbol-function 'ghostel--terminal-live-p)
+                 (lambda (&rest _) t))
+                ((symbol-function 'ghostel--redraw)
+                 (lambda (&rest _)
+                   (ert-fail "Inhibited redraw must not call native redraw")))
+                ((symbol-function 'run-with-timer)
+                 (lambda (delay repeat fn &rest args)
+                   (setq timer-delay delay
+                         timer-repeat repeat
+                         timer-fn fn
+                         timer-args args)
+                   'ghostel-test-ime-timer)))
+        (ghostel--redraw-now buf))
+      (should (equal timer-delay ghostel-timer-delay))
+      (should (null timer-repeat))
+      (should (eq timer-fn #'ghostel--redraw-now))
+      (should (equal timer-args (list buf)))
+      (should (eq ghostel--redraw-timer 'ghostel-test-ime-timer))
+      (when (timerp old-timer)
+        (cancel-timer old-timer)))))
+
+(ert-deftest ghostel-test-ime-mode-installs-buffer-local-wrapper ()
+  "`ghostel-ime-mode' installs and removes its buffer-local wiring."
+  (ghostel-test--with-compile-buffer buf
+    (let ((original (lambda (_key) nil)))
+      (setq-local input-method-function original)
+      (ghostel-ime-mode 1)
+      (should (eq ghostel-ime--original-input-method-function original))
+      (should (eq input-method-function #'ghostel-ime--wrap-input-method))
+      (should (memq #'ghostel-ime-lisp-composing-p
+                    ghostel-inhibit-redraw-functions))
+      (should (memq #'ghostel-ime--install input-method-activate-hook))
+      (should (memq #'ghostel-ime--uninstall input-method-deactivate-hook))
+      (should (memq #'ghostel-ime--reassert post-command-hook))
+      (should (eq (car (last post-command-hook)) #'ghostel-ime--reassert))
+      (ghostel-ime-mode -1)
+      (should (eq input-method-function original))
+      (should (null ghostel-ime--original-input-method-function))
+      (should-not (memq #'ghostel-ime-lisp-composing-p
+                        ghostel-inhibit-redraw-functions))
+      (should-not (memq #'ghostel-ime--reassert post-command-hook)))))
+
+(ert-deftest ghostel-test-ime-reasserts-wrapper-after-external-reset ()
+  "An external manager must not leave the raw IM wrapper dropped.
+An input-method or editing-state manager may restore the raw translator
+without firing `input-method-activate-hook'.  `ghostel-ime--reassert',
+run on `post-command-hook', rewraps before the next key is read."
+  (ghostel-test--with-compile-buffer buf
+    (ghostel-ime-mode 1)
+    (let ((real (lambda (_key) nil)))
+      (setq-local input-method-function real)
+      (ghostel-ime--install)
+      (should (eq input-method-function #'ghostel-ime--wrap-input-method))
+      ;; External manager puts the raw translator back, IM still active.
+      (setq-local current-input-method "korean-hangul")
+      (setq-local input-method-function real)
+      (ghostel-ime--reassert)
+      (should (eq input-method-function #'ghostel-ime--wrap-input-method))
+      ;; With no active input method, reassert is a no-op (does not wrap
+      ;; a stray function).
+      (setq-local current-input-method nil)
+      (setq-local input-method-function real)
+      (ghostel-ime--reassert)
+      (should (eq input-method-function real)))
+    (ghostel-ime-mode -1)))
+
+(ert-deftest ghostel-test-ime-install-ignores-list-sentinel ()
+  "Install must not capture the `list' pass-through sentinel as original.
+It waits for the activation hook to deliver a genuine translator."
+  (ghostel-test--with-compile-buffer buf
+    (setq-local input-method-function #'list)
+    (ghostel-ime-mode 1)
+    (should (eq input-method-function #'list))
+    (should (null ghostel-ime--original-input-method-function))
+    (let ((real (lambda (_key) nil)))
+      (setq-local input-method-function real)
+      (ghostel-ime--install)
+      (should (eq ghostel-ime--original-input-method-function real))
+      (should (eq input-method-function #'ghostel-ime--wrap-input-method)))
+    (ghostel-ime-mode -1)))
+
+(ert-deftest ghostel-test-ime-wrap-forwards-cjk-buffer-commits ()
+  "Buffer-inserted CJK commits are forwarded to the PTY and removed locally."
+  (ghostel-test--with-compile-buffer buf
+    (setq buffer-read-only nil)
+    (dolist (text '("한" "あ" "中"))
+      (erase-buffer)
+      (let (sent observed-composing)
+        (setq-local ghostel-ime--original-input-method-function
+                    (lambda (_key)
+                      (setq observed-composing (ghostel-ime-lisp-composing-p))
+                      (insert text)
+                      nil))
+        (cl-letf (((symbol-function 'ghostel--buffer-editable-p)
+                   (lambda () t))
+                  ((symbol-function 'ghostel--send-string)
+                   (lambda (string) (push string sent))))
+          (should (null (ghostel-ime--wrap-input-method ?x))))
+        (should observed-composing)
+        (should-not (ghostel-ime-lisp-composing-p))
+        (should (equal (buffer-string) ""))
+        (should (equal sent
+                       (list (encode-coding-string text 'utf-8))))))))
+
+(ert-deftest ghostel-test-ime-composing-p-detects-quail-overlay ()
+  "A live non-empty `quail-overlay' marks Lisp IME composition active."
+  (let ((buf (generate-new-buffer " *ghostel-test-ime-quail*"))
+        overlay)
+    (unwind-protect
+        (with-current-buffer buf
+          (insert "compose")
+          (setq overlay (make-overlay (point-min) (1+ (point-min)) buf))
+          (setq-local quail-overlay overlay)
+          (should (ghostel-ime-lisp-composing-p buf))
+          (with-temp-buffer
+            (should (ghostel-ime-lisp-composing-p buf)))
+          (move-overlay overlay (point-min) (point-min) buf)
+          (should-not (ghostel-ime-lisp-composing-p buf)))
+      (when (and overlay (overlayp overlay))
+        (delete-overlay overlay))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-ime-reinstalls-on-reactivation ()
+  "Re-activating an input method must re-wrap, even after a deactivate.
+This is the path an external state manager drives when it toggles the
+IME off in one state and back on in another; the wrapper must return
+and capture the genuine translator again, not stay dropped."
+  (ghostel-test--with-compile-buffer buf
+    (ghostel-ime-mode 1)
+    (let ((real (lambda (_key) nil)))
+      ;; First activation: the buffer-local activate hook wraps.
+      (setq-local input-method-function real)
+      (run-hooks 'input-method-activate-hook)
+      (should (eq input-method-function #'ghostel-ime--wrap-input-method))
+      ;; Deactivation resets the function the way `deactivate-input-method'
+      ;; does, then the deactivate hook restores the original.
+      (run-hooks 'input-method-deactivate-hook)
+      (setq-local input-method-function nil)
+      ;; Reactivation must wrap again.
+      (setq-local input-method-function real)
+      (run-hooks 'input-method-activate-hook)
+      (should (eq input-method-function #'ghostel-ime--wrap-input-method))
+      (should (eq ghostel-ime--original-input-method-function real)))
+    (ghostel-ime-mode -1)))
+
+(ert-deftest ghostel-test-ime-wrapper-survives-mode-switches ()
+  "The IME wrapper must persist across ghostel input-mode transitions.
+Entering line/char mode and returning to semi-char must not silently
+drop the buffer-local `input-method-function' wrapper installed by
+`ghostel-ime-mode'."
+  :tags '(native)
+  (let ((inhibit-message t))
+    (ghostel-test--with-terminal-buffer (buf term 5 80 1000)
+      (set-window-buffer (selected-window) buf)
+      (setq ghostel--process 'fake-proc)
+      ;; Establish a prompt so line mode can locate the input boundary.
+      (ghostel--write-input term "\e]133;A\e\\$ \e]133;B\e\\")
+      (let ((inhibit-read-only t))
+        (ghostel--redraw term t))
+      (ghostel-ime-mode 1)
+      (let ((real (lambda (_key) nil)))
+        (setq-local input-method-function real)
+        (ghostel-ime--install)
+        (should (eq input-method-function #'ghostel-ime--wrap-input-method))
+        (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+                  ((symbol-function 'process-send-string) #'ignore)
+                  ((symbol-function 'ghostel--invalidate) #'ignore)
+                  ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+          (dolist (enter (list #'ghostel-line-mode #'ghostel-char-mode))
+            (funcall enter)
+            (ghostel-semi-char-mode)
+            (should (eq ghostel--input-mode 'semi-char))
+            (should (eq input-method-function
+                        #'ghostel-ime--wrap-input-method))))))))
+
+(provide 'ghostel-ime-test)
+;;; ghostel-ime-test.el ends here


### PR DESCRIPTION
Hi @dakra,

Before anything else — **thank you for ghostel**. This project is genuinely precious to me, and I mean that.

## A bit about who I am

I'm a Doom Emacs user and a CJK (Korean — Hangul) speaker, and I work daily in **both GUI Emacs and `-nw` (terminal) Emacs**. The `-nw` path matters to me as much as the GUI path. For years, getting Korean IME to behave reliably inside terminal-style buffers inside Emacs has been a constant low-grade pain. ghostel solved enough of that — and was clean enough underneath — that I rebuilt my terminal workflow around it.

I'm also a ghostty user, and honestly: I had been quietly thinking I might have to attempt this kind of project myself at some point. I'm very glad someone with your skill level got there first and built it properly. Truly grateful.

## How I use ghostel

- Doom Emacs config: https://github.com/junghan0611/doomemacs-config
- The exact ghostel setup I daily-drive (single SSOT for GUI + `-nw`): https://github.com/junghan0611/doomemacs-config/blob/main/lisp/term-config.el
- Main workload inside ghostel buffers: [`pi`](https://github.com/junghan0611/pi-shell-acp) (an ACP-based agent harness I develop) and Claude Code. Both are heavy streaming TUIs that emit small PTY chunks at high frequency — which turns out to be the exact race-condition trigger this PR addresses.
- Korean input method: `hangul2-input-method` via Emacs' built-in `quail`.

## What this PR proposes

Two related changes, ~170 lines total, **all in `lisp/ghostel.el`**, **zero native zig changes**.

### 1. Forward IME-committed text to PTY for Emacs input methods

Some Emacs input methods commit text by directly inserting into the buffer (`hangul-insert-character` → `(self-insert-command 1)` as a *function call* with `last-command-event` bound) instead of returning events from `input-method-function`. A function call bypasses `[remap self-insert-command]`, so the character lands in the ghostel buffer but is never sent to the PTY — the next redraw erases it.

Fix: locally wrap `input-method-function` in ghostel buffers. Around the original IME call, observe whether point advanced; if so the IME committed text by buffer insertion. Capture that text, delete it from the buffer, and forward it to the PTY as UTF-8. The shell echoes it back through the normal redraw path, so the buffer ends up consistent without racing the redraw. IMEs that already return events (most quail packages) pass straight through. Restricted to PTY-forwarding modes (semi-char, char); line mode untouched.

### 2. Guard `ghostel--redraw` against running mid-composition

When a TUI streams output via ~256B PTY chunks while the user composes Korean via `hangul2-input-method`, syllables vanish — or 30+ byte chaos sequences (literally like `자갈ㅓㅏㅓㅏㅏㅏㅓㅏㅓㅏㅓ`) get forwarded to the PTY.

Race: `hangul2-input-method` runs a `read-key-sequence` loop inside the IME wrapper, using the ghostel buffer as a scratch area; each key mutates the buffer via `hangul-insert-character` → `self-insert-command`. In parallel, agent output triggers `ghostel--filter`'s immediate-redraw path, which calls `ghostel--delayed-redraw` synchronously; that body invokes the native `ghostel--redraw` to erase + reinsert the buffer from libghostty's VT grid. `quail-overlay` markers get invalidated mid-loop while `inhibit-modification-hooks t` silences quail's notifications, and the wrapper's `buffer-substring` then captures stale text.

Existing limit: `ghostel--active-preedit-overlay` only tracks `x-preedit-overlay` / `pgtk-preedit-overlay` — GUI native IME. Emacs-lisp IMEs (`quail-overlay` family: hangul, anthy, …) were never in scope; `--capture-preedit-state` / `--restore-preedit-state` don't see them.

Fix: a small predicate `ghostel--ime-lisp-composing-p` (a dynamic flag set by the IME wrapper + a live `quail-overlay` check) guards every code path that can end in `ghostel--redraw` rewriting the buffer:

- The sync immediate-redraw branch in `ghostel--filter` — falls through to the bulk path during composition.
- The body of `ghostel--delayed-redraw` — split into `ghostel--delayed-redraw-body`, with the guard living in the renamed wrapper. Catches every caller (theme sync, PTY filter immediate path, PTY filter bulk timer, `M-x ghostel-force-redraw`, window resize) in one place.

**GUI native IME streaming behavior is intentionally unchanged** — the predicate excludes `x-preedit-overlay` / `pgtk-preedit-overlay`. Line mode is unaffected. While the symptom that surfaced this is Korean hangul, the fix uses `quail-overlay` (Emacs core), so it generalizes to **any lisp IME** — Japanese anthy, Chinese, …

Detailed race-window analysis, invariant, and refactor guidance for future-you are documented inline as commentary blocks (the `;; Lisp IME composition guard` section).

## Why this is a draft

I don't send PRs the moment I write something. I keep the patch on a fork branch, pull upstream into it on a regular cadence, and use the result as my daily driver — that's how I shake bugs out. ghostel is your main project; it deserves to be treated that way.

By now this series has survived **two upstream merges including the v0.30.0 release plus 118 commits**, including refactors that touched the exact same area (`9ff243f Centralize ghostel buffer terminal initialization`, `22e535a Break out invalidation logic out of redraw`) — with no merge conflicts and no behavioral regressions in daily use. That gives me reasonable confidence the placement is structural rather than coincidental.

That said, it stays as a **draft** until you weigh in. Things I'd love your judgement on:

- **Filesystem layout** — keep inline in `lisp/ghostel.el`, or move to a new `lisp/ghostel-ime.el`. I left it inline because every call site lives in `ghostel.el`, but I have no strong preference.
- **Squash policy** — currently 6 commits, preserving the diagnostic narrative (each commit body reads like a small race-condition write-up). Happy to fold into ~3 if you prefer fewer, larger commits.
- **Commentary tone** — I included a lot of "if upstream restructures X, the guard's intent is …" notes inside the file. Useful, or noise?
- **Tests** — the race is concurrent (PTY stream vs. IME compose loop), so I documented it as a commentary block rather than as ert. I can take a swing at a hypothesis-style test if you'd want one before merge.
- **Don't merge?** — entirely fine. Please just say so and I'll keep it on my fork. The main reason I opened the PR at all is so other CJK users running streaming TUI agents inside ghostel can find this.

## Branch / commits

- Fork & branch: [`junghan0611/ghostel` `fix/korean-ime-commit`](https://github.com/junghan0611/ghostel/tree/fix/korean-ime-commit)
- Foundation: `8d3320d Forward IME-committed text to PTY for Emacs input methods` (2026-05-07)
- Mode restriction follow-up: `d9c5b11 Restrict IME commit forwarding to PTY-forwarding input modes`
- Guard series: `3b518a0` (helpers, no behavior change) → `83f110c` (immediate-redraw) → `88cdb7a` (delayed-redraw safety net) → `db2484d` (commentary fix)

---

다시 한 번, 진심으로 감사합니다.

— @junghan0611
