### PR TITLE
Don't leak libghostty VT warnings to stderr in release builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Internal libghostty VT-parser warnings no longer leak to the module's
+  stderr in release builds. In a terminal Emacs (`emacs -nw`) that stderr is
+  the controlling tty, so the warnings were painted onto the screen outside
+  Emacs's redisplay and lingered — e.g. `unimplemented mode: 9001` left a
+  stale line near the mode line after running lazygit (#425). Such logs are
+  now available only via `M-x ghostel-debug-start` (`*ghostel-debug*`);
+  debug builds keep console output as before.
+
 ## [0.35.4] — 2026-06-19
 
 ### Fixed

--- a/src/module.zig
+++ b/src/module.zig
@@ -143,7 +143,10 @@ fn logFn(
     comptime format: []const u8,
     args: anytype,
 ) void {
-    std.log.defaultLog(message_level, scope, format, args);
+    // Debug only: in `emacs -nw' the module's stderr is the user's tty.
+    if (builtin.mode == .Debug) {
+        std.log.defaultLog(message_level, scope, format, args);
+    }
 
     if (!vt_log_active) return;
     const env = emacs.current_env orelse return;

--- a/test/ghostel-debug-test.el
+++ b/test/ghostel-debug-test.el
@@ -467,5 +467,58 @@ delta in the phase timings section."
       (kill-buffer buf))))
 
 
+(ert-deftest ghostel-test-vt-warnings-do-not-leak-to-stderr ()
+  "VT-parser warnings must not reach the module's stderr (#425).
+In `emacs -nw' the module's stderr is the controlling tty, so a stray
+write (e.g. lazygit triggering \"unimplemented mode: 9001\") paints raw
+bytes onto the screen outside Emacs's redisplay and lingers near the
+mode line.  A release build must stay silent on stderr; logs are
+available only via `ghostel-debug-start'.  Spawns a child batch Emacs
+that feeds the offending sequence and asserts its stderr is clean."
+  :tags '(native)
+  (let* ((emacs (expand-file-name invocation-name invocation-directory))
+         (lisp (file-name-directory (locate-library "ghostel")))
+         (stderr-file (make-temp-file "ghostel-stderr"))
+         ;; Replicate the parent's `load-path' so the bare `-Q' child can load
+         ;; ghostel and its deps (e.g. compat on Emacs < 30, which CI supplies
+         ;; via -L); `\e' is a real ESC byte parsed as the VT set/reset of 9001.
+         (code (format
+                (concat "(progn (setq load-path '%S) (require 'ghostel)"
+                        " (let ((tm (ghostel--new 25 80 1000)))"
+                        " (ghostel--write-vt tm \"\e[?9001h\")"
+                        " (ghostel--write-vt tm \"\e[?9001l\")))")
+                load-path)))
+    (unwind-protect
+        (with-temp-buffer
+          (let ((status (call-process emacs nil (list t stderr-file) nil
+                                      "--batch" "-Q" "-L" lisp
+                                      "--eval" code)))
+            (should (equal 0 status)))
+          (let ((stderr (with-temp-buffer
+                          (insert-file-contents stderr-file)
+                          (buffer-string))))
+            (should-not (string-match-p "unimplemented mode" stderr))
+            (should-not (string-match-p "warning(stream)" stderr))))
+      (delete-file stderr-file))))
+
+(ert-deftest ghostel-test-vt-log-still-routes-to-debug-buffer ()
+  "With `vt-log' enabled, parser warnings still reach the debug buffer.
+Guards that silencing stderr (#425) didn't break the opt-in diagnosis
+path: `ghostel--enable-vt-log' must route libghostty logs to
+`ghostel-debug--log-buffer' via `ghostel--debug-log-vt'."
+  :tags '(native)
+  (skip-unless (fboundp 'ghostel--enable-vt-log))
+  (let ((ghostel-debug--log-buffer (generate-new-buffer " *ghostel-vt-log*")))
+    (unwind-protect
+        (progn
+          (ghostel--enable-vt-log)
+          (let ((term (ghostel--new 25 80 1000)))
+            (ghostel--write-vt term "\e[?9001h"))
+          (with-current-buffer ghostel-debug--log-buffer
+            (should (string-match-p "unimplemented mode: 9001"
+                                    (buffer-string)))))
+      (ghostel--disable-vt-log)
+      (kill-buffer ghostel-debug--log-buffer))))
+
 (provide 'ghostel-debug-test)
 ;;; ghostel-debug-test.el ends here


### PR DESCRIPTION
Fixes #425.

## Problem

When lazygit (and other TUI apps) exit inside ghostel in `emacs -nw`, a line like `warning(stream): unimplemented mode: 9001` is left painted near the mode line and stays until a full redraw.

Root cause: the native module's `logFn` forwarded **every** libghostty `std.log` message to stderr unconditionally (`std.log.defaultLog`). In a terminal Emacs the module's stderr *is* the controlling tty, so VT-parser warnings get written as raw bytes onto the screen, outside Emacs's redisplay model — so Emacs never repaints over them. It's not specific to mode 9001: any unimplemented sequence the parser meets (e.g. `unknown CSI m`) leaks the same way. GUI Emacs is unaffected because its stderr goes to the launching console.

## Fix

Gate the stderr write behind `builtin.mode == .Debug`. The shipped module is built `-Doptimize=ReleaseFast`, so release users get no stderr writes at all; libghostty logs remain available on demand via `M-x ghostel-debug-start` → `*ghostel-debug*` (the existing opt-in `vt-log` path is untouched). Debug builds keep console output as before.

## Tests

Two `:native` regression tests in `test/ghostel-debug-test.el`:

- `ghostel-test-vt-warnings-do-not-leak-to-stderr` — spawns a child batch Emacs, feeds `ESC[?9001h`/`l`, and asserts its stderr contains no `unimplemented mode` / `warning(stream)`. Genuine red→green guard (the pre-fix build leaked exactly that).
- `ghostel-test-vt-log-still-routes-to-debug-buffer` — confirms `ghostel--enable-vt-log` still routes warnings to `*ghostel-debug*`, so silencing stderr didn't break diagnosis.

## Verification

- `make -j8 all` passes (build + elisp/native/zig/evil tests + checkdoc + package-lint).
- Live, against the rebuilt ReleaseFast module:
  - real `emacs -nw` + mode 9001 → warning no longer painted on the terminal (reproduced before the fix).
  - real lazygit inside ghostel → no libghostty stream warnings reach stderr.

Out of scope, left untouched: the Debug-only memory-leak printer (`module.zig`) and the post-fork child-context stderr writes in `PtyProcess.zig`.