### PR TITLE
Detect a refocus click from the focus-in event, not a focus transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,11 @@ All notable changes to this project will be documented in this file.
 - A single left-click that gives an Emacs frame input focus — clicking back
   into Emacs from another application, or into another Emacs frame — no longer
   enters copy mode; it is treated as a pure focus click like a click in a
-  previously-unselected window (#403).
+  previously-unselected window (#403).  The refocus click is now detected from
+  the focus-in event itself rather than a tracked focus transition, so it keeps
+  working when the window system's focus state is stale — notably on macOS (NS),
+  where a dropped focus-out can leave `frame-focus-state' stuck reporting focus
+  and previously made every refocus click enter copy mode after a while.
 
 ## [0.34.0] — 2026-06-08
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2659,7 +2659,7 @@ in an already-focused frame, before focusing it, for
   (let* ((win (posn-window (event-start event)))
          (frame (window-frame win))
          ;; First press since the frame gained focus, or press dispatched
-         ;; before the focus-in (nil, not `unknown'): a focus click (#403).
+         ;; before the focus-in (nil, not `unknown'): a focus click.
          (refocused (or (frame-parameter frame 'ghostel--frame-refocused)
                         (null (frame-focus-state frame)))))
     (set-frame-parameter frame 'ghostel--frame-refocused nil)
@@ -5330,17 +5330,21 @@ and the buffer is the active selection within it)."
                      (eq win (frame-selected-window frame)))))
             (get-buffer-window-list buf nil t)))
 
+(defun ghostel--frame-focus-flags (&rest _)
+  "Flag each focused frame so its next left-press is a focus click.
+For `ghostel-mouse-press-or-copy-mode'; called after a frame focus change."
+  ;; The refocusing click delivers a focus-in just before the press, so flag
+  ;; whichever frame reports focus at the event.  Read it fresh each time, not
+  ;; diffed against a stored value that a dropped focus-out can leave stale.
+  (dolist (frame (frame-list))
+    (set-frame-parameter frame 'ghostel--frame-refocused
+                         (eq (frame-focus-state frame) t))))
+
 (defun ghostel--focus-change (&rest _)
-  "Update focus state for every live ghostel buffer.
+  "Send terminal focus events for every live ghostel buffer.
 Called from `after-focus-change-function', `window-selection-change-functions',
 `window-buffer-change-functions'.  Sends a focus event only when the buffer's
-logical focus state transitions.  Further gates on terminal mode 1004.
-Also flags just-refocused frames for `ghostel-mouse-press-or-copy-mode'."
-  (dolist (frame (frame-list))
-    (let ((focused (eq (frame-focus-state frame) t)))
-      (unless (eq focused (frame-parameter frame 'ghostel--frame-focused))
-        (set-frame-parameter frame 'ghostel--frame-focused focused)
-        (set-frame-parameter frame 'ghostel--frame-refocused focused))))
+logical focus state transitions.  Further gates on terminal mode 1004."
   (dolist (buf (buffer-list))
     (when (buffer-live-p buf)
       (with-current-buffer buf
@@ -6428,6 +6432,7 @@ a Ghostel window making it lose its anchoring."
   (shell-completion-vars)
   (setq ghostel--input-mode 'semi-char)
   (use-local-map ghostel-semi-char-mode-map)
+  (add-function :after after-focus-change-function #'ghostel--frame-focus-flags)
   (add-function :after after-focus-change-function #'ghostel--focus-change)
   (add-hook 'window-selection-change-functions #'ghostel--focus-change)
   (add-hook 'window-buffer-change-functions #'ghostel--focus-change)

--- a/test/ghostel-mouse-paste-test.el
+++ b/test/ghostel-mouse-paste-test.el
@@ -593,7 +593,7 @@ outcome via `copy-mode-called' (reset by each click) and point."
 
 (ert-deftest ghostel-test-mouse-1-click-refocused-frame-is-focus-click ()
   "First click after the frame regains focus only focuses; the second freezes.
-The window stays selected while the frame is in the background (#403)."
+The window stays selected while the frame is in the background."
   :tags '(native)
   (ghostel-test--with-click t
     (insert "hello world")
@@ -623,32 +623,54 @@ Treating `unknown' as unfocused would break click->copy-mode on ttys."
     (click)
     (should copy-mode-called)))
 
-(ert-deftest ghostel-test-focus-change-flags-refocused-frame ()
-  "`ghostel--focus-change' sets the refocus flag on focus gain, clears on loss."
+(ert-deftest ghostel-test-mouse-1-click-stale-focus-is-focus-click ()
+  "Refocus click is a focus click even when `frame-focus-state' reports stale t.
+On NS a frame can keep reporting focus after losing it; the refocusing
+click still delivers a focus-in, which `ghostel--frame-focus-flags' turns
+into a pending flag, so the press is a focus click."
+  :tags '(native)
+  (ghostel-test--with-click t
+    (insert "hello world")
+    (setq-local ghostel--cursor-char-pos 11)
+    (goto-char 8)
+    ;; Frame reports focus with no pending flag yet.
+    (set-frame-parameter nil 'ghostel--frame-refocused nil)
+    ;; The refocusing click delivers a focus-in -> after-focus-change ->
+    (ghostel--frame-focus-flags)
+    (click)
+    (should-not copy-mode-called)
+    (should (= (point) 11))             ; snapped to the live cursor
+    ;; A genuine second interaction click (no new focus-in) freezes.
+    (click)
+    (should copy-mode-called)))
+
+(ert-deftest ghostel-test-frame-focus-flags-event-based ()
+  "`ghostel--frame-focus-flags' flags every frame that reports focus.
+It reads the current focus state on each event, so a frame already
+reporting t is flagged.  `unknown' (ttys) is not t, so unflagged."
   :tags '(native)
   (let ((state nil))
     (unwind-protect
         (cl-letf (((symbol-function 'frame-focus-state)
-                   (lambda (&optional _f) state))
-                  ;; Keep the buffer focus-event loop inert.
-                  ((symbol-function 'buffer-list) (lambda () nil)))
-          (set-frame-parameter nil 'ghostel--frame-focused nil)
-          (set-frame-parameter nil 'ghostel--frame-refocused nil)
-          (ghostel--focus-change)
-          (should-not (frame-parameter nil 'ghostel--frame-refocused))
-          (setq state t)
-          (ghostel--focus-change)
-          (should (frame-parameter nil 'ghostel--frame-refocused))
-          ;; No transition: a consumed flag stays consumed.
-          (set-frame-parameter nil 'ghostel--frame-refocused nil)
-          (ghostel--focus-change)
-          (should-not (frame-parameter nil 'ghostel--frame-refocused))
-          ;; Losing focus clears a pending flag.
+                   (lambda (&optional _f) state)))
+          ;; Unfocused: no flag (and a stale flag is cleared).
           (set-frame-parameter nil 'ghostel--frame-refocused t)
-          (setq state nil)
-          (ghostel--focus-change)
+          (ghostel--frame-focus-flags)
+          (should-not (frame-parameter nil 'ghostel--frame-refocused))
+          ;; Focus-in: flag set.
+          (setq state t)
+          (ghostel--frame-focus-flags)
+          (should (frame-parameter nil 'ghostel--frame-refocused))
+          ;; Flag consumed by a press; a fresh focus-in re-flags a frame
+          ;; that still reports focus.
+          (set-frame-parameter nil 'ghostel--frame-refocused nil)
+          (ghostel--frame-focus-flags)
+          (should (frame-parameter nil 'ghostel--frame-refocused))
+          ;; `unknown' is not t: treated as unfocused, no flag.
+          (setq state 'unknown)
+          (set-frame-parameter nil 'ghostel--frame-refocused nil)
+          (ghostel--frame-focus-flags)
           (should-not (frame-parameter nil 'ghostel--frame-refocused)))
-      (set-frame-parameter nil 'ghostel--frame-focused nil)
       (set-frame-parameter nil 'ghostel--frame-refocused nil))))
 
 (ert-deftest ghostel-test-mouse-1-release-tracking-forwards ()


### PR DESCRIPTION
## Problem

A left-click that refocuses an Emacs frame (clicking back into Emacs from another app, or into another Emacs frame) is meant to be a *pure focus click*: it places point and stays in semi-char mode rather than entering copy mode. In practice it works for a while and then, after some app/frame switch, **every refocus click enters copy mode** and freezes the buffer (#403 regression).

## Root cause

Detection relied on a recorded `nil`→`t` focus *transition* plus `frame-focus-state`. Both signals depend on the window system delivering `focus-out` events — which the macOS **NS port does not do reliably**. A dropped `focus-out` leaves `frame-focus-state` stuck reporting focus *and* the recorded state stuck non-transitioning, so a later refocus click becomes byte-for-byte indistinguishable from an in-window interaction click → copy mode.

This was confirmed:
- a deterministic reproduction (the stale-`t` refocus click is identical to a genuine interaction click at the press handler);
- a live probe on the real NS port (Emacs 32): `frame-focus-state` is demonstrably reachable into a stale-`t` state (e.g. via `x-focus-frame`, frame raises), `focus-out` is not delivered on many paths, and a later real focus change does not clear a stale `t`;
- `nsterm.m`: `windowDidBecomeKey` stores `FOCUS_IN_EVENT` **unconditionally**, so the refocusing click always delivers a fresh `focus-in` regardless of stale internal state.

## Fix

Flag the refocus click from the **`focus-in` event itself** instead of a transition. New `ghostel--frame-focus-flags` runs on `after-focus-change-function` only — never on the redisplay-time window hooks that also drive `ghostel--focus-change` — and marks every frame that currently reports focus. The click that brings a frame to the foreground always delivers a `focus-in` just before the press (even when an earlier `focus-out` was dropped), so reading the live focus state at each focus event is robust where transition tracking is not.

`ghostel--focus-change` keeps only its terminal focus-event duties; the unused `ghostel--frame-focused` parameter is removed. The press handler is unchanged.

### Residual trade-off

If `after-focus-change` fires *spuriously* with the frame focused *between* two interaction clicks (e.g. a command calls `raise-frame`/`select-frame-set-input-focus` mid-session), the next interaction click would be treated as a focus click and skip copy mode. This is rare in pure terminal use and is the inverse, far less disruptive failure. The cross-app case fundamentally requires the `focus-in` signal — there is no focus-event-free discriminator.

## Testing

- `ghostel.el` byte-compiles clean with `byte-compile-error-on-warn`.
- `make test test-native test-zig` → exit 0, 0 unexpected.
- Added `ghostel-test-mouse-1-click-stale-focus-is-focus-click` (the stale-`t` regression — fails on the old code) and `ghostel-test-frame-focus-flags-event-based`; replaced the old transition test.

> Note: interactive focus behaviour can't be exercised through `emacs --batch`; the unit tests + NS source confirm the mechanism, but the true cross-app *click → focus-in → no copy mode* path is best confirmed in a live GUI.