### PR TITLE
Update src coding guidelines and cleanup post-refactor misses

### DIFF
--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -2,51 +2,49 @@
 
 ## Architectural guidelines
 
-- Calling `render_state.update(...)`, directly or indirectly, **consumes** dirty state from the terminal. For this reason, **only** the Renderer (in `Renderer.zig`) may do so. Any other usage of `render_state.update` **will** break the `Renderer`.
-- With the above in mind: If you need information from the rendering process - add ways for the `Renderer` to communicate that information as output from the rendering process. This can be in the form of text properties, buffer local variables. A last resort method is also to add callbacks, but this is more fragile and harder to follow.
+- Calling `render_state.update(...)`, directly or indirectly, **consumes** dirty state from the terminal. For this reason, **only** the Renderer (in `Renderer.zig`) may do so. Any other usage of `render_state.update` **will** break the Renderer.
+- If you need information from the rendering process, add a way for the Renderer to communicate it as render output: text properties, buffer-local variables, or, as a last resort, callbacks.
+
+## Emacs module function entries
+
+- Functions registered through `emacs.FunctionEntry` should implement `pub fn call(env: emacs.Env, nargs: isize, args: [*c]emacs.Value) !emacs.Value`.
+- Prefer `try` and `return error.SomeError` inside those functions. `Env.registerFunction` is the boundary that catches errors, logs the stack trace in debug builds, signals an Emacs error, and returns `nil`. This intentionally trades bespoke user-facing messages for lower boilerplate; debug builds provide the developer detail.
+- Do not add repetitive `catch |err| { env.logStackTrace(...); env.signalError(...); return env.nil(); }` boilerplate in each registered function.
+- Catch locally only when the local semantics really differ: clearing/handling a module non-local exit, intentionally returning `nil`, or continuing independent items in a loop.
 
 ## Error handling
 
-- **Errors are always errors.** Never swallow with bare `catch {}` or `catch continue`. Log or propagate every real error.
+- **Errors are always errors.** Never swallow with bare `catch {}` or `catch continue`. Log, propagate, or make the intentional ignore/continue semantics obvious.
+- Prefer error unions for invalid input or parse failures that are real errors. Use optionals for absence, not for failures that should be reported.
+- Use precise error names (`error.InvalidTerminalHandle`, `error.OutOfRange`, etc.) so centralized module error reporting remains useful.
 
 ## Calling Emacs functions
 
-Prefer `Env` convenience wrappers (`env.insert(...)`, `env.list(...)`, `env.set(...)`, etc.) over calling Emacs functions directly. When no wrapper exists, use `env.f("function-name", .{arg1, arg2})` — the function name must be in the intern cache (`sym` in `emacs.zig`). Arguments are auto-converted from Zig types.
+- Use `env.f("function-name", .{arg1, arg2})` for ordinary Elisp calls. The function name must be present in `interned_symbols` in `emacs.zig`.
+- Use existing `Env` helpers when they add conversion or module-API value beyond a trivial Elisp call (`env.list`, `env.cons`, `env.set`, `env.symbolValue`, constructors, extraction helpers, etc.). Do not add one-line wrappers like `env.point()` or `env.insert()` just to shorten `env.f`.
+- When passing symbol arguments, use the intern cache (`emacs.sym.foo`). In code with several symbols, prefer `const s = emacs.sym;`.
+- Keep `interned_symbols` minimal: add symbols when needed by `env.f` or symbol arguments, and remove unused symbols.
 
-## C ABI boundary (module.zig callbacks)
+## Value conversion
 
-Functions with `callconv(.c)` cannot propagate Zig errors — handle them explicitly at the call site:
+- Prefer `env.cast(T, value)` over `env.extractInteger`/`env.extractFloat` plus manual `@intCast`/`@floatCast`. It supports integers, floats, and booleans.
+- When narrowing to a smaller integer where out-of-range input is possible, use `std.math.cast` after `env.cast(i64, value)` and return an explicit error on failure.
+- Zig values passed to `env.f`, `env.list`, `env.cons`, and similar helpers are auto-converted with `env.makeValue`.
+
+## C ABI callbacks — do not change calling convention
+
+Any function with `callconv(.c)` is part of a fixed ABI contract with Emacs. Do not change its signature, calling convention, or return type without understanding the ABI contract on both sides.
+
+Functions that truly are `callconv(.c)` cannot propagate Zig errors. Handle errors explicitly at that boundary:
 
 ```zig
-// For paths that can fail deep in the call stack (redraw, encode, emitPlacements):
-something.deepWork() catch |err| {
-    env.logStackTrace(@errorReturnTrace());
-    env.signalError("deepWork failed: %s", .{@errorName(err)});
-    return env.nil();
-};
-
-// For simple one-call getters:
-const val = term.getSomething() catch |err| {
-    env.signalError("getSomething failed: %s", .{@errorName(err)});
-    return env.nil();
-};
-
-// For void C callbacks (callconv(.c) returning void), use logError instead of signalError:
 const val = term.getSomething() catch |err| {
     env.logError("getSomething failed: %s", .{@errorName(err)});
     return;
 };
-
-// For per-item errors inside a loop where items are independent, log and continue:
-const val = term.getSomething() catch |err| {
-    env.logError("getSomething failed: %s", .{@errorName(err)});
-    continue;
-};
 ```
 
