### PR TITLE
Remove usage of stty from the native PTY path

### DIFF
--- a/lisp/ghostel-debug.el
+++ b/lisp/ghostel-debug.el
@@ -61,7 +61,7 @@ Populated by `ghostel-debug-ghostel'.  A plist with:
   :time, :default-directory, :remote-p
   :start-process-time — when `ghostel--start-process' was entered
                         (just before any TRAMP shell-detection round-trip)
-  :program, :program-args, :height, :width, :stty-flags, :extra-env
+  :program, :program-args, :cols, :rows, :extra-env
   :command          — the wrapper command ghostel passed to
                       `make-process' (the ((\"/bin/sh\" \"-c\" \"<wrapper>\"))
                       list).  Captured via `cl-letf*' on `make-process'
@@ -1081,9 +1081,7 @@ delta is what ghostel + TRAMP actually contributed."
     (insert (format "Program args:        %s\n"
                     (if args (format "%S" args) "(none)"))))
   (insert (format "Geometry:            %sx%s (cols x rows)\n"
-                  (plist-get cap :width) (plist-get cap :height)))
-  (insert (format "stty flags:          %s\n"
-                  (plist-get cap :stty-flags)))
+                  (plist-get cap :cols) (plist-get cap :rows)))
   (let ((extra (plist-get cap :extra-env)))
     (insert "extra-env:           ")
     (if (null extra)
@@ -1412,12 +1410,11 @@ it into the spawn-capture plist.  Self-removing — fires at most once."
   (apply orig args))
 
 (defun ghostel-debug--capture-spawn-pty
-    (orig program program-args height width stty-flags extra-env
-          &optional remote-p)
+    (orig program program-args extra-env &optional remote-p)
   "Around-advice on `ghostel--spawn-pty' that snapshots the spawn.
-ORIG is the original function; PROGRAM, PROGRAM-ARGS, HEIGHT, WIDTH,
-STTY-FLAGS, EXTRA-ENV, REMOTE-P are forwarded verbatim and recorded
-into `ghostel-debug--spawn-capture'.  Self-removing — fires at most once.
+ORIG is the original function; PROGRAM, PROGRAM-ARGS, EXTRA-ENV, and
+REMOTE-P are forwarded verbatim and recorded into
+`ghostel-debug--spawn-capture'.  Self-removing — fires at most once.
 
 Captures the wrapper command via `cl-letf*' on `make-process' rather
 than reading `process-command' on the returned process: on TRAMP's
@@ -1459,8 +1456,7 @@ two differ, the renderer flags it."
                       (setq intercepted-cmd
                             (plist-get plist :command)))
                     (apply orig-make-process plist))))
-              (funcall orig program program-args height width
-                       stty-flags extra-env remote-p))))
+              (funcall orig program program-args extra-env remote-p))))
       ;; `ghostel--spawn-pty' runs in the new ghostel buffer (the
       ;; spawn target), so `setq-local' here lands on the right
       ;; buffer-local.
@@ -1471,9 +1467,8 @@ two differ, the renderer flags it."
                   :remote-p (and remote-p t)
                   :program program
                   :program-args program-args
-                  :height height
-                  :width width
-                  :stty-flags stty-flags
+                  :cols ghostel--term-cols
+                  :rows ghostel--term-rows
                   :extra-env extra-env
                   :process-environment spawn-env
                   :command intercepted-cmd

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -5556,7 +5556,7 @@ Reads the local integration script, writes it (with any necessary
 preamble) to a temporary file on the remote host.  When the bundled
 terminfo is available locally, also pushes it to a remote temp dir
 over the same TRAMP connection and adds `TERMINFO=...' to the env.
-Returns a plist (:env :args :stty :temp-files :temp-dirs) for
+Returns a plist (:env :args :temp-files :temp-dirs) for
 `ghostel--start-process'.
 Returns nil on failure."
   (condition-case err
@@ -5591,7 +5591,7 @@ Returns nil on failure."
                                           "fi\n"
                                           integration))
              (list :env nil :args (list "--rcfile" path)
-                   :stty ghostel--default-stty :temp-files (list temp))))
+                   :temp-files (list temp))))
           ;; Zsh: ZDOTDIR replaces .zshenv search, so we restore it,
           ;; source the user's .zshenv, then load integration.
           ('zsh
@@ -5620,7 +5620,7 @@ Returns nil on failure."
                                           "    'builtin' 'unset' '_ghostel_file'\n"
                                           "}\n"))
              (list :env (list (format "ZDOTDIR=%s" remote-dir))
-                   :args nil :stty ghostel--default-stty
+                   :args nil
                    :temp-dirs (list temp-dir))))
           ;; Fish: -C runs after config, so just source the script.
           ('fish
@@ -5631,7 +5631,7 @@ Returns nil on failure."
              (list :env nil
                    :args (list "-C" (format "source %s"
                                             (shell-quote-argument path)))
-                   :stty ghostel--default-stty :temp-files (list temp)))))))
+                   :temp-files (list temp)))))))
         (if tinfo
             (ghostel--merge-integration-plists base tinfo)
           base))
@@ -5771,41 +5771,20 @@ verbatim.  `COLORTERM=truecolor' is exported unconditionally."
     (concat "TERM=" (shell-quote-argument ghostel-term)
             "; COLORTERM=truecolor; export TERM COLORTERM; "))))
 
