### PR TITLE
Fall back to line-count anchoring on Emacs 28

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -5990,6 +5990,15 @@ supported."
              (list preserve-vscroll-p))
     (set-window-vscroll window vscroll pixels-p)))
 
+(defconst ghostel--pixel-anchor-supported-p
+  (let ((max-args (cdr (subr-arity (symbol-function 'window-text-pixel-size)))))
+    (and (integerp max-args) (>= max-args 7)))
+  "Non-nil when `window-text-pixel-size' accepts the cons FROM form.
+Emacs 29 shipped the cons FROM that `ghostel--pixel-anchor' needs together
+with IGNORE-LINE-AT-END (arity 7), so the arity probes for it; `fboundp'
+would not, since the function predates the form.  Emacs 28 falls back to
+line-count anchoring, exact for ghostel's uniform row heights.")
+
 (defun ghostel--pixel-anchor (window target)
   "Return (START . VSCROLL) anchoring TARGET at WINDOW's bottom.
 Ask Emacs redisplay for the exact pixel position that places TARGET at
@@ -6011,7 +6020,7 @@ In text frames, use line-count geometry with no vscroll."
       (with-current-buffer buffer
         (let ((target (point-max)))
           (if-let* ((anchor (and (display-graphic-p (window-frame window))
-                                 (fboundp 'window-text-pixel-size)
+                                 ghostel--pixel-anchor-supported-p
                                  (ghostel--pixel-anchor window target))))
               (progn
                 (set-window-start window (car anchor))

--- a/test/ghostel-scroll-test.el
+++ b/test/ghostel-scroll-test.el
@@ -214,6 +214,17 @@ while `window-pixel-height' stays constant)."
       (ghostel-test-scroll--set-gui-anchor-start win)
       (should (ghostel--window-anchored-p win)))))
 
+(ert-deftest ghostel-test-pixel-anchor-gate-matches-emacs-version ()
+  "`ghostel--pixel-anchor-supported-p' gates on the Emacs 29 cons FROM form.
+The cons-cell meaning of `window-text-pixel-size's FROM argument, which
+`ghostel--pixel-anchor' relies on, arrived in Emacs 29.  The predicate
+must therefore be nil on Emacs 28 (where a cons FROM signals
+`wrong-type-argument') and non-nil from Emacs 29 on.  This guards against
+regressing to a bare `fboundp' check, which is true on Emacs 28 because
+`window-text-pixel-size' has existed since Emacs 25 (issue #384)."
+  (should (eq (and ghostel--pixel-anchor-supported-p t)
+              (>= emacs-major-version 29))))
+
 (ert-deftest ghostel-test-second-window-does-not-disturb-scrollback ()
   "Opening another window on the buffer does not move a scrolled peer."
   :tags '(native)


### PR DESCRIPTION
## Summary
#385 anchors graphical windows with `window-text-pixel-size` using a cons `FROM` cell (buffer position + pixel offset) and its third return element. That meaning of `FROM` arrived in **Emacs 29**, but ghostel supports **Emacs 28.1**.

The `(fboundp 'window-text-pixel-size)` guard is insufficient — the function has existed since Emacs 25, so on Emacs 28 the guard passes and the cons `FROM` is handed to a function that doesn't understand it, signalling `wrong-type-argument` (or returning bogus geometry) and breaking the anchor on **GUI Emacs 28**. Batch CI doesn't catch it: the graphical branch is gated on `display-graphic-p`, which is nil in batch.

## Fix
- Add `ghostel--pixel-anchor-supported-p`, a `subr-arity` feature probe (Emacs 29 raised the arity to 7 via `IGNORE-LINE-AT-END`, shipped alongside the cons `FROM`), mirroring the existing `ghostel--set-window-vscroll-preserve-supported-p`.
- Gate the pixel path on it. On Emacs 28 the graphical case now uses the line-count branch, which is exact for ghostel's uniform row heights and produces the same bottom anchoring (and the same +1 margin that resolved #384).
- Add a regression test (untagged, so it runs in the Emacs 28.2 elisp CI job) asserting the gate matches the Emacs 29 boundary.

## Verification
- `make -j8 all` passes.
- Emulating Emacs 28 (a `window-text-pixel-size` that rejects a cons `FROM`): the pre-fix path raises `wrong-type-argument`, while the fix falls back and anchors cleanly (point tracks the terminal cursor; margin +1).
- On Emacs ≥29 the gate is non-nil, so the pixel-precise path is unchanged.

Follow-up to #385 / #384.