### PR TITLE
Allow line-mode at a shell prompt on the alternate screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,13 +323,18 @@ it.
 Line mode and fullscreen TUIs (vim, less, htop, …) cannot share the
 same keystroke stream — the TUI needs every key forwarded raw, while
 line mode buffers them locally.  Ghostel handles this transparently:
-when an alt-screen TUI starts, line mode pauses (any in-progress
-input is stashed) and the buffer drops to semi-char so the TUI gets
-its keys.  When the TUI exits, line mode resumes at the new prompt
-and the stashed input is reinstated.  Pressing `C-c C-l` while a TUI
-is already running arms the same auto-resume so line mode activates
-when the TUI exits.  An explicit mode switch (`C-c C-j`,
-`ghostel-char-mode`, etc.) cancels the armed auto-resume.
+when an alt-screen TUI starts, line mode drops to semi-char so the
+TUI gets its keys, with a brief message that it will resume on exit.
+When the TUI exits, line mode resumes at the new prompt.
+
+Pressing `C-c C-l` on the alt screen does the right thing for what is
+running.  Over a raw TUI it arms that same auto-resume, so line mode
+activates when the TUI exits; an explicit mode switch (`C-c C-j`,
+`ghostel-char-mode`, etc.) cancels the arming.  At an inner shell
+prompt — a `tmux`/`screen` session whose OSC 133 markers reach
+Ghostel via passthrough — `C-c C-l` enters line mode at that prompt
+directly.  When those markers do not pass through, `C-u C-c C-l`
+forces entry anyway.
 
 | Key         | Action                                   |
 |-------------|------------------------------------------|

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2714,7 +2714,7 @@ the prompt."
 Covers both `global-hl-line-mode' and buffer-local `hl-line-mode'.")
 
 (defvar-local ghostel--line-mode-paused nil
-  "Snapshot plist captured when alt-screen forced line mode to pause.
+  "Sentinel plist marking line mode as paused, awaiting alt-screen exit.
 Nil when not paused.  Set by `ghostel--line-mode-pause' (auto-pause
 when an alt-screen TUI starts) and by `ghostel--line-mode-defer-entry'
 \(when the user invokes `ghostel-line-mode' while a TUI is already
@@ -3187,6 +3187,12 @@ renderer (chars typed via the PTY in a previous mode).  Cleared to
 many backspaces to erase them — keeps a subsequent send from
 duplicating the prefix when the shell echoes our line back.")
 
+(defvar-local ghostel--line-mode-on-alt-screen nil
+  "Non-nil when line mode was entered deliberately on the alt screen.
+Set by `ghostel--line-mode-enter'; tells `ghostel--line-mode-pre-redraw'
+not to auto-pause line mode merely because the alt screen is up.
+Cleared by `ghostel--line-mode-teardown'.")
+
 (defun ghostel--regex-prompt-end (pos)
   "Return position past the prompt prefix on POS's line, or nil.
 Matches `ghostel-prompt-regexp' anchored at BOL of POS's line.
@@ -3326,6 +3332,16 @@ modes used by less, htop, vim, etc.)."
   (and ghostel--term
        (or (ghostel--mode-enabled ghostel--term 1049)
            (ghostel--mode-enabled ghostel--term 1047))))
+
+(defun ghostel--line-mode-prompt-on-screen-p ()
+  "Return non-nil when a real OSC 133 prompt char sits on the cursor's row.
+Only a `ghostel-prompt' property counts (no regex or cursor fallback),
+so line mode can tell an inner shell prompt reached via tmux/screen passthrough
+from a raw fullscreen TUI when deciding whether to enter on the alt screen."
+  (when-let* ((cursor ghostel--cursor-char-pos)
+              (bol (save-excursion (goto-char cursor)
+                                   (line-beginning-position))))
+    (and (text-property-not-all bol cursor 'ghostel-prompt nil) t)))
 
 (defun ghostel--line-mode-apply-readonly (marker-pos)
   "Mark `[point-min, MARKER-POS)' read-only with the rear-nonsticky trick.
@@ -3510,6 +3526,10 @@ in line mode (the interactive entry validates these)."
         (setq ghostel--line-mode-adopted-count (- input-end prompt-end)))
       (setq ghostel--line-mode-history-index nil)
       (setq ghostel--char-mode-override-active nil)