-(defun ghostel--spawn-pty (program program-args height width stty-flags
-                                   extra-env &optional remote-p)
+(defun ghostel--spawn-pty (program program-args extra-env &optional remote-p)
   "Spawn PROGRAM with PROGRAM-ARGS as a PTY-backed process in the current buffer.
 
-Wraps PROGRAM in `/bin/sh -c' so that `stty' can configure the PTY
-\(with STTY-FLAGS plus rows=HEIGHT columns=WIDTH) and the screen is
-cleared before PROGRAM is exec'd.  EXTRA-ENV is prepended to
-`process-environment'.  Non-nil REMOTE-P spawns the process via the
-TRAMP file handler (for remote shells).
+The native local path execs PROGRAM directly and configures the PTY
+in C (see `ghostel--spawn-via-native').  The Emacs path wraps PROGRAM
+in `/bin/sh -c' so `stty' can configure the PTY before PROGRAM reads
+its terminal attributes (see `ghostel--spawn-via-emacs').  EXTRA-ENV
+is prepended to `process-environment'.  Non-nil REMOTE-P spawns the
+process via the TRAMP file handler (for remote shells).
 
 Returns the lifecycle process object for the PTY path: the shell
 process for Emacs-owned PTYs, or the event pipe process that stands in
 for the native child process."
-  ;; Wrap the program in /bin/sh -c so we can configure the PTY
-  ;; before the program reads its terminal attributes.  See
-  ;; `ghostel--default-stty' for the default flag set and rationale;
-  ;; STTY-FLAGS is whatever the caller picked (typically that default
-  ;; or a remote-integration variant).  The clear-screen hides the
-  ;; stty output.  exec replaces the wrapper so only the target
-  ;; program remains.
-  (let* ((shell-command
-          (list "/bin/sh" "-c"
-                (concat
-                 ;; Remote spawns: pick TERM via an on-remote probe
-                 (and remote-p (ghostel--remote-term-preamble))
-                 "stty " stty-flags
-                 (format " rows %d columns %d" height width)
-                 " 2>/dev/null; "
-                 "printf '\\033[H\\033[2J'; exec "
-                 (shell-quote-argument program)
-                 (and program-args
-                      (concat " "
-                              (mapconcat #'shell-quote-argument
-                                         program-args " "))))))
-         (process-environment
+  (let* ((process-environment
           (append
            ghostel-environment
            (cons "INSIDE_EMACS=ghostel"
@@ -5832,32 +5811,50 @@ for the native child process."
     ;; `setenv' to inject/override entries that the child inherits.
     ;; See `ghostel-pre-spawn-hook'.
     (run-hooks 'ghostel-pre-spawn-hook)
-    (ghostel--spawn-process shell-command remote-p)))
+    (ghostel--spawn-process program program-args remote-p)))
 
-(defun ghostel--spawn-process (shell-command remote-p)
-  "Dispatch SHELL-COMMAND to the native or Emacs PTY spawner.
+(defun ghostel--spawn-process (program program-args remote-p)
+  "Dispatch the spawn of PROGRAM (with PROGRAM-ARGS) to native or Emacs.
 Local buffers use the native PTY path when `ghostel-use-native-pty'
 is non-nil; remote (REMOTE-P) buffers always go through Emacs so
 TRAMP can manage the remote shell."
   (setq ghostel--process
         (if (and ghostel-use-native-pty (not remote-p))
-            (ghostel--spawn-via-native shell-command)
-          (ghostel--spawn-via-emacs shell-command remote-p))))
+            (ghostel--spawn-via-native (cons program program-args))
+          (ghostel--spawn-via-emacs program program-args remote-p))))
 
