### PR TITLE
Stream mouse motion live during alt-screen drags

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2527,6 +2527,35 @@ Return non-nil if the event was forwarded (mouse tracking is active)."
 
 ;;; Mouse input
 
+(defvar-local ghostel--mouse-drag-button nil
+  "Button number held during an in-progress mouse-tracking drag.
+Nil when no drag is in progress.")
+
+(defvar-local ghostel--mouse-drag-last-cell nil
+  "Last (ROW . COL) forwarded as a motion event during a drag.
+Used by `ghostel--mouse-drag-motion' to suppress duplicate motion
+events for the same cell: libghostty is not given a `last_cell' to
+deduplicate against, so without this every `mouse-movement' event
+\(many per cell) would re-encode and spam the PTY.")
+
+(defvar ghostel--mouse-drag-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map [mouse-movement] #'ghostel--mouse-drag-motion)
+    ;; Movement events that land on a non-text area arrive with a
+    ;; prefix (e.g. [mode-line mouse-movement]).  Route those prefixes
+    ;; back through this same map so a drag straying over the
+    ;; mode-line/fringe/margin still resolves to the motion handler and
+    ;; does not prematurely tear the drag down.
+    (dolist (prefix '( mode-line header-line tab-line vertical-line
+                       left-fringe right-fringe left-margin right-margin
+                       right-divider bottom-divider))
+      (define-key map (vector prefix) map))
+    map)
+  "Transient keymap active while a mouse-tracking drag is in progress.
+Installed by `ghostel--mouse-begin-drag-tracking'; routes
+`mouse-movement' events to `ghostel--mouse-drag-motion' so the
+running program receives a live motion stream during the drag.")
+
 (defun ghostel--mouse-button-number (event)
   "Return the ghostty mouse button number for EVENT."
   (pcase (event-basic-type event)
@@ -2557,7 +2586,56 @@ Return non-nil if the event was forwarded (mouse tracking is active)."
                             0  ; press
                             (ghostel--mouse-button-number event)
                             row col
-                            (ghostel--mouse-mods event)))))
+                            (ghostel--mouse-mods event))
+      ;; Emacs only emits `mouse-movement' events while `track-mouse'is non-nil,
+      ;; and coalesces a drag into a single `drag-mouse-N' event at release.
+      ;; To give the running program a live motion stream during the drag,
+      ;; start tracking now (only when a DEC mouse-tracking mode is on,
+      ;; so char mode does not arm it for a program that ignores mouse input).
+      (when (ghostel--mouse-tracking-active-p)
+        (ghostel--mouse-begin-drag-tracking event)))))
+
+(defun ghostel--mouse-begin-drag-tracking (event)
+  "Arm live motion forwarding for a drag started by EVENT.
+Records the held button, enables Emacs motion events by setting the variable
+`track-mouse', and installs `ghostel--mouse-drag-map' as a transient map so
+each intermediate `mouse-movement' event is forwarded to the terminal by
+`ghostel--mouse-drag-motion'.  The map stays active until the next non-motion
+command (the button release, which `keep-pred' detects)."
+  (setq ghostel--mouse-drag-button (ghostel--mouse-button-number event)
+        ghostel--mouse-drag-last-cell nil)
+  (let ((old-track-mouse track-mouse)
+        (buffer (current-buffer)))
+    (setq track-mouse 'dragging)
+    (set-transient-map
+     ghostel--mouse-drag-map
+     (lambda () (eq this-command 'ghostel--mouse-drag-motion))
+     (lambda ()
+       (with-current-buffer buffer
+         (setq track-mouse old-track-mouse
+               ghostel--mouse-drag-button nil
+               ghostel--mouse-drag-last-cell nil))))))
+
+(defun ghostel--mouse-drag-motion (event)
+  "Forward mouse-movement EVENT as a motion event during a drag.
+Bound in `ghostel--mouse-drag-map' while a drag is in progress.
+Labels the motion with the button recorded at press time
+\(`mouse-movement' events carry no button) and skips events that stay
+within the same cell so the PTY is not flooded with redundant motion."
+  (interactive "e")
+  (when (and ghostel--term ghostel--process (process-live-p ghostel--process)
+             ghostel--mouse-drag-button)
+    (let* ((posn (event-start event))
+           (col-row (posn-col-row posn))
+           (col (car col-row))
+           (row (cdr col-row)))
+      (unless (equal (cons row col) ghostel--mouse-drag-last-cell)
+        (setq ghostel--mouse-drag-last-cell (cons row col))
+        (ghostel--mouse-event ghostel--term
+                              2  ; motion
+                              ghostel--mouse-drag-button
+                              row col
+                              (ghostel--mouse-mods event))))))
 
 (defun ghostel--mouse-release (event)
   "Handle mouse button release EVENT for terminal mouse tracking."
@@ -2574,7 +2652,12 @@ Return non-nil if the event was forwarded (mouse tracking is active)."
                             (ghostel--mouse-mods event)))))
 
 (defun ghostel--mouse-drag (event)
-  "Handle mouse drag EVENT as motion for terminal mouse tracking."
+  "Handle drag-end EVENT as a button release for terminal mouse tracking.
+A `drag-mouse-N' event is only delivered at the *end* of a drag, so it marks
+the button release.  Live motion during the drag is streamed separately by
+`ghostel--mouse-drag-motion'; this handler's job is to complete the protocol
+with a release at the final position.  (Sending a release rather than a motion
+also matters for DEC mode 1000, which reports releases but never motion.)"
   (interactive "e")
   (when (and ghostel--term ghostel--process (process-live-p ghostel--process))
     (let* ((posn (event-end event))
@@ -2582,7 +2665,7 @@ Return non-nil if the event was forwarded (mouse tracking is active)."
            (col (car col-row))
            (row (cdr col-row)))
       (ghostel--mouse-event ghostel--term
-                            2  ; motion
+                            1  ; release
                             (ghostel--mouse-button-number event)
                             row col
                             (ghostel--mouse-mods event)))))

--- a/test/ghostel-mouse-paste-test.el
+++ b/test/ghostel-mouse-paste-test.el
@@ -669,7 +669,10 @@ buffer right after they finished selecting."
       (should-not copy-mode-called))))
 
 (ert-deftest ghostel-test-mouse-1-drag-tracking-forwards ()
-  "Drag-end with active tracking forwards via `ghostel--mouse-drag'."
+  "Drag-end with active tracking forwards a release via `ghostel--mouse-drag'.
+A `drag-mouse-N' event is only delivered at the end of a drag, so it
+marks the button release (live motion is streamed separately during the
+drag by `ghostel--mouse-drag-motion')."
   :tags '(native)
   (let ((fake-event `(drag-mouse-1
                       (,(selected-window) 1 (5 . 2) 0)
@@ -690,7 +693,92 @@ buffer right after they finished selecting."
                 ((symbol-function 'process-live-p) (lambda (_p) t)))
         (ghostel-mouse-drag-or-set-region fake-event))
       (should-not set-region-called)
-      (should (equal 2 (nth 0 mouse-event-args))))))   ; action = motion
+      (should (equal 1 (nth 0 mouse-event-args))))))   ; action = release
+
+(ert-deftest ghostel-test-mouse-press-arms-drag-tracking ()
+  "A forwarded press with tracking active arms live motion tracking.
+It sets the variable `track-mouse' to `dragging', records the held
+button, and installs `ghostel--mouse-drag-map' as a transient map.  The
+captured `keep-pred' keeps the map only while the motion handler is
+running, and `on-exit' restores motion tracking and clears the state."
+  :tags '(native)
+  (let ((fake-event `(down-mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (captured-map nil)
+        (captured-keep-pred nil)
+        (captured-on-exit nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--process 'fake)
+      (let ((track-mouse nil))
+        (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                   (lambda (_term mode) (eq mode 1002)))
+                  ((symbol-function 'ghostel--mouse-event)
+                   (lambda (&rest _) t))
+                  ((symbol-function 'process-live-p) (lambda (_p) t))
+                  ((symbol-function 'select-window) (lambda (_w) nil))
+                  ((symbol-function 'set-transient-map)
+                   (lambda (map &optional keep-pred on-exit &rest _)
+                     (setq captured-map map
+                           captured-keep-pred keep-pred
+                           captured-on-exit on-exit))))
+          (ghostel--mouse-press fake-event))
+        ;; Tracking armed.
+        (should (eq track-mouse 'dragging))
+        (should (equal 1 ghostel--mouse-drag-button))
+        (should (eq captured-map ghostel--mouse-drag-map))
+        ;; keep-pred holds the map only during the motion handler.
+        (should (let ((this-command 'ghostel--mouse-drag-motion))
+                  (funcall captured-keep-pred)))
+        (should-not (let ((this-command 'ghostel-mouse-release-or-set-point))
+                      (funcall captured-keep-pred)))
+        ;; on-exit restores track-mouse and clears the drag state.
+        (funcall captured-on-exit)
+        (should-not track-mouse)
+        (should-not ghostel--mouse-drag-button)
+        (should-not ghostel--mouse-drag-last-cell)))))
+
+(ert-deftest ghostel-test-mouse-drag-motion-forwards-and-dedups ()
+  "`ghostel--mouse-drag-motion' streams motion for the held button.
+It labels each motion with `ghostel--mouse-drag-button' (movement
+events carry no button) and suppresses repeated events in the same
+cell so the PTY is not flooded."
+  :tags '(native)
+  (let ((forwards nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--process 'fake)
+      (setq-local ghostel--mouse-drag-button 1)
+      (cl-letf (((symbol-function 'ghostel--mouse-event)
+                 (lambda (_term action button row col mods)
+                   (push (list action button row col mods) forwards)
+                   t))
+                ((symbol-function 'process-live-p) (lambda (_p) t)))
+        ;; First movement at (col 10 . row 5) forwards a motion (action 2)
+        ;; tagged with the held button 1.
+        (ghostel--mouse-drag-motion `(mouse-movement (,(selected-window) 1 (10 . 5) 0)))
+        ;; Same cell again: deduped, no new forward.
+        (ghostel--mouse-drag-motion `(mouse-movement (,(selected-window) 1 (10 . 5) 0)))
+        ;; New cell: forwarded.
+        (ghostel--mouse-drag-motion `(mouse-movement (,(selected-window) 1 (11 . 6) 0))))
+      (setq forwards (nreverse forwards))
+      (should (equal 2 (length forwards)))
+      (should (equal '(2 1 5 10) (butlast (nth 0 forwards))))
+      (should (equal '(2 1 6 11) (butlast (nth 1 forwards)))))))
+
+(ert-deftest ghostel-test-mouse-drag-motion-needs-held-button ()
+  "`ghostel--mouse-drag-motion' is a no-op when no button is held.
+Guards against stray movement events arriving outside a drag."
+  :tags '(native)
+  (let ((forwarded nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--process 'fake)
+      (setq-local ghostel--mouse-drag-button nil)
+      (cl-letf (((symbol-function 'ghostel--mouse-event)
+                 (lambda (&rest _) (setq forwarded t) t))
+                ((symbol-function 'process-live-p) (lambda (_p) t)))
+        (ghostel--mouse-drag-motion `(mouse-movement (,(selected-window) 1 (10 . 5) 0))))
+      (should-not forwarded))))
 
 (ert-deftest ghostel-test-mouse-1-press-tracking-forwards-to-terminal ()
   "Left-press with active mouse-tracking forwards to libghostty.


### PR DESCRIPTION
Programs that handle their own mouse selection (e.g. vim with
`:set mouse=a`) only updated the selection on release, not during the
drag.  Emacs coalesces a drag into a single `drag-mouse-N' event at
release and emits intermediate `mouse-movement' events only while
`track-mouse' is non-nil, which ghostel never enabled.

On a forwarded press while a DEC mouse-tracking mode is active, arm
`track-mouse' and install a transient keymap that forwards each
`mouse-movement' as a motion event, mirroring eat's approach.  Motion
is tagged with the button recorded at press time (movement events carry
none, and libghostty emits nothing for an unknown button) and deduped
per cell.  A `drag-mouse-N' event marks the drag end, so it now forwards
a release rather than a motion -- also correct for mode 1000, which
reports releases but never motion.