### PR TITLE
Fix ghostel-eval-cmds defcustom type

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -461,7 +461,7 @@ for static env entries that don't depend on runtime state."
 Each entry is (NAME FUNCTION) where NAME is the string sent from
 the shell and FUNCTION is the Elisp function to invoke.
 All arguments are passed as strings."
-  :type '(alist :key-type string :value-type function))
+  :type '(repeat (list (string :tag "Name") (function :tag "Function"))))
 
 (defcustom ghostel-enable-osc52 nil
   "Allow terminal applications to set the clipboard via OSC 52.


### PR DESCRIPTION
Small fix to a defcustom type signature that I found. I _think_ this is the only one with a similar issue.

Reproduction: `(setopt ghostel-eval-cmds ghostel-eval-cmds)` results in a `*Warning*` buffer with: 

`⛔ Warning (emacs): Value ‘(("find-file" find-file) ("find-file-other-window" find-file-other-window) ("dired" dired) ("dired-other-window" dired-other-window) ("message" message))’ does not match type (alist :key-type string :value-type function)`