### PR TITLE
Enter copy/Emacs mode when the mark is activated in semi-char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Activating the mark in semi-char mode (`C-SPC` / `set-mark-command`,
+  expand-region variants, `C-x h`, or any other region-activating command)
+  now switches to a read-only mode, mirroring mouse selection, so streaming
+  output cannot clobber a keyboard-driven region.  Implemented via a
+  buffer-local `activate-mark-hook`, so it works for whatever command the
+  user has bound — no specific keys are intercepted.  The target mode is
+  picked by the new `ghostel-mark-activation-input-mode` defcustom (`copy`
+  default, `emacs`, or nil to keep the old stay-in-semi-char behavior).
+  Mouse selection still follows `ghostel-mouse-drag-input-mode`
+  independently.
+
+### Fixed
+- Char mode now captures GUI `C-SPC` and forwards it to the terminal as NUL;
+  previously only the TTY `C-@` representation was bound, so a GUI
+  Ctrl+Space in char mode fell through to the global `set-mark-command`.
+
 ## [0.34.0] — 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -297,6 +297,17 @@ no mode switch.  When a TUI has DEC mouse-tracking enabled
 (1000/1002/1003 — htop, lazygit, etc.) the click is forwarded to the
 program and none of the above applies.
 
+Keyboard selections get the same protection: when a command activates
+the mark in semi-char mode — `C-SPC` (`set-mark-command`), an
+expand-region variant, `C-x h`, anything that turns the region on —
+ghostel switches to the mode picked by
+`ghostel-mark-activation-input-mode` (default `'copy`; also `'emacs`,
+or `nil` to stay in semi-char).  This hooks mark *activation* rather
+than any particular key, so custom bindings such as
+`set-mark-or-expand` trigger it too.  On a TTY, Ctrl+Space is
+indistinguishable from `C-@` (NUL) and is forwarded to the terminal
+instead; in char mode Ctrl+Space always reaches the terminal as NUL.
+
 ### Line mode
 
 Entered with `C-c C-l`.  Line mode buffers the user's input locally in

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -782,6 +782,20 @@ is not in semi-char-mode when the gesture completes."
                  (const :tag "Emacs mode"          emacs)
                  (const :tag "Do not switch"       nil)))
 
+(defcustom ghostel-mark-activation-input-mode 'copy
+  "Input mode to switch to when the mark becomes active in semi-char mode.
+Triggered by any command that activates the region, e.g. `set-mark-command',
+expand-region variants, `mark-whole-buffer', `exchange-point-and-mark'.
+
+Mouse selection is governed separately by `ghostel-mouse-drag-input-mode'."
+  :type '(choice (const :tag "Copy mode (default)" copy)
+                 (const :tag "Emacs mode"          emacs)
+                 (const :tag "Do not switch"       nil)))
+
+(defvar ghostel--inhibit-mark-activation nil
+  "When non-nil, `ghostel--mark-activated' is a no-op.
+Bound by the mouse handlers, which pick the input mode themselves.")
+
 (defcustom ghostel-word-boundary-string " \t\"'`|:;,()[]{}<>$│"
   "Characters that terminate words in ghostel buffers.
 
@@ -1554,7 +1568,7 @@ Matches Ghostty 1.2.0's `bold-color' configuration."
   "The position of the terminal cursor in the buffer.")
 
 (defvar-local ghostel--rendered-font nil
-  "The font last used for rendering. Internally used by native code.")
+  "The font last used for rendering.  Internally used by native code.")
 
 (defvar ghostel--query-font-cache nil
   "Dynamically bound cache for `query-font' during one native redraw.")
