### PR TITLE
Make mode-switch keys work in copy and Emacs modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ and watch `mode-line-process` for the current mode indicator.
 | copy        | `:Copy`   | frozen   | read-only   | precise text selection without scroll churn   |
 | line        | `:Line`   | live     | editable    | compose input with Emacs keys, send on `RET`  |
 
-### Mode-switch keybindings (available from every live mode)
+### Mode-switch keybindings (available from every mode except char mode)
 
 | Key       | Action                                    |
 |-----------|-------------------------------------------|
@@ -238,6 +238,9 @@ mode (`C-c C-j`) when you want to type to the shell.  `C-y` is the
 exception: it pastes via bracketed paste as a deliberate action and
 snaps point back to the live cursor.
 
+`C-c C-e` toggles Emacs mode off again (returning to the mode you came
+from), and `C-c C-t` switches to copy mode to freeze the output.
+
 Use this for searching through scrollback while a build is running,
 filtering streaming logs with `M-x occur`, marking and copying across
 the visible history, or running any buffer-based command over the
@@ -250,6 +253,10 @@ updates the buffer until you exit.  Use this when you want to select
 text precisely without the terminal scrolling underneath your cursor.
 The aggressive copy-mode keymap exits on self-insert, so typing a
 letter sends it to the terminal and returns to semi-char mode.
