### PR TITLE
Report gethostname(2), not zsh $HOST, in shell OSC 7 (#417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ All notable changes to this project will be documented in this file.
   independently.
 
 ### Fixed
+- ZSH shell integration now reports gethostname(2) in its OSC 7 directory update
+  (matching the bash and fish integrations and Emacs `system-name`), instead of
+  zsh's `$HOST`, which is canonicalized to the fully qualified domain name when a
+  DNS search domain is configured.  Previously the FQDN disagreed with
+  `system-name` (the short hostname), so the local shell was misclassified as
+  remote and switched on TRAMP (#417).
+- Fish shell integration now caches the hostname once at load instead of forking
+  the `hostname` command on every prompt, matching the bash and zsh integrations.
 - Char mode now captures GUI `C-SPC` and forwards it to the terminal as NUL;
   previously only the TTY `C-@` representation was bound, so a GUI
   Ctrl+Space in char mode fell through to the global `set-mark-command`.

--- a/etc/shell/ghostel.fish
+++ b/etc/shell/ghostel.fish
@@ -14,9 +14,14 @@
 # Idempotency guard — skip if already loaded (e.g. auto-injected).
 functions -q __ghostel_osc7; and return
 
+# Capture gethostname(2) once for OSC 7 (matches the bash/zsh
+# capture-once approach; avoids forking `hostname' on every prompt).
+# A global so the `--on-event fish_prompt' handler sees it when it fires.
+set -g __ghostel_host (hostname)
+
 # Report working directory to the terminal via OSC 7
 function __ghostel_osc7 --on-event fish_prompt
-    printf '\e]7;file://%s%s\a' (hostname) "$PWD"
+    printf '\e]7;file://%s%s\a' "$__ghostel_host" "$PWD"
 end
 
 # --- Semantic prompt markers (OSC 133) ---

--- a/etc/shell/ghostel.zsh
+++ b/etc/shell/ghostel.zsh
@@ -17,10 +17,19 @@
 # Idempotency guard — skip if already loaded (e.g. auto-injected).
 (( $+functions[__ghostel_osc7] )) && return
 
+# Capture gethostname(2) once for OSC 7, matching Emacs `(system-name)'.
+# zsh canonicalizes $HOST to the FQDN under a DNS search domain, which
+# would make the local shell look remote and wrongly switch on TRAMP.
+# `hostname' reports gethostname(2) verbatim (as the bash and fish
+# integrations do); fall back to $HOST if it is missing or empty.  The
+# `|| ...' form keeps that fallback errexit-safe.
+__ghostel_host=$(command hostname 2>/dev/null) || __ghostel_host=$HOST
+[[ -n $__ghostel_host ]] || __ghostel_host=$HOST
+
 # Report working directory to the terminal via OSC 7
 __ghostel_osc7() {
     builtin emulate -L zsh -o no_warn_create_global -o no_aliases
-    builtin printf '\e]7;file://%s%s\a' "$HOST" "$PWD"
+    builtin printf '\e]7;file://%s%s\a' "$__ghostel_host" "$PWD"
 }
 
 # --- Semantic prompt markers (OSC 133) ---

--- a/test/ghostel-shell-test.el
+++ b/test/ghostel-shell-test.el
@@ -439,6 +439,52 @@ sets libghostty's recorded cwd.  Mirrors the bash race test."
       ;; The LAST OSC 7 must be ours.
       (should-not (string-match-p "competing-host" (car (last osc7s)))))))
 
