### PR TITLE
Make ghostel-set-title-function a pure title-to-name function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- `ghostel-set-title-function` is now a pure function: it receives the
+  terminal title (OSC 2) and returns the buffer name to use, or nil to
+  leave the name unchanged.  Ghostel performs the rename, buffer-name
+  uniquification, and the "don't clobber a manually renamed buffer"
+  guard, so a custom title function no longer needs to know about
+  `rename-buffer` or any internal bookkeeping.
+
 ## [0.31.0] — 2026-05-28
 
 ### Added

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -385,11 +385,12 @@ project:
                  (const :tag "Both (union)" both)))
 
 (defcustom ghostel-set-title-function #'ghostel--set-title-default
-  "Function called when the terminal reports a new title (OSC 2).
-Called with one argument, the title string, in the ghostel buffer.
-Set to nil to disable title tracking entirely.
-The default, `ghostel--set-title-default', renames the buffer to
-\"*ghostel: TITLE*\" unless the user has renamed it manually."
+  "Function that maps a terminal title (OSC 2) to a buffer name.
+Called in the ghostel buffer with one argument, the title string, and
+should return the buffer name to use, or nil to leave the name unchanged.
+Ghostel renames the buffer to the returned name, declining
+to do so when the user has renamed the buffer manually.
+Set to nil to disable title tracking entirely."
   :type '(choice (const :tag "Disabled" nil) function))
 
 (defcustom ghostel-kill-buffer-on-exit t
@@ -1679,10 +1680,9 @@ variable re-enables automatic renaming for the next title update.")
 
 (defvar-local ghostel--buffer-identity nil
   "Canonical buffer name used to find this buffer on subsequent `ghostel' calls.
-Set at buffer creation to the value of `ghostel-buffer-name' (or its
-numbered variant) before any title-tracking renames.  Used so that
-`ghostel' and `ghostel-project' can reuse an existing buffer even after
-`ghostel--set-title-default' has renamed it.")
+Set at buffer creation to the value of `ghostel-buffer-name' (or its numbered
+variant) before any title-tracking renames.  Used so that `ghostel' can reuse
+an existing buffer even after `ghostel--set-title' has renamed it.")
 
 (defvar-local ghostel--prompt-positions nil
   "List of prompt positions as (buffer-line . exit-status) pairs.
@@ -5513,19 +5513,22 @@ No-op when FG/BG match the cached values from the previous call."
       (setq ghostel--face-cookie-fg-bg pair))))
 
 (defun ghostel--set-title-default (title)
-  "Update the buffer name with TITLE from the terminal.
-Only acts when the buffer has not been manually renamed by the user."
-  (when (or (null ghostel--managed-buffer-name)
-            (equal (buffer-name) ghostel--managed-buffer-name))
-    (let ((new-name (format "*ghostel: %s*" title)))
-      (rename-buffer new-name t)
-      ;; Keep the actual name because `rename-buffer' may uniquify it.
-      (setq ghostel--managed-buffer-name (buffer-name)))))
+  "Return the default ghostel buffer name for TITLE: \"*ghostel: TITLE*\"."
+  (format "*ghostel: %s*" title))
 
 (defun ghostel--set-title (title)
-  "Dispatch TITLE changes to `ghostel-set-title-function'."
-  (when ghostel-set-title-function
-    (funcall ghostel-set-title-function title)))
+  "Rename the buffer from a terminal TITLE report (OSC 2).
+Call `ghostel-set-title-function' with TITLE to compute the new buffer name,
+unless the user has renamed the buffer manually before.
+A nil return value (or nil function) leaves the buffer name unchanged."
+  (when (and ghostel-set-title-function
+             (or (null ghostel--managed-buffer-name)
+                 (equal (buffer-name) ghostel--managed-buffer-name)))
+    (let ((new-name (funcall ghostel-set-title-function title)))
+      (when (and new-name (not (equal new-name (buffer-name))))
+        (rename-buffer new-name t)
+        ;; Keep the actual name because `rename-buffer' may uniquify it.
+        (setq ghostel--managed-buffer-name (buffer-name))))))
 
 (defun ghostel--set-cursor-style (style visible)
   "Set the cursor style based on terminal state.

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -618,6 +618,66 @@ and typed text was invisible."
       (when (buffer-live-p buf)
         (kill-buffer buf)))))
 
