### PR TITLE
Redraw immediately when showing ghostel buffers

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -6244,11 +6244,11 @@ and the TTY display that needs it off keeps working in parallel)."
         (setq-local auto-composition-mode tt)))))
 
 (defun ghostel--window-buffer-change (window)
-  "Anchor window and force redraw when buffer gets displayed in WINDOW."
+  "Anchor WINDOW and redraw it immediately when its buffer is displayed."
   (when (and (window-live-p window)
              (eq (window-buffer window) (current-buffer)))
     (ghostel--anchor-window window)
-    (ghostel--invalidate)))
+    (ghostel--redraw-now (current-buffer))))
 
 (defun ghostel--anchor-on-resize (window)
   "Scroll WINDOW to the active area if it was already anchored.

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -1706,12 +1706,10 @@ When the buffer reappears, it is immediately redrawn."
               ;; Redraw blocked: buffer still shows the old content.
               (should-not (string-match-p "while-hidden" (buffer-string)))
 
-              ;; Reshow the buffer; hook calls ghostel--invalidate again.
+              ;; Reshow the buffer; the hook redraws immediately without
+              ;; waiting for the delayed invalidation timer.
               (set-window-buffer win buf)
-              (cl-letf (((symbol-function 'run-with-timer)
-                         (lambda (_delay _repeat fn &rest args)
-                           (apply fn args) nil)))
-                (run-hook-with-args 'window-buffer-change-functions win))
+              (run-hook-with-args 'window-buffer-change-functions win)
 
               (should (string-match-p "while-hidden" (buffer-string))))))
       (set-window-buffer win orig-buf)


### PR DESCRIPTION
## Summary
- redraw ghostel buffers immediately from `window-buffer-change-functions`
- update the hidden-buffer regression test to assert the immediate redraw path
- refresh the helper docstring to match the new behavior

## Tests
- `make build`
- `emacs --batch -Q -L lisp -L test -l ert -l test/ghostel-test-helpers.el -l test/ghostel-render-test.el --eval "(ert-run-tests-batch-and-exit 'ghostel-test-defers-redraw-while-hidden)"`