-## C ABI callbacks — do not change calling convention
-
-Any function with `callconv(.c)` is part of a fixed ABI contract with libghostty or Emacs. Do not change its signature, calling convention, or return type without understanding the ABI contract on both sides.
+For Emacs functions registered through `FunctionEntry`, prefer the error-union `call` pattern described above instead; the generated C wrapper handles the ABI boundary.
 
 ## Logging
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -2,51 +2,49 @@
 
 ## Architectural guidelines
 
-- Calling `render_state.update(...)`, directly or indirectly, **consumes** dirty state from the terminal. For this reason, **only** the Renderer (in `Renderer.zig`) may do so. Any other usage of `render_state.update` **will** break the `Renderer`.
-- With the above in mind: If you need information from the rendering process - add ways for the `Renderer` to communicate that information as output from the rendering process. This can be in the form of text properties, buffer local variables. A last resort method is also to add callbacks, but this is more fragile and harder to follow.
+- Calling `render_state.update(...)`, directly or indirectly, **consumes** dirty state from the terminal. For this reason, **only** the Renderer (in `Renderer.zig`) may do so. Any other usage of `render_state.update` **will** break the Renderer.
+- If you need information from the rendering process, add a way for the Renderer to communicate it as render output: text properties, buffer-local variables, or, as a last resort, callbacks.
+
+## Emacs module function entries
+
+- Functions registered through `emacs.FunctionEntry` should implement `pub fn call(env: emacs.Env, nargs: isize, args: [*c]emacs.Value) !emacs.Value`.
+- Prefer `try` and `return error.SomeError` inside those functions. `Env.registerFunction` is the boundary that catches errors, logs the stack trace in debug builds, signals an Emacs error, and returns `nil`. This intentionally trades bespoke user-facing messages for lower boilerplate; debug builds provide the developer detail.
+- Do not add repetitive `catch |err| { env.logStackTrace(...); env.signalError(...); return env.nil(); }` boilerplate in each registered function.
+- Catch locally only when the local semantics really differ: clearing/handling a module non-local exit, intentionally returning `nil`, or continuing independent items in a loop.
 
 ## Error handling
 
-- **Errors are always errors.** Never swallow with bare `catch {}` or `catch continue`. Log or propagate every real error.
+- **Errors are always errors.** Never swallow with bare `catch {}` or `catch continue`. Log, propagate, or make the intentional ignore/continue semantics obvious.
+- Prefer error unions for invalid input or parse failures that are real errors. Use optionals for absence, not for failures that should be reported.
+- Use precise error names (`error.InvalidTerminalHandle`, `error.OutOfRange`, etc.) so centralized module error reporting remains useful.
 
 ## Calling Emacs functions
 
-Prefer `Env` convenience wrappers (`env.insert(...)`, `env.list(...)`, `env.set(...)`, etc.) over calling Emacs functions directly. When no wrapper exists, use `env.f("function-name", .{arg1, arg2})` — the function name must be in the intern cache (`sym` in `emacs.zig`). Arguments are auto-converted from Zig types.
+- Use `env.f("function-name", .{arg1, arg2})` for ordinary Elisp calls. The function name must be present in `interned_symbols` in `emacs.zig`.
+- Use existing `Env` helpers when they add conversion or module-API value beyond a trivial Elisp call (`env.list`, `env.cons`, `env.set`, `env.symbolValue`, constructors, extraction helpers, etc.). Do not add one-line wrappers like `env.point()` or `env.insert()` just to shorten `env.f`.
+- When passing symbol arguments, use the intern cache (`emacs.sym.foo`). In code with several symbols, prefer `const s = emacs.sym;`.
+- Keep `interned_symbols` minimal: add symbols when needed by `env.f` or symbol arguments, and remove unused symbols.
 
