### PR TITLE
Skip minibuffer reanchor in copy mode

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3071,13 +3071,12 @@ returns to whichever input mode was active before."
       (setq ghostel--pre-readonly-mode nil)
       ;; Return to the live viewport before reenabling terminal input.
       (goto-char (point-max))
-      ;; Force the anchor even when DEC 2026 synchronized output is active.
-      (ghostel--anchor-window)
       (setq ghostel--force-next-redraw t)
       (pcase target
         ('char  (ghostel-char-mode))
         ('emacs (ghostel-emacs-mode))
         (_      (ghostel-semi-char-mode)))
+      (ghostel--anchor-window)
       (ghostel-force-redraw))
     (message "Read-only mode exited")))
 
@@ -6084,9 +6083,13 @@ the bottom of WINDOW."
 (defun ghostel--anchor-window (&optional window)
   "Scroll WINDOW so that the last row is aligned to the bottom of the window.
 In graphical frames, use Emacs's pixel layout for exact bottom alignment.
-In text frames, use line-count geometry with no vscroll."
+In text frames, use line-count geometry with no vscroll.
+Do nothing unless WINDOW displays a live Ghostel terminal."
   (when-let* ((window (or window (selected-window)))
-              (buffer (window-buffer window)))
+              (buffer (window-buffer window))
+              ((with-current-buffer buffer
+                 (and (derived-mode-p 'ghostel-mode)
+                      (ghostel--terminal-live-p)))))
     (with-selected-window window
       (with-current-buffer buffer
         (let ((target (point-max)))

--- a/test/ghostel-scroll-test.el
+++ b/test/ghostel-scroll-test.el
@@ -168,6 +168,29 @@ SPEC is (BUFFER TERM ANCHORED-WINDOW HISTORY-WINDOW)."
 							  (should (= history-point-before (window-point history)))
 							  (should-not (ghostel-test-scroll--bottom-visible-p history)))))
 
+(ert-deftest ghostel-test-minibuffer-exit-preserves-copy-mode-point ()
+  "Minibuffer exit does not re-anchor frozen copy-mode windows."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (ghostel-test-scroll--write-lines term "scroll" 80)
+    (ghostel--redraw term t)
+    (ghostel-test-scroll--anchor-window (selected-window))
+    (setq ghostel--input-mode 'copy)
+    (let ((target (save-excursion
+                    (goto-char (point-max))
+                    (forward-line -3)
+                    (line-beginning-position)))
+          timer-fn)
+      (set-window-point (selected-window) target)
+      (cl-letf (((symbol-function 'run-at-time)
+                 (lambda (_secs _repeat function &rest args)
+                   (setq timer-fn (lambda () (apply function args)))
+                   'ghostel-test-timer)))
+        (ghostel--minibuffer-exit))
+      (should timer-fn)
+      (funcall timer-fn)
+      (should (= target (window-point))))))
+
 (ert-deftest ghostel-test-minibuffer-exit-skips-replaced-window-buffer ()
   "A deferred minibuffer re-anchor only applies to the captured buffer."
   (let ((orig-config (current-window-configuration))
@@ -511,6 +534,7 @@ rows in the viewport — with or without the trailing newline."
          (progn
            (set-window-buffer (selected-window) buf)
            (with-current-buffer buf
+             (ghostel-mode)
              (let* ((rows (max 1 (window-body-height)))
                     (ghostel--term 'fake)
                     (ghostel--term-rows rows)


### PR DESCRIPTION
## Summary
- only schedule minibuffer-exit reanchors for live ghostel terminals
- recheck that deferred reanchors still target the same live ghostel buffer
- add a regression test for frozen copy-mode windows

## Test
- `make -C /private/tmp/ghostel-394 .build/tests/native-ghostel-scroll-test.ok`

Fixes #394