+      ;; A deliberate alt-screen entry must survive the next redraw's
+      ;; auto-pause, and supersedes any armed sentinel.
+      (setq ghostel--line-mode-on-alt-screen (ghostel--line-mode-alt-screen-p))
+      (setq ghostel--line-mode-paused nil)
       (setq ghostel--input-mode 'line)
       (use-local-map ghostel-line-mode-map)
       (setq ghostel--mode-line-tag (ghostel--mode-line-tag-make 'line ":Line"))
@@ -3540,7 +3560,7 @@ in line mode (the interactive entry validates these)."
       (ghostel--line-mode-maybe-prespawn-bash-completion)
       t)))
 
-(defun ghostel-line-mode ()
+(defun ghostel-line-mode (&optional force)
   "Switch to line mode — edit input locally, send to shell on RET.
 The user types into an editable region between the last prompt
 and `point-max'.  Full Emacs editing (yank, `kill-word',
@@ -3566,17 +3586,30 @@ without OSC 133 (python3, irb, sqlite3, …) work too.  When OSC
 133 markers are present on the cursor's row, the prompt prefix is
 recognised and the input boundary lands right after it.
 
-While a fullscreen TUI is on the alt screen, line mode cannot
-edit (the TUI needs every keystroke raw); calling this command
-during an alt-screen session arms a deferred-activation sentinel
-instead, and line mode resumes automatically when the TUI exits."
-  (interactive)
+On the alt screen, line mode enters at an inner shell prompt whose
+OSC 133 markers reach Ghostel (tmux/screen passthrough); over a raw
+TUI (vim, less) it instead arms and resumes when the TUI exits.  A
+prefix arg (FORCE) forces immediate entry regardless — use it at an
+inner prompt whose OSC 133 does not pass through the multiplexer."
+  (interactive "P")
   (unless ghostel--term
     (user-error "No terminal in this buffer"))
   (cond
-   ((eq ghostel--input-mode 'line))
+   ((eq ghostel--input-mode 'line))     ; already in line mode
+   ;; Forced: trust the user, bypass the alt-screen gate.
+   (force
+    (if (ghostel--line-mode-enter)
+        (message "Line mode: RET sends the whole line; C-c C-j to exit")
+      (user-error "Line mode could not locate the cursor or a prompt")))
+   ;; Alt screen with a real prompt on the cursor row (inner shell) — enter.
+   ((and (ghostel--line-mode-alt-screen-p)
+         (ghostel--line-mode-prompt-on-screen-p)
+         (ghostel--line-mode-enter))
+    (message "Line mode: RET sends the whole line; C-c C-j to exit"))
+   ;; Alt screen, no detectable prompt (raw TUI) — arm instead.
    ((ghostel--line-mode-alt-screen-p)
     (ghostel--line-mode-defer-entry))
+   ;; Primary screen — normal entry.
    ((ghostel--line-mode-enter)
     (message "Line mode: RET sends the whole line; C-c C-j to exit"))
    (t
@@ -3641,10 +3674,9 @@ forces a final redraw so the buffer truncation done at entry is
 re-materialized from libghostty.
 
 When PAUSE is non-nil, skip forwarding pending input to the PTY,
-skip the readline-clearing backspaces (the alt-screen TUI would
-receive them), and skip the trailing redraw — used by
-`ghostel--line-mode-pause' which has already snapshotted the input
-and is running inside `ghostel--redraw-now'."
+skip the readline-clearing backspaces (the alt-screen TUI would receive them),
+and skip the trailing redraw; used by `ghostel--line-mode-pause',
+which discards any type-ahead and runs inside `ghostel--redraw-now'."
   ;; Undo is off outside line mode; disable it before the teardown edits
   ;; below so none of them are recorded.
   (setq buffer-undo-list t)
@@ -3673,6 +3705,7 @@ and is running inside `ghostel--redraw-now'."
   (setq ghostel--line-input-end nil)
   (setq ghostel--line-mode-history-index nil)
   (setq ghostel--line-mode-adopted-count nil)
+  (setq ghostel--line-mode-on-alt-screen nil)
   (when ghostel--line-mode-saved-full-redraw
     (if (car ghostel--line-mode-saved-full-redraw)
         (setq-local ghostel-full-redraw
@@ -3688,21 +3721,21 @@ and is running inside `ghostel--redraw-now'."
         (ghostel--redraw ghostel--term t)))))
 
 (defun ghostel--line-mode-pause ()
-  "Snapshot in-progress input, tear down line mode, switch to semi-char.
-Called by `ghostel--line-mode-pre-redraw' on a 1049/1047 transition
-into the alt screen.  Stashes the snapshot in
-`ghostel--line-mode-paused' so a later alt-screen-off cycle can
-re-enter line mode at the new prompt with the user's typing
-restored."
-  (let ((snapshot (or (ghostel--line-mode-snapshot)
-                      (list :input "" :point-offset nil :mark-offset nil))))
-    (ghostel--line-mode-teardown 'pause)
-    (setq ghostel--char-mode-override-active nil)
-    (setq ghostel--input-mode 'semi-char)
-    (use-local-map ghostel-semi-char-mode-map)
-    (setq ghostel--mode-line-tag nil)
-    (ghostel--mode-line-refresh)
-    (setq ghostel--line-mode-paused snapshot)))
+  "Drop line mode to semi-char while a full-screen app holds the alt screen.
+Called by `ghostel--line-mode-pre-redraw' on a 1049/1047 transition into
+the alt screen.  Arms `ghostel--line-mode-paused' so the alt-screen-off cycle
+re-enters line mode at the new prompt."
+  (ghostel--line-mode-teardown 'pause)
+  (setq ghostel--char-mode-override-active nil)
+  (setq ghostel--input-mode 'semi-char)
+  (use-local-map ghostel-semi-char-mode-map)
+  (setq ghostel--mode-line-tag nil)
+  (ghostel--mode-line-refresh)
+  (setq ghostel--line-mode-paused
+        (list :input "" :point-offset nil :mark-offset nil))
+  (message "Line mode paused; resumes when the TUI exits (%s to force now)"
+           (substitute-command-keys
+            "\\<ghostel-mode-map>\\[universal-argument] \\[ghostel-line-mode]")))
 
 (defun ghostel--line-mode-try-resume ()
   "Re-enter line mode and restore the paused snapshot, if possible.
@@ -3727,20 +3760,23 @@ input captured by an earlier auto-pause)."
   (unless ghostel--line-mode-paused
     (setq ghostel--line-mode-paused
           (list :input "" :point-offset nil :mark-offset nil)))
-  (message "Line mode armed — will activate when the TUI exits"))
+  (message "Line mode armed; will activate when the TUI exits (%s to force now)"
+           (substitute-command-keys
+            "\\<ghostel-mode-map>\\[universal-argument] \\[ghostel-line-mode]")))
 
 (defun ghostel--line-mode-pre-redraw ()
-  "Pause line mode if alt-screen is on while in line mode.
-Runs at the top of `ghostel--redraw-now' after process output has
-already been fed to the terminal, but before the renderer paints.
-Pausing here lets us snapshot the
-in-progress input before libghostty's grid (which does not contain
-it) drives the renderer over the buffer.  After pausing,
-`ghostel--input-mode' is no longer `line', so subsequent calls
-fall through — there is no need for an explicit transition cache."
-  (when (and (eq ghostel--input-mode 'line)
-             (ghostel--line-mode-alt-screen-p))
-    (ghostel--line-mode-pause)))
+  "Pause line mode when the alt screen comes up under it.
+Runs atop `ghostel--redraw-now' before the renderer paints, so line
+mode tears down before libghostty's grid (which lacks the input)
+overwrites the buffer.  A deliberate alt-screen entry
+\(`ghostel--line-mode-on-alt-screen') is exempt; the flag clears
+once the alt screen goes away so a later TUI pauses normally."
+  (when (eq ghostel--input-mode 'line)
+    (if (ghostel--line-mode-alt-screen-p)
+        (unless ghostel--line-mode-on-alt-screen
+          (ghostel--line-mode-pause))
+      ;; Back on the primary screen — re-arm the pause for the next TUI.
+      (setq ghostel--line-mode-on-alt-screen nil))))
 
 (defun ghostel--line-mode-post-redraw ()
   "Resume line mode if alt-screen is off and a paused snapshot is armed.

--- a/test/ghostel-line-mode-test.el
+++ b/test/ghostel-line-mode-test.el
@@ -403,9 +403,10 @@ sentinel and enters line mode for real once the TUI exits."
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-line-mode-pauses-on-alt-screen-on ()
-  "1049 ON while in line-mode snapshots input and drops to semi-char.
-The in-progress input lands in `ghostel--line-mode-paused' so a
-later alt-screen exit can restore it."
+  "1049 ON while in line-mode discards type-ahead and drops to semi-char.
+`ghostel--line-mode-paused' is armed (an empty sentinel) so a later
+alt-screen exit re-enters line mode, but the typed input is not
+preserved."
   (let ((buf (generate-new-buffer " *ghostel-test-line-pause*")))
     (unwind-protect
         (with-current-buffer buf
@@ -429,9 +430,11 @@ later alt-screen exit can restore it."
               (setq alt-on t)
               (ghostel--line-mode-pre-redraw)
               (should (eq ghostel--input-mode 'semi-char))
+              ;; Paused sentinel is armed, but the type-ahead is discarded.
               (should ghostel--line-mode-paused)
-              (should (equal (plist-get ghostel--line-mode-paused :input)
-                             "ls"))
+              (should (equal (plist-get ghostel--line-mode-paused :input) ""))
+              ;; The typed "ls" was deleted from the buffer, not preserved.
+              (should-not (string-match-p "ls" (buffer-string)))
               ;; Input region was extracted from the buffer.
               (should-not (markerp ghostel--line-input-start))
               ;; Read-only props from line-mode entry are gone.
@@ -440,9 +443,10 @@ later alt-screen exit can restore it."
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-line-mode-resumes-on-alt-screen-off ()
-  "1049 OFF with a prompt in the buffer re-enters line mode + restores input.
-Drives the pause, then the resume; the snapshotted input lands at
-the new prompt-end and the buffer is back in line mode."
+  "1049 OFF with a prompt in the buffer re-enters line mode.
+Drives the pause, then the resume; the buffer is back in line mode
+at the new prompt.  Type-ahead from before the pause is not
+restored."
   (let ((buf (generate-new-buffer " *ghostel-test-line-resume*")))
     (unwind-protect
         (with-current-buffer buf
@@ -475,11 +479,13 @@ the new prompt-end and the buffer is back in line mode."
               (ghostel--line-mode-post-redraw)
               (should (eq ghostel--input-mode 'line))
               (should-not ghostel--line-mode-paused)
-              (should (equal (ghostel--line-mode-input-text) "ls -la")))))
+              ;; Re-entered at the new prompt with empty input — the
+              ;; pre-pause type-ahead is not carried across.
+              (should (equal (ghostel--line-mode-input-text) "")))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-line-mode-resume-defers-without-prompt ()
-  "Resume with no prompt in the buffer keeps the paused snapshot for next cycle."
+  "Resume with no prompt in the buffer keeps the paused sentinel for next cycle."
   (let ((buf (generate-new-buffer " *ghostel-test-line-resume-defer*")))
     (unwind-protect
         (with-current-buffer buf
@@ -506,18 +512,17 @@ the new prompt-end and the buffer is back in line mode."
               (let ((inhibit-read-only t)) (erase-buffer))
               (setq alt-on nil)
               (ghostel--line-mode-post-redraw)
-              ;; Still paused, snapshot intact, mode still semi-char.
+              ;; Still paused (sentinel intact), mode still semi-char.
               (should (eq ghostel--input-mode 'semi-char))
               (should ghostel--line-mode-paused)
-              (should (equal (plist-get ghostel--line-mode-paused :input)
-                             "echo hi"))
+              (should (equal (plist-get ghostel--line-mode-paused :input) ""))
               ;; Add the new prompt and run another post-redraw —
               ;; resume succeeds.
               (insert (propertize "$ " 'ghostel-prompt t))
               (ghostel--line-mode-post-redraw)
               (should (eq ghostel--input-mode 'line))
               (should-not ghostel--line-mode-paused)
-              (should (equal (ghostel--line-mode-input-text) "echo hi")))))
+              (should (equal (ghostel--line-mode-input-text) "")))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-line-mode-paused-cleared-on-manual-switch ()
@@ -1683,6 +1688,294 @@ force the editor default; teardown must restore the saved value."
               (ghostel-semi-char-mode)
               (should (null cursor-type))
               (should-not ghostel--line-mode-saved-cursor-type))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-enters-on-alt-screen-with-osc133-prompt ()
+  "On the alt screen, a real OSC 133 prompt on the cursor row enters line mode.
+A shell prompt inside tmux/screen whose OSC 133 passed through
+carries `ghostel-prompt' on the cursor row, so line mode should
+enter at that prompt instead of arming."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-alt-enter*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (setq ghostel--cursor-char-pos (point))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (_term mode) (= mode 1049)))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string) #'ignore)
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore))
+              (should (eq ghostel--input-mode 'semi-char))
+              (ghostel-line-mode)
+              ;; Entered for real — not armed.
+              (should (eq ghostel--input-mode 'line))
+              (should-not ghostel--line-mode-paused)
+              ;; Flagged as a deliberate alt-screen entry.
+              (should ghostel--line-mode-on-alt-screen))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-arms-on-alt-screen-without-osc133 ()
+  "On the alt screen with no OSC 133 prompt, line mode arms (raw-TUI guard).
+A raw fullscreen TUI (vim/less) paints glyphs but carries no
+`ghostel-prompt' on the cursor row, so line mode must NOT enter —
+it would scrape garbage.  It arms a deferred sentinel instead."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-alt-arm*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          ;; vim-like row: plain text, no prompt prop.
+          (let ((inhibit-read-only t))
+            (insert "~ NORMAL line one"))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (setq ghostel--cursor-char-pos (point))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (_term mode) (= mode 1049)))
+                      ((symbol-function 'ghostel--invalidate) #'ignore))
+              (should (eq ghostel--input-mode 'semi-char))
+              (ghostel-line-mode)
+              ;; Stayed in semi-char, armed an empty snapshot.
+              (should (eq ghostel--input-mode 'semi-char))
+              (should ghostel--line-mode-paused)
+              (should (equal (plist-get ghostel--line-mode-paused :input)
+                             "")))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-force-enters-on-alt-screen ()
+  "A prefix arg forces line-mode entry on the alt screen even without OSC 133.
+The multiplexer-without-passthrough user's escape hatch: with a
+cursor to anchor on, a prefix arg bypasses the gate and enters."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-alt-force*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          ;; No prompt prop — only a cursor anchors the boundary.
+          (let ((inhibit-read-only t))
+            (insert "bash-5.2$ "))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc)
+                (ghostel-prompt-regexp nil))  ; force the bare-cursor path
+            (setq ghostel--cursor-char-pos (point))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (_term mode) (= mode 1049)))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string) #'ignore)
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore))
+              ;; Sanity: without the prefix this would arm, not enter.
+              (should-not (ghostel--line-mode-prompt-on-screen-p))
+              (let ((current-prefix-arg '(4)))
+                (call-interactively #'ghostel-line-mode))
+              (should (eq ghostel--input-mode 'line))
+              (should-not ghostel--line-mode-paused)
+              (should ghostel--line-mode-on-alt-screen))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-force-errors-without-anchor ()
+  "Forced entry with nothing to anchor still errors — never silently no-ops.
+With no cursor and no prompt prop, `ghostel--line-mode-enter'
+returns nil; the forced branch must surface the `user-error'
+rather than leave the mode unchanged."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-force-noanchor*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((inhibit-read-only t))
+            (insert "no prompt here"))
+          (let ((ghostel--term 'fake)
+                (ghostel--cursor-char-pos nil))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (_term mode) (= mode 1049))))
+              (let ((current-prefix-arg '(4)))
+                (should-error (call-interactively #'ghostel-line-mode)
+                              :type 'user-error)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-alt-screen-entry-not-paused-by-redraw ()
+  "A deliberate alt-screen line-mode survives the next pre-redraw.
+Regression for the pause-on-redraw self-defeat: without the
+`ghostel--line-mode-on-alt-screen' flag, `pre-redraw' would pause
+the freshly-entered line mode on the very next redraw because
+alt-screen is still on, making the whole entry a no-op."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-alt-survive*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (setq ghostel--cursor-char-pos (point))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (_term mode) (= mode 1049)))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string) #'ignore)
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore))
+              (ghostel-line-mode)
+              (should (eq ghostel--input-mode 'line))
+              ;; Next redraw with alt-screen still on must NOT pause us.
+              (ghostel--line-mode-pre-redraw)
+              (should (eq ghostel--input-mode 'line))
+              (should-not ghostel--line-mode-paused))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-normal-pause-still-fires ()
+  "Auto-pause still fires for line mode entered on the PRIMARY screen.
+Guards against the `on-alt-screen' flag accidentally suppressing
+the normal vim-launched-from-a-shell-prompt pause: entry on the
+primary screen leaves the flag nil, so a later alt-screen
+transition pauses as before (type-ahead discarded)."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-normal-pause*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((alt-on nil)
+                (ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (_term mode)
+                         (and alt-on (memq mode '(1049 1047)) t)))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string) #'ignore)
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore))
+              ;; Enter on the primary screen — flag stays nil.
+              (ghostel-line-mode)
+              (should (eq ghostel--input-mode 'line))
+              (should-not ghostel--line-mode-on-alt-screen)
+              (insert "ls")
+              ;; Now a TUI starts; pre-redraw must pause as before.
+              (setq alt-on t)
+              (ghostel--line-mode-pre-redraw)
+              (should (eq ghostel--input-mode 'semi-char))
+              (should ghostel--line-mode-paused)
+              (should (equal (plist-get ghostel--line-mode-paused :input) "")))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-prompt-on-screen-p-ignores-regex ()
+  "`ghostel--line-mode-prompt-on-screen-p' only counts the OSC 133 prop.
+The regex must NOT be treated as a prompt signal on the alt screen:
+a TUI row that happens to look like `$ ' is not a real prompt.  The
+predicate returns nil for a regex-only match and non-nil only when
+the `ghostel-prompt' prop is present."
+  (let ((buf (generate-new-buffer " *ghostel-test-prompt-on-screen*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          ;; Row matches `ghostel-prompt-regexp' (`$ ') but has no prop.
+          (let ((inhibit-read-only t))
+            (insert "$ ls -la"))
+          (setq ghostel--term 'fake)
+          (setq ghostel--cursor-char-pos (point))
+          (should (ghostel--regex-prompt-end ghostel--cursor-char-pos))
+          (should-not (ghostel--line-mode-prompt-on-screen-p))
+          ;; Now add a real prop on the cursor row → non-nil.
+          (let ((inhibit-read-only t))
+            (erase-buffer)
+            (insert (propertize "$ " 'ghostel-prompt t))
+            (insert "ls -la"))
+          (setq ghostel--cursor-char-pos (point))
+          (should (ghostel--line-mode-prompt-on-screen-p)))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-force-after-arm-preserves-input-on-alt-exit ()
+  "Arming then force-entering must not double-enter when the TUI later exits.
+Regression for the stale armed-snapshot bug: a first plain
+`ghostel-line-mode' without OSC 133 passthrough arms a sentinel;
+the advertised forced call (with a prefix argument) then enters.
+A real entry
+must clear that sentinel, otherwise the alt-screen-off `post-redraw'
+would call
+`ghostel--line-mode-try-resume' on top of the already-active line
+mode — re-running `ghostel--line-mode-enter', wiping the user's
+typed input (it restores the empty armed snapshot) and clobbering
+the saved `ghostel-full-redraw' state captured on first entry."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-force-after-arm*"))
+        (alt-on t))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (setq ghostel--cursor-char-pos (point))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (_term mode) (and alt-on (= mode 1049))))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string) #'ignore)
+                      ((symbol-function 'ghostel--send-encoded) #'ignore)
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore))
+              ;; First press, no passthrough → arm a sentinel.
+              (ghostel--line-mode-defer-entry)
+              (should ghostel--line-mode-paused)
+              ;; The advertised escape hatch: C-u C-c C-l → force entry.
+              (ghostel-line-mode t)
+              (should (eq ghostel--input-mode 'line))
+              ;; The fix: the real entry cleared the stale sentinel.
+              (should-not ghostel--line-mode-paused)
+              ;; Capture the saved redraw state so we can detect a
+              ;; second entry re-capturing it from modified values.
+              (should-not (car ghostel--line-mode-saved-full-redraw))
+              ;; User types a command in line mode.
+              (goto-char (point-max))
+              (insert "ls -la")
+              ;; User exits the multiplexer: alt screen turns off, a
+              ;; redraw runs pre- then post-redraw.
+              (setq alt-on nil)
+              (ghostel--line-mode-pre-redraw)
+              (ghostel--line-mode-post-redraw)
+              ;; Still in line mode, input intact, no double-enter.
+              (should (eq ghostel--input-mode 'line))
+              (should (equal (ghostel--line-mode-input-text) "ls -la"))
+              (should-not ghostel--line-mode-paused)
+              (should-not (car ghostel--line-mode-saved-full-redraw)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-alt-exit-clears-flag-so-primary-tui-pauses ()
+  "Leaving the alt screen drops the deliberate-entry flag.
+Regression for the stale `ghostel--line-mode-on-alt-screen' flag:
+after entering line mode at an inner tmux prompt and then exiting
+the multiplexer (alt screen off) while staying in line mode, a TUI
+later launched at the now-primary prompt must auto-pause as usual —
+the flag must not keep suppressing the pause forever."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-alt-exit-flag*"))
+        (alt-on t))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (setq ghostel--cursor-char-pos (point))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (_term mode)
+                         (and alt-on (memq mode '(1049 1047)) t)))
+                      ((symbol-function 'process-live-p) (lambda (_p) t))
+                      ((symbol-function 'process-send-string) #'ignore)
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore))
+              ;; Enter at an inner shell prompt inside tmux (branch c).
+              (ghostel-line-mode)
+              (should (eq ghostel--input-mode 'line))
+              (should ghostel--line-mode-on-alt-screen)
+              ;; Exit the multiplexer: alt off, still in line mode.  The
+              ;; next redraw's pre-redraw must clear the flag.
+              (setq alt-on nil)
+              (ghostel--line-mode-pre-redraw)
+              (should (eq ghostel--input-mode 'line))
+              (should-not ghostel--line-mode-on-alt-screen)
+              ;; Now a real TUI starts at the primary prompt: pre-redraw
+              ;; must pause, exactly as for a normal primary-screen entry.
+              (setq alt-on t)
+              (ghostel--line-mode-pre-redraw)
+              (should (eq ghostel--input-mode 'semi-char))
+              (should ghostel--line-mode-paused))))
       (kill-buffer buf))))
 
 (provide 'ghostel-line-mode-test)


### PR DESCRIPTION
Refused entry whenever the alt screen was active (e.g. a shell prompt
inside tmux/screen) and only "armed". Now: enter when a real OSC 133
prompt is on the cursor row (new ghostel--line-mode-prompt-on-screen-p);
C-u C-c C-l forces entry; otherwise arm, advertising the override. A
buffer-local on-alt-screen flag stops the next redraw from re-pausing a
deliberate alt-screen line-mode.