### PR TITLE
evil-ghostel: keep Ctrl passthrough active in alt-screen

### DIFF
--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -85,6 +85,16 @@ Sets the initial value of the buffer-local state.  Use
        (not (ghostel--mode-enabled ghostel--term 1049))
        (eq ghostel--input-mode 'semi-char)))
 
+(defun evil-ghostel--ctrl-passthrough-active-p ()
+  "Return non-nil when insert-state Ctrl keys should go to the terminal.
+Unlike `evil-ghostel--active-p', this intentionally stays active in
+alt-screen mode: full-screen TUIs own the keyboard, so readline-style
+Ctrl keys like \\`C-u', \\`C-w', \\`C-r' must not fall back to Evil's
+insert-state editing commands."
+  (and evil-ghostel-mode
+       ghostel--term
+       (eq ghostel--input-mode 'semi-char)))
+
 (defun evil-ghostel--line-mode-active-p ()
   "Return non-nil when line mode editing is in effect.
 Line mode buffers shell input as plain buffer text inside
@@ -636,7 +646,7 @@ own bindings (e.g. \\`C-a' → `ghostel-beginning-of-input-or-line',
 \\`C-d' → `ghostel-line-mode-delete-char-or-eof') win over evil's
 defaults; without that, the minor-mode aux map containing this
 passthrough would shadow line mode's local-map binding."
-  (if (evil-ghostel--active-p)
+  (if (evil-ghostel--ctrl-passthrough-active-p)
       (progn
         (ghostel--send-encoded key "ctrl")
         ;; C-a / C-e / C-u / C-w / C-r / C-n / C-p all reposition the

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -953,6 +953,25 @@ position the cursor no longer holds."
      (evil-ghostel--passthrough-ctrl "a")
      (should-not evil-ghostel--shadow-cursor))))
 
+(ert-deftest evil-ghostel-test-ctrl-passthrough-sends-in-alt-screen ()
+  "Insert-state Ctrl passthrough remains active in alt-screen TUIs.
+`evil-ghostel--active-p' excludes alt-screen so normal-mode editing
+falls through there, but C-u/C-w/etc. must still go to the terminal
+instead of invoking Evil's insert-state editing commands."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (setq-local ghostel--input-mode 'semi-char)
+   (cl-letf (((symbol-function 'ghostel--mode-enabled)
+              (lambda (_term mode) (= mode 1049))))
+     (should-not (evil-ghostel--active-p))
+     (should (evil-ghostel--ctrl-passthrough-active-p))
+     (let (sent)
+       (cl-letf (((symbol-function 'ghostel--send-encoded)
+                  (lambda (key mods &rest _)
+                    (setq sent (cons key mods)))))
+         (evil-ghostel--passthrough-ctrl "u"))
+       (should (equal '("u" . "ctrl") sent))))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: insert-state entry skips vertical sync
 ;; -----------------------------------------------------------------------
@@ -1545,7 +1564,8 @@ sticks."
     evil-ghostel-test-delete-word-with-trailing-space
     evil-ghostel-test-change-partial-no-post-delete-sync
     evil-ghostel-test-insert-entry-same-viewport-row-with-scrollback
-    evil-ghostel-test-ctrl-passthrough-invalidates-shadow)
+    evil-ghostel-test-ctrl-passthrough-invalidates-shadow
+    evil-ghostel-test-ctrl-passthrough-sends-in-alt-screen)
   "Tests that require only Elisp (no native module).")
 
 (defun evil-ghostel-test-run-elisp ()


### PR DESCRIPTION
Insert-state Ctrl passthrough used `evil-ghostel--active-p`, which intentionally returns nil in DECSET 1049 alt-screen mode. This caused `C-u` to fall back to Evil's insert-state binding and delete buffer text instead of being sent to the terminal.

Introduce a narrower predicate for Ctrl passthrough that remains active in semi-char mode during alt-screen sessions, leaving the broader Evil editing/cursor-sync predicate unchanged.

Add a regression test covering `C-u` passthrough in alt-screen mode.