### PR TITLE
Fix CJK glyph space claiming

### DIFF
--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -603,45 +603,16 @@ fn adjustGlyph(
         start_val,
         end_val,
     ) orelse return;
-    var char_width: i64 = if (cell.wide) 2 else 1;
-    var slot_width = default_font_info.width * char_width;
 
     // Skip adjustments if size already matches perfectly
-    if (metrics.width == slot_width and
+    const native_char_width: i64 = if (cell.wide) 2 else 1;
+    const native_slot_width = default_font_info.width * native_char_width;
+    if (metrics.width == native_slot_width and
         metrics.ascent == default_font_info.ascent and
         metrics.descent == default_font_info.descent) return;
 
-    // Let's check if we can claim some space after the glyph to be able to render
-    // it larger than the cell size while still maintaining alignment.
-    const pre_char_width = char_width;
-    while (cell.col + char_width < self.term.cols) : ({
-        char_width += 1;
-        slot_width = default_font_info.width * char_width;
-    }) {
-        const cell_aspect = @as(f64, @floatFromInt(slot_width)) /
-            @as(f64, @floatFromInt(default_font_info.ascent + default_font_info.descent));
-        const glyph_aspect = @as(f64, @floatFromInt(metrics.width)) /
-            @as(f64, @floatFromInt(metrics.ascent + metrics.descent));
-        // If the aspect of the glyph is narrower than that of the cell, we're done
-        if (glyph_aspect < cell_aspect) break;
-
-        const claim_pos = row_start + cell.char_end + (char_width - pre_char_width);
-        // Lines are right-trimmed of trailing spaces, so positions at and past
-        // the newline represent empty space we can freely claim.
-        if (claim_pos >= row_end - 1) continue;
-
-        const c = env.cast(i64, env.f("char-after", .{claim_pos}));
-        if (c == ' ') {
-            _ = env.f("put-text-property", .{
-                claim_pos,
-                claim_pos + 1,
-                s.display,
-                env.cons(s.space, env.list(.{ s.@":width", 0 })),
-            });
-        } else {
-            break;
-        }
-    }
+    const char_width = self.adjustWidth(env, row_start, row_end, cell, metrics);
+    const slot_width = default_font_info.width * char_width;
 
     // Height is clamped per side, not on the sum: the row realizes
     // max(ascent) + max(descent) across all glyphs sharing the baseline, so a
@@ -668,6 +639,62 @@ fn adjustGlyph(
         s.display,
         display_spec,
     });
