### PR TITLE
Render cursor-line padding precisely

### DIFF
--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -399,20 +399,15 @@ pub const RowContent = struct {
     /// A list of continuous property runs
     runs: std.ArrayList(Run) = .empty,
 
-    /// Build text content and style runs for the current row in the iterator.
-    /// Style runs use character (codepoint) offsets for Emacs put-text-property.
-    ///
-    /// Trailing blank cells — spaces with the default cell style — are
-    /// trimmed off the end of the row so the Emacs buffer does not carry
-    /// libghostty's full-width viewport padding. A cell is NOT blank if
-    /// its character is non-space, or if its style has any non-default
-    /// attribute (e.g. a colored background, underline, etc.), so visibly-
-    /// styled blanks are preserved.
+    /// The character position of the cursor
+    cursor_char_pos: ?usize = null,
+
     pub fn build(
         self: *RowContent,
         alloc: Allocator,
         renderer: *Self,
         row: *const gt.RenderState.Row,
+        cursor_col: ?u16,
         adjustment_threshold: u32,
     ) !void {
         try self.clear();
@@ -425,10 +420,14 @@ pub const RowContent = struct {
 
         const page = &row.pin.node.data;
         var current_prop_key: ?CellPropKey = null;
-        var col: usize = 0;
+        var col: u16 = 0;
         while (col < row.cells.len) : (col += 1) {
             const cell = row.cells.get(col);
             const raw_cell = page.getRowAndCell(col, row.pin.y).cell;
+
+            const has_cursor = col == cursor_col;
+            if (has_cursor) self.cursor_char_pos = self.char_len;
+
             if (cell.raw.wide == .spacer_tail or cell.raw.wide == .spacer_head) continue;
 
             // We use a "key" that holds a minimum set of values that are cheap to
@@ -469,10 +468,15 @@ pub const RowContent = struct {
             const last_run = &self.runs.items[self.runs.items.len - 1];
             last_run.end_char = self.char_len;
 
-            // We trim cells that neither have content nor styling
+            // We trim cells that neither have content nor styling. A blank
+            // cursor cell only requires enough whitespace to place point at
+            // the cursor column, not an extra rendered space under it.
             if (raw_cell.hasText() or last_run.props != null) {
                 trim_byte_len = self.text.items.len;
                 trim_char_len = self.char_len;
+            } else if (has_cursor) {
+                trim_byte_len = byte_start;
+                trim_char_len = char_start;
             }
         }
 
@@ -500,6 +504,7 @@ pub const RowContent = struct {
         self.adjust_cells.clearRetainingCapacity();
         self.runs.clearRetainingCapacity();
         self.char_len = 0;
+        self.cursor_char_pos = null;
     }
 
     fn appendCodepoints(self: *RowContent, alloc: Allocator, cluster: []const u21) !void {
@@ -607,11 +612,18 @@ fn adjustGlyph(
 }
 
 /// Insert row text and apply property runs.
-fn insertRow(self: *Self, alloc: Allocator, env: emacs.Env, row: *const gt.RenderState.Row) !usize {
+fn insertRow(
+    self: *Self,
+    alloc: Allocator,
+    env: emacs.Env,
+    row: *const gt.RenderState.Row,
+    cursor_col: ?u16,
+) !usize {
     try self.row.build(
         alloc,
         self,
         row,
+        cursor_col,
         if (self.font_info) |f| f.coverage else std.math.maxInt(u32),
     );
 
@@ -638,40 +650,14 @@ fn insertRow(self: *Self, alloc: Allocator, env: emacs.Env, row: *const gt.Rende
         env.putTextProperty(nl_pos, point, "ghostel-wrap", env.t());
     }
 
-    return @intCast(row_end - row_start);
-}
-
-/// Convert a terminal column to an Emacs character offset by iterating
-/// the row's cells.  Returns `true` and positions point on success;
-/// `false` if the cell data is unavailable (caller should fall back to
-/// `move-to-column`).
-///
-/// This avoids relying on Emacs' `char-width`, which can disagree with
-/// the terminal's column width for certain characters (e.g. box-drawing
-/// glyphs on CJK/pgtk systems where `char-width` returns 2 but the
-/// terminal treats them as single-width).
-fn positionCursorByCell(self: *Self, env: emacs.Env, cx: u16, cy: u16) !bool {
-    if (cx == 0) return true; // already at column 0
-
-    // Walk cells 0..cx-1, counting Emacs characters.
-    var col: u16 = 0;
-    var char_count: i64 = 0;
-    const cells = &self.render_state.row_data.items(.cells)[cy];
-    while (col < cx) : (col += 1) {
-        const cell = cells.get(col);
-        if (cell.raw.wide == .spacer_head or cell.raw.wide == .spacer_tail) continue;
-
-        const graphemes_len = 1 + if (cell.raw.hasGrapheme()) cell.grapheme.len else 0;
-        char_count += @intCast(graphemes_len);
+    if (self.row.cursor_char_pos) |pos| {
+        env.set(
+            "ghostel--cursor-char-pos",
+            @as(usize, @intCast(row_start)) + pos,
+        );
     }
 
-    // Cap at end of line so we never jump past it into the next row
-    // (can happen when cursor is on a trimmed trailing blank).
-    const pt = env.extractInteger(env.point());
-    const eol = env.extractInteger(env.lineEndPosition());
-    const max_chars = eol - pt;
-    env.gotoChar(pt + @min(char_count, max_chars));
-    return true;
+    return @intCast(row_end - row_start);
 }
 
 pub fn render(
@@ -681,7 +667,7 @@ pub fn render(
     pin: gt.Pin,
 ) !void {
     self.term.screens.active.pages.scroll(.{ .pin = pin });
-    try self.render_state.update(alloc, self.term);
+    try self.updateRenderState(alloc);
 
     if (self.render_state.dirty != .false) {
         // Set buffer default face
@@ -732,7 +718,14 @@ pub fn render(
                     env.deleteRegion(old_line_start, old_line_end);
                 }
 
-                const line_char_len = try self.insertRow(alloc, env, &row);
+                const cursor_col = blk: {
+                    if (self.render_state.cursor.viewport) |vp| {
+                        if (vp.y == i) break :blk vp.x;
+                    }
+
+                    break :blk null;
+                };
+                const line_char_len = try self.insertRow(alloc, env, &row, cursor_col);
                 if (page) |p| p.char_len += line_char_len;
             } else {
                 _ = env.forwardLine(1);
@@ -744,32 +737,40 @@ pub fn render(
     }
 }
 
-fn renderCursor(self: *Self, env: emacs.Env) !void {
-    // Walk to the current viewport start
-    self.gotoActiveStart(env);
-    const active_start_int = env.extractInteger(env.point());
+fn updateRenderState(self: *Self, alloc: Allocator) !void {
+    const pre_cursor: ?gt.RenderState.Cursor.Viewport =
+        self.render_state.cursor.viewport;
 
-    // Position cursor (active-relative row -> absolute line).
-    // X/Y are only valid when HAS_VALUE is true, so query separately
-    // to avoid stopping the style batch above on NO_VALUE.
-    if (self.render_state.cursor.viewport) |vp| {
-        env.gotoChar(active_start_int);
-        _ = env.forwardLine(@as(i64, vp.y));
-        if (!try self.positionCursorByCell(env, vp.x, vp.y)) {
-            env.moveToColumn(@as(i64, vp.x));
+    try self.render_state.update(alloc, self.term);
+    if (self.render_state.dirty == .full) return;
+
+    const post_cursor: ?gt.RenderState.Cursor.Viewport =
+        self.render_state.cursor.viewport;
+
+    if (!std.meta.eql(pre_cursor, post_cursor)) {
+        // The cursor moved. Both the old row and the new row are dirty.
+        if (self.render_state.dirty == .false) {
+            self.render_state.dirty = .partial;
         }
+        const row_dirty = self.render_state.row_data.items(.dirty);
+        if (pre_cursor) |vp| row_dirty[vp.y] = true;
+        if (post_cursor) |vp| row_dirty[vp.y] = true;
+    }
+}
 
+fn renderCursor(self: *Self, env: emacs.Env) !void {
+    if (self.render_state.cursor.viewport) |vp| {
         _ = env.set("ghostel--cursor-pos", env.cons(vp.x, vp.y));
-        _ = env.set("ghostel--cursor-char-pos", env.point());
     } else {
         _ = env.set("ghostel--cursor-pos", env.nil());
-        _ = env.set("ghostel--cursor-char-pos", env.nil());
     }
 
     _ = env.f("ghostel--set-cursor-style", .{
         @intFromEnum(self.render_state.cursor.visual_style),
         if (self.render_state.cursor.visible) env.t() else env.nil(),
     });
+
+    _ = env.f("goto-char", .{env.symbolValue("ghostel--cursor-char-pos")});
 }
 
 // Render all pages from start_pin through the end of the active area,

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -288,6 +288,47 @@ are retained — only unwritten padding cells are trimmed."
               (should (equal "$ " (car lines))))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-render-untrims-cursor-line-to-cursor-column ()
+  "A cursor past EOL keeps only enough blanks to place point there."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-cursor-untrim*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 3 20 100))
+                 (inhibit-read-only t))
+            (ghostel--write-input term "\e[H\e[2Jhi\e[1;11H")
+            (ghostel--redraw term t)
+            (should (equal '(10 . 0) ghostel--cursor-pos))
+            (goto-char ghostel--cursor-char-pos)
+            (should (= 10 (current-column)))
+            (let ((line (buffer-substring-no-properties
+                         (line-beginning-position)
+                         (line-end-position))))
+              (should (equal (concat "hi" (make-string 8 ?\s)) line)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-render-retrims-old-cursor-line-on-cursor-move ()
+  "Moving the cursor trims the old line and untrims the new one."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-cursor-retrim*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 3 20 100))
+                 (inhibit-read-only t))
+            (ghostel--write-input term "\e[H\e[2Jhi\e[1;11H")
+            (ghostel--redraw term t)
+            (ghostel--write-input term "\e[2;6H")
+            (ghostel--redraw term)
+            (should (equal '(5 . 1) ghostel--cursor-pos))
+            (let ((lines (split-string (buffer-substring-no-properties
+                                        (point-min) (point-max))
+                                       "\n")))
+              (should (equal "hi" (nth 0 lines)))
+              (should (equal (make-string 5 ?\s) (nth 1 lines))))
+            (goto-char ghostel--cursor-char-pos)
+            (should (= 5 (current-column)))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-soft-wrap-copy ()
   "Test that soft-wrapped newlines are filtered during copy."
   :tags '(native)


### PR DESCRIPTION
Fixes #341.

## Summary
- keep exactly enough trailing blanks on the cursor row to place point at the terminal cursor column
- re-trim the previous cursor row when the cursor moves away
- skip cursor dirty-row bookkeeping after full render-state invalidation

## Verification
- `zig build`
- `emacs --batch -Q -L lisp -L test -l ert -l test/ghostel-test-helpers.el -l test/ghostel-render-test.el --eval "(ert-run-tests-batch-and-exit '(tag native))"` (73/73)