### PR TITLE
Enter copy mode on a left-click in an already-focused window

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -765,7 +765,7 @@ Customize the faces `ghostel-fake-cursor' and
   :type 'boolean)
 
 (defcustom ghostel-mouse-drag-input-mode 'copy
-  "Input mode to switch to after a left-button drag or multi-click selects text.
+  "Input mode to switch to after a left-button mouse click or selection.
 
 - `copy' (default): enter `ghostel-copy-mode'.  Pauses redraws -
   the selection is stable and the buffer is read-only.
@@ -777,7 +777,7 @@ Customize the faces `ghostel-fake-cursor' and
 
 Has no effect when a DEC mouse-tracking mode (1000/1002/1003) is
 active (the press is forwarded to the program) or when the buffer
-is not in semi-char-mode when the drag completes."
+is not in semi-char-mode when the gesture completes."
   :type '(choice (const :tag "Copy mode (default)" copy)
                  (const :tag "Emacs mode"          emacs)
                  (const :tag "Do not switch"       nil)))
@@ -2471,6 +2471,11 @@ Return non-nil if the event was forwarded (mouse tracking is active)."
 
 ;;; Mouse input
 
+(defvar ghostel--mouse-press-was-selected nil
+  "Non-nil if the window under the last left-press was already selected.
+Set at press, read at release to tell a focus click (which only focuses)
+from a click in an already-focused window (which enters copy mode).")
+
 (defvar-local ghostel--mouse-drag-button nil
   "Button number held during an in-progress mouse-tracking drag.
 Nil when no drag is in progress.")
@@ -2626,36 +2631,47 @@ to consume mouse input."
 
 (defun ghostel-mouse-press-or-copy-mode (event)
   "Forward EVENT to the terminal, or hand off to `mouse-drag-region'.
-When a DEC mouse-tracking mode (1000/1002/1003) is enabled, behaves
-like `ghostel--mouse-press' and forwards the press to the running
-program.  Otherwise hands EVENT off to `mouse-drag-region' so Emacs's
-standard click-to-set-point and drag-to-select work.  Copy mode is
-not entered here - a pure click should only focus the window and
-move point.  When the press grows into a drag,
-`ghostel-mouse-drag-or-set-region' enters copy mode after the region
-is set so subsequent terminal output cannot clobber the selection."
+With a DEC mouse-tracking mode (1000/1002/1003) on, forwards the press
+to the program; otherwise hands off to `mouse-drag-region'.  Records in
+`ghostel--mouse-press-was-selected' whether the window was already
+selected before focusing it, for `ghostel-mouse-release-or-set-point'."
   (interactive "e")
