### PR TITLE
Make package-lint target self-provision its dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,20 +38,9 @@ jobs:
         with:
           version: '29.4'
 
-      - name: Install lint deps
-        # `package-lint' resolves cross-package deps via
-        # `package-archive-contents' and `package-alist'.  Installing
-        # ghostel from the local checkout adds it to `package-alist' so
-        # evil-ghostel's `(ghostel "0.8.0")' Package-Require resolves —
-        # ghostel itself isn't on any ELPA.
-        run: |
-          emacs --batch -Q \
-            --eval "(package-initialize)" \
-            --eval "(package-refresh-contents)" \
-            --eval "(package-install 'package-lint)" \
-            --eval "(package-install-file (expand-file-name \"lisp/ghostel.el\"))"
-
       - name: Run package-lint, checkdoc, docquotes
+        # `make package-lint' self-provisions its deps (package-lint +
+        # a local ghostel install) into an isolated package-user-dir.
         run: make package-lint checkdoc docquotes
 
   test-zig:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ export EMACSFLAGS
 XDG_CACHE_HOME ?= $(HOME)/.cache
 MELPAZOID_DIR  ?= $(XDG_CACHE_HOME)/melpazoid
 EVIL_DIR       ?= $(XDG_CACHE_HOME)/evil
+LINT_ELPA_DIR  ?= $(XDG_CACHE_HOME)/ghostel-lint-elpa
+LINT_DEPS_STAMP := $(LINT_ELPA_DIR)/.deps-installed
 
 ELC := lisp/ghostel.elc lisp/ghostel-debug.elc lisp/ghostel-compile.elc \
        lisp/ghostel-eshell.elc lisp/ghostel-comint.elc \
@@ -106,8 +108,22 @@ byte-compile: $(ELC)
 
 lint: byte-compile package-lint checkdoc docquotes
 
-package-lint:
+# `package-lint' needs two things present that aren't on any default load path:
+# the linter itself, and a resolvable `ghostel' package.
+# Provision both into an isolated `package-user-dir'
+# so `make package-lint' runs standalone.
+$(LINT_DEPS_STAMP):
 	$(EMACS) --batch $(EMACSFLAGS) -Q \
+		--eval "(setq package-user-dir \"$(LINT_ELPA_DIR)\")" \
+		--eval "(package-initialize)" \
+		--eval "(package-refresh-contents)" \
+		--eval "(package-install 'package-lint)" \
+		--eval "(package-install-file (expand-file-name \"lisp/ghostel.el\"))"
+	@touch $@
+
+package-lint: $(LINT_DEPS_STAMP)
+	$(EMACS) --batch $(EMACSFLAGS) -Q \
+		--eval "(setq package-user-dir \"$(LINT_ELPA_DIR)\")" \
 		--eval "(package-initialize)" \
 		--eval "(require 'package-lint)" \
 		-f package-lint-batch-and-exit \


### PR DESCRIPTION
## Summary
- `make package-lint` assumed `package-lint` and a resolvable `ghostel` package were already installed, so it only worked in CI (where a separate workflow step installed them). It failed standalone, and the CI-style workaround would install `ghostel` into the developer's real `~/.emacs.d/elpa`.
- Provision both deps into an isolated `package-user-dir` (`$(XDG_CACHE_HOME)/ghostel-lint-elpa`) via a stamped rule, so `make package-lint` runs standalone. The stamp means repeat runs skip the network.
- Drop the now-redundant "Install lint deps" step from the CI lint job.

## Notes
- `package-lint` resolves from NonGNU ELPA (a default `-Q` archive), so no MELPA needs adding.
- `package-install-file lisp/ghostel.el` registers `ghostel` in `package-alist` (pulling in `compat`) so `evil-ghostel`'s `(ghostel "0.8.0")` requirement resolves.
- The cache lives under `XDG_CACHE_HOME` like the existing evil/melpazoid caches and is not removed by `make clean`.

## Test plan
- [x] `rm -rf ~/.cache/ghostel-lint-elpa && make package-lint` — provisions deps and lints clean (exit 0)
- [x] Second `make package-lint` — skips provisioning (no network), lints clean (exit 0)