@@ -1789,12 +1803,16 @@ When NO-EXCEPTIONS is non-nil, also bind the keys in
   ;; the `[M-backspace]' symbol path; without this binding, TTY
   ;; Alt-Backspace falls through to global `backward-kill-word'.
   (define-key map (kbd "M-DEL") #'ghostel--send-event)
-  ;; C-@ (NUL, same as C-SPC) — used by programs like Emacs-in-terminal
+  ;; Ctrl+Space is NUL. A TTY delivers it as `C-@'.  GUI Emacs as the distinct
+  ;; event `C-SPC', which only char mode captures.  In semi-char `C-SPC' falls
+  ;; through to the global map so mark commands run there.
   (define-key map (kbd "C-@")
               (lambda () (interactive) (ghostel--send-string "\x00")))
   ;; Char mode extras: also bind non-letter exception keys so nothing
   ;; gets stolen by Emacs while a TUI app runs.
   (when no-exceptions
+    (define-key map (kbd "C-SPC")
+                (lambda () (interactive) (ghostel--send-string "\x00")))
     (define-key map (kbd "C-\\")
                 (lambda () (interactive) (ghostel--send-string "\x1c")))
     (define-key map (kbd "M-:") #'ghostel--send-event)))
@@ -2641,7 +2659,10 @@ selected before focusing it, for `ghostel-mouse-release-or-set-point'."
     (select-window win)
     (if (ghostel--mouse-tracking-active-p)
         (ghostel--mouse-press event)
-      (mouse-drag-region event))))
+      ;; `mouse-drag-region' activates the mark mid-drag; the release
+      ;; handler picks the input mode, so keep the hook out of it.
+      (let ((ghostel--inhibit-mark-activation t))
+        (mouse-drag-region event)))))
 
 (defun ghostel-mouse-release-or-set-point (event &optional promote-to-region)
   "Forward EVENT to the terminal, or set point / switch input mode.
@@ -2667,7 +2688,8 @@ stays in semi-char (skipped when `ghostel-mouse-drag-input-mode' is nil)."
      ;; Multi-click, or a single click in an already-selected window: set
      ;; point/selection, then freeze (a focus click never reaches here).
      (t
-      (mouse-set-point event promote-to-region)
+      (let ((ghostel--inhibit-mark-activation t))
+        (mouse-set-point event promote-to-region))
       (when active
         (pcase ghostel-mouse-drag-input-mode
           ('copy  (ghostel-copy-mode))
@@ -2685,7 +2707,8 @@ region is set to mode configured in `ghostel-mouse-drag-input-mode'."
   (interactive "e")
   (if (ghostel--mouse-tracking-active-p)
       (ghostel--mouse-drag event)
-    (mouse-set-region event)
+    (let ((ghostel--inhibit-mark-activation t))
+      (mouse-set-region event))
     (when (eq ghostel--input-mode 'semi-char)
       (pcase ghostel-mouse-drag-input-mode
         ('copy  (ghostel-copy-mode))
@@ -3061,6 +3084,17 @@ returns to whichever input mode was active before."
       (ghostel-readonly-exit)
     (ghostel--enter-readonly 'copy t ":Copy"
                              "Copy mode: Press any key to exit")))
+
+(defun ghostel--mark-activated ()
+  "Switch input mode when the region becomes active in semi-char mode.
+On buffer-local `activate-mark-hook'; the keyboard analog of
+`ghostel-mouse-drag-or-set-region'.  Runs after the activating
+command set the region, so the selection survives the switch."
+  (when (and (not ghostel--inhibit-mark-activation)
+             (eq ghostel--input-mode 'semi-char))
+    (pcase ghostel-mark-activation-input-mode
+      ('copy  (ghostel-copy-mode))
+      ('emacs (ghostel-emacs-mode)))))
 
 (defun ghostel-readonly-exit ()
   "Exit copy or Emacs mode and return to the mode active before entry."
@@ -6370,6 +6404,7 @@ a Ghostel window making it lose its anchoring."
   (add-hook 'window-buffer-change-functions #'ghostel--window-buffer-change nil t)
   (add-hook 'window-buffer-change-functions #'ghostel--sync-tty-composition nil t)
   (add-hook 'window-size-change-functions #'ghostel--anchor-on-resize nil t)
+  (add-hook 'activate-mark-hook #'ghostel--mark-activated nil t)
   (add-hook 'minibuffer-exit-hook #'ghostel--minibuffer-exit)
   (ghostel--suppress-interfering-modes)
   (ghostel-imenu-setup)

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -774,5 +774,115 @@ Exiting returns to whatever mode the user was in beforehand, mirroring
               (should-not buffer-read-only))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-mark-activation-enters-copy-mode ()
+  "Activating the mark in semi-char enters copy mode; the region survives."
+  (let ((buf (generate-new-buffer " *ghostel-test-mark-copy*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake)
+                (ghostel--redraw-timer nil)
+                (ghostel-mark-activation-input-mode 'copy)
+                ;; Batch Emacs has no transient-mark-mode, which makes
+                ;; the `deactivate-mark' on exit a no-op.
+                (transient-mark-mode t))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--anchor-window) #'ignore))
+              (insert "some terminal output")
+              (goto-char 5)
+              ;; Any mark-activating command works; C-SPC's is the canonical one.
+              (set-mark-command nil)
+              (should (eq ghostel--input-mode 'copy))
+              (should (= (mark) 5))
+              (should mark-active)
+              ;; Exiting returns to semi-char and drops the region.
+              (ghostel-readonly-exit)
+              (should (eq ghostel--input-mode 'semi-char))
+              (should-not mark-active))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-mark-activation-enters-emacs-mode ()
+  "With `ghostel-mark-activation-input-mode' set to `emacs', Emacs mode."
+  (let ((buf (generate-new-buffer " *ghostel-test-mark-emacs*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake)
+                (ghostel--redraw-timer nil)
+                (ghostel-mark-activation-input-mode 'emacs))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--anchor-window) #'ignore))
+              (set-mark-command nil)
+              (should (eq ghostel--input-mode 'emacs))
+              (should (= (mark) (point)))
+              (should mark-active))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-mark-activation-nil-stays-semi-char ()
+  "With `ghostel-mark-activation-input-mode' nil, no mode switch happens."
+  (let ((buf (generate-new-buffer " *ghostel-test-mark-nil*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake)
+                (ghostel-mark-activation-input-mode nil))
+            (set-mark-command nil)
+            (should (eq ghostel--input-mode 'semi-char))
+            (should mark-active)))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-mark-activation-only-in-semi-char ()
+  "Mark activation in char or copy mode does not switch (or toggle) modes."
+  (let ((buf (generate-new-buffer " *ghostel-test-mark-other-modes*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake)
+                (ghostel--redraw-timer nil)
+                (ghostel-mark-activation-input-mode 'copy))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--anchor-window) #'ignore))
+              ;; Char mode: marking must not yank the user out of the TUI.
+              (ghostel-char-mode)
+              (push-mark (point) t t)
+              (should (eq ghostel--input-mode 'char))
+              (ghostel-semi-char-mode)
+              ;; Copy mode: marking must not toggle copy mode back off.
+              (ghostel-copy-mode)
+              (push-mark (point) t t)
+              (should (eq ghostel--input-mode 'copy)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-mark-activation-mouse-knob-wins ()
+  "A mouse drag follows `ghostel-mouse-drag-input-mode', not the mark knob."
+  (let ((buf (generate-new-buffer " *ghostel-test-mark-mouse*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake)
+                (ghostel--redraw-timer nil)
+                (ghostel-mouse-drag-input-mode 'emacs)
+                (ghostel-mark-activation-input-mode 'copy))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--anchor-window) #'ignore)
+                      ((symbol-function 'ghostel--mouse-tracking-active-p)
+                       (lambda () nil))
+                      ;; The real mouse-set-region activates the mark.
+                      ((symbol-function 'mouse-set-region)
+                       (lambda (_event) (push-mark (point) t t))))
+              (ghostel-mouse-drag-or-set-region nil)
+              ;; The mouse knob picked the mode — the hook stayed out.
+              (should (eq ghostel--input-mode 'emacs)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-ctrl-space-keybindings ()
+  "Char mode captures both Ctrl+Space events; semi-char only TTY `C-@'.
+GUI `C-SPC' must stay unbound in semi-char so it falls through to the
+global mark command, whose activation `ghostel--mark-activated' handles."
+  (should-not (lookup-key ghostel-semi-char-mode-map (kbd "C-SPC")))
+  (should (functionp (lookup-key ghostel-semi-char-mode-map (kbd "C-@"))))
+  (dolist (key '("C-SPC" "C-@"))
+    (should (functionp (lookup-key ghostel-char-mode-map (kbd key))))))
+
 (provide 'ghostel-modes-test)
 ;;; ghostel-modes-test.el ends here


### PR DESCRIPTION
Keyboard selections now get the same protection mouse selections do:
when a command activates the region in semi-char mode, switch to a
read-only mode so streaming terminal output cannot clobber it.

Implemented as a buffer-local `activate-mark-hook' rather than a key
binding, so it fires for whatever command the user runs --
`set-mark-command' (C-SPC), expand-region variants, `mark-whole-buffer',
a custom `set-mark-or-expand', etc. -- instead of intercepting one key.
The target mode is the new `ghostel-mark-activation-input-mode' defcustom
(copy default, emacs, or nil to keep the old stay-in-semi-char behavior).

The mouse handlers bind `ghostel--inhibit-mark-activation' around
`mouse-drag-region' / `mouse-set-region' / `mouse-set-point' so mouse
selection keeps following `ghostel-mouse-drag-input-mode' independently
and the mid-drag activation can't swap keymaps during the gesture.

Also bind GUI C-SPC in char mode to send NUL: previously only the TTY
C-@ representation was bound, so a GUI Ctrl+Space in char mode leaked
through to the global `set-mark-command'.