+}
+
+fn adjustWidth(
+    self: *Self,
+    env: emacs.Env,
+    row_start: i64,
+    row_end: i64,
+    cell: *const RowContent.CellInfo,
+    metrics: GlyphMetricsCache.Metrics,
+) i64 {
+    const s = emacs.sym;
+    const default_font_info = self.font_info.?;
+
+    if (cell.wide) {
+        // Cell is already wide
+        return 2;
+    }
+
+    // Let's check if we can claim some space after the glyph to be able to render
+    // it larger than the cell size while still maintaining alignment.
+    const cell_aspect = @as(f64, @floatFromInt(default_font_info.width)) /
+        @as(f64, @floatFromInt(default_font_info.ascent + default_font_info.descent));
+    const glyph_aspect = @as(f64, @floatFromInt(metrics.width)) /
+        @as(f64, @floatFromInt(metrics.ascent + metrics.descent));
+
+    if (glyph_aspect < cell_aspect) {
+        // We don't even need more space
+        return 1;
+    }
+
+    if (cell.col + 1 >= self.term.cols) {
+        // Can't claim out of bounds
+        return 1;
+    }
+
+    const claim_pos = row_start + cell.char_end;
+    if (claim_pos >= row_end - 1) {
+        // Next position is after end of line but within bounds,
+        // can claim freely
+        return 2;
+    }
+
+    // Finally, check if we have a space after the character. If so hide it and
+    // then claim it.
+    const c = env.cast(i64, env.f("char-after", .{claim_pos}));
+    if (c == ' ') {
+        _ = env.f("put-text-property", .{
+            claim_pos,
+            claim_pos + 1,
+            s.display,
+            env.cons(s.space, env.list(.{ s.@":width", 0 })),
+        });
+        return 2;
+    }
+
+    return 1;
 }
 
 fn getGlyphMetrics(

--- a/test/ghostel-glyph-test.el
+++ b/test/ghostel-glyph-test.el
@@ -222,7 +222,7 @@ descent below the line."
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-glyph-adjust-double-width-small ()
-  "A double-width glyph with narrower aspect than its slot gets min-width of 2."
+  "A double-width glyph is adjusted to its native width."
   :tags '(native)
   (let ((buf (generate-new-buffer " *ghostel-test-glyph-2*")))
     (unwind-protect
@@ -234,7 +234,8 @@ descent below the line."
                    (ghostel--term-rows 5)
                    (inhibit-read-only t)
                    (df (ghostel-test--make-font ghostel-test--default-font-info))
-                   ;; Glyph: 18px wide x 20px tall; narrower aspect breaks claim loop
+                   ;; Glyph: 18px wide x 20px tall, fitting within its native
+                   ;; two-cell slot.
                    (glyph-font (ghostel-test--make-font
                                 ["MockGlyph" "mock.ttf" 12 120 10 10 18 18 0]
                                 [[0 1 ?あ 0 18 0 0 10 10 0]])))
@@ -249,6 +250,43 @@ descent below the line."
                  (should disp)
                  (let ((min-w (cadr (assq 'min-width disp))))
                    (should (equal min-w '(2)))))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-glyph-adjust-cjk-never-claims-extra-space ()
+  "A CJK glyph never claims extra space at EOL or before a space."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-glyph-cjk-no-claim*")))
+    (unwind-protect
+        (save-window-excursion
+          (with-selected-window (display-buffer buf)
+            (ghostel-mode)
+            (let* ((term (ghostel--new 5 80 1000))
+                   (ghostel--term term)
+                   (ghostel--term-rows 5)
+                   (inhibit-read-only t)
+                   (df (ghostel-test--make-font ghostel-test--default-font-info))
+                   ;; Glyph: 30px wide x 20px tall; too wide for its native
+                   ;; two-cell slot, but CJK cells must not claim more space.
+                   (glyph-font (ghostel-test--make-font
+                                ["MockGlyph" "mock.ttf" 12 120 10 10 30 30 0]
+                                [[0 1 ?あ 0 30 0 0 10 10 0]])))
+              ;; Keep a non-space after the space so it is not right-trimmed.
+              (ghostel--write-input term "あ x\r\nあ")
+              (ghostel-test--with-glyph-mocks
+               (:default-font df
+                              :glyph-font glyph-font)
+               (ghostel--redraw term t)
+               (goto-char (point-min))
+               (let ((disp-before-space (get-text-property (point) 'display)))
+                 (should disp-before-space)
+                 (should (equal (cadr (assq 'min-width disp-before-space)) '(2))))
+               (forward-char 1)
+               (should (equal (char-after) ?\s))
+               (should-not (get-text-property (point) 'display))
+               (forward-line 1)
+               (let ((disp-at-eol (get-text-property (point) 'display)))
+                 (should disp-at-eol)
+                 (should (equal (cadr (assq 'min-width disp-at-eol)) '(2))))))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-glyph-adjust-identical-metrics ()
@@ -278,7 +316,7 @@ descent below the line."
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-glyph-adjust-claims-following-space ()
-  "A wide glyph claims an adjacent space by giving it :width 0."
+  "An oversized single-width glyph claims an adjacent space as :width 0."
   :tags '(native)
   (let ((buf (generate-new-buffer " *ghostel-test-glyph-4*")))
     (unwind-protect
@@ -295,7 +333,7 @@ descent below the line."
                    (glyph-font (ghostel-test--make-font
                                 ["MockGlyph" "mock.ttf" 12 120 10 10 12 12 0]
                                 [[0 1 ?\u0100 0 12 0 0 10 10 0]])))
-              ;; Write: [wide-glyph][space]
+              ;; Write: [oversized glyph][space]
               (ghostel--write-input term "\u0100 ")
               (ghostel-test--with-glyph-mocks
                (:default-font df
@@ -310,7 +348,7 @@ descent below the line."
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-glyph-adjust-claims-past-eol ()
-  "A wide glyph claims trailing empty space past the written text."
+  "An oversized single-width glyph claims at most one trailing cell."
   :tags '(native)
   (let ((buf (generate-new-buffer " *ghostel-test-glyph-5*")))
     (unwind-protect
@@ -322,7 +360,7 @@ descent below the line."
                    (ghostel--term-rows 5)
                    (inhibit-read-only t)
                    (df (ghostel-test--make-font ghostel-test--default-font-info))
-                   ;; Glyph: 25px wide x 10px tall (needs >2 cells)
+                   ;; Glyph: 25px wide x 10px tall (would need >2 cells).
                    (glyph-font (ghostel-test--make-font
                                 ["MockGlyph" "mock.ttf" 12 120 5 5 25 25 0]
                                 [[0 1 ?\u0100 0 25 0 0 5 5 0]])))
@@ -335,11 +373,11 @@ descent below the line."
                (let ((disp (get-text-property (point) 'display)))
                  (should disp)
                  (let ((min-w (cadr (assq 'min-width disp))))
-                   (should (>= (car min-w) 2))))))))
+                   (should (equal min-w '(2)))))))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-glyph-adjust-last-column-no-claim ()
-  "When the glyph is at the last column, claiming loop never runs."
+  "A glyph at the last column does not claim out-of-bounds space."
   :tags '(native)
   (let ((buf (generate-new-buffer " *ghostel-test-glyph-6*")))
     (unwind-protect
@@ -362,7 +400,6 @@ descent below the line."
                (ghostel--redraw term t)
                (goto-char (point-min))
                (end-of-line)
-               ;; cell.col + char_width < cols is 9 + 1 < 10 = false
                (let ((disp (get-text-property (1- (point)) 'display)))
                  (should disp)
                  (let ((min-w (cadr (assq 'min-width disp))))


### PR DESCRIPTION
## Summary
- stop glyph width adjustment from claiming extra cells for wide/CJK characters
- limit single-width glyph claiming to at most one in-bounds cell
- add glyph tests covering CJK before a space and at end of line, plus bounded single-width claiming

## Tests
- `rm -f .build/tests/native-ghostel-glyph-test.ok && make .build/tests/native-ghostel-glyph-test.ok`