### PR TITLE
Don't enter copy mode on a focus-click micro-drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,19 +20,25 @@ All notable changes to this project will be documented in this file.
 - Char mode now captures GUI `C-SPC` and forwards it to the terminal as NUL;
   previously only the TTY `C-@` representation was bound, so a GUI
   Ctrl+Space in char mode fell through to the global `set-mark-command`.
-- A single left-click that gives an Emacs frame input focus — clicking back
-  into Emacs from another application, or into another Emacs frame — no longer
-  enters copy mode; it is treated as a pure focus click like a click in a
-  previously-unselected window (#403).  The refocus click is now detected from
-  the focus-in event itself rather than a tracked focus transition, so it keeps
-  working when the window system's focus state is stale — notably on macOS (NS),
-  where a dropped focus-out can leave `frame-focus-state' stuck reporting focus
-  and previously made every refocus click enter copy mode after a while.
-- A focus click into an inactive Ghostel window no longer enters copy mode when
-  a tiny involuntary pointer movement makes Emacs report it as `drag-mouse-1`
-  instead of `mouse-1`.  Such a micro-drag selects nothing, so it now stays in
-  semi-char and snaps point to the live cursor, like the single-click focus path
-  (#403).
+- A left-click that only focuses a Ghostel window — bringing the frame to the
+  foreground from another application or Emacs frame, or selecting an unfocused
+  window in the current frame — is now treated as a pure focus click and never
+  enters copy mode (#403).  It snaps point to the live cursor and stays in
+  semi-char.  This closes every path that previously froze such a click:
+  - The refocus click is detected from the focus-in event itself rather than a
+    tracked focus transition, so it keeps working when the window system's focus
+    state is stale — notably on macOS (NS), where a dropped focus-out can leave
+    `frame-focus-state' stuck reporting focus and previously made every refocus
+    click enter copy mode after a while.
+  - A tiny involuntary pointer movement that makes Emacs report the click as
+    `drag-mouse-1' instead of `mouse-1' selects nothing, so the micro-drag is
+    handled like a plain single click rather than a region drag.
+  - Selecting a previously-unselected window leaves an empty region active, whose
+    activation the command loop finalized after the press handler returned;
+    `ghostel--mark-activated' now ignores mark activations that originate from the
+    mouse handlers (gating on `this-command'), so that deferred activation no
+    longer freezes the buffer.  Mouse selection stays governed by
+    `ghostel-mouse-drag-input-mode' alone.
 
 ## [0.34.0] — 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ All notable changes to this project will be documented in this file.
   working when the window system's focus state is stale — notably on macOS (NS),
   where a dropped focus-out can leave `frame-focus-state' stuck reporting focus
   and previously made every refocus click enter copy mode after a while.
+- A focus click into an inactive Ghostel window no longer enters copy mode when
+  a tiny involuntary pointer movement makes Emacs report it as `drag-mouse-1`
+  instead of `mouse-1`.  Such a micro-drag selects nothing, so it now stays in
+  semi-char and snaps point to the live cursor, like the single-click focus path
+  (#403).
 
 ## [0.34.0] — 2026-06-08
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -793,10 +793,6 @@ Mouse selection is governed separately by `ghostel-mouse-drag-input-mode'."
                  (const :tag "Emacs mode"          emacs)
                  (const :tag "Do not switch"       nil)))
 
-(defvar ghostel--inhibit-mark-activation nil
-  "When non-nil, `ghostel--mark-activated' is a no-op.
-Bound by the mouse handlers, which pick the input mode themselves.")
-
 (defcustom ghostel-word-boundary-string " \t\"'`|:;,()[]{}<>$│"
   "Characters that terminate words in ghostel buffers.
 
@@ -2670,9 +2666,9 @@ in an already-focused frame, before focusing it, for
     (if (ghostel--mouse-tracking-active-p)
         (ghostel--mouse-press event)
       ;; `mouse-drag-region' activates the mark mid-drag; the release
-      ;; handler picks the input mode, so keep the hook out of it.
-      (let ((ghostel--inhibit-mark-activation t))
-        (mouse-drag-region event)))))
+      ;; handler picks the input mode.  `ghostel--mark-activated' ignores
+      ;; activations made under the mouse handlers, so the hook stays out of it.
+      (mouse-drag-region event))))
 
 (defun ghostel-mouse-release-or-set-point (event &optional promote-to-region)
   "Forward EVENT to the terminal, or set point / switch input mode.
@@ -2698,8 +2694,7 @@ in semi-char (skipped when `ghostel-mouse-drag-input-mode' is nil)."
      ;; Multi-click, or a single click in an already-selected window: set
      ;; point/selection, then freeze (a focus click never reaches here).
      (t
-      (let ((ghostel--inhibit-mark-activation t))
-        (mouse-set-point event promote-to-region))
+      (mouse-set-point event promote-to-region)
       (when active
         (pcase ghostel-mouse-drag-input-mode
           ('copy  (ghostel-copy-mode))
@@ -2726,8 +2721,7 @@ so a focus click stays in semi-char like a plain click."
         (posn-point (event-end event)))
     (ghostel-mouse-release-or-set-point event))
    (t
-    (let ((ghostel--inhibit-mark-activation t))
-      (mouse-set-region event))
+    (mouse-set-region event)
     (when (eq ghostel--input-mode 'semi-char)
       (pcase ghostel-mouse-drag-input-mode
         ('copy  (ghostel-copy-mode))
@@ -3109,7 +3103,13 @@ returns to whichever input mode was active before."
 On buffer-local `activate-mark-hook'; the keyboard analog of
 `ghostel-mouse-drag-or-set-region'.  Runs after the activating
 command set the region, so the selection survives the switch."
-  (when (and (not ghostel--inhibit-mark-activation)
+  ;; Mouse gestures pick the input mode in the mouse handlers themselves; the
+  ;; command loop can finalize their (often empty) mark activation after the
+  ;; handler has returned, so gate on the originating command rather than a
+  ;; dynamic binding the activation outlives.
+  (when (and (not (memq this-command '(ghostel-mouse-press-or-copy-mode
+                                       ghostel-mouse-release-or-set-point
+                                       ghostel-mouse-drag-or-set-region)))
              (eq ghostel--input-mode 'semi-char))
     (pcase ghostel-mark-activation-input-mode
       ('copy  (ghostel-copy-mode))

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2713,16 +2713,25 @@ handler so the selection survives release; without this,
 `mouse-drag-track's exit hook deactivates the mark and our
 intercept keeps `mouse-set-region' from re-establishing the region.
 When the buffer is in semi-char mode, switches input mode once the
-region is set to mode configured in `ghostel-mouse-drag-input-mode'."
+region is set to the mode configured in `ghostel-mouse-drag-input-mode'.
+An empty drag, a click that wiggled into a `drag-mouse-1' without selecting
+anything, is dispatched to `ghostel-mouse-release-or-set-point',
+so a focus click stays in semi-char like a plain click."
   (interactive "e")
-  (if (ghostel--mouse-tracking-active-p)
-      (ghostel--mouse-drag event)
+  (cond
+   ((ghostel--mouse-tracking-active-p)
+    (ghostel--mouse-drag event))
+   ;; An empty drag selected nothing: the wiggle was really a click
+   ((eq (posn-point (event-start event))
+        (posn-point (event-end event)))
+    (ghostel-mouse-release-or-set-point event))
+   (t
     (let ((ghostel--inhibit-mark-activation t))
       (mouse-set-region event))
     (when (eq ghostel--input-mode 'semi-char)
       (pcase ghostel-mouse-drag-input-mode
         ('copy  (ghostel-copy-mode))
-        ('emacs (ghostel-emacs-mode))))))
+        ('emacs (ghostel-emacs-mode)))))))
 
 (defun ghostel-mouse-down-2-or-noop (event)
   "Forward EVENT to the terminal when a mouse-tracking mode is on.

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -871,11 +871,40 @@ Exiting returns to whatever mode the user was in beforehand, mirroring
                       ((symbol-function 'mouse-set-region)
                        (lambda (_event) (push-mark (point) t t))))
               ;; A real drag selecting a region (distinct start/end points).
-              (ghostel-mouse-drag-or-set-region
-               `(drag-mouse-1 (,(selected-window) 1 (1 . 1) 0)
-                              (,(selected-window) 5 (5 . 1) 0)))
+              ;; `this-command' is what the command loop binds when dispatching
+              ;; the drag; `ghostel--mark-activated' reads it to stay out of
+              ;; mouse gestures, so the test must set it like a real dispatch.
+              (let ((this-command 'ghostel-mouse-drag-or-set-region))
+                (ghostel-mouse-drag-or-set-region
+                 `(drag-mouse-1 (,(selected-window) 1 (1 . 1) 0)
+                                (,(selected-window) 5 (5 . 1) 0))))
               ;; The mouse knob picked the mode — the hook stayed out.
               (should (eq ghostel--input-mode 'emacs)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-mark-activation-ignores-focus-click ()
+  "A focus click on an unselected window must not freeze into copy mode.
+Selecting a previously-unselected window via `mouse-drag-region' leaves an
+empty region active; the command loop finalizes that activation after the
+press handler returns, with `this-command' still the press command.
+`ghostel--mark-activated' must ignore it so the focus click stays in
+semi-char."
+  (let ((buf (generate-new-buffer " *ghostel-test-mark-focus-click*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((ghostel--term 'fake)
+                (ghostel--redraw-timer nil)
+                (ghostel-mark-activation-input-mode 'copy)
+                ;; The deferred activation runs with `this-command' bound to
+                ;; the press command that triggered the click gesture.
+                (this-command 'ghostel-mouse-press-or-copy-mode))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                      ((symbol-function 'ghostel--anchor-window) #'ignore))
+              (insert "some terminal output")
+              ;; An empty region (point == mark), like a window-selecting click.
+              (push-mark (point) t t)
+              (should (eq ghostel--input-mode 'semi-char)))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-ctrl-space-keybindings ()

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -870,7 +870,10 @@ Exiting returns to whatever mode the user was in beforehand, mirroring
                       ;; The real mouse-set-region activates the mark.
                       ((symbol-function 'mouse-set-region)
                        (lambda (_event) (push-mark (point) t t))))
-              (ghostel-mouse-drag-or-set-region nil)
+              ;; A real drag selecting a region (distinct start/end points).
+              (ghostel-mouse-drag-or-set-region
+               `(drag-mouse-1 (,(selected-window) 1 (1 . 1) 0)
+                              (,(selected-window) 5 (5 . 1) 0)))
               ;; The mouse knob picked the mode — the hook stayed out.
               (should (eq ghostel--input-mode 'emacs)))))
       (kill-buffer buf))))

--- a/test/ghostel-mouse-paste-test.el
+++ b/test/ghostel-mouse-paste-test.el
@@ -823,6 +823,64 @@ on the next redraw - neither copy nor Emacs mode is entered."
       (should-not copy-mode-called)
       (should-not emacs-mode-called))))
 
+(ert-deftest ghostel-test-mouse-1-drag-focus-click-microdrag-stays-semi-char ()
+  "A focus-click micro-drag (drag-mouse-1, no region) stays in semi-char.
+A tiny pointer wiggle on a click that only focuses the window makes Emacs
+report `drag-mouse-1' with equal start/end points; it sets no region, snaps
+to the live cursor, and does not enter copy mode."
+  :tags '(native)
+  (let ((fake-event `(drag-mouse-1
+                      (,(selected-window) 5 (161 . 6) 0)
+                      (,(selected-window) 5 (161 . 7) 0)))
+        (ghostel-mouse-drag-input-mode 'copy)
+        (ghostel--mouse-press-was-selected nil)
+        (set-region-called nil)
+        (copy-mode-called nil)
+        (emacs-mode-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (insert "hello world")
+      (setq-local ghostel--cursor-char-pos 11)
+      (goto-char 3)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-region)
+                 (lambda (_event) (setq set-region-called t)))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t)))
+                ((symbol-function 'ghostel-emacs-mode)
+                 (lambda () (setq emacs-mode-called t))))
+        (ghostel-mouse-drag-or-set-region fake-event))
+      (should-not set-region-called)     ; no region established for a focus click
+      (should-not copy-mode-called)
+      (should-not emacs-mode-called)
+      (should (= (point) 11)))))         ; snapped to the live cursor
+
+(ert-deftest ghostel-test-mouse-1-drag-microdrag-already-selected-enters-copy-mode ()
+  "A micro-drag in an already-selected window still enters copy mode.
+Equal start/end points only stay in semi-char for a focus click; a wiggle
+in a window that was already selected is dispatched to the release path and
+freezes like a single click there."
+  :tags '(native)
+  (let ((fake-event `(drag-mouse-1
+                      (,(selected-window) 5 (161 . 6) 0)
+                      (,(selected-window) 5 (161 . 7) 0)))
+        (ghostel-mouse-drag-input-mode 'copy)
+        (ghostel--mouse-press-was-selected t)
+        (copy-mode-called nil))
+    (with-temp-buffer
+      (setq-local ghostel--term 'fake)
+      (setq-local ghostel--input-mode 'semi-char)
+      (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                 (lambda (_term _mode) nil))
+                ((symbol-function 'mouse-set-point)
+                 (lambda (_event &optional _promote) nil))
+                ((symbol-function 'ghostel-copy-mode)
+                 (lambda () (setq copy-mode-called t))))
+        (ghostel-mouse-drag-or-set-region fake-event))
+      (should copy-mode-called))))
+
 (ert-deftest ghostel-test-mouse-1-drag-no-tracking-copy-mode-no-toggle ()
   "Drag-end in copy mode does not call `ghostel-copy-mode' again.
 Calling `ghostel-copy-mode' from within copy mode would toggle it


### PR DESCRIPTION
## Problem

A left-click into an inactive Ghostel window to focus it can wiggle the pointer just enough that Emacs reports the gesture as `drag-mouse-1` instead of `mouse-1`. That event is bound to `ghostel-mouse-drag-or-set-region`, which switched input mode **unconditionally** — so the focus click froze the buffer into copy mode even though nothing was selected and the press guard had correctly flagged it as a focus click.

This is the complementary drag-path case to #403 (which fixed the `mouse-1` path): the press guard worked, but `drag-mouse-1` bypassed the release handler entirely.

## Fix

An empty drag (equal start/end `posn-point`) selected nothing, so it's really a click — dispatch it to `ghostel-mouse-release-or-set-point`, which already handles both sub-cases correctly:

- a **focus click** snaps point to the live cursor and stays in semi-char;
- a click in an **already-selected** window freezes (copy mode).

A real drag (distinct points) still sets the region and switches mode as before. This also collapses the duplicated focus-click logic — the drag handler now reuses the click handler instead of re-deriving it.

## Testing

- `ghostel.el` byte-compiles clean (`byte-compile-error-on-warn`).
- `make test test-native test-zig` → 0 unexpected.
- New tests: focus-click micro-drag stays in semi-char + snaps to cursor; already-selected micro-drag still freezes. `ghostel-test-mark-activation-mouse-knob-wins` updated to pass a real drag event (it previously passed `nil`, which the old event-blind code accepted).
- **Live-verified** in a real GUI Emacs (elate 0.7.0 focus/event injection): the identical empty `drag-mouse-1` event yields `semi-char` as a focus click and `copy` as an in-place click, and a real drag enters `copy`. The #403 refocus-click fix was re-verified live in the same session.