### PR TITLE
Treat the click that refocuses a frame as a focus click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to this project will be documented in this file.
 - Char mode now captures GUI `C-SPC` and forwards it to the terminal as NUL;
   previously only the TTY `C-@` representation was bound, so a GUI
   Ctrl+Space in char mode fell through to the global `set-mark-command`.
+- A single left-click that gives an Emacs frame input focus — clicking back
+  into Emacs from another application, or into another Emacs frame — no longer
+  enters copy mode; it is treated as a pure focus click like a click in a
+  previously-unselected window (#403).
 
 ## [0.34.0] — 2026-06-08
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -777,7 +777,8 @@ Customize the faces `ghostel-fake-cursor' and
 
 Has no effect when a DEC mouse-tracking mode (1000/1002/1003) is
 active (the press is forwarded to the program) or when the buffer
-is not in semi-char-mode when the gesture completes."
+is not in semi-char-mode when the gesture completes.
+A click that focuses the window or its frame never switches mode."
   :type '(choice (const :tag "Copy mode (default)" copy)
                  (const :tag "Emacs mode"          emacs)
                  (const :tag "Do not switch"       nil)))
@@ -2490,9 +2491,9 @@ Return non-nil if the event was forwarded (mouse tracking is active)."
 ;;; Mouse input
 
 (defvar ghostel--mouse-press-was-selected nil
-  "Non-nil if the window under the last left-press was already selected.
-Set at press, read at release to tell a focus click (which only focuses)
-from a click in an already-focused window (which enters copy mode).")
+  "Non-nil if the last left-press hit an already-selected window.
+Nil also when the press is the click that focused the frame.  Read
+at release to tell a focus click from an interaction click.")
 
 (defvar-local ghostel--mouse-drag-button nil
   "Button number held during an in-progress mouse-tracking drag.
@@ -2651,11 +2652,20 @@ to consume mouse input."
   "Forward EVENT to the terminal, or hand off to `mouse-drag-region'.
 With a DEC mouse-tracking mode (1000/1002/1003) on, forwards the press
 to the program; otherwise hands off to `mouse-drag-region'.  Records in
-`ghostel--mouse-press-was-selected' whether the window was already
-selected before focusing it, for `ghostel-mouse-release-or-set-point'."
+`ghostel--mouse-press-was-selected' whether the window was already selected,
+in an already-focused frame, before focusing it, for
+`ghostel-mouse-release-or-set-point'."
   (interactive "e")
-  (let ((win (posn-window (event-start event))))
-    (setq ghostel--mouse-press-was-selected (eq win (selected-window)))
+  (let* ((win (posn-window (event-start event)))
+         (frame (window-frame win))
+         ;; First press since the frame gained focus, or press dispatched
+         ;; before the focus-in (nil, not `unknown'): a focus click (#403).
+         (refocused (or (frame-parameter frame 'ghostel--frame-refocused)
+                        (null (frame-focus-state frame)))))
+    (set-frame-parameter frame 'ghostel--frame-refocused nil)
+
+    (setq ghostel--mouse-press-was-selected
+          (and (eq win (selected-window)) (not refocused)))
     (select-window win)
     (if (ghostel--mouse-tracking-active-p)
         (ghostel--mouse-press event)
@@ -2668,10 +2678,10 @@ selected before focusing it, for `ghostel-mouse-release-or-set-point'."
   "Forward EVENT to the terminal, or set point / switch input mode.
 With tracking off, sets point (PROMOTE-TO-REGION keeps the word/line
 selection of a multi-click) and, in semi-char mode, switches to
-`ghostel-mouse-drag-input-mode' after a multi-click or a single click
-in an already-selected window.  A single click that only focuses a
-previously-unselected window instead snaps point to the live cursor and
-stays in semi-char (skipped when `ghostel-mouse-drag-input-mode' is nil)."
+`ghostel-mouse-drag-input-mode' after a multi-click or a single click in an
+already-selected window.  A single click that only focuses a previously
+unselected window or frame instead snaps point to the live cursor and stays
+in semi-char (skipped when `ghostel-mouse-drag-input-mode' is nil)."
   (interactive "e\np")
   (let ((active (and ghostel-mouse-drag-input-mode
                      (eq ghostel--input-mode 'semi-char))))
@@ -5310,11 +5320,15 @@ and the buffer is the active selection within it)."
 
 (defun ghostel--focus-change (&rest _)
   "Update focus state for every live ghostel buffer.
-Called from `after-focus-change-function',
-`window-selection-change-functions', and
-`window-buffer-change-functions'.  Sends a focus event only when
-the buffer's logical focus state transitions; `ghostel--focus-event'
-further gates on terminal mode 1004."
+Called from `after-focus-change-function', `window-selection-change-functions',
+`window-buffer-change-functions'.  Sends a focus event only when the buffer's
+logical focus state transitions.  Further gates on terminal mode 1004.
+Also flags just-refocused frames for `ghostel-mouse-press-or-copy-mode'."
+  (dolist (frame (frame-list))
+    (let ((focused (eq (frame-focus-state frame) t)))
+      (unless (eq focused (frame-parameter frame 'ghostel--frame-focused))
+        (set-frame-parameter frame 'ghostel--frame-focused focused)
+        (set-frame-parameter frame 'ghostel--frame-refocused focused))))
   (dolist (buf (buffer-list))
     (when (buffer-live-p buf)
       (with-current-buffer buf
@@ -5323,9 +5337,9 @@ further gates on terminal mode 1004."
                    ghostel--process
                    (process-live-p ghostel--process))
           (let ((focused (and (ghostel--buffer-focused-p buf) t)))
-            (unless (eq focused ghostel--focus-state)
-              (when (ghostel--focus-event ghostel--term focused)
-                (setq ghostel--focus-state focused)))))))))
+            (when (and (not (eq focused ghostel--focus-state))
+                       (ghostel--focus-event ghostel--term focused))
+              (setq ghostel--focus-state focused))))))))
 
 
 ;;; Process management

--- a/test/ghostel-mouse-paste-test.el
+++ b/test/ghostel-mouse-paste-test.el
@@ -352,6 +352,7 @@ mode or otherwise interfere."
   "Release with no tracking hands off to `mouse-set-point'."
   :tags '(native)
   (let ((fake-event `(mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (ghostel--mouse-press-was-selected t)
         (set-point-arg nil)
         (mouse-event-called nil))
     (with-temp-buffer
@@ -373,6 +374,7 @@ without forwarding the second arg, `mouse-set-point' would just
 move point and clobber the word selection set by `mouse-drag-region'."
   :tags '(native)
   (let ((fake-event `(double-mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+        (ghostel--mouse-press-was-selected t)
         (set-point-promote nil))
     (with-temp-buffer
       (setq-local ghostel--term 'fake)
@@ -550,22 +552,104 @@ switch to, so the click just sets point and enters no mode."
       (should emacs-mode-called)
       (should-not copy-mode-called))))
 
-(ert-deftest ghostel-test-mouse-1-press-records-was-selected ()
-  "Press records `ghostel--mouse-press-was-selected' for the clicked window.
-The window in the event equals `(selected-window)', so the press flags
-it as an already-selected (non-focus) click."
+(defmacro ghostel-test--with-click (focus-state &rest body)
+  "Run BODY in a stubbed semi-char buffer where (click) does press + release.
+FOCUS-STATE is what `frame-focus-state' reports.  BODY observes the
+outcome via `copy-mode-called' (reset by each click) and point."
+  (declare (indent 1))
+  `(let ((ghostel-mouse-drag-input-mode 'copy)
+         (ghostel--mouse-press-was-selected nil)
+         (copy-mode-called nil))
+     (with-temp-buffer
+       (setq-local ghostel--term 'fake)
+       (setq-local ghostel--input-mode 'semi-char)
+       (unwind-protect
+           (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                      (lambda (_term _mode) nil))
+                     ((symbol-function 'mouse-drag-region) (lambda (_event) nil))
+                     ((symbol-function 'mouse-set-point)
+                      (lambda (_event &optional _promote) nil))
+                     ((symbol-function 'select-window) (lambda (&rest _) nil))
+                     ((symbol-function 'frame-focus-state)
+                      (lambda (&optional _f) ,focus-state))
+                     ((symbol-function 'ghostel-copy-mode)
+                      (lambda () (setq copy-mode-called t))))
+             (cl-flet ((click ()
+                         (setq copy-mode-called nil)
+                         (ghostel-mouse-press-or-copy-mode
+                          `(down-mouse-1 (,(selected-window) 1 (10 . 5) 0)))
+                         (ghostel-mouse-release-or-set-point
+                          `(mouse-1 (,(selected-window) 1 (10 . 5) 0)) 1)))
+               ,@body))
+         (set-frame-parameter nil 'ghostel--frame-refocused nil)))))
+
+(ert-deftest ghostel-test-mouse-1-click-focused-frame-enters-copy-mode ()
+  "Single click in a selected window of a focused frame enters copy mode."
   :tags '(native)
-  (let ((fake-event `(down-mouse-1 (,(selected-window) 1 (10 . 5) 0)))
-        (ghostel--mouse-press-was-selected nil))
-    (with-temp-buffer
-      (setq-local ghostel--term 'fake)
-      (setq-local ghostel--input-mode 'semi-char)
-      (cl-letf (((symbol-function 'ghostel--mode-enabled)
-                 (lambda (_term _mode) nil))
-                ((symbol-function 'mouse-drag-region) (lambda (_event) nil))
-                ((symbol-function 'select-window) (lambda (&rest _) nil)))
-        (ghostel-mouse-press-or-copy-mode fake-event))
-      (should ghostel--mouse-press-was-selected))))
+  (ghostel-test--with-click t
+    (set-frame-parameter nil 'ghostel--frame-refocused nil)
+    (click)
+    (should copy-mode-called)))
+
+(ert-deftest ghostel-test-mouse-1-click-refocused-frame-is-focus-click ()
+  "First click after the frame regains focus only focuses; the second freezes.
+The window stays selected while the frame is in the background (#403)."
+  :tags '(native)
+  (ghostel-test--with-click t
+    (insert "hello world")
+    (setq-local ghostel--cursor-char-pos 11)
+    (goto-char 8)
+    (set-frame-parameter nil 'ghostel--frame-refocused t)
+    (click)
+    (should-not copy-mode-called)
+    (should (= (point) 11))             ; snapped to the live cursor
+    (click)
+    (should copy-mode-called)))
+
+(ert-deftest ghostel-test-mouse-1-click-before-focus-in-is-focus-click ()
+  "Click dispatched before the focus-in is processed only focuses."
+  :tags '(native)
+  (ghostel-test--with-click nil
+    (set-frame-parameter nil 'ghostel--frame-refocused nil)
+    (click)
+    (should-not copy-mode-called)))
+
+(ert-deftest ghostel-test-mouse-1-click-focus-unknown-enters-copy-mode ()
+  "Click with `frame-focus-state' `unknown' still enters copy mode.
+Treating `unknown' as unfocused would break click->copy-mode on ttys."
+  :tags '(native)
+  (ghostel-test--with-click 'unknown
+    (set-frame-parameter nil 'ghostel--frame-refocused nil)
+    (click)
+    (should copy-mode-called)))
+
+(ert-deftest ghostel-test-focus-change-flags-refocused-frame ()
+  "`ghostel--focus-change' sets the refocus flag on focus gain, clears on loss."
+  :tags '(native)
+  (let ((state nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'frame-focus-state)
+                   (lambda (&optional _f) state))
+                  ;; Keep the buffer focus-event loop inert.
+                  ((symbol-function 'buffer-list) (lambda () nil)))
+          (set-frame-parameter nil 'ghostel--frame-focused nil)
+          (set-frame-parameter nil 'ghostel--frame-refocused nil)
+          (ghostel--focus-change)
+          (should-not (frame-parameter nil 'ghostel--frame-refocused))
+          (setq state t)
+          (ghostel--focus-change)
+          (should (frame-parameter nil 'ghostel--frame-refocused))
+          ;; No transition: a consumed flag stays consumed.
+          (set-frame-parameter nil 'ghostel--frame-refocused nil)
+          (ghostel--focus-change)
+          (should-not (frame-parameter nil 'ghostel--frame-refocused))
+          ;; Losing focus clears a pending flag.
+          (set-frame-parameter nil 'ghostel--frame-refocused t)
+          (setq state nil)
+          (ghostel--focus-change)
+          (should-not (frame-parameter nil 'ghostel--frame-refocused)))
+      (set-frame-parameter nil 'ghostel--frame-focused nil)
+      (set-frame-parameter nil 'ghostel--frame-refocused nil))))
 
 (ert-deftest ghostel-test-mouse-1-release-tracking-forwards ()
   "Release with active tracking forwards via `ghostel--mouse-release'."


### PR DESCRIPTION
A left-click that gives an Emacs frame input focus - clicking back in
from another application or from another Emacs frame - entered copy
mode: the window inside the frame stays selected while the frame is in
the background, and the focus-in is processed before the press command
runs, so the press looked like a click in an already-selected window
and a4e4127 put the buffer in copy-mode on release.

`ghostel--focus-change' now records per-frame focus transitions in the
frame parameters `ghostel--frame-focused' / `ghostel--frame-refocused';
`ghostel-mouse-press-or-copy-mode' consumes the pending refocus flag and
records such a press as a focus click, likewise when the frame still
reports definitely-unfocused (press dispatched before the focus-in was
processed).  `unknown' focus state (terminals without focus reporting)
is not treated as unfocused so click->copy-mode keeps working there.

Consume-on-press means the *first* left click after the frame regains
focus is the focus click, even if it comes long after the refocus
(e.g. alt-tab, type, then click) - a deliberate tradeoff over timestamp
heuristics, which misfire when event processing is delayed between the
focus-in and the click.

Fixes #403