+(ert-deftest ghostel-test-zsh-osc7-uses-gethostname-not-fqdn ()
+  "Zsh OSC 7 must report gethostname(2), not the canonicalized $HOST (#417).
+
+zsh canonicalizes $HOST to the FQDN when a DNS search domain is set, which
+disagrees with gethostname(2) (Emacs function `system-name').  The integration
+must instead report the `hostname' command's value so the local-host comparison
+in `ghostel--update-directory' succeeds and the buffer is not misclassified as
+remote.  The probe pollutes $HOST with an FQDN (as zsh's canonicalization
+would) and puts a fake `hostname' on PATH; the integration must emit the fake
+`hostname' value, not the polluted $HOST.  Mirrors the bash sibling test
+`ghostel-test-bash-osc7-ignores-env-hostname'."
+  :tags '(native)
+  (skip-unless (executable-find "zsh"))
+  (let* ((root (or (ghostel--resource-root)
+                   (file-name-directory (locate-library "ghostel"))))
+         (shell-zsh (expand-file-name "etc/shell/ghostel.zsh" root)))
+    (skip-unless (file-exists-p shell-zsh))
+    (let ((bindir (make-temp-file "ghostel-fakebin" t))
+          (fake "ghostel-test-real-host")
+          (fqdn "ghostel-test-real-host.example.com"))
+      (unwind-protect
+          (let ((script (expand-file-name "hostname" bindir)))
+            (with-temp-file script
+              (insert "#!/bin/sh\nprintf '%s\\n' " fake "\n"))
+            (set-file-modes script #o755)
+            (let* ((process-environment
+                    (append (list (concat "PATH=" bindir ":" (getenv "PATH"))
+                                  "INSIDE_EMACS=ghostel")
+                            process-environment))
+                   ;; Pollute $HOST with the FQDN, as zsh does when a DNS
+                   ;; search domain is set — the integration must ignore it.
+                   (probe (format "cd /; HOST=%s; source %s; __ghostel_osc7"
+                                  fqdn shell-zsh))
+                   (output (with-temp-buffer
+                             (call-process "zsh" nil (current-buffer) nil
+                                           "-f" "-c" probe)
+                             (buffer-string))))
+              ;; Probe emits: \e]7;file://HOST/\a
+              (should (string-match "\e\\]7;file://\\([^/]*\\)/" output))
+              (let ((emitted (match-string 1 output)))
+                ;; Reports gethostname(2) (the fake `hostname'), …
+                (should (equal emitted fake))
+                ;; … not the canonicalized $HOST FQDN.
+                (should-not (equal emitted fqdn)))))
+        (delete-directory bindir t)))))
+
 (ert-deftest ghostel-test-osc7-parsing ()
   "Test that OSC 7 sequences are parsed by libghostty."
   :tags '(native)


### PR DESCRIPTION
## Problem

Fixes #417. zsh canonicalizes its `$HOST` parameter to the fully qualified domain name when a DNS search domain is configured (e.g. via `/etc/resolv.conf`). The zsh shell integration emitted `$HOST` in its OSC 7 directory report, so on the **local** machine it reported `hostname.domain` while Emacs `(system-name)` (gethostname) is the short `hostname`.

`ghostel--local-host-p` compares the reported host against `(system-name)` and never strips a domain from the *incoming* host, so the FQDN failed to match — the local shell was misclassified as remote and the buffer was switched onto TRAMP.

## Fix (shell-side)

- **zsh**: capture `gethostname(2)` once via the `hostname` command into `__ghostel_host` and emit that instead of `$HOST`. This matches what the bash (`\H` via `${var@P}`) and fish (`(hostname)`) integrations already report, and what Emacs `(system-name)` compares against. The `|| __ghostel_host=$HOST` fallback keeps the capture from aborting the `source` under `setopt errexit` when `hostname` is missing.
- **fish**: cache `(hostname)` once at load instead of forking it on every `fish_prompt` — a consistency/efficiency refactor matching the bash/zsh capture-once approach (fish already reported the correct value).

`lisp/ghostel.el` (`ghostel--local-host-p`) is **deliberately left unchanged**. A tempting Emacs-side fix — stripping the DNS domain from both the reported host and `(system-name)` before comparing — cannot distinguish "my local machine reporting its own FQDN" from "a different remote host that shares my short hostname" (e.g. local `www` vs. remote `www.foo.bar`); it would misclassify that remote as local. The two cases are indistinguishable by hostname string alone, so the fix belongs in the shells.

## Tests

New native ERT test `ghostel-test-zsh-osc7-uses-gethostname-not-fqdn` (mirrors the bash sibling `ghostel-test-bash-osc7-ignores-env-hostname`): pollutes `$HOST` with an FQDN, puts a fake `hostname` on `PATH`, and asserts the integration emits the `hostname` value and **not** the polluted FQDN.

Verified live (sandboxed Emacs): the old integration reproduces the misclassification (`default-directory` → `/scp:host.example.com:/tmp/`, `file-remote-p` non-nil); the fixed zsh integration stays local (`/tmp/`, `file-remote-p` nil) despite a polluted `$HOST`; fish still tracks directories across multiple `cd`s. Native + elisp shell test suites pass; `errexit`-with-missing-`hostname` confirmed to still load the integration.