-  (select-window (posn-window (event-start event)))
-  (if (ghostel--mouse-tracking-active-p)
-      (ghostel--mouse-press event)
-    (mouse-drag-region event)))
+  (let ((win (posn-window (event-start event))))
+    (setq ghostel--mouse-press-was-selected (eq win (selected-window)))
+    (select-window win)
+    (if (ghostel--mouse-tracking-active-p)
+        (ghostel--mouse-press event)
+      (mouse-drag-region event))))
 
 (defun ghostel-mouse-release-or-set-point (event &optional promote-to-region)
-  "Forward EVENT to the terminal, or hand off to `mouse-set-point'.
-Companion to `ghostel-mouse-press-or-copy-mode' for the left-button
-release event.  With tracking off, defers to Emacs's standard
-click handler so the release of a non-drag click sets point normally.
-PROMOTE-TO-REGION is passed through to `mouse-set-point' so that
-double-click and triple-click events keep the word/line selection."
+  "Forward EVENT to the terminal, or set point / switch input mode.
+With tracking off, sets point (PROMOTE-TO-REGION keeps the word/line
+selection of a multi-click) and, in semi-char mode, switches to
+`ghostel-mouse-drag-input-mode' after a multi-click or a single click
+in an already-selected window.  A single click that only focuses a
+previously-unselected window instead snaps point to the live cursor and
+stays in semi-char (skipped when `ghostel-mouse-drag-input-mode' is nil)."
   (interactive "e\np")
-  (if (ghostel--mouse-tracking-active-p)
-      (ghostel--mouse-release event)
-    (mouse-set-point event promote-to-region)
-    (when (and (eq ghostel--input-mode 'semi-char)
-               (> (event-click-count event) 1))
-      (pcase ghostel-mouse-drag-input-mode
-        ('copy  (ghostel-copy-mode))
-        ('emacs (ghostel-emacs-mode))))))
+  (let ((active (and ghostel-mouse-drag-input-mode
+                     (eq ghostel--input-mode 'semi-char))))
+    (cond
+     ((ghostel--mouse-tracking-active-p)
+      (ghostel--mouse-release event))
+     ;; Pure focus click of a previously-unselected window: just focus,
+     ;; snapping point to the live input cursor instead of the click.
+     ((and active
+           (= (event-click-count event) 1)
+           (not ghostel--mouse-press-was-selected))
+      (goto-char (or ghostel--cursor-char-pos (point-max)))
+      (deactivate-mark))
+     ;; Multi-click, or a single click in an already-selected window: set
+     ;; point/selection, then freeze (a focus click never reaches here).
+     (t
+      (mouse-set-point event promote-to-region)
+      (when active
+        (pcase ghostel-mouse-drag-input-mode
+          ('copy  (ghostel-copy-mode))
+          ('emacs (ghostel-emacs-mode))))))))
 
 (defun ghostel-mouse-drag-or-set-region (event)
   "Forward EVENT to the terminal, or hand off to `mouse-set-region'.

--- a/test/ghostel-mouse-paste-test.el
+++ b/test/ghostel-mouse-paste-test.el
@@ -416,6 +416,157 @@ and the live cursor advancing would extend the region."
       (should-not emacs-mode-called)
       (should (equal '(set-point copy-mode) (nreverse call-order))))))
 
+(ert-deftest ghostel-test-mouse-1-release-single-click-already-selected-enters-copy-mode ()
+  "Plain single click in an already-selected semi-char window enters copy mode.
+Mirrors the drag/multi-click handlers: point is set first, then the
+buffer freezes so streaming output cannot clobber the view."
+  :tags '(native)
+  (let ((fake-event `(mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (ghostel-mouse-drag-input-mode 'copy)
+        (ghostel--mouse-press-was-selected t)
+        (set-point-event nil)
+        (copy-mode-called nil)
+        (emacs-mode-called nil)
+        (call-order nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-point)
+                 (lambda (event &optional _promote)
+                   (setq set-point-event event)
+                   (push 'set-point call-order)))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda ()
+                   (setq copy-mode-called t)
+                   (push 'copy-mode call-order)))
+                ((symbol-function 'ghostel-emacs-mode)
+                 (lambda () (setq emacs-mode-called t))))
+        (ghostel-mouse-release-or-set-point fake-event 1))
+      (should (equal fake-event set-point-event))
+      (should copy-mode-called)
+      (should-not emacs-mode-called)
+      ;; Point must be set before copy mode freezes the buffer.
+      (should (equal '(set-point copy-mode) (nreverse call-order))))))
+
+(ert-deftest ghostel-test-mouse-1-release-single-click-focus-click-only-focuses ()
+  "A focus click of an unselected window only focuses.
+With the feature on (`ghostel-mouse-drag-input-mode' non-nil) the click
+does not enter copy mode (the #257 case) and snaps point to the live
+cursor (`ghostel--cursor-char-pos'), not the click position."
+  :tags '(native)
+  (let ((fake-event `(mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (ghostel-mouse-drag-input-mode 'copy)
+        (ghostel--mouse-press-was-selected nil)
+        (set-point-called nil)
+        (copy-mode-called nil))
+    (with-temp-buffer
+      (insert "hello world")
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (setq-local ghostel--cursor-char-pos 11)  ; live input position
+      (goto-char 8)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-point)
+                 (lambda (_event &optional _promote) (setq set-point-called t)))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t))))
+        (ghostel-mouse-release-or-set-point fake-event 1))
+      (should-not set-point-called)
+      (should-not copy-mode-called)
+      ;; Cursor snapped to the live input position, not the click.
+      (should (= (point) 11)))))
+
+(ert-deftest ghostel-test-mouse-1-release-focus-click-feature-off-sets-point ()
+  "With the feature off, a focus click sets point like standard Emacs.
+When `ghostel-mouse-drag-input-mode' is nil, a single click in a
+previously-unselected window sets point normally and enters no mode."
+  :tags '(native)
+  (let ((fake-event `(mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (ghostel-mouse-drag-input-mode nil)
+        (ghostel--mouse-press-was-selected nil)
+        (set-point-event nil)
+        (copy-mode-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-point)
+                 (lambda (event &optional _promote) (setq set-point-event event)))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t))))
+        (ghostel-mouse-release-or-set-point fake-event 1))
+      (should (equal fake-event set-point-event))
+      (should-not copy-mode-called))))
+
+(ert-deftest ghostel-test-mouse-1-release-single-click-already-selected-nil-target-stays ()
+  "Already-selected single click with a nil target only sets point.
+With `ghostel-mouse-drag-input-mode' nil there is no copy/Emacs mode to
+switch to, so the click just sets point and enters no mode."
+  :tags '(native)
+  (let ((fake-event `(mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (ghostel-mouse-drag-input-mode nil)
+        (ghostel--mouse-press-was-selected t)
+        (copy-mode-called nil)
+        (emacs-mode-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-point)
+                 (lambda (_event &optional _promote) nil))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t)))
+                ((symbol-function 'ghostel-emacs-mode)
+                 (lambda () (setq emacs-mode-called t))))
+        (ghostel-mouse-release-or-set-point fake-event 1))
+      (should-not copy-mode-called)
+      (should-not emacs-mode-called))))
+
+(ert-deftest ghostel-test-mouse-1-release-single-click-already-selected-emacs-target ()
+  "Single click in an already-selected window honors `ghostel-mouse-drag-input-mode' = `emacs'."
+  :tags '(native)
+  (let ((fake-event `(mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (ghostel-mouse-drag-input-mode 'emacs)
+        (ghostel--mouse-press-was-selected t)
+        (copy-mode-called nil)
+        (emacs-mode-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-point)
+                 (lambda (_event &optional _promote) nil))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t)))
+                ((symbol-function 'ghostel-emacs-mode)
+                 (lambda () (setq emacs-mode-called t))))
+        (ghostel-mouse-release-or-set-point fake-event 1))
+      (should emacs-mode-called)
+      (should-not copy-mode-called))))
+
+(ert-deftest ghostel-test-mouse-1-press-records-was-selected ()
+  "Press records `ghostel--mouse-press-was-selected' for the clicked window.
+The window in the event equals `(selected-window)', so the press flags
+it as an already-selected (non-focus) click."
+  :tags '(native)
+  (let ((fake-event `(down-mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (ghostel--mouse-press-was-selected nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-drag-region) (lambda (_event) nil))
+                ((symbol-function 'select-window) (lambda (&rest _) nil)))
+        (ghostel-mouse-press-or-copy-mode fake-event))
+      (should ghostel--mouse-press-was-selected))))
+
 (ert-deftest ghostel-test-mouse-1-release-tracking-forwards ()
   "Release with active tracking forwards via `ghostel--mouse-release'."
   :tags '(native)


### PR DESCRIPTION
## What

A plain left-click in a ghostel buffer now switches input mode the same way a drag or double/triple-click already does — picked by `ghostel-mouse-drag-input-mode` (default `copy`) — **but only when the click lands in a window that was already selected.**

A click that *focuses* a previously-unselected window is treated as a pure focus click: it only gives the window focus and snaps point to the live input cursor. It never moves point to the click or freezes the buffer.

This restores the click→copy-mode behavior that was reverted in 924d26d (#257) — without the regression that made focus clicks silently freeze the buffer.

## Behavior

In semi-char mode, no DEC mouse-tracking active:

| Gesture | Window already focused? | Result |
|---|---|---|
| Single click | no (focus click) | focus only — point snaps to the live input cursor |
| Single click | yes | set point → switch to `ghostel-mouse-drag-input-mode` |
| Double/triple click | either | select word/line → switch mode (focus click first just focuses) |
| Drag | either | set region → switch mode (live highlight preserved) |

Setting `ghostel-mouse-drag-input-mode` to `nil` disables the feature, restoring standard click-sets-point behavior everywhere. DEC mouse-tracking (htop, lazygit, …) still forwards clicks to the program.

## How

- `ghostel-mouse-press-or-copy-mode` records in `ghostel--mouse-press-was-selected` whether the clicked window was selected *before* the press (captured before `select-window`).
- `ghostel-mouse-release-or-set-point` reads it to tell a focus click from an interaction click, snapping point to `ghostel--cursor-char-pos` (the live cursor) for the former.

## Tests

6 new native tests in `test/ghostel-mouse-paste-test.el` (single click already-selected → copy/emacs/nil; pure focus click → focus only + point at input cursor; feature-off focus click → standard set-point; press records the flag). Full `make test` / `make test-native` pass; byte-compile clean.

## Note

Manual prose for this feature (in `README.org` / `ghostel.texi`) is not included — those files are untracked in the repo.