-## C ABI boundary (module.zig callbacks)
+## Value conversion
 
-Functions with `callconv(.c)` cannot propagate Zig errors — handle them explicitly at the call site:
+- Prefer `env.cast(T, value)` over `env.extractInteger`/`env.extractFloat` plus manual `@intCast`/`@floatCast`. It supports integers, floats, and booleans.
+- When narrowing to a smaller integer where out-of-range input is possible, use `std.math.cast` after `env.cast(i64, value)` and return an explicit error on failure.
+- Zig values passed to `env.f`, `env.list`, `env.cons`, and similar helpers are auto-converted with `env.makeValue`.
+
+## C ABI callbacks — do not change calling convention
+
+Any function with `callconv(.c)` is part of a fixed ABI contract with Emacs. Do not change its signature, calling convention, or return type without understanding the ABI contract on both sides.
+
+Functions that truly are `callconv(.c)` cannot propagate Zig errors. Handle errors explicitly at that boundary:
 
 ```zig
-// For paths that can fail deep in the call stack (redraw, encode, emitPlacements):
-something.deepWork() catch |err| {
-    env.logStackTrace(@errorReturnTrace());
-    env.signalError("deepWork failed: %s", .{@errorName(err)});
-    return env.nil();
-};
-
-// For simple one-call getters:
-const val = term.getSomething() catch |err| {
-    env.signalError("getSomething failed: %s", .{@errorName(err)});
-    return env.nil();
-};
-
-// For void C callbacks (callconv(.c) returning void), use logError instead of signalError:
 const val = term.getSomething() catch |err| {
     env.logError("getSomething failed: %s", .{@errorName(err)});
     return;
 };
-
-// For per-item errors inside a loop where items are independent, log and continue:
-const val = term.getSomething() catch |err| {
-    env.logError("getSomething failed: %s", .{@errorName(err)});
-    continue;
-};
 ```
 
-## C ABI callbacks — do not change calling convention
-
-Any function with `callconv(.c)` is part of a fixed ABI contract with libghostty or Emacs. Do not change its signature, calling convention, or return type without understanding the ABI contract on both sides.
+For Emacs functions registered through `FunctionEntry`, prefer the error-union `call` pattern described above instead; the generated C wrapper handles the ABI boundary.
 
 ## Logging
 

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -13,7 +13,6 @@ const input = @import("input.zig");
 const kitty_graphics = @import("kitty_graphics.zig");
 const utils = @import("utils.zig");
 const parseHexColor = utils.parseHexColor;
-const parseHexByte = utils.parseHexByte;
 
 const Self = @This();
 
@@ -271,6 +270,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 effects.title_changed = &titleChangedCallback;
                 effects.size = &sizeCallback;
                 const term = try init(module_alloc, cols, rows, max_scrollback, effects);
+                errdefer term.deinit();
                 // Set default colors (light gray on black)
                 term.setColorForeground(.{ .r = 204, .g = 204, .b = 204 });
                 term.setColorBackground(.{ .r = 0, .g = 0, .b = 0 });
@@ -298,10 +298,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
         .impl = struct {
             pub fn call(env: emacs.Env, _: isize, args: [*c]emacs.Value) !emacs.Value {
                 const term = env.getUserPtr(Self, args[0]) orelse return error.InvalidTerminalHandle;
-                const raw = env.extractStringAlloc(module_alloc, args[1], &term.buffer) catch |err| {
-                    env.signalError("Failed to extract string: %s", .{@errorName(err)});
-                    return env.nil();
-                };
+                const raw = try env.extractStringAlloc(module_alloc, args[1], &term.buffer);
                 term.vtWrite(raw);
                 return env.nil();
             }
@@ -473,8 +470,6 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 gt.input.encodeFocus(&writer, event) catch return env.nil();
                 const encoded = writer.buffered();
                 if (encoded.len == 0) return env.nil();
-                emacs.current_env = env;
-                defer emacs.current_env = null;
                 _ = env.f("ghostel--flush-output", .{encoded});
                 return env.t();
             }
@@ -493,32 +488,12 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 const term = env.getUserPtr(Self, args[0]) orelse return error.InvalidTerminalHandle;
                 var str_buf: [2048]u8 = undefined;
                 const colors_str = try env.extractString(args[1], &str_buf);
+                if (colors_str.len < 16 * 7) return error.InvalidPaletteLength;
                 var palette = term.terminal.colors.palette.current;
                 var idx: usize = 0;
