### PR TITLE
Avoid stale minibuffer reanchors

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -6315,11 +6315,17 @@ scroll to active area to keep it focused even during resize."
   "Schedule anchoring of all the currently anchored Ghostel windows.
 The minibuffer when used with packages such as Vertico can cause a resize of
 a Ghostel window making it lose its anchoring."
-  (when-let* ((anchored (cl-delete-if-not #'ghostel--window-anchored-p
-                                          (window-list))))
+  (when-let* ((anchored (cl-loop for win in (window-list)
+                                 when (ghostel--window-anchored-p win)
+                                 collect (cons win (window-buffer win)))))
     (run-at-time 0 nil
                  (lambda ()
-                   (dolist (win anchored) (ghostel--anchor-window win))))))
+                   (dolist (entry anchored)
+                     (let ((win (car entry))
+                           (buffer (cdr entry)))
+                       (when (and (window-live-p win)
+                                  (eq (window-buffer win) buffer))
+                         (ghostel--anchor-window win))))))))
 
 
 ;;; Major mode

--- a/test/ghostel-scroll-test.el
+++ b/test/ghostel-scroll-test.el
@@ -168,6 +168,41 @@ SPEC is (BUFFER TERM ANCHORED-WINDOW HISTORY-WINDOW)."
 							  (should (= history-point-before (window-point history)))
 							  (should-not (ghostel-test-scroll--bottom-visible-p history)))))
 
+(ert-deftest ghostel-test-minibuffer-exit-skips-replaced-window-buffer ()
+  "A deferred minibuffer re-anchor only applies to the captured buffer."
+  (let ((orig-config (current-window-configuration))
+        (ghostel-buf (generate-new-buffer " *ghostel-test-minibuffer*"))
+        (doc-buf (generate-new-buffer " *ghostel-test-doc*"))
+        timer-fn)
+    (unwind-protect
+        (progn
+          (delete-other-windows)
+          (with-current-buffer ghostel-buf
+            (ghostel-mode))
+          (set-window-buffer (selected-window) ghostel-buf)
+          (should (ghostel--window-anchored-p (selected-window)))
+          (cl-letf (((symbol-function 'run-at-time)
+                     (lambda (_secs _repeat function &rest args)
+                       (setq timer-fn (lambda () (apply function args)))
+                       'ghostel-test-timer)))
+            (ghostel--minibuffer-exit))
+          (should timer-fn)
+          (with-current-buffer doc-buf
+            (dotimes (i 500)
+              (insert (format "line %d\n" i)))
+            (goto-char (point-min)))
+          (set-window-buffer (selected-window) doc-buf)
+          (set-window-start (selected-window) (point-min) t)
+          (set-window-point (selected-window) (point-min))
+          (funcall timer-fn)
+          (should (= (window-start) (point-min)))
+          (should (= (window-point) (point-min))))
+      (set-window-configuration orig-config)
+      (when (buffer-live-p ghostel-buf)
+        (kill-buffer ghostel-buf))
+      (when (buffer-live-p doc-buf)
+        (kill-buffer doc-buf)))))
+
 (defun ghostel-test-scroll--set-gui-anchor-start (win)
   "Park WIN's `window-start' at the GUI-anchored steady state.
 The graphical branch of `ghostel--anchor-window' parks `window-start' one


### PR DESCRIPTION
## Summary
- Capture `(window . buffer)` pairs for deferred minibuffer reanchors
- Re-anchor only if the window is still live and still showing the captured buffer
- Add a regression test for minibuffer jumps that replace the window buffer

## Tests
- `emacs --batch -Q -L lisp -L test -l ert -l test/ghostel-test-helpers.el -l test/ghostel-scroll-test.el --eval "(ert-run-tests-batch-and-exit 'ghostel-test-minibuffer-exit-skips-replaced-window-buffer)"`
- `make .build/tests/elisp-ghostel-scroll-test.ok`
- `make build .build/tests/native-ghostel-scroll-test.ok`

Closes #395