-(defun ghostel--spawn-via-emacs (shell-command &optional remote-p)
-  "Spawn SHELL-COMMAND through Emacs process machinery.
-REMOTE-P is passed as `:file-handler' so TRAMP can run remote
-commands.  The returned process owns the PTY and receives
-`ghostel--filter' and `ghostel--sentinel'."
-  (let ((proc (make-process
-               :name "ghostel"
-               :buffer (current-buffer)
-               :command shell-command
-               :connection-type 'pty
-               :file-handler remote-p
-               :filter #'ghostel--filter
-               :sentinel #'ghostel--sentinel
-               :noquery t)))
+(defun ghostel--spawn-via-emacs (program program-args &optional remote-p)
+  "Spawn PROGRAM with PROGRAM-ARGS through Emacs process machinery.
+PROGRAM is wrapped in `/bin/sh -c' so that `stty' (with
+`ghostel--default-stty') can configure the PTY line discipline before
+PROGRAM reads its terminal attributes; the screen is then cleared to
+hide the stty output and `exec' replaces the wrapper so only PROGRAM
+remains.  See `ghostel--default-stty' for the default flag set and
+rationale.  REMOTE-P is passed as `:file-handler' so TRAMP can run
+remote commands, and selects an on-remote TERM probe preamble.  The
+returned process owns the PTY and receives `ghostel--filter' and
+`ghostel--sentinel'."
+  (let* ((shell-command
+          (list "/bin/sh" "-c"
+                (concat
+                 ;; Remote spawns: pick TERM via an on-remote probe
+                 (and remote-p (ghostel--remote-term-preamble))
+                 "stty " ghostel--default-stty " 2>/dev/null; "
+                 "printf '\033[H\033[2J'; exec "
+                 (shell-quote-argument program)
+                 (and program-args
+                      (concat " "
+                              (mapconcat #'shell-quote-argument
+                                         program-args " "))))))
+         (proc (make-process
+                :name "ghostel"
+                :buffer (current-buffer)
+                :command shell-command
+                :connection-type 'pty
+                :file-handler remote-p
+                :filter #'ghostel--filter
+                :sentinel #'ghostel--sentinel
+                :noquery t)))
     (setq ghostel--pid (process-id proc))
     ;; Raw binary I/O — no encoding/decoding by Emacs
     (set-process-coding-system proc 'binary 'binary)
@@ -5867,18 +5864,18 @@ commands.  The returned process owns the PTY and receives
     (process-put proc 'adjust-window-size-function nil)
     proc))
 
-(defun ghostel--spawn-via-native (shell-command)
-  "Spawn SHELL-COMMAND through the native PTY implementation.
-Returns the event pipe process used as the Emacs-side handle for the
-native child process.  The native reader writes terminal events to the
-pipe, and its detached reaper writes a final exit status before closing
-it."
+(defun ghostel--spawn-via-native (command)
+  "Spawn COMMAND through the native PTY implementation.
+COMMAND is a list of argv strings.  Returns the event pipe process used
+as the Emacs-side handle for the native child process.  The native
+reader writes terminal events to the pipe, and its detached reaper
+writes a final exit status before closing it."
   (let* ((pipe (make-pipe-process
                 :name "ghostel-native-process"
                 :buffer (current-buffer)
                 :filter #'ghostel--events-filter
                 :noquery t))
-         (pid (ghostel--spawn-native-process ghostel--term shell-command pipe)))
+         (pid (ghostel--spawn-native-process ghostel--term command pipe)))
     (setq ghostel--pid pid)
 
     (set-process-sentinel pipe
@@ -5904,15 +5901,7 @@ it."
 Local buffers use the native PTY path when `ghostel-use-native-pty'
 is non-nil.  Remote TRAMP buffers spawn through Emacs so TRAMP can
 run the shell on the remote host."
-  ;; Read dims from the buffer-locals set by `ghostel--init-buffer'.
-  ;; Recomputing from `(window-body-height)' here
-  ;; would query the *selected* window, which can differ from the
-  ;; buffer's window when the buffer is shown in a popup that didn't
-  ;; get selected — leaving the PTY and the libghostty terminal sized
-  ;; against different windows (issue #192).
-  (let* ((height (max 1 ghostel--term-rows))
-         (width (max 1 ghostel--term-cols))
-         (remote-p (file-remote-p default-directory))
+  (let* ((remote-p (file-remote-p default-directory))
          (shell-spec (ghostel--resolve-shell-spec))
          (shell (car shell-spec))
          (extra-shell-args (cdr shell-spec))
@@ -5980,9 +5969,6 @@ run the shell on the remote host."
                              (list "--posix"))
                             (t nil)))
          (shell-args (append extra-shell-args integration-args))
-         (stty-flags (if remote-integration
-                         (plist-get remote-integration :stty)
-                       ghostel--default-stty))
          (extra-env (append
                      (unless remote-p
                        (list (format "EMACS_GHOSTEL_PATH=%s" ghostel-dir)))
@@ -5997,8 +5983,8 @@ run the shell on the remote host."
                        (cons shell shell-args)))
          (spawn-program (car spawn-spec))
          (spawn-args (cdr spawn-spec))
-         (proc (ghostel--spawn-pty spawn-program spawn-args height width
-                                   stty-flags extra-env remote-p)))
+         (proc (ghostel--spawn-pty spawn-program spawn-args
+                                   extra-env remote-p)))
     (when remote-integration
       (ghostel--cleanup-temp-paths
        (plist-get remote-integration :temp-files)
@@ -6614,12 +6600,10 @@ Returns the buffer."
 
 BUFFER is switched into `ghostel-mode' (if not already) and a new
 terminal is created sized to the window displaying BUFFER, or
-80x24 if BUFFER is not currently displayed.  No shell integration
-is applied — PROGRAM is exec'd directly via `ghostel--spawn-pty'.
-PROGRAM is shell-quoted before it is passed to `/bin/sh -c', so
-shell metacharacters are not interpreted; pass extra tokens via
-ARGS, a list of strings.  Returns the lifecycle process object for
-the selected PTY path.
+80x24 if BUFFER is not currently displayed.  No shell integration is applied.
+PROGRAM and ARGS are passed as distinct argv entries, so shell metacharacters
+are not interpreted; pass extra tokens via ARGS, a list of strings.  Returns
+the lifecycle process object for the selected PTY path.
 
 Signals `user-error' if BUFFER already has a live ghostel process."
   (ghostel--load-module t)
@@ -6641,8 +6625,7 @@ Signals `user-error' if BUFFER already has a live ghostel process."
     (with-current-buffer buffer
       (ghostel--init-buffer buffer height width)
       (let ((remote-p (file-remote-p default-directory)))
-        (ghostel--spawn-pty program args ghostel--term-rows ghostel--term-cols
-                            ghostel--default-stty nil remote-p)))))
+        (ghostel--spawn-pty program args nil remote-p)))))
 
 ;;;###autoload
 (defun ghostel-project (&optional arg)

--- a/src/PtyProcess.zig
+++ b/src/PtyProcess.zig
@@ -8,6 +8,7 @@ const c = @cImport({
     @cInclude("fcntl.h");
     @cInclude("sys/ioctl.h");
     @cInclude("sys/wait.h");
+    @cInclude("termios.h");
 });
 
 const Self = @This();
@@ -21,16 +22,16 @@ const Pty = struct {
         var self: @This() = .{};
         self.primary_fd = c.posix_openpt(c.O_RDWR | c.O_NOCTTY | c.O_CLOEXEC);
         if (posix.errno(self.primary_fd) != .SUCCESS) {
-            return error.PtyOpenFailed;
+            return error.OpenPtFailed;
         }
         errdefer posix.close(self.primary_fd);
 
         if (posix.errno(c.grantpt(self.primary_fd)) != .SUCCESS) {
-            return error.PtyGrantFailed;
+            return error.OpenPtFailed;
         }
 
         if (posix.errno(c.unlockpt(self.primary_fd)) != .SUCCESS) {
-            return error.PtyUnlockFailed;
+            return error.OpenPtFailed;
         }
 
         const ptsname_err = posix.errno(c.ptsname_r(
@@ -39,7 +40,7 @@ const Pty = struct {
             self.replica_name.len,
         ));
         if (ptsname_err != .SUCCESS) {
-            return error.PtsnameFailed;
+            return error.OpenPtFailed;
         }
 
         self.replica_fd = try posix.openZ(
@@ -47,6 +48,26 @@ const Pty = struct {
             .{ .ACCMODE = .RDWR },
             0,
         );
+        errdefer posix.close(self.replica_fd);
+
+        // Configure the line discipline on the replica.  On macOS/BSD the
+        // master (ptm) fd rejects termios ioctls with ENOTTY — only the
+        // replica carries the terminal attributes — so this must run on
+        // `replica_fd', not `primary_fd'.
+        var attrs: c.termios = undefined;
+        if (c.tcgetattr(self.replica_fd, &attrs) != 0) {
+            return error.OpenPtFailed;
+        }
+        // Enable UTF-8 mode so backspace erases multi-byte characters.
+        attrs.c_iflag |= c.IUTF8;
+        // Disable XON/XOFF flow control so C-q (DC1) and C-s (DC3) pass
+        // through to the application instead of being swallowed by the
+        // line discipline.  Ghostel's send-next-key escape hatch and the
+        // direct C-q binding rely on these bytes reaching the child.
+        attrs.c_iflag &= ~@as(@TypeOf(attrs.c_iflag), c.IXON);
+        if (c.tcsetattr(self.replica_fd, c.TCSANOW, &attrs) != 0) {
+            return error.OpenPtFailed;
+        }
 
         return self;
     }

--- a/test/ghostel-debug-test.el
+++ b/test/ghostel-debug-test.el
@@ -178,8 +178,7 @@ sections all materialize."
                                 :remote-p t
                                 :program "/bin/bash"
                                 :program-args nil
-                                :height 24 :width 80
-                                :stty-flags ghostel--default-stty
+                                :cols 80 :rows 24
                                 :extra-env nil
                                 :process-environment
                                 '("INSIDE_EMACS=ghostel"
@@ -327,8 +326,7 @@ byte delta."
                                 :remote-p nil
                                 :program "/bin/sh"
                                 :program-args nil
-                                :height 24 :width 80
-                                :stty-flags ghostel--default-stty
+                                :cols 80 :rows 24
                                 :extra-env nil
                                 :process-environment process-environment
                                 :command '("/bin/sh" "-c" "exec /bin/sh")
@@ -400,8 +398,7 @@ so no actual shell is spawned."
                        (setq-local ghostel--term-rows 24)
                        (setq-local ghostel--term-cols 80)
                        (cl-incf calls)
-                       (ghostel--spawn-pty "/bin/sh" nil 24 80
-                                           "-ixon" nil nil)))))
+                       (ghostel--spawn-pty "/bin/sh" nil nil nil)))))
           (unwind-protect
               (progn
                 (ghostel-debug-ghostel)
@@ -418,8 +415,8 @@ so no actual shell is spawned."
                 (let ((cap (buffer-local-value
                             'ghostel-debug--spawn-capture buf)))
                   (should cap)
-                  (should (eq 24 (plist-get cap :height)))
-                  (should (eq 80 (plist-get cap :width)))
+                  (should (eq 80 (plist-get cap :cols)))
+                  (should (eq 24 (plist-get cap :rows)))
                   (should (equal "/bin/sh" (plist-get cap :program)))
                   ;; :command is the wrapper ghostel passed to make-process
                   ;; — captured via cl-letf* on make-process *before* the

--- a/test/ghostel-exec-test.el
+++ b/test/ghostel-exec-test.el
@@ -37,7 +37,8 @@
                     ((symbol-function 'ghostel--spawn-pty)
                      (lambda (&rest args) (setq captured args) 'fake-proc)))
             (ghostel-exec buf "ls" nil)
-            (should (nth 6 captured))))
+            ;; Signature: (program args extra-env remote-p).
+            (should (nth 3 captured))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-exec-uses-default-size-when-buffer-not-displayed ()
@@ -322,7 +323,7 @@ unmodified so later visual buffers still send `q' to the program."
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-exec-calls-spawn-pty-with-expected-args ()
-  "`ghostel-exec' forwards PROGRAM, ARGS, size, stty flags, and remote-p."
+  "`ghostel-exec' forwards PROGRAM, ARGS, extra-env, and remote-p."
   (let ((buf (generate-new-buffer " *ghostel-exec-test*"))
         captured)
     (unwind-protect
@@ -334,15 +335,12 @@ unmodified so later visual buffers still send `q' to the program."
                   ((symbol-function 'ghostel--spawn-pty)
                    (lambda (&rest args) (setq captured args) 'fake-proc)))
           (ghostel-exec buf "less" '("/etc/hosts"))
-          ;; Signature: program args height width stty-flags extra-env remote-p
+          ;; Signature: (program args extra-env remote-p).
           (should (equal (nth 0 captured) "less"))
           (should (equal (nth 1 captured) '("/etc/hosts")))
-          (should (numberp (nth 2 captured)))
-          (should (numberp (nth 3 captured)))
-          (should (equal (nth 4 captured) ghostel--default-stty))
-          (should (null (nth 5 captured)))
+          (should (null (nth 2 captured)))
           ;; Local default-directory — no TRAMP — so remote-p must be nil.
-          (should (null (nth 6 captured))))
+          (should (null (nth 3 captured))))
       (kill-buffer buf))))
 
 

--- a/test/ghostel-shell-test.el
+++ b/test/ghostel-shell-test.el
@@ -460,8 +460,7 @@ below it."
     (ghostel-test--with-pty-matrix backend
 				   (ghostel-test--with-terminal-buffer (buf term 8 80 200)
 								       (setq-local ghostel-detect-password-prompts nil)
-								       (let ((proc (ghostel--spawn-pty "/bin/zsh" '("-fi") 8 80
-												       ghostel--default-stty nil nil)))
+								       (let ((proc (ghostel--spawn-pty "/bin/zsh" '("-fi") nil nil)))
 									 ;; Wait for the initial default prompt to reach the terminal.
 									 (ghostel-test--wait-until
 									  (lambda ()
@@ -522,7 +521,6 @@ below it."
 									       (buffer-substring-no-properties
 										(line-beginning-position)
 										(line-end-position)))))))))))
-
 (ert-deftest ghostel-test-zsh-prompt-cells-tagged-with-self-reorder-theme ()
   "Tag prompt cells when a self-reordering theme overrides PROMPT.
 Prompt themes that re-assert their position at the END of
@@ -552,8 +550,7 @@ checks that the most recent prompt's `top-line' row carries the
     (ghostel-test--with-pty-matrix backend
 				   (ghostel-test--with-terminal-buffer (buf term 8 80 200)
 								       (setq-local ghostel-detect-password-prompts nil)
-								       (let ((proc (ghostel--spawn-pty "/bin/zsh" '("-fi") 8 80
-												       ghostel--default-stty nil nil)))
+								       (let ((proc (ghostel--spawn-pty "/bin/zsh" '("-fi") nil nil)))
 									 (ghostel-test--wait-until
 									  (lambda ()
 									    (not (string-empty-p (ghostel-test--rendered-terminal-text))))
@@ -604,7 +601,6 @@ checks that the most recent prompt's `top-line' row carries the
 									   (goto-char (point-max))
 									   (should (search-backward "top-line" nil t))
 									   (should (get-text-property (point) 'ghostel-prompt))))))))
-
 (ert-deftest ghostel-test-pty-password-input-p-tracks-noecho ()
   "Password-mode probing tracks canonical no-echo state."
   :tags '(native)

--- a/test/ghostel-spawn-test.el
+++ b/test/ghostel-spawn-test.el
@@ -23,19 +23,24 @@ runs with the stub in place."
 
 (defmacro ghostel-test--with-spawn-process-capture (capture &rest body)
   "Run BODY while capturing the inputs at the PTY spawn boundary.
-CAPTURE is set to a plist with the shell command, `process-environment',
-buffering bindings, current buffer, and `default-directory' observed at
+CAPTURE is set to a plist with the spawned :program and :args,
+:remote-p, the `process-environment', the buffering bindings, the
+current :buffer, and `default-directory' observed at
 `ghostel--spawn-process' \(the single dispatcher over the native/Emacs
 spawners).  The dispatcher is stubbed, so no process is spawned.
 
-This captures what `ghostel--spawn-pty' builds, which is identical for
-both backends, so there is no need to exercise the PTY matrix here."
+The dispatcher sees the same program/args/env for both backends — only
+how they reach the PTY differs (native execs directly; the Emacs path
+wraps them in `/bin/sh -c', see
+`ghostel-test-spawn-via-emacs-builds-stty-wrapper') — so there is no
+need to exercise the PTY matrix here."
   (declare (indent 1))
   `(let (,capture)
      (cl-letf (((symbol-function 'ghostel--spawn-process)
-                (lambda (shell-command remote-p)
+                (lambda (program program-args remote-p)
                   (setq ,capture
-                        (list :command (copy-tree shell-command)
+                        (list :program program
+                              :args (copy-tree program-args)
                               :env (copy-sequence process-environment)
                               :adaptive process-adaptive-read-buffering
                               :read-max read-process-output-max
@@ -64,6 +69,26 @@ both backends, so there is no need to exercise the PTY matrix here."
 Writes `GHOSTEL_WINSIZE_INIT:ROWS,COLS' at startup and
 `GHOSTEL_WINSIZE_WINCH:ROWS,COLS' on every SIGWINCH, so tests can assert
 the dimensions the child actually sees on each PTY backend.")
+
+(defconst ghostel-test--pty-read-dc1-script
+  (string-join
+   '("import sys"
+     ;; Announce readiness only after the PTY is configured (the Emacs
+     ;; path runs `stty -ixon' before exec'ing us), so the test knows
+     ;; when it is safe to send C-q without racing the flag setup.
+     "sys.stdout.write('GHOSTEL_READY\\r\\n')"
+     "sys.stdout.flush()"
+     "line = sys.stdin.buffer.readline()"
+     "tag = 'DC1' if b'\\x11' in line else 'NONE'"
+     "sys.stdout.write('GHOSTEL_GOTBYTE:%s\\r\\n' % tag)"
+     "sys.stdout.flush()")
+   "\n")
+  "Python code that reads one cooked-mode line from its PTY and reports it.
+Writes `GHOSTEL_READY' once its PTY is set up, then `GHOSTEL_GOTBYTE:DC1'
+if the line it reads contained a DC1 byte (0x11) or
+`GHOSTEL_GOTBYTE:NONE' otherwise.  With XON/XOFF flow control (`ixon')
+enabled, the line discipline swallows DC1 before the child sees it, so
+this distinguishes a PTY that honors `-ixon' from one that does not.")
 
 (defun ghostel-test--latest-winsize (tag)
   "Return the most recent (ROWS . COLS) reported for TAG, or nil.
@@ -256,48 +281,8 @@ written by `ghostel-test--pty-winsize-script'."
                            "-c" "exec -l /bin/bash --login --posix")
                          (cdr spawn))))))))
 
-(ert-deftest ghostel-test-start-process-sets-size-via-stty-not-env ()
-  "Initial terminal size must be baked into the `stty' wrapper, not env vars.
-Setting `LINES'/`COLUMNS' env vars freezes ncurses apps like htop at
-start-up size and breaks live resize."
-  (ghostel-test--with-spawn-process-capture capture
-    (with-temp-buffer
-      (setq-local ghostel--term-rows 43
-                  ghostel--term-cols 137)
-      (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
-             (ghostel-shell "/bin/sh")
-             (ghostel-shell-integration nil)
-             (ghostel-macos-login-shell nil)
-             (default-directory "/tmp/"))
-        (ghostel--start-process)
-        (let ((cmd (plist-get capture :command))
-              (env (plist-get capture :env)))
-          (should (equal '("/bin/sh" "-c") (seq-take cmd 2)))
-          (should (string-match-p "stty .* rows 43 columns 137"
-                                  (nth 2 cmd)))
-          (should (string-match-p "-ixon" (nth 2 cmd)))
-          (should-not (seq-some (lambda (s) (string-prefix-p "LINES=" s))
-                                env))
-          (should-not (seq-some (lambda (s) (string-prefix-p "COLUMNS=" s))
-                                env))
-          (should (member "TERM=xterm-ghostty" env))
-          (should (member "TERM_PROGRAM=ghostty" env))
-          ;; Match by regex so version bumps don't break the test — the
-          ;; contract is "exported and parseable as semver", not a literal string.
-          (should (seq-some (lambda (s)
-                              (string-match-p
-                               "\\`TERM_PROGRAM_VERSION=[0-9]+\\.[0-9]+\\.[0-9]+\\'"
-                               s))
-                            env))
-          (should (seq-some (lambda (s) (string-prefix-p "TERMINFO=" s))
-                            env))
-          (should (member "COLORTERM=truecolor" env)))))))
-
-(ert-deftest ghostel-test-start-process-local-bash-integration-keeps-early-echo ()
-  "Local bash integration must keep `stty echo' in the wrapper.
-Old bash versions can initialize readline before the ENV-injected
-integration script runs, so input echo must be enabled before exec.
-`sane' in `ghostel--default-stty' is what guarantees echo here."
+(ert-deftest ghostel-test-start-process-local-bash-integration-adds-env ()
+  "Local bash integration adds `--posix' and ENV injection for bash."
   (ghostel-test--with-spawn-process-capture capture
     (with-temp-buffer
       (setq-local ghostel--term-rows 25
@@ -311,14 +296,9 @@ integration script runs, so input echo must be enabled before exec.
              (ghostel-macos-login-shell nil)
              (default-directory "/tmp/"))
         (ghostel--start-process)
-        (let ((cmd (plist-get capture :command))
-              (env (plist-get capture :env)))
-          (should (equal '("/bin/sh" "-c") (seq-take cmd 2)))
-          (should (string-match-p
-                   (concat "stty " (regexp-quote ghostel--default-stty))
-                   (nth 2 cmd)))
-          (should (string-match-p "\\bsane\\b" (nth 2 cmd)))
-          (should (string-match-p "exec /bin/bash --posix" (nth 2 cmd)))
+        (let ((env (plist-get capture :env)))
+          (should (equal "/bin/bash" (plist-get capture :program)))
+          (should (equal '("--posix") (plist-get capture :args)))
           (should (member "GHOSTEL_BASH_INJECT=1" env))
           (should (seq-some (lambda (s) (string-prefix-p "ENV=" s))
                             env)))))))
@@ -329,9 +309,25 @@ It must also raise `read-process-output-max'.  Before Emacs 31 the
 former defaulted to t and throttled bursty TUI redraws."
   (ghostel-test--with-spawn-process-capture capture
     (with-temp-buffer
-      (ghostel--spawn-pty "/bin/sh" nil 24 80 "-ixon" nil nil)
+      (ghostel--spawn-pty "/bin/sh" nil nil nil)
       (should (null (plist-get capture :adaptive)))
       (should (>= (plist-get capture :read-max) (* 1024 1024))))))
+
+(ert-deftest ghostel-test-spawn-emacs-pty-enables-input-echo ()
+  "The Emacs PTY path enables input echo before PROGRAM reads."
+  :tags '(native)
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let ((ghostel-use-native-pty nil))
+    (ghostel-test--with-terminal-buffer (buf term 8 80 200)
+      (let ((proc (ghostel--spawn-pty
+                   "/bin/sh"
+                   '("-c" "printf 'GHOSTEL_ECHO_READY\r\n'; IFS= read -r _line; printf 'GHOSTEL_ECHO_DONE\r\n'")
+                   nil nil)))
+        (ghostel-test--wait-for-text "GHOSTEL_ECHO_READY" proc 5)
+        (ghostel--write-pty ghostel--term "GHOSTEL_ECHO_TOKEN\r")
+        (ghostel-test--wait-for-text "GHOSTEL_ECHO_DONE" proc 5)
+        (should (string-match-p "GHOSTEL_ECHO_TOKEN"
+                                (ghostel-test--terminal-text)))))))
 
 (ert-deftest ghostel-test-spawn-initial-winsize-reaches-child ()
   "The child PTY is sized to the terminal dimensions at spawn.
@@ -349,6 +345,33 @@ child through both backends and asserts the size it sees."
         (let ((got (ghostel-test--wait-until
                     (lambda () (ghostel-test--latest-winsize "INIT")) proc 6)))
           (should (equal (cons ghostel--term-rows ghostel--term-cols) got)))))))
+
+(ert-deftest ghostel-test-spawn-ixon-disabled-c-q-reaches-child ()
+  "DC1 (0x11) reaches the child instead of being eaten by XON/XOFF flow control.
+With `ixon' enabled (the PTY default) the line discipline swallows
+DC1 and DC3; ghostel disables it — natively in C
+\(`PtyProcess'), and via `-ixon' in the Emacs-path `stty' wrapper — so
+the direct key binding and send-next-key can deliver these bytes.
+Driven through both PTY backends."
+  :tags '(native)
+  (let ((python (executable-find "python3")))
+    (skip-unless python)
+    (ghostel-test--with-pty-matrix backend
+      (ghostel-test--with-exec-buffer
+          (buf proc python (list "-c" ghostel-test--pty-read-dc1-script))
+        ;; Wait until the child has configured its PTY and is reading,
+        ;; so `-ixon' is in effect before C-q arrives (otherwise the
+        ;; byte races the Emacs-path `stty' and is eaten while IXON is
+        ;; still on).
+        (should (ghostel-test--wait-for-text "GHOSTEL_READY" proc 6))
+        ;; Send C-q (DC1, 0x11) then Enter to flush the cooked-mode line.
+        (ghostel--write-pty ghostel--term (string ?\C-q ?\r))
+        (let ((report (ghostel-test--wait-until
+                       (lambda ()
+                         (let ((txt (ghostel-test--terminal-text)))
+                           (and (string-match-p "GHOSTEL_GOTBYTE:" txt) txt)))
+                       proc 6)))
+          (should (string-match-p "GHOSTEL_GOTBYTE:DC1" report)))))))
 
 (ert-deftest ghostel-test-resize-redraw-delivers-new-winsize-to-child ()
   "Resize + redraw delivers SIGWINCH carrying the NEW size to the child.

--- a/test/ghostel-terminal-test.el
+++ b/test/ghostel-terminal-test.el
@@ -34,9 +34,9 @@
 (ert-deftest ghostel-test-write-input-preserves-bare-lf-on-primary ()
   "On the primary screen, a bare LF preserves the column.
 The emulator never synthesizes a CR: cooked-mode \\n is turned into
-CRLF by the PTY's ONLCR (enabled via `stty sane' in the spawn
-wrapper), and raw-mode apps that emit bare LF mean a column-preserving
-linefeed.  Synthesizing a CR collapsed inline TUIs that position with
+CRLF by the PTY's ONLCR (on by default in the line discipline), and
+raw-mode apps that emit bare LF mean a column-preserving linefeed.
+Synthesizing a CR collapsed inline TUIs that position with
 column-preserving LF + relative CUB to the left margin (issue #388,
 the Antigravity CLI logo)."
   :tags '(native)

--- a/test/ghostel-test-helpers.el
+++ b/test/ghostel-test-helpers.el
@@ -91,37 +91,16 @@ succeeds."
     result))
 
 (defmacro ghostel-test--with-pty-matrix (backend &rest body)
-  "Run BODY once per currently available local PTY backend.
+  "Run BODY once per local PTY backend.
 BACKEND is bound to `emacs-pty' and `native-pty' in turn.  The
 corresponding `ghostel-use-native-pty' value is let-bound around
-BODY, and failures include the backend name in ERT output.
-
-Unexpected per-backend `ert-skip' signals are not swallowed: a
-parity test should not pass after silently dropping one leg.  The
-only backend-specific availability exception handled here is native
-PTY creation failing with PtyOpenFailed."
+BODY, and failures include the backend name in ERT output."
   (declare (indent 1))
-  `(let ((ghostel-test--ran-backend nil)
-         (ghostel-test--skip-reasons nil))
-     (dolist (entry '((emacs-pty . nil) (native-pty . t)))
-       (let ((,backend (car entry))
-             (ghostel-use-native-pty (cdr entry)))
-         (ert-info ((format "backend: %S" ,backend))
-           (condition-case err
-               (progn
-                 ,@body
-                 (setq ghostel-test--ran-backend t))
-             (error
-              (if (and (eq ,backend 'native-pty)
-                       (string-match-p "PtyOpenFailed"
-                                       (error-message-string err)))
-                  (push (error-message-string err) ghostel-test--skip-reasons)
-                (signal (car err) (cdr err))))))))
-     (unless ghostel-test--ran-backend
-       (ert-skip (mapconcat #'identity
-                            (or ghostel-test--skip-reasons
-                                '("No PTY backend available"))
-                            "; ")))))
+  `(dolist (entry '((emacs-pty . nil) (native-pty . t)))
+     (let ((,backend (car entry))
+           (ghostel-use-native-pty (cdr entry)))
+       (ert-info ((format "backend: %S" ,backend))
+         ,@body))))
 
 (defun ghostel-test--lifecycle-process (&optional buffer)
   "Return BUFFER's active ghostel lifecycle process, if any.

--- a/test/ghostel-tramp-test.el
+++ b/test/ghostel-tramp-test.el
@@ -87,17 +87,21 @@ Local spawns must not get the preamble; their TERM still rides in
         (ghostel-environment nil)
         captured-env
         captured-cmd)
-    (cl-letf (((symbol-function #'ghostel--spawn-via-emacs)
-               (lambda (shell-command &optional _remote-p)
-                 (setq captured-env process-environment
-                       captured-cmd shell-command)
-                 'fake-proc)))
+    (cl-letf (((symbol-function 'make-process)
+               (lambda (&rest args)
+                 (setq captured-env (copy-sequence process-environment)
+                       captured-cmd (plist-get args :command))
+                 'fake-proc))
+              ((symbol-function 'process-id) (lambda (_proc) 12345))
+              ((symbol-function 'set-process-coding-system) #'ignore)
+              ((symbol-function 'set-process-window-size) #'ignore)
+              ((symbol-function 'process-put) #'ignore))
       ;; Remote spawn → preamble in wrapper, TERM/TERMINFO not
       ;; added by ghostel.  Use a clean `process-environment' so
       ;; the assertion is about ghostel's contribution, not the
       ;; test runner's ambient env.
       (let ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp")))
-        (ghostel--spawn-pty "/bin/sh" nil 25 80 "-ixon" nil t)
+        (ghostel--spawn-pty "/bin/sh" nil nil t)
         (let ((script (nth 2 captured-cmd)))
           (should (string-match-p "infocmp xterm-ghostty" script))
           (should (string-match-p "export TERM COLORTERM" script))
@@ -113,7 +117,7 @@ Local spawns must not get the preamble; their TERM still rides in
       (setq captured-env nil
             captured-cmd nil)
       (let ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp")))
-        (ghostel--spawn-pty "/bin/sh" nil 25 80 "-ixon" nil nil)
+        (ghostel--spawn-pty "/bin/sh" nil nil nil)
         (let ((script (nth 2 captured-cmd)))
           (should-not (string-match-p "infocmp" script))
           (should (member "TERM=xterm-ghostty" captured-env)))))))


### PR DESCRIPTION
Native PTY has full control over the TTY so we don't need the stty wrapper. Also removes the size setting fromt the stty call, and overrides the actual TTY sizing that exists on both Emacs and native path and is the cause of resize bugs with ghostel-exec.