### PR TITLE
Clamp fallback glyph scale per-side (ascent/descent) to stop whole-row jitter

### DIFF
--- a/src/GlyphMetricsCache.zig
+++ b/src/GlyphMetricsCache.zig
@@ -41,7 +41,7 @@ pub const Key = struct {
     }
 };
 
-pub const Metrics = struct { width: i64, height: i64 };
+pub const Metrics = struct { width: i64, ascent: i64, descent: i64 };
 
 pub fn put(self: *Self, alloc: Allocator, key: Key, metrics: Metrics) !void {
     std.debug.assert(key.utf8 == .borrowed);
@@ -109,7 +109,7 @@ test "GlyphMetricsCache: put and then get" {
     defer cache.deinit(testing.allocator);
 
     const key = testKey(1, 2, "A");
-    const metrics: Metrics = .{ .width = 10, .height = 20 };
+    const metrics: Metrics = .{ .width = 10, .ascent = 12, .descent = 8 };
 
     try cache.put(testing.allocator, key, metrics);
 
@@ -121,8 +121,8 @@ test "GlyphMetricsCache: put, replace, and then get" {
     defer cache.deinit(testing.allocator);
 
     const key = testKey(1, 2, "A");
-    const initial: Metrics = .{ .width = 10, .height = 20 };
-    const replacement: Metrics = .{ .width = 30, .height = 40 };
+    const initial: Metrics = .{ .width = 10, .ascent = 12, .descent = 8 };
+    const replacement: Metrics = .{ .width = 30, .ascent = 22, .descent = 18 };
 
     try cache.put(testing.allocator, key, initial);
     const utf8_buf_len = cache.utf8_buf.items.len;

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -70,7 +70,8 @@ const MaterializedPage = struct {
 
 const FontInfo = struct {
     width: u32,
-    height: u32,
+    ascent: u32,
+    descent: u32,
     coverage: u32,
     glyph_scale_floor: f64,
     metrics_cache: GlyphMetricsCache = .{},
@@ -232,7 +233,8 @@ fn updateFontInfo(self: *Self, alloc: Allocator, env: emacs.Env) bool {
 
         self.font_info = .{
             .width = env.cast(u32, env.vecGet(default_font_info, 6)),
-            .height = cell_ascent + cell_descent,
+            .ascent = cell_ascent,
+            .descent = cell_descent,
             .coverage = probeCoverage(env, new_font),
             .glyph_scale_floor = floor,
         };
@@ -605,7 +607,9 @@ fn adjustGlyph(
     var slot_width = default_font_info.width * char_width;
 
     // Skip adjustments if size already matches perfectly
-    if (metrics.width == slot_width and metrics.height == default_font_info.height) return;
+    if (metrics.width == slot_width and
+        metrics.ascent == default_font_info.ascent and
+        metrics.descent == default_font_info.descent) return;
 
     // Let's check if we can claim some space after the glyph to be able to render
     // it larger than the cell size while still maintaining alignment.
@@ -615,9 +619,9 @@ fn adjustGlyph(
         slot_width = default_font_info.width * char_width;
     }) {
         const cell_aspect = @as(f64, @floatFromInt(slot_width)) /
-            @as(f64, @floatFromInt(default_font_info.height));
+            @as(f64, @floatFromInt(default_font_info.ascent + default_font_info.descent));
         const glyph_aspect = @as(f64, @floatFromInt(metrics.width)) /
-            @as(f64, @floatFromInt(metrics.height));
+            @as(f64, @floatFromInt(metrics.ascent + metrics.descent));
         // If the aspect of the glyph is narrower than that of the cell, we're done
         if (glyph_aspect < cell_aspect) break;
 
@@ -639,12 +643,22 @@ fn adjustGlyph(
         }
     }
 
-    // We add a fudge factor of +1 to the denominator to ensure fit
+    // We add a fudge factor of +1 to the denominator to ensure fit.
+    //
+    // Height is clamped per side, not on the sum: the row realizes
+    // max(ascent) + max(descent) across all glyphs sharing the baseline, so a
+    // glyph grows the row if either its ascent exceeds the default ascent or
+    // its descent exceeds the default descent.  Scaling by the sum ratio
+    // (default_height / glyph_height) can leave one side over the line — e.g. a
+    // glyph that is tall above the baseline but shallow below it.  Bounding
+    // each side independently is the exact clamp.
     const scale_width = @as(f64, @floatFromInt(slot_width)) /
         @as(f64, @floatFromInt(metrics.width + 1));
-    const scale_height = @as(f64, @floatFromInt(default_font_info.height)) /
-        @as(f64, @floatFromInt(metrics.height + 1));
-    const computed_scale = @min(scale_width, scale_height);
+    const scale_ascent = @as(f64, @floatFromInt(default_font_info.ascent)) /
+        @as(f64, @floatFromInt(metrics.ascent + 1));
+    const scale_descent = @as(f64, @floatFromInt(default_font_info.descent)) /
+        @as(f64, @floatFromInt(metrics.descent + 1));
+    const computed_scale = @min(scale_width, @min(scale_ascent, scale_descent));
     const scale = @max(computed_scale, default_font_info.glyph_scale_floor);
 
     const min_width_spec = env.list(.{ s.@"min-width", env.list(.{char_width}) });
@@ -682,15 +696,21 @@ fn getGlyphMetrics(
     // [FONT-OBJECT CHAR ...]
     const font = env.vecGet(header, 0);
     const font_info = env.f("ghostel--query-font-cached", .{font});
+    // Keep ascent and descent separate: the line height is max(ascent) +
+    // max(descent) over the row, so a glyph fits only when its ascent and
+    // descent each fit the default font's — the sum is not enough.
     const ascent = env.cast(i64, env.vecGet(font_info, 4));
     const descent = env.cast(i64, env.vecGet(font_info, 5));
-    const height = ascent + descent;
 
     // Each element is a vector containing information of a glyph in this format:
     // [FROM-IDX TO-IDX C CODE WIDTH LBEARING RBEARING ASCENT DESCENT ADJUSTMENT]
     const width = env.cast(u32, env.vecGet(glyph, 4));
 
-    const metrics = GlyphMetricsCache.Metrics{ .width = width, .height = height };
+    const metrics = GlyphMetricsCache.Metrics{
+        .width = width,
+        .ascent = ascent,
+        .descent = descent,
+    };
     if (self.font_info) |*fi| {
         try fi.metrics_cache.put(alloc, borrowed_key, metrics);
     }

--- a/test/ghostel-glyph-test.el
+++ b/test/ghostel-glyph-test.el
@@ -146,10 +146,16 @@ SPECS is a plist with these keys:
                  (should (equal (cadr (assq 'min-width disp)) '(2))))))))
       (kill-buffer buf))))
 
-(ert-deftest ghostel-test-glyph-adjust-single-width-small ()
-  "An oversized single-width glyph gets a scale < 1.0 to fit the cell."
+(ert-deftest ghostel-test-glyph-adjust-clamps-on-ascent ()
+  "An oversized glyph is clamped by its ascent when only the ascent overflows.
+The default font is 10 ascent / 10 descent.  This glyph's ascent (20)
+exceeds the default ascent while its descent (5) fits, so the row would
+grow above the baseline.  The scale must bound the ascent side
+\(10/(20+1) ~ 0.476\), which is stricter than the sum ratio
+\(20/(25+1) ~ 0.769\) the old height-based code used and which would have
+left the ascent over the line."
   :tags '(native)
-  (let ((buf (generate-new-buffer " *ghostel-test-glyph-1*")))
+  (let ((buf (generate-new-buffer " *ghostel-test-glyph-ascent*")))
     (unwind-protect
         (save-window-excursion
           (with-selected-window (display-buffer buf)
@@ -159,10 +165,10 @@ SPECS is a plist with these keys:
                    (ghostel--term-rows 5)
                    (inhibit-read-only t)
                    (df (ghostel-test--make-font ghostel-test--default-font-info))
-                   ;; Glyph: 12px wide x 25px tall (larger than 10x20 cell)
+                   ;; ascent 20 > default 10; descent 5 < default 10.
                    (glyph-font (ghostel-test--make-font
-                                ["MockGlyph" "mock.ttf" 12 120 12 13 12 12 0]
-                                [[0 1 ?\u0100 0 12 0 0 12 13 0]])))
+                                ["MockGlyph" "mock.ttf" 12 120 20 5 10 10 0]
+                                [[0 1 ?\u0100 0 10 0 0 20 5 0]])))
               ;; Write a character above the coverage threshold.
               (ghostel--write-input term "\u0100")
               (ghostel-test--with-glyph-mocks
@@ -174,7 +180,45 @@ SPECS is a plist with these keys:
                  (should disp)
                  (let ((scale (cadr (assq 'height disp))))
                    (should scale)
-                   (should (< scale 1.0))))))))
+                   ;; Bound by the ascent side, not the looser sum ratio.
+                   (should (< (abs (- scale (/ 10.0 (1+ 20)))) 1e-6))
+                   (should (< scale (/ 20.0 (1+ 25))))))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-glyph-adjust-clamps-on-descent ()
+  "An oversized glyph is clamped by its descent when only the descent overflows.
+Mirror of the ascent case: this glyph's descent (20) exceeds the default
+descent (10) while its ascent (5) fits.  The scale must bound the descent
+side \(10/(20+1) ~ 0.476\); the sum ratio \(20/(25+1) ~ 0.769\) would
+leave the descent below the line."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-glyph-descent*")))
+    (unwind-protect
+        (save-window-excursion
+          (with-selected-window (display-buffer buf)
+            (ghostel-mode)
+            (let* ((term (ghostel--new 5 80 1000))
+                   (ghostel--term term)
+                   (ghostel--term-rows 5)
+                   (inhibit-read-only t)
+                   (df (ghostel-test--make-font ghostel-test--default-font-info))
+                   ;; ascent 5 < default 10; descent 20 > default 10.
+                   (glyph-font (ghostel-test--make-font
+                                ["MockGlyph" "mock.ttf" 12 120 5 20 10 10 0]
+                                [[0 1 ?\u0100 0 10 0 0 5 20 0]])))
+              (ghostel--write-input term "\u0100")
+              (ghostel-test--with-glyph-mocks
+               (:default-font df
+                              :glyph-font glyph-font)
+               (ghostel--redraw term t)
+               (goto-char (point-min))
+               (let ((disp (get-text-property (point) 'display)))
+                 (should disp)
+                 (let ((scale (cadr (assq 'height disp))))
+                   (should scale)
+                   ;; Bound by the descent side, not the looser sum ratio.
+                   (should (< (abs (- scale (/ 10.0 (1+ 20)))) 1e-6))
+                   (should (< scale (/ 20.0 (1+ 25))))))))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-glyph-adjust-double-width-small ()
@@ -328,7 +372,7 @@ SPECS is a plist with these keys:
 (ert-deftest ghostel-test-glyph-scale-floor-clamps-scale ()
   "A non-zero `ghostel-glyph-scale-floor' prevents shrinking below the floor.
 Sets floor to 1.0 and feeds a glyph larger than the cell.  With floor
-0.0 the glyph would be scaled to ~0.8; with floor 1.0 it stays at 1.0."
+0.0 the glyph would be scaled to ~0.71; with floor 1.0 it stays at 1.0."
   :tags '(native)
   (let ((buf (generate-new-buffer " *ghostel-test-glyph-floor*")))
     (unwind-protect
@@ -342,7 +386,7 @@ Sets floor to 1.0 and feeds a glyph larger than the cell.  With floor
                    (inhibit-read-only t)
                    (df (ghostel-test--make-font ghostel-test--default-font-info))
                    ;; Glyph: 12px wide x 25px tall (larger than 10x20 cell);
-                   ;; without floor this would scale to ~0.8.
+                   ;; without floor this would scale to ~0.71.
                    (glyph-font (ghostel-test--make-font
                                 ["MockGlyph" "mock.ttf" 12 120 12 13 12 12 0]
                                 [[0 1 ?\u0100 0 12 0 0 12 13 0]])))


### PR DESCRIPTION
Fixes #399.

## Problem

A fallback-font glyph can grow its row by 1px even though `adjustGlyph` is supposed to scale it to fit the cell. On TUIs that blink such a glyph in and out every frame (e.g. Claude Code's `⏺`/`⎿` status line), the row grows and shrinks per frame — visible jitter.

## Root cause

Emacs realizes a line's height as `max(ascent) + max(descent)` across all glyphs on the shared baseline. A fallback glyph therefore overflows the cell if **either** its ascent exceeds the default font's ascent **or** its descent exceeds the default descent.

`adjustGlyph` scaled by the *sum* ratio (`default_height / glyph_height`), which does not constrain either side individually. A glyph that is tall above the baseline but shallow below it (measured: `⏺` → Iosevka ascent 12 / descent 3 against a D2Coding 10 / 4 cell) passes the sum test yet still pushes the row 1px over the cell. The `+1` denominator fudge only buys a boundary value, not a margin, so the realized row flips between cell and cell+1 across frames.

## Fix

Cache ascent and descent **separately** — for both the default font (`FontInfo`) and the per-glyph metrics (`GlyphMetricsCache.Metrics`) — and clamp each side independently:

```
scale = min(scale_width,
            default_ascent  / (glyph_ascent  + 1),
            default_descent / (glyph_descent + 1))
```

This is the exact clamp implied by how Emacs lays out the baseline, so it generalizes across font pairings rather than being tuned to one. No per-frame measurement, no caching of fit verdicts, no new tunables.

For `⏺` on D2Coding this yields `min(10/13, 4/4) = 0.769`, which realizes a stable 14px row (verified by measurement) versus the old `0.875` that realized 15px.

## Tests

- `GlyphMetricsCache` unit tests updated for the new `Metrics` shape.
- The height-based glyph test is split into two: one that binds on **ascent** and one that binds on **descent**. Each asserts the scale equals the binding per-side ratio and is strictly below the old sum ratio.
- `zig build`, `zig build test`, and all 12 native glyph tests pass.