### PR TITLE
Forward C-] / C-/ and their C-M- variants in semi-char/char mode

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1775,13 +1775,15 @@ When NO-EXCEPTIONS is non-nil, also bind the keys in
     (when (or no-exceptions
               (not (member key-str ghostel-keymap-exceptions)))
       (define-key map (kbd key-str) #'ghostel--send-event)))
-  ;; Control-Meta keys - C-M-<letter> only; C-M-<punct>/<digit> aren't
-  ;; widely supported by terminal apps.
-  (dolist (c (number-sequence ?a ?z))
-    (let ((key-str (format "C-M-%c" c)))
-      (when (or no-exceptions
-                (not (member key-str ghostel-keymap-exceptions)))
-        (define-key map (kbd key-str) #'ghostel--send-event))))
+  ;; C-M-<letter>, plus C-] / C-/ and their C-M- forms.
+  ;; The non-letter keys the encoder maps to a control byte.
+  (dolist (key-str (append
+                    (mapcar (lambda (c) (format "C-M-%c" c))
+                            (number-sequence ?a ?z))
+                    '("C-]" "C-/" "C-M-]" "C-M-/")))
+    (when (or no-exceptions
+              (not (member key-str ghostel-keymap-exceptions)))
+      (define-key map (kbd key-str) #'ghostel--send-event)))
   ;; M-DEL: TTY Emacs delivers Alt-Backspace as ESC + 0x7f, which
   ;; resolves to ?\M-\d.  The `M-<backspace>' form above only covers
   ;; the `[M-backspace]' symbol path; without this binding, TTY

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -92,6 +92,9 @@ Covers punctuation, digits, uppercase, space, and lowercase letters."
         (sim (aref (kbd "C-S-<return>") 0) "return"   "ctrl,shift")
         (sim (aref (kbd "M-.") 0)  "."  "meta")
         (sim (aref (kbd "M-1") 0)  "1"  "meta")
+        ;; Control + non-letter punctuation decomposes to base + ctrl.
+        (sim ?\C-]      "]" "ctrl")
+        (sim ?\M-\C-]   "]" "ctrl,meta")
         ;; backtab (Emacs's name for S-TAB)
         (sim (aref (kbd "<backtab>") 0)   "tab"       "shift")))))
 
@@ -492,6 +495,57 @@ instead of running Emacs commands like `forward-sexp'."
           (should-not (eq binding #'ghostel--send-event))
         (should (eq binding #'ghostel--send-event))))))
 
+(ert-deftest ghostel-test-control-punct-key-bindings ()
+  "Control + non-letter keys route to `ghostel--send-event' in semi-char.
+C-] and C-/ previously fell through to Emacs (C-] = `abort-recursive-edit',
+C-/ = `undo') instead of reaching the shell/readline.  Only the keys that
+the ghostty encoder maps to a terminal byte are forwarded."
+  (dolist (key-str '("C-]" "C-/"))
+    (should (eq (lookup-key ghostel-semi-char-mode-map (kbd key-str))
+                #'ghostel--send-event)))
+  ;; Deliberately NOT forwarded (no terminal byte / would shadow Emacs):
+  ;; C-^ / C-_ aren't encodable; C-,/C-. have no C0 byte; C-0..C-9 are
+  ;; `digit-argument'.  These must keep their non-send-event resolution.
+  (dolist (key-str '("C-^" "C-_" "C-," "C-." "C-0" "C-9"))
+    (should-not (eq (lookup-key ghostel-semi-char-mode-map (kbd key-str))
+                    #'ghostel--send-event)))
+  ;; C-\ stays a default exception in semi-char (falls through to Emacs).
+  (should-not (eq (lookup-key ghostel-semi-char-mode-map (kbd "C-\\"))
+                  #'ghostel--send-event))
+  ;; C-@ keeps its explicit NUL lambda (not send-event).
+  (should (commandp (lookup-key ghostel-semi-char-mode-map (kbd "C-@"))))
+  ;; ESC (C-[) must NOT be hijacked or TTY escape decoding breaks.
+  (should-not (eq (lookup-key ghostel-semi-char-mode-map (kbd "C-["))
+                  #'ghostel--send-event))
+  ;; The ESC-prefix CSI/SS3 forms (ESC [ and ESC O) used by TTY input
+  ;; decoding for arrows/function keys must stay unbound here.
+  (should-not (eq (lookup-key ghostel-semi-char-mode-map [27 ?\[])
+                  #'ghostel--send-event))
+  (should-not (eq (lookup-key ghostel-semi-char-mode-map [27 ?O])
+                  #'ghostel--send-event))
+  ;; M-# (and the rest of the M-<punct> sweep) keeps working.
+  (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "M-#"))
+              #'ghostel--send-event)))
+
+(ert-deftest ghostel-test-control-meta-punct-key-bindings ()
+  "Control-Meta + non-letter keys route to `ghostel--send-event'."
+  (dolist (key-str '("C-M-]" "C-M-/"))
+    (should (eq (lookup-key ghostel-semi-char-mode-map (kbd key-str))
+                #'ghostel--send-event))))
+
+(ert-deftest ghostel-test-control-punct-char-mode ()
+  "Char mode forwards C-]/C-/ but keeps the explicit C-\\ lambda."
+  (dolist (key-str '("C-]" "C-/" "C-M-]" "C-M-/"))
+    (should (eq (lookup-key ghostel-char-mode-map (kbd key-str))
+                #'ghostel--send-event)))
+  ;; C-\ in char mode keeps its explicit \x1c lambda (not send-event).
+  (should (commandp (lookup-key ghostel-char-mode-map (kbd "C-\\"))))
+  (should-not (eq (lookup-key ghostel-char-mode-map (kbd "C-\\"))
+                  #'ghostel--send-event))
+  ;; ESC still must not be hijacked in char mode either.
+  (should-not (eq (lookup-key ghostel-char-mode-map (kbd "C-["))
+                  #'ghostel--send-event)))
+
 (ert-deftest ghostel-test-encode-key-legacy-control-meta ()
   "Control-Meta letter chords encode to ESC + control byte in legacy mode.
 Regression test for issue #239: these byte sequences match readline
@@ -507,6 +561,26 @@ Regression test for issue #239: these byte sequences match readline
       (setq sent nil)
       (should (ghostel--encode-key term "v" "ctrl,meta" nil))
       (should (equal "\e\x16" sent)))))
+
+(ert-deftest ghostel-test-encode-key-legacy-control-punct ()
+  "Control punctuation encodes to the correct C0 byte in legacy mode.
+C-] is the headline case (-> 0x1d); C-/ -> 0x1f.  Control-Meta prepends
+ESC, matching the bytes eat sends.  (Only the punctuation the ghostty
+encoder recognizes is forwarded; see `ghostel--define-terminal-keys'.)"
+  :tags '(native)
+  (let* ((term (ghostel--new 25 80 1000))
+         (sent nil))
+    (cl-letf (((symbol-function 'ghostel--flush-output)
+               (lambda (data) (setq sent data))))
+      (pcase-dolist (`(,name ,bytes) '(("]" "\x1d") ("/" "\x1f")))
+        (setq sent nil)
+        (should (ghostel--encode-key term name "ctrl" nil))
+        (should (equal bytes sent)))
+      ;; Control-Meta prepends ESC: C-M-] -> 0x1b 0x1d, C-M-/ -> 0x1b 0x1f.
+      (pcase-dolist (`(,name ,bytes) '(("]" "\e\x1d") ("/" "\e\x1f")))
+        (setq sent nil)
+        (should (ghostel--encode-key term name "ctrl,meta" nil))
+        (should (equal bytes sent))))))
 
 (ert-deftest ghostel-test-send-encoded-meta-period ()
   "M-. sends ESC + period via raw fallback (legacy alt encoding)."


### PR DESCRIPTION
These fell through to Emacs (C-] = abort-recursive-edit, C-/ = undo)
instead of reaching the shell; readline uses C-] (character-search),
C-M-] (character-search-backward), and C-_/C-/ (undo).

The set is deliberately narrow. ghostty's encoder (mapKey in
src/input.zig) only recognizes a fixed punctuation set, and only some of
those carry a control byte; ] and / are the ones that both encode and
have a terminal meaning not already covered. Others are intentionally
left to Emacs:
  - C-, C-. C-; C-= C-' C-` ...: no terminal byte; binding would silently
    swallow keys.
  - C-^ / C-_: not encodable directly; their bytes (0x1e / 0x1f) are
    reachable via C-/ on common layouts.
  - C-0..C-9: digit-argument; forwarding would break numeric prefixes.
  - C-?: arrives as DEL, already bound.

Closes #380