### PR TITLE
Fix oversized last CJK character on a line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ All notable changes to this project will be documented in this file.
   independently.
 
 ### Fixed
+- ZSH shell integration now reports gethostname(2) in its OSC 7 directory update
+  (matching the bash and fish integrations and Emacs `system-name`), instead of
+  zsh's `$HOST`, which is canonicalized to the fully qualified domain name when a
+  DNS search domain is configured.  Previously the FQDN disagreed with
+  `system-name` (the short hostname), so the local shell was misclassified as
+  remote and switched on TRAMP (#417).
+- Fish shell integration now caches the hostname once at load instead of forking
+  the `hostname` command on every prompt, matching the bash and zsh integrations.
 - Char mode now captures GUI `C-SPC` and forwards it to the terminal as NUL;
   previously only the TTY `C-@` representation was bound, so a GUI
   Ctrl+Space in char mode fell through to the global `set-mark-command`.

--- a/etc/shell/ghostel.fish
+++ b/etc/shell/ghostel.fish
@@ -14,9 +14,14 @@
 # Idempotency guard — skip if already loaded (e.g. auto-injected).
 functions -q __ghostel_osc7; and return
 
+# Capture gethostname(2) once for OSC 7 (matches the bash/zsh
+# capture-once approach; avoids forking `hostname' on every prompt).
+# A global so the `--on-event fish_prompt' handler sees it when it fires.
+set -g __ghostel_host (hostname)
+
 # Report working directory to the terminal via OSC 7
 function __ghostel_osc7 --on-event fish_prompt
-    printf '\e]7;file://%s%s\a' (hostname) "$PWD"
+    printf '\e]7;file://%s%s\a' "$__ghostel_host" "$PWD"
 end
 
 # --- Semantic prompt markers (OSC 133) ---

--- a/etc/shell/ghostel.zsh
+++ b/etc/shell/ghostel.zsh
@@ -17,10 +17,19 @@
 # Idempotency guard — skip if already loaded (e.g. auto-injected).
 (( $+functions[__ghostel_osc7] )) && return
 
+# Capture gethostname(2) once for OSC 7, matching Emacs `(system-name)'.
+# zsh canonicalizes $HOST to the FQDN under a DNS search domain, which
+# would make the local shell look remote and wrongly switch on TRAMP.
+# `hostname' reports gethostname(2) verbatim (as the bash and fish
+# integrations do); fall back to $HOST if it is missing or empty.  The
+# `|| ...' form keeps that fallback errexit-safe.
+__ghostel_host=$(command hostname 2>/dev/null) || __ghostel_host=$HOST
+[[ -n $__ghostel_host ]] || __ghostel_host=$HOST
+
 # Report working directory to the terminal via OSC 7
 __ghostel_osc7() {
     builtin emulate -L zsh -o no_warn_create_global -o no_aliases
-    builtin printf '\e]7;file://%s%s\a' "$HOST" "$PWD"
+    builtin printf '\e]7;file://%s%s\a' "$__ghostel_host" "$PWD"
 }
 
 # --- Semantic prompt markers (OSC 133) ---

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -613,22 +613,32 @@ fn adjustGlyph(
 
     // Let's check if we can claim some space after the glyph to be able to render
     // it larger than the cell size while still maintaining alignment.
-    const pre_char_width = char_width;
-    while (cell.col + char_width < self.term.cols) : ({
+    const initial_char_width = char_width;
+    while (cell.col + char_width < self.term.cols) {
         char_width += 1;
         slot_width = default_font_info.width * char_width;
-    }) {
         const cell_aspect = @as(f64, @floatFromInt(slot_width)) /
             @as(f64, @floatFromInt(default_font_info.ascent + default_font_info.descent));
         const glyph_aspect = @as(f64, @floatFromInt(metrics.width)) /
             @as(f64, @floatFromInt(metrics.ascent + metrics.descent));
-        // If the aspect of the glyph is narrower than that of the cell, we're done
-        if (glyph_aspect < cell_aspect) break;
+        // If the aspect of the glyph fits in the current slot width, undo the
+        // increment — the glyph doesn't need this extra column.
+        if (glyph_aspect <= cell_aspect) {
+            char_width -= 1;
+            slot_width = default_font_info.width * char_width;
+            break;
+        }
 
-        const claim_pos = row_start + cell.char_end + (char_width - pre_char_width);
+        const claim_pos = row_start + cell.char_end + (char_width - initial_char_width);
         // Lines are right-trimmed of trailing spaces, so positions at and past
-        // the newline represent empty space we can freely claim.
-        if (claim_pos >= row_end - 1) continue;
+        // the newline represent empty space that we could freely claim, but
+        // doing so always makes the last glyph on a line larger than its
+        // mid-line counterparts.
+        if (claim_pos >= row_end - 1) {
+            char_width -= 1;
+            slot_width = default_font_info.width * char_width;
+            break;
+        }
 
         const c = env.cast(i64, env.f("char-after", .{claim_pos}));
         if (c == ' ') {
@@ -639,6 +649,8 @@ fn adjustGlyph(
                 env.cons(s.space, env.list(.{ s.@":width", 0 })),
             });
         } else {
+            char_width -= 1;
+            slot_width = default_font_info.width * char_width;
             break;
         }
     }

--- a/test/ghostel-shell-test.el
+++ b/test/ghostel-shell-test.el
@@ -439,6 +439,52 @@ sets libghostty's recorded cwd.  Mirrors the bash race test."
       ;; The LAST OSC 7 must be ours.
       (should-not (string-match-p "competing-host" (car (last osc7s)))))))
 
