### PR TITLE
Run compile finish hooks before ghostel final mode switch

### DIFF
--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -357,6 +357,7 @@ same as in any compilation buffer."
                (command ghostel-compile--command)
                (directory ghostel-compile--directory)
                (footer (ghostel-compile--footer-text exit start-time end-time))
+               (msg (ghostel-compile--status-message exit))
                (inhibit-read-only t))
           (setq ghostel-compile--last-exit exit)
           (when ghostel-compile-debug
@@ -365,6 +366,10 @@ same as in any compilation buffer."
           (when start
             (ghostel-compile--trim-trailing-blanks start))
           (ghostel-compile--teardown-terminal)
+          ;; Run standard compilation finish hooks before switching major mode:
+          ;; callers may install buffer-local hooks or continuation state, and
+          ;; `funcall' below kills those locals as part of the mode change.
+          (run-hook-with-args 'compilation-finish-functions buffer msg)
           ;; Switch major mode now that the process is dead.  Preserve state
           ;; that `kill-all-local-variables' would otherwise wipe.  A
           ;; per-buffer override (set by the `compilation-start' advice
@@ -376,8 +381,10 @@ same as in any compilation buffer."
                  (saved-start-time start-time)
                  (saved-directory directory)
                  (saved-interactive ghostel-compile--interactive)
+                 (saved-compilation-arguments-local
+                  (local-variable-p 'compilation-arguments))
                  (saved-compilation-arguments
-                  (and (local-variable-p 'compilation-arguments)
+                  (and saved-compilation-arguments-local
                        compilation-arguments))
                  (target-mode (or ghostel-compile--view-mode-override
                                   ghostel-compile-finished-major-mode)))
@@ -428,9 +435,8 @@ same as in any compilation buffer."
         (ghostel-compile--set-mode-line-exit exit)
         (setq next-error-last-buffer buffer)
         (ghostel-compile--auto-jump buffer)
-        (let ((msg (ghostel-compile--status-message exit)))
-          (run-hook-with-args 'compilation-finish-functions buffer msg)
-          (run-hook-with-args 'ghostel-compile-finish-functions buffer msg))))))
+        (run-hook-with-args 'ghostel-compile-finish-functions
+                            buffer (ghostel-compile--status-message exit))))))
 
 
 ;;; Spawning

--- a/test/ghostel-compile-test.el
+++ b/test/ghostel-compile-test.el
@@ -9,6 +9,8 @@
 
 (require 'ghostel-test-helpers)
 
+(defvar-local ghostel-test-compile--finish-continuation nil)
+
 (ert-deftest ghostel-test-compile-finalize-scans-errors ()
   "`ghostel-compile--finalize' parses errors in the scan region."
   (ghostel-test--with-compile-buffer buf
@@ -393,6 +395,25 @@ scrolled below the window."
       (should (equal "finished\n" (cdar g-calls)))
       (should (equal 1 (length c-calls)))                     ; compile hook
       (should (equal "finished\n" (cdar c-calls))))))
+
+(ert-deftest ghostel-test-compile-buffer-local-finish-hook-state-is-available ()
+  "Buffer-local compile finish hook state is available at finalization."
+  (ghostel-test--with-compile-buffer buf
+    (let ((finish-called nil)
+          (continuation-called nil))
+      (setq-local ghostel-test-compile--finish-continuation
+                  (lambda () (setq continuation-called t)))
+      (add-hook 'compilation-finish-functions
+                (lambda (_buffer _message)
+                  (setq finish-called t)
+                  (funcall ghostel-test-compile--finish-continuation))
+                nil t)
+      (setq ghostel-compile--command "true"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--scan-marker (copy-marker (point-max)))
+      (ghostel-compile--finalize buf 0 (current-time))
+      (should finish-called)
+      (should continuation-called))))
 
 (ert-deftest ghostel-test-compile-auto-jump-to-first-error ()
   "With `compilation-auto-jump-to-first-error' set, jump after parsing."


### PR DESCRIPTION
ghostel-compile finalizes a run by switching from the live ghostel buffer into the finished compilation view mode. That mode switch calls kill-all-local-variables. Tools that start work from compilation-finish-functions may install buffer-local hook functions or buffer-local continuation state on the compilation buffer; if ghostel-compile waits until after the mode switch to run those hooks, that state has already been discarded and the continuation never runs.

Run the standard compilation-finish-functions hook while the original buffer-local state is still intact, before switching major mode. Keep ghostel-compile-finish-functions after the buffer has been converted to its finished read-only compilation view, since that hook is specific to ghostel's finalized buffer state.

Add a regression test with a generic buffer-local continuation used by a buffer-local compilation finish hook. This covers Dape's compile-to-debug continuation without depending on Dape private variables.