### PR TITLE
Match Ghostty's word boundaries for double-click selection

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -794,6 +794,44 @@ is not in semi-char-mode when the drag completes."
                  (const :tag "Emacs mode"          emacs)
                  (const :tag "Do not switch"       nil)))
 
+(defcustom ghostel-word-boundary-string " \t\"'`|:;,()[]{}<>$│"
+  "Characters that terminate words in ghostel buffers.
+
+Mirrors Ghostty's `selection-word-chars' default.  Characters not listed
+here are word constituents, so double-click selects whole hostnames
+\(`api.example.com') and paths (`~/src/foo/bar.txt').
+
+The value is realized into `ghostel-mode-syntax-table', which drives mouse
+word selection and word-based motion/search.
+Use `setopt' or `customize-set-variable' so the table is rebuilt."
+  :type 'string
+  :initialize #'custom-initialize-default
+  :set (lambda (sym newval)
+         (set-default sym newval)
+         (when (boundp 'ghostel-mode-syntax-table)
+           (ghostel--rebuild-mode-syntax-table))))
+
+(defvar ghostel-mode-syntax-table (make-syntax-table)
+  "Syntax table for `ghostel-mode'.")
+
+(defun ghostel--rebuild-mode-syntax-table ()
+  "Realize `ghostel-word-boundary-string' into `ghostel-mode-syntax-table'.
+
+Mutates the table in place, so live ghostel buffers keep their
+buffer-local syntax-table reference and see customization changes.
+
+Printable ASCII starts as word syntax; configured boundaries become plain
+punctuation.  Keeping boundaries as `.' (not paren/string syntax) prevents
+double-click selection from invoking `forward-sexp'.
+Whitespace keeps whitespace syntax."
+  (cl-loop for ch from ?! to ?~
+           do (modify-syntax-entry ch "w" ghostel-mode-syntax-table))
+  (dolist (ch (string-to-list ghostel-word-boundary-string))
+    (unless (memq ch '(?\s ?\t ?\n ?\r ?\f ?\v))
+      (modify-syntax-entry ch "." ghostel-mode-syntax-table))))
+
+(ghostel--rebuild-mode-syntax-table)
+
 (defcustom ghostel-scroll-on-input t
   "Automatically scroll to the bottom when typing in the terminal.
 When non-nil, any character typed while the viewport is scrolled

--- a/test/ghostel-word-boundary-test.el
+++ b/test/ghostel-word-boundary-test.el
@@ -1,0 +1,102 @@
+;;; ghostel-word-boundary-test.el --- Tests for ghostel: word boundaries  -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; `ghostel-mode-syntax-table' and the `ghostel-word-boundary-string'
+;; defcustom that drives it.  All tests are pure elisp — no native module
+;; required.  We enter `ghostel-mode' via `ghostel-test--with-compile-buffer'
+;; so the buffer's syntax table is whatever `define-derived-mode' installs,
+;; matching the production buffers a user actually clicks in.
+;;
+;; Tests assert via two paths.  `thing-at-point 'word' goes through
+;; `bounds-of-thing-at-point', the call chain `M-f' / `M-b', Evil `iw' / `aw'
+;; and isearch word matching follow.  `mouse-start-end' with mode 1 is the
+;; call `mouse-set-point' makes for double-click promotion (via
+;; `mouse-set-region').  Both share the syntax table here, but exercising
+;; them separately catches regressions in either path.
+
+;;; Code:
+
+(require 'ghostel-test-helpers)
+
+(ert-deftest ghostel-test-syntax-table-selects-hostname ()
+  "Word selection covers a full dotted hostname.
+
+Default boundaries make `.' a word constituent, so a click inside `example'
+returns the whole `api.example.com' run."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (insert "api.example.com"))
+    (goto-char (point-min))
+    (search-forward "example")
+    (backward-char 4)                    ; somewhere inside `example'
+    (should (equal (thing-at-point 'word t) "api.example.com"))))
+
+(ert-deftest ghostel-test-syntax-table-selects-path ()
+  "Word selection covers a full filesystem path."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (insert "~/src/foo/bar.txt"))
+    (goto-char (point-min))
+    (search-forward "foo")
+    (backward-char 2)
+    (should (equal (thing-at-point 'word t) "~/src/foo/bar.txt"))))
+
+(ert-deftest ghostel-test-syntax-table-stops-at-boundary ()
+  "Default boundary characters still split words.
+
+Confirms the rebuild does not collapse every codepoint to word syntax —
+SPC, `|', and U+2502 should each terminate a selection."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (insert "alpha bravo|charlie\u2502delta"))
+    (dolist (word '("alpha" "bravo" "charlie" "delta"))
+      (goto-char (point-min))
+      (search-forward word)
+      (backward-char 2)
+      (should (equal (thing-at-point 'word t) word)))))
+
+(ert-deftest ghostel-test-syntax-table-mouse-start-end ()
+  "`mouse-start-end' with mode 1 grows a click into the surrounding word.
+
+`mouse-set-point' calls `mouse-set-region' → `mouse-start-end' on a
+multi-click event; this is the actual call chain `mouse-1' double-click
+takes after `ghostel-mouse-release-or-set-point' delegates to
+`mouse-set-point'.  The other tests go through `bounds-of-thing-at-point',
+which only catches a subset of the same syntax-table classification."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (insert "api.example.com"))
+    (goto-char (point-min))
+    (search-forward "example")
+    (backward-char 4)
+    (let* ((bounds (mouse-start-end (point) (point) 1))
+           (text (buffer-substring-no-properties (nth 0 bounds)
+                                                 (nth 1 bounds))))
+      (should (equal text "api.example.com")))))
+
+(ert-deftest ghostel-test-syntax-table-rebuild-on-customize ()
+  "`customize-set-variable' rebuilds `ghostel-mode-syntax-table' in place.
+
+Live ghostel buffers hold a reference to `ghostel-mode-syntax-table' via
+`set-syntax-table', so the rebuild has to mutate the existing object — a
+fresh table would leave existing buffers with the old boundaries."
+  (let ((saved ghostel-word-boundary-string))
+    (unwind-protect
+        (ghostel-test--with-compile-buffer buf
+          (let ((inhibit-read-only t))
+            (insert "git@github.com:dakra/ghostel"))
+          (goto-char (point-min))
+          (search-forward "github")
+          (backward-char 2)
+          ;; Default: `:' is a boundary, so the word stops before `:dakra'.
+          (should (equal (thing-at-point 'word t) "git@github.com"))
+          ;; Drop `:' from the boundary set — same string with `:' removed.
+          (customize-set-variable 'ghostel-word-boundary-string
+                                  " \t\"'`|;,()[]{}<>$\u2502")
+          (should (equal (thing-at-point 'word t)
+                         "git@github.com:dakra/ghostel")))
+      (customize-set-variable 'ghostel-word-boundary-string saved))))
+
+(provide 'ghostel-word-boundary-test)
+;;; ghostel-word-boundary-test.el ends here


### PR DESCRIPTION
Closes #350.

## Summary
- Add `ghostel-word-boundary-string`, a defcustom defaulting to Ghostty's `selection-word-chars` set — SPC TAB `'` `"` U+2502 `` ` `` `|` `:` `;` `,` `(` `)` `[` `]` `{` `}` `<` `>` `$` plus NUL — sourced from [`src/terminal/selection_codepoints.zig`](https://github.com/ghostty-org/ghostty/blob/main/src/terminal/selection_codepoints.zig).
- Define `ghostel-mode-syntax-table` from that string at load time. `define-derived-mode` picks it up automatically, so double-click word selection, word motion, and word-based search use terminal-friendly boundaries.
- The `:set` handler mutates the existing table object via `modify-syntax-entry`, so live ghostel buffers — which store a reference via `set-syntax-table` — stay in sync without re-entering the mode. Same rebuild-in-place pattern as `ghostel-keymap-exceptions`.

User-visible result: a double-click inside `api.example.com` selects the whole hostname, inside `~/src/foo/bar.txt` selects the whole path, inside `git@github.com` selects the whole identifier. Evil `iw` / `aw`, `M-f` / `M-b`, and isearch word matching pick up the same boundaries.

## Notes
- Demoting `()`, `[]`, `{}`, `"`, `'` from their open/close-paren and string-quote syntax classes to plain `.` is intentional and matches Ghostty. `show-paren-mode`, `forward-sexp`, and `M-x check-parens` behave differently in ghostel buffers as a result; for terminal content that's the right trade-off.
- Ghostel only owns the printable ASCII range when rebuilding. Adding a non-ASCII codepoint to the boundary string demotes it as expected; removing one previously added does not undo the explicit syntax-table entry without restarting Emacs. Documented in the defcustom docstring.

## Verification
- `make byte-compile` — clean with `byte-compile-error-on-warn t`.
- `make checkdoc`, `make docquotes`, `make package-lint` — clean.
- `make test` — all elisp test files pass, including the new `test/ghostel-word-boundary-test.el` (5 ERT tests covering hostname / path selection, boundary still splits, `mouse-start-end` mode 1 against the actual production call chain, and rebuild-on-customize).