+(ert-deftest ghostel-test-zsh-osc7-uses-gethostname-not-fqdn ()
+  "Zsh OSC 7 must report gethostname(2), not the canonicalized $HOST (#417).
+
+zsh canonicalizes $HOST to the FQDN when a DNS search domain is set, which
+disagrees with gethostname(2) (Emacs function `system-name').  The integration
+must instead report the `hostname' command's value so the local-host comparison
+in `ghostel--update-directory' succeeds and the buffer is not misclassified as
+remote.  The probe pollutes $HOST with an FQDN (as zsh's canonicalization
+would) and puts a fake `hostname' on PATH; the integration must emit the fake
+`hostname' value, not the polluted $HOST.  Mirrors the bash sibling test
+`ghostel-test-bash-osc7-ignores-env-hostname'."
+  :tags '(native)
+  (skip-unless (executable-find "zsh"))
+  (let* ((root (or (ghostel--resource-root)
+                   (file-name-directory (locate-library "ghostel"))))
+         (shell-zsh (expand-file-name "etc/shell/ghostel.zsh" root)))
+    (skip-unless (file-exists-p shell-zsh))
+    (let ((bindir (make-temp-file "ghostel-fakebin" t))
+          (fake "ghostel-test-real-host")
+          (fqdn "ghostel-test-real-host.example.com"))
+      (unwind-protect
+          (let ((script (expand-file-name "hostname" bindir)))
+            (with-temp-file script
+              (insert "#!/bin/sh\nprintf '%s\\n' " fake "\n"))
+            (set-file-modes script #o755)
+            (let* ((process-environment
+                    (append (list (concat "PATH=" bindir ":" (getenv "PATH"))
+                                  "INSIDE_EMACS=ghostel")
+                            process-environment))
+                   ;; Pollute $HOST with the FQDN, as zsh does when a DNS
+                   ;; search domain is set — the integration must ignore it.
+                   (probe (format "cd /; HOST=%s; source %s; __ghostel_osc7"
+                                  fqdn shell-zsh))
+                   (output (with-temp-buffer
+                             (call-process "zsh" nil (current-buffer) nil
+                                           "-f" "-c" probe)
+                             (buffer-string))))
+              ;; Probe emits: \e]7;file://HOST/\a
+              (should (string-match "\e\\]7;file://\\([^/]*\\)/" output))
+              (let ((emitted (match-string 1 output)))
+                ;; Reports gethostname(2) (the fake `hostname'), …
+                (should (equal emitted fake))
+                ;; … not the canonicalized $HOST FQDN.
+                (should-not (equal emitted fqdn)))))
+        (delete-directory bindir t)))))
+
 (ert-deftest ghostel-test-osc7-parsing ()
   "Test that OSC 7 sequences are parsed by libghostty."
   :tags '(native)


### PR DESCRIPTION
  The fix the CJK last character become larger:
  
  
  The space-claiming loop had three related bugs causing the last CJK
  character on a line to render larger than mid-line counterparts:

  1. The while-loop iteration expression incremented char_width before
  the body ran, so breaking on the first iteration (aspect fits,
  non-space neighbor, or trailing space) left char_width one column
  too high.  Every break path now undoes the increment.
  2. The aspect ratio check used strict < instead of <=, so when
  the glyph aspect exactly matched the cell aspect, the loop kept
  going one more column than needed.
  3. Positions past the newline were treated as freely claimable
  (continue), letting the last glyph on a line expand into
  unlimited trailing space.  Now we break instead — trailing space
  would always make the last glyph larger than the rest.