### PR TITLE
Fix q keymap leak in ghostel-eshell--visual-exit

### DIFF
--- a/lisp/ghostel-eshell.el
+++ b/lisp/ghostel-eshell.el
@@ -60,7 +60,12 @@ to dismiss the buffer."
      (when (buffer-live-p buffer)
        (with-current-buffer buffer
          (goto-char (point-max))
-         (local-set-key (kbd "q") #'kill-current-buffer)
+         ;; Bind `q' in a fresh buffer-local map to not mutate the shared
+         ;; `ghostel-semi-char-mode-map' and leak into other buffers.
+         (let ((map (make-sparse-keymap)))
+           (set-keymap-parent map (current-local-map))
+           (keymap-set map "q" #'kill-current-buffer)
+           (use-local-map map))
          (dolist (win (get-buffer-window-list buffer nil t))
            (set-window-point win (point-max))))))))
 

--- a/test/ghostel-exec-test.el
+++ b/test/ghostel-exec-test.el
@@ -116,5 +116,30 @@ buffer eventually shows up."
       (eshell/ghostel "vim" "file.txt")
       (should (equal captured '("vim" "file.txt"))))))
 
+(ert-deftest ghostel-test-eshell-visual-exit-q-binding-is-buffer-local ()
+  "`ghostel-eshell--visual-exit' must not leak `q' into the shared keymap.
+It binds `q' to `kill-current-buffer' in the finished buffer's own
+local map; the shared `ghostel-semi-char-mode-map' must stay
+unmodified so later visual buffers still send `q' to the program."
+  (let ((buf (generate-new-buffer " *ghostel-visual-exit*")))
+    (unwind-protect
+        ;; Run the `run-at-time' deferral synchronously so the test is
+        ;; not at the mercy of timer scheduling.
+        (cl-letf (((symbol-function 'run-at-time)
+                   (lambda (_time _repeat fn &rest args) (apply fn args))))
+          (with-current-buffer buf
+            (ghostel-mode))
+          ;; Sanity: the shared map has no direct `q' binding to begin
+          ;; with (bare `q' resolves through the self-insert remap).
+          (should-not (lookup-key ghostel-semi-char-mode-map (kbd "q")))
+          (ghostel-eshell--visual-exit buf "finished\n")
+          ;; The finished buffer dismisses on `q'...
+          (with-current-buffer buf
+            (should (eq (lookup-key (current-local-map) (kbd "q"))
+                        #'kill-current-buffer)))
+          ;; ...but the shared map is untouched (no leak, issue #372).
+          (should-not (lookup-key ghostel-semi-char-mode-map (kbd "q"))))
+      (kill-buffer buf))))
+
 (provide 'ghostel-exec-test)
 ;;; ghostel-exec-test.el ends here


### PR DESCRIPTION
## Problem

`ghostel-eshell--visual-exit` bound `q` to `kill-current-buffer` via `local-set-key`, which mutates `(current-local-map)`. At process-exit time the visual buffer is still in semi-char mode, so that map is the shared `ghostel-semi-char-mode-map` used by *every* ghostel buffer.

As a result, `q -> kill-current-buffer` leaked into later visual commands and regular ghostel terminals, where `q` should be sent to the running program instead (e.g. quitting `less`).

## Fix

Install the binding in a fresh buffer-local keymap parented off the current local map, so `q` dismisses only the finished buffer and the shared map is left untouched.

## Test

Adds `ghostel-test-eshell-visual-exit-q-binding-is-buffer-local`: it runs the `run-at-time` deferral synchronously, then asserts the finished buffer's own map binds `q -> kill-current-buffer` **and** the shared `ghostel-semi-char-mode-map` keeps no direct `q` binding (the assertion that fails against the old code).

`make -j8 all` passes.

Fixes #372