### PR TITLE
Fix viewport anchoring when the mode-line is disabled

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -5953,19 +5953,23 @@ remain handled inside the renderer."
      (or begin (ghostel--viewport-start) (point-min))
      (or end (point-max)))))
 
-(defun ghostel--window-anchored-p (window &optional pixel-height)
-  "Non-nil if WINDOW is auto-following the new output.
-When PIXEL-HEIGHT is non-nil, that value is used for calculation rather than
-`(window-pixel-height)'."
+(defun ghostel--window-anchored-p (window &optional body-pixel-height)
+  "Non-nil if WINDOW is scrolled to follow the live terminal output.
+WINDOW follows the output when the lines from its `window-start' to
+`point-max' fit within its body, measured from BODY-PIXEL-HEIGHT (default
+`window-body-height' in pixels, excluding the mode-line and header-line to
+match the terminal grid), plus one line of tolerance for the partial top
+line the graphical anchor leaves via `window-vscroll'."
   (with-current-buffer (window-buffer window)
     (when-let* (((derived-mode-p 'ghostel-mode))
                 ((not (eq ghostel--input-mode 'emacs)))
                 (dlh (default-line-height))
-                (pixel-height (or pixel-height (window-pixel-height window)))
-                (line-count (/ (float pixel-height) (float dlh)))
+                (body-pixel-height (or body-pixel-height
+                                       (window-body-height window t)))
+                (screen-lines (/ (float body-pixel-height) (float dlh)))
                 (ws (window-start window))
                 (ws-lines-to-end (count-lines ws (point-max))))
-      (<= ws-lines-to-end line-count))))
+      (<= ws-lines-to-end (1+ (floor screen-lines))))))
 
 (defconst ghostel--set-window-vscroll-preserve-supported-p
   (let ((max-args (cdr (subr-arity (symbol-function 'set-window-vscroll)))))
@@ -6211,7 +6215,7 @@ If WINDOW was already anchored at the active area before resizing, WINDOW will
 scroll to active area to keep it focused even during resize."
   (with-current-buffer (window-buffer window)
     (when (ghostel--window-anchored-p window
-                                      (window-old-pixel-height window))
+                                      (window-old-body-pixel-height window))
       (ghostel--anchor-window window))))
 
 (defun ghostel--minibuffer-exit ()

--- a/test/ghostel-scroll-test.el
+++ b/test/ghostel-scroll-test.el
@@ -168,6 +168,52 @@ SPEC is (BUFFER TERM ANCHORED-WINDOW HISTORY-WINDOW)."
 							  (should (= history-point-before (window-point history)))
 							  (should-not (ghostel-test-scroll--bottom-visible-p history)))))
 
+(defun ghostel-test-scroll--set-gui-anchor-start (win)
+  "Park WIN's `window-start' at the GUI-anchored steady state.
+The graphical branch of `ghostel--anchor-window' parks `window-start' one
+line above the topmost grid row to make room for its partial-top-line
+vscroll, so a bottom-anchored GUI window has
+`ws-lines-to-end' = floor(window-screen-lines) + 1.  That branch is gated
+on `display-graphic-p', which is never true in batch, so set
+`window-start' directly to reproduce the same position."
+  (let* ((target (1+ (floor (with-selected-window win
+                              (window-screen-lines)))))
+         (start (save-excursion
+                  (goto-char (point-max))
+                  (forward-line (- target))
+                  (line-beginning-position))))
+    (set-window-start win start t)))
+
+(ert-deftest ghostel-test-window-anchored-p-survives-mode-line-toggle ()
+  "`ghostel--window-anchored-p' ignores the mode-line's height (issue #373).
+A GUI-anchored window's `window-start' sits floor(window-screen-lines)+1
+lines above `point-max'.  The predicate must judge it \"following output\"
+whether or not a mode-line is present.  Measuring the threshold from the
+full `window-pixel-height' (mode-line included) only worked because the
+mode-line donated the +1 line of slack; disabling it removed that slack
+and stranded the cursor off-screen.
+
+In batch the GUI anchor's `forward-line -1' (display-graphic-p only)
+cannot run, so `window-start' is set directly; toggling the mode-line in
+batch reproduces the GUI geometry shift (the window body grows by one line
+while `window-pixel-height' stays constant)."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (let ((win (selected-window)))
+      (ghostel-test-scroll--write-lines term "scroll" 60)
+      (ghostel--redraw term t)
+      ;; Control: mode-line present — an anchored window reads as following.
+      (ghostel-test-scroll--set-gui-anchor-start win)
+      (should (ghostel--window-anchored-p win))
+      ;; Disable the mode-line and let the geometry settle; the body grows
+      ;; by one line.  Re-derive the anchored `window-start' for the larger
+      ;; body and assert the predicate still follows.  (Fails on HEAD
+      ;; before the fix; passes after.)
+      (setq-local mode-line-format nil)
+      (redisplay t)
+      (ghostel-test-scroll--set-gui-anchor-start win)
+      (should (ghostel--window-anchored-p win)))))
+
 (ert-deftest ghostel-test-second-window-does-not-disturb-scrollback ()
   "Opening another window on the buffer does not move a scrolled peer."
   :tags '(native)


### PR DESCRIPTION
## Problem

Disabling the mode-line in a GUI ghostel buffer made the terminal "lose track of the cursor": the prompt scrolled off-screen and the command line rendered corrupted, because live output stopped being followed.

## Root cause

`ghostel--window-anchored-p` decides whether a window is still glued to the live bottom and must be re-anchored after each redraw. It measured the window's capacity from `window-pixel-height`, which spans the **whole** window — body plus mode-line, header-line, and bottom divider. But the terminal grid, and the `window-start` the anchor produces, are sized from the window **body** (`window-screen-lines`).

The graphical branch of `ghostel--anchor-window` parks `window-start` one line above the top grid row for its partial-top-line vscroll trick, so a correctly bottom-anchored GUI window has `ws-lines-to-end = body_rows + 1`. That extra line only fit under the threshold because the mode-line happened to inflate `window-pixel-height` by ~1 line. Remove the mode-line and the slack vanishes: a genuinely anchored window is misjudged "not following output", the redraw never re-anchors it, and Emacs's own scrolling takes over.

| | mode-line ON | mode-line OFF |
|---|---|---|
| `window-pixel-height` (constant) | 1036 | 1036 |
| grid rows (`window-screen-lines`) | 73 | 74 |
| `ws-lines-to-end` | 74 | 75 |
| old `(<= ws-lines-to-end line-count=74)` | **t** | **nil** ← bug |

## Fix

- Measure the threshold from the window **body** (`window-body-height` PIXELWISE — excludes the mode-line and header-line, consistent with how the grid is sized) and make the one-line tolerance the anchor needs **explicit**: `(<= ws-lines-to-end (1+ (floor screen-lines)))`, instead of relying on the mode-line to supply it by accident.
- Switch `ghostel--anchor-on-resize` to `window-old-body-pixel-height` so the pre-resize check uses the same body metric.

Where a mode-line exists the new threshold equals the old one, so the common case is unchanged. Otherwise it is strictly more correct — a tall mode-line face or a header-line no longer widen the "still anchored" band — and it never widens the tolerance.

## Tests

Adds a native regression test that reproduces the geometry in batch: a mode-line toggle leaves `window-pixel-height` constant while the body grows by one line, the same shape as the GUI bug. It fails before this change and passes after.

Verified live in a `-Q` NS GUI daemon driving the real redraw path: with the mode-line off the predicate now reports anchored, the cursor stays visible, and no lines are stranded below the window. `make -j8 all` is green (build, byte-compile/lint, elisp + native + evil tests).

Fixes #373.