+
+`C-c C-t` toggles copy mode off again, and `C-c C-e` switches to Emacs
+mode — read-only but live, so output resumes — without going through
+semi-char.
 
 | Key           | Action                           |
 |---------------|----------------------------------|

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2002,8 +2002,6 @@ See `ghostel-readonly-fast-exit'."
   "<return>"                      #'ghostel-readonly-RET-or-exit-and-send
   "C-c M-l"                       #'ghostel-readonly-exit-and-clear
   "q"                             #'ghostel-readonly-exit
-  "C-c C-e"                       #'ghostel-readonly-exit
-  "C-c C-t"                       #'ghostel-readonly-exit
   "C-g"                           #'ghostel-readonly-exit)
 
 ;; Char mode must override minor-mode keymaps.  Without this, a user
@@ -2996,16 +2994,18 @@ a non-read-only mode."
     (ghostel--fake-cursor-update)))
 
 (defun ghostel-emacs-mode ()
-  "Switch to Emacs mode — read-only buffer with the terminal still running.
+  "Toggle Emacs mode — read-only buffer with the terminal still running.
 The terminal keeps running and scrollback keeps growing.  The
 buffer is read-only, so standard Emacs commands like `isearch',
 `occur', `M-x', `C-SPC' / `M-w', and regular navigation all work
-unmodified over the entire materialised scrollback.  Exit with an
-explicit mode-switch command (`\\[ghostel-semi-char-mode]'), or
-\\`q'/\\`C-g'/any self-insert key when `ghostel-readonly-fast-exit'
-is non-nil."
+unmodified over the entire materialised scrollback.  When already
+in Emacs mode this exits back to the previous mode (mirroring
+`ghostel-copy-mode'); otherwise exit with an explicit mode-switch
+command (`\\[ghostel-semi-char-mode]'), or \\`q'/\\`C-g'/any
+self-insert key when `ghostel-readonly-fast-exit' is non-nil."
   (interactive)
-  (unless (eq ghostel--input-mode 'emacs)
+  (if (eq ghostel--input-mode 'emacs)
+      (ghostel-readonly-exit)
     (ghostel--enter-readonly
      'emacs nil ":Emacs"
      (format "Emacs mode: terminal live, %s to exit"

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -722,6 +722,51 @@ Otherwise the window stays where the user navigated."
   (should (eq (lookup-key ghostel-mode-map (kbd "C-c C-t"))
               #'ghostel-copy-mode)))
 
+(ert-deftest ghostel-test-readonly-fast-exit-switch-keybindings ()
+  "Fast-exit copy/Emacs mode keeps the full mode-switch matrix (issue #342).
+The mode-switch keys stay bound to their mode commands rather than being
+repurposed as exit shortcuts, while the quit keys stay bound to the fast exit."
+  (should (eq (lookup-key ghostel-readonly-fast-exit-mode-map (kbd "C-c C-e"))
+              #'ghostel-emacs-mode))
+  (should (eq (lookup-key ghostel-readonly-fast-exit-mode-map (kbd "C-c C-t"))
+              #'ghostel-copy-mode))
+  (should (eq (lookup-key ghostel-readonly-fast-exit-mode-map (kbd "C-c C-j"))
+              #'ghostel-semi-char-mode))
+  (should (eq (lookup-key ghostel-readonly-fast-exit-mode-map (kbd "C-c M-d"))
+              #'ghostel-char-mode))
+  (should (eq (lookup-key ghostel-readonly-fast-exit-mode-map (kbd "C-c C-l"))
+              #'ghostel-line-mode))
+  (should (eq (lookup-key ghostel-readonly-fast-exit-mode-map (kbd "q"))
+              #'ghostel-readonly-exit))
+  (should (eq (lookup-key ghostel-readonly-fast-exit-mode-map (kbd "C-g"))
+              #'ghostel-readonly-exit)))
+
+(ert-deftest ghostel-test-emacs-mode-toggles-off ()
+  "`ghostel-emacs-mode' is a toggle: calling it while in Emacs mode exits.
+Exiting returns to whatever mode the user was in beforehand, mirroring
+`ghostel-copy-mode'."
+  (let ((buf (generate-new-buffer " *ghostel-test-emacs-toggle*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake)
+                (ghostel--redraw-timer nil))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--scroll-bottom) #'ignore))
+              ;; semi-char → emacs → (toggle) semi-char
+              (ghostel-emacs-mode)
+              (should (eq ghostel--input-mode 'emacs))
+              (ghostel-emacs-mode)
+              (should (eq ghostel--input-mode 'semi-char))
+              (should-not buffer-read-only)
+              ;; char → emacs → (toggle) char
+              (ghostel-char-mode)
+              (ghostel-emacs-mode)
+              (should (eq ghostel--input-mode 'emacs))
+              (ghostel-emacs-mode)
+              (should (eq ghostel--input-mode 'char)))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-prompt-nav-enters-emacs-mode ()
   "`ghostel-next-prompt' auto-enters Emacs mode, not copy mode."
   (let ((buf (generate-new-buffer " *ghostel-test-prompt-nav*")))


### PR DESCRIPTION
## Summary

Closes #342.

The eat-style mode-switch keys (`C-c C-e` → Emacs, `C-c C-j` → semi-char, `C-c M-d` → char, `C-c C-l` → line, `C-c C-t` → copy) already worked in semi-char and line modes, and char mode intentionally only exits via `M-RET`. The gap was in **copy and Emacs modes**: under the default `ghostel-readonly-fast-exit`, `C-c C-e` and `C-c C-t` were repurposed as exit shortcuts, so e.g. `C-c C-e` in copy mode exited to semi-char instead of switching to Emacs mode.

- Drop the `C-c C-e` / `C-c C-t` → `ghostel-readonly-exit` overrides from `ghostel-readonly-fast-exit-mode-map` so they inherit the switch bindings from `ghostel-mode-map`.
- Make `ghostel-emacs-mode` a toggle, mirroring `ghostel-copy-mode`.

Copy and Emacs modes are now symmetric: `C-c C-e` toggles Emacs mode, `C-c C-t` toggles copy mode, and each switches into the other read-only mode. The fast-exit affordances (`q`, `C-g`, self-insert) are unchanged.

## Test plan

- [x] `make test` (elisp) and `make test-native` pass
- [x] `make checkdoc` passes
- [x] New tests: `ghostel-test-readonly-fast-exit-switch-keybindings`, `ghostel-test-emacs-mode-toggles-off`
- [x] Live dispatch against the real engine: copy + `C-c C-e` → Emacs; Emacs + `C-c C-e` → exit; Emacs + `C-c C-t` → copy; copy + `C-c C-t` → exit; copy + `q` → exit; copy + `C-c M-d` → char