-                var pos: usize = 0;
-                while (idx < 16 and pos + 7 <= colors_str.len) {
-                    if (colors_str[pos] != '#') {
-                        pos += 1;
-                        continue;
-                    }
-                    const r = parseHexByte(colors_str[pos + 1], colors_str[pos + 2]) catch {
-                        pos += 7;
-                        idx += 1;
-                        continue;
-                    };
-                    const g = parseHexByte(colors_str[pos + 3], colors_str[pos + 4]) catch {
-                        pos += 7;
-                        idx += 1;
-                        continue;
-                    };
-                    const b = parseHexByte(colors_str[pos + 5], colors_str[pos + 6]) catch {
-                        pos += 7;
-                        idx += 1;
-                        continue;
-                    };
-                    palette[idx] = .{ .r = r, .g = g, .b = b };
-                    idx += 1;
-                    pos += 7;
+                while (idx < 16) : (idx += 1) {
+                    const pos = idx * 7;
+                    palette[idx] = try parseHexColor(colors_str[pos .. pos + 7]);
                 }
                 term.setColorPalette(palette);
                 return env.t();
@@ -620,7 +595,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
         ,
         .impl = struct {
             pub fn call(env: emacs.Env, _: isize, args: [*c]emacs.Value) !emacs.Value {
-                const term = env.getUserPtr(Self, args[0]) orelse return env.nil();
+                const term = env.getUserPtr(Self, args[0]) orelse return error.InvalidTerminalHandle;
                 const options = gt.formatter.Options{
                     .emit = .plain,
                     .unwrap = true,
@@ -629,10 +604,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 var formatter = gt.formatter.TerminalFormatter.init(&term.terminal, options);
                 var writer = std.io.Writer.Allocating.init(module_alloc);
                 defer writer.deinit();
-                formatter.format(&writer.writer) catch {
-                    env.signalError("formatter failed", .{});
-                    return env.nil();
-                };
+                try formatter.format(&writer.writer);
                 const written = writer.written();
                 if (written.len == 0) return env.nil();
                 return env.makeString(written);

--- a/src/comint_filter.zig
+++ b/src/comint_filter.zig
@@ -460,14 +460,8 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
         .impl = struct {
             pub fn call(env: emacs.Env, _: isize, args: [*c]emacs.Value) !emacs.Value {
                 const filter = env.getUserPtr(Self, args[0]) orelse return error.InvalidComintFilter;
-                const data = env.extractStringAlloc(module_alloc, args[1], &filter.buffer) catch |err| {
-                    env.signalError("Failed to extract string: %s", .{@errorName(err)});
-                    return env.nil();
-                };
-                return filter.feed(env, data) catch |err| {
-                    env.signalError("comint filter failed: %s", .{@errorName(err)});
-                    return env.nil();
-                };
+                const data = try env.extractStringAlloc(module_alloc, args[1], &filter.buffer);
+                return try filter.feed(env, data);
             }
         },
     },
@@ -487,21 +481,13 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
             pub fn call(env: emacs.Env, _: isize, args: [*c]emacs.Value) !emacs.Value {
                 const filter = env.getUserPtr(Self, args[0]) orelse return error.InvalidComintFilter;
                 var str_buf: [2048]u8 = undefined;
-                const colors_str = env.extractString(args[1], &str_buf) catch |err| {
-                    env.signalError("invalid palette string: %s", .{@errorName(err)});
-                    return env.nil();
-                };
+                const colors_str = try env.extractString(args[1], &str_buf);
+                if (colors_str.len < 16 * 7) return error.InvalidPaletteLength;
                 var palette16: [16]gt.color.RGB = @splat(.{});
                 var idx: usize = 0;
-                var pos: usize = 0;
-                while (idx < 16 and pos + 7 <= colors_str.len) {
-                    if (colors_str[pos] != '#') {
-                        pos += 1;
-                        continue;
-                    }
+                while (idx < 16) : (idx += 1) {
+                    const pos = idx * 7;
                     palette16[idx] = try parseHexColor(colors_str[pos .. pos + 7]);
-                    idx += 1;
-                    pos += 7;
                 }
                 filter.setPalette16(palette16);
                 return env.t();


### PR DESCRIPTION
## Summary
- update src/AGENTS.md and src/CLAUDE.md for the new module error-handling/env.f/env.cast guidelines
- remove remaining per-function error boilerplate where centralized FunctionEntry handling is sufficient
- fix post-construction cleanup and align palette/terminal handle error behavior

## Verification
- zig build