+(ert-deftest ghostel-test-set-title-default-is-pure ()
+  "`ghostel--set-title-default' maps TITLE to a name with no side effects."
+  (with-temp-buffer
+    (let ((name (buffer-name)))
+      (should (equal "*ghostel: My Title*"
+                     (ghostel--set-title-default "My Title")))
+      ;; Pure: computing the name must not rename the current buffer.
+      (should (equal name (buffer-name))))))
+
+(ert-deftest ghostel-test-set-title-custom-pure-function ()
+  "A pure `ghostel-set-title-function' drives the rename.
+Ghostel applies the returned name and still guards a manual rename."
+  (let (buf)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--new)
+                   (lambda (&rest _args) 'fake-term))
+                  ((symbol-function 'ghostel--set-size) #'ignore)
+                  ((symbol-function 'ghostel--apply-palette)
+                   (lambda (&rest _args) nil))
+                  ((symbol-function 'ghostel--start-process)
+                   (lambda () nil)))
+          (let ((ghostel-set-title-function
+                 (lambda (title) (format "term[%s]" title))))
+            (ghostel)
+            (setq buf (current-buffer))
+            (with-current-buffer buf
+              (ghostel--set-title "A")
+              (should (equal "term[A]" (buffer-name)))
+              (should (equal "term[A]" ghostel--managed-buffer-name))
+              ;; Manual rename is respected: later titles do not clobber it.
+              (rename-buffer "manual title" t)
+              (ghostel--set-title "B")
+              (should (equal "manual title" (buffer-name)))
+              (should (equal "term[A]" ghostel--managed-buffer-name)))))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-set-title-nil-return-keeps-name ()
+  "A nil return from `ghostel-set-title-function' leaves the name unchanged."
+  (let (buf)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--new)
+                   (lambda (&rest _args) 'fake-term))
+                  ((symbol-function 'ghostel--set-size) #'ignore)
+                  ((symbol-function 'ghostel--apply-palette)
+                   (lambda (&rest _args) nil))
+                  ((symbol-function 'ghostel--start-process)
+                   (lambda () nil)))
+          ;; `ignore' returns nil for any title.
+          (let ((ghostel-set-title-function #'ignore))
+            (ghostel)
+            (setq buf (current-buffer))
+            (with-current-buffer buf
+              (should (equal "*ghostel*" (buffer-name)))
+              (ghostel--set-title "Whatever")
+              (should (equal "*ghostel*" (buffer-name)))
+              (should (equal "*ghostel*" ghostel--managed-buffer-name)))))
+      (when (buffer-live-p buf)
+        (kill-buffer buf)))))
+
 
 
 ;;; Hyperlinks and URL rendering


### PR DESCRIPTION
## Summary

Make `ghostel-set-title-function` a pure function: it receives the terminal title (OSC 2) and returns the buffer name to use, or `nil` to leave the name unchanged. All side effects move into the internal dispatcher `ghostel--set-title`, which now owns:

- the manual-rename guard (don't clobber a buffer the user renamed),
- the `rename-buffer` call and its uniquify flag,
- updating `ghostel--managed-buffer-name`.

A custom title function no longer needs to know about any of that internal bookkeeping — it just maps a title string to a buffer name.

## Changes

- `ghostel--set-title-default` reduced to a pure `(format "*ghostel: %s*" title)`.
- `ghostel--set-title` performs the guard + rename + bookkeeping, treats a `nil` return as "leave the name unchanged", and skips redundant renames.
- `ghostel-set-title-function` defcustom docstring updated to describe the title→name contract.
- Fixed a stale docstring reference (`ghostel--set-title-default` → `ghostel--set-title`).

## Tests

- New: `ghostel-test-set-title-default-is-pure`, `ghostel-test-set-title-custom-pure-function`, `ghostel-test-set-title-nil-return-keeps-name`.
- Existing `ghostel-test-title-does-not-overwrite-manual-rename` and `…-tracking-disabled` pass unchanged, confirming end-to-end behavior is preserved.
- `make -j8 all` (build + lint + tests) is green.
