### PR TITLE
Switch input mode when point leaves the live input point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `isearch` and minibuffer navigation (`consult-line`, etc.) in semi-char mode
+  now switch to a read-only mode when they leave you parked in the scrollback,
+  mirroring a mouse click — so the next redraw no longer yanks point back to
+  the prompt.  The target mode is picked by the new
+  `ghostel-point-leave-input-mode` defcustom (`copy` default, `emacs`, or nil
+  to disable).  Wired into `isearch-mode-end-hook` and `minibuffer-exit-hook`;
+  for other jump packages (avy, flash, …) add the new command
+  `ghostel-maybe-leave-input` to their after-jump hook or as `:after` advice.
+  Mouse selection and region activation keep their independent
+  `ghostel-mouse-drag-input-mode` / `ghostel-mark-activation-input-mode` knobs.
+
 ### Changed
 - Internal libghostty VT-parser warnings no longer leak to the module's
   stderr in release builds. In a terminal Emacs (`emacs -nw`) that stderr is

--- a/README.org
+++ b/README.org
@@ -464,6 +464,27 @@ too.  Note that on a TTY Ctrl+Space is indistinguishable from =C-@= (NUL) and
 is forwarded to the terminal instead; in char mode Ctrl+Space always reaches
 the terminal as NUL (GUI and TTY alike).
 
+The same applies when a command merely *moves point* off the live input point
+without selecting anything.  =isearch= (via =isearch-mode-end-hook=) and
+minibuffer commands like =consult-line= (via =minibuffer-exit-hook=) switch to
+the mode picked by =ghostel-point-leave-input-mode= (=copy= by default,
+=emacs=, or =nil= to disable), so the position is frozen and the content is
+navigable instead of the next redraw yanking point back to the prompt.
+
+Other jump packages have no built-in hook, so wire them up with the command
+=ghostel-maybe-leave-input=.  It is a no-op unless, in semi-char mode, point has
+moved off the live cursor, in which case it applies =ghostel-point-leave-input-mode=.
+It ignores its arguments, so it serves as both a hook function and =:after= advice:
+
+#+begin_src emacs-lisp
+;; A package that runs a hook after jumping (e.g. flash):
+(add-hook 'flash-after-jump-hook #'ghostel-maybe-leave-input)
+
+;; A package without one (e.g. avy) — advise its jump action:
+(with-eval-after-load 'avy
+  (advice-add 'avy-action-goto :after #'ghostel-maybe-leave-input))
+#+end_src
+
 ** Line mode
 :properties:
 :custom_id: line-mode
@@ -1205,6 +1226,7 @@ tables below group them by area; defaults shown are the out-of-the-box values.
 | =ghostel-readonly-fake-cursor=       | =t=                 | Draw a hint cursor at the live terminal position in copy/Emacs modes.                                                |
 | =ghostel-mouse-drag-input-mode=      | =copy=              | Mode to enter after a click/drag/multi-click selection: =copy=, =emacs=, or =nil=.                                         |
 | =ghostel-mark-activation-input-mode= | =copy=              | Mode to enter when a command activates the mark: =copy=, =emacs=, or =nil=.                                                |
+| =ghostel-point-leave-input-mode=     | =copy=              | Mode to enter when point leaves the input point (isearch/minibuffer): =copy=, =emacs=, or =nil=.                            |
 | =ghostel-word-boundary-string=       | (see docstring)   | Characters that terminate words for double-click selection and word motion (mirrors Ghostty's =selection-word-chars=). |
 | =ghostel-scroll-on-input=            | =t=                 | Jump to the bottom when typing while scrolled into scrollback.                                                       |
 | =ghostel-bold-color=                 | =nil=               | How bold text is colored: =nil=, =bright=, or a =#RRGGBB= string.                                                          |

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -777,6 +777,17 @@ Mouse selection is governed separately by `ghostel-mouse-drag-input-mode'."
                  (const :tag "Emacs mode"          emacs)
                  (const :tag "Do not switch"       nil)))
 
+(defcustom ghostel-point-leave-input-mode 'copy
+  "Input mode to switch to when point leaves the live input point in semi-char.
+Triggered by any command that moves point off the terminal cursor without a
+mouse click or region activation.  Something like `isearch', `consult-line',
+`avy', `goto-line', wheel scrolling, etc.
+
+See also `ghostel-mouse-drag-input-mode', `ghostel-mark-activation-input-mode'."
+  :type '(choice (const :tag "Copy mode (default)" copy)
+                 (const :tag "Emacs mode"          emacs)
+                 (const :tag "Do not switch"       nil)))
+
 (defcustom ghostel-word-boundary-string " \t\"'`|:;,()[]{}<>$│"
   "Characters that terminate words in ghostel buffers.
 
@@ -2151,7 +2162,7 @@ Returns the sequence string, or nil for unknown keys."
              (memq ghostel--input-mode '(copy emacs)))
     (ghostel-readonly-exit))
   (when (and ghostel-scroll-on-input ghostel--term)
-    (ghostel--anchor-window)))
+    (ghostel--anchor-window nil t)))
 
 (defun ghostel--self-insert ()
   "Send the last typed character to the terminal."
@@ -3072,6 +3083,22 @@ command set the region, so the selection survives the switch."
       ('copy  (ghostel-copy-mode))
       ('emacs (ghostel-emacs-mode)))))
 
+(defun ghostel-maybe-leave-input (&rest _)
+  "Leave semi-char for `ghostel-point-leave-input-mode' if point left the input.
+A no-op unless, in semi-char mode, point has moved off the live terminal cursor.
+Wired into `isearch-mode-end-hook' and `minibuffer-exit-hook'.
+Add it to other jump commands as a hook or `:after' advice (see the README)."
+  (interactive)
+  (when (and ghostel-point-leave-input-mode
+             (eq ghostel--input-mode 'semi-char)
+             ghostel--term
+             ghostel--cursor-char-pos
+             (not executing-kbd-macro)
+             (/= (point) ghostel--cursor-char-pos))
+    (pcase ghostel-point-leave-input-mode
+      ('copy  (ghostel-copy-mode))
+      ('emacs (ghostel-emacs-mode)))))
+
 (defun ghostel-readonly-exit ()
   "Exit copy or Emacs mode and return to the mode active before entry."
   (interactive)
@@ -3086,7 +3113,7 @@ command set the region, so the selection survives the switch."
         ('char  (ghostel-char-mode))
         ('emacs (ghostel-emacs-mode))
         (_      (ghostel-semi-char-mode)))
-      (ghostel--anchor-window)
+      (ghostel--anchor-window nil t)
       (ghostel-force-redraw))
     (message "Read-only mode exited")))
 
@@ -6123,16 +6150,24 @@ the bottom of WINDOW."
               (start (nth 2 size)))
     (cons start (max 0 (- (nth 1 size) body-height)))))
 
-(defun ghostel--anchor-window (&optional window)
+(defun ghostel--anchor-window (&optional window force)
   "Scroll WINDOW so that the last row is aligned to the bottom of the window.
 In graphical frames, use Emacs's pixel layout for exact bottom alignment.
 In text frames, use line-count geometry with no vscroll.
-Do nothing unless WINDOW displays a live Ghostel terminal."
+Do nothing unless WINDOW displays a live Ghostel terminal.
+
+Copy mode is never anchored (the viewport is frozen).  Emacs mode is
+anchored only when FORCE is non-nil, reserved for deliberate anchors such
+as paste/yank that should scroll to the live cursor even in Emacs mode;
+auto-follow callers leave FORCE nil so a buffer reading its scrollback in
+Emacs mode keeps its position.  Semi-char/char/line always anchor."
   (when-let* ((window (or window (selected-window)))
               (buffer (window-buffer window))
               ((with-current-buffer buffer
                  (and (derived-mode-p 'ghostel-mode)
-                      (ghostel--terminal-live-p)))))
+                      (if (eq ghostel--input-mode 'emacs)
+                          force
+                        (ghostel--terminal-live-p))))))
     (with-selected-window window
       (with-current-buffer buffer
         (let ((target (point-max)))
@@ -6360,6 +6395,18 @@ a Ghostel window making it lose its anchoring."
                                   (eq (window-buffer win) buffer))
                          (ghostel--anchor-window win))))))))
 
+(defun ghostel--minibuffer-exit-maybe-leave ()
+  "Run `ghostel-maybe-leave-input' after a minibuffer command, deferred.
+Covers minibuffer-driven navigation such as `consult-line', whose marker-based
+point landing can lag minibuffer teardown.  Deferred so the originating window
+and point settle first.  See `ghostel-point-leave-input-mode'."
+  (run-at-time 0 nil
+               (lambda ()
+                 (when-let* ((buf (window-buffer (selected-window))))
+                   (with-current-buffer buf
+                     (when (derived-mode-p 'ghostel-mode)
+                       (ghostel-maybe-leave-input)))))))
+
 (defun ghostel--kill-buffer-query ()
   "Return non-nil when the current ghostel buffer may be killed.
 Honors `ghostel-query-before-killing' and `ghostel--command-running'
@@ -6415,7 +6462,9 @@ for both native and Emacs PTY paths."
   (add-hook 'window-buffer-change-functions #'ghostel--sync-tty-composition nil t)
   (add-hook 'window-size-change-functions #'ghostel--adjust-size nil t)
   (add-hook 'minibuffer-exit-hook #'ghostel--minibuffer-exit)
+  (add-hook 'minibuffer-exit-hook #'ghostel--minibuffer-exit-maybe-leave)
   (add-hook 'activate-mark-hook #'ghostel--mark-activated nil t)
+  (add-hook 'isearch-mode-end-hook #'ghostel-maybe-leave-input nil t)
   (add-hook 'kill-buffer-query-functions #'ghostel--kill-buffer-query nil t)
   ;; Show the hyperlink URI at point in eldoc.
   (add-hook 'eldoc-documentation-functions #'ghostel--eldoc-link nil t)

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -955,5 +955,123 @@ but the cursor is at the end of the REPL's prompt."
             (should (equal encoded "return"))))
       (kill-buffer buf))))
 
+;;; Auto-leave: switch out of semi-char when point leaves the input point
+
+(defmacro ghostel-test--with-auto-leave-buffer (&rest body)
+  "Run BODY in a fresh semi-char `ghostel-mode' buffer set up for auto-leave.
+Inserts \"echo hi\", parks the live cursor at `point-max', and stubs the
+window-touching helpers `ghostel--invalidate' / `ghostel--anchor-window'
+so copy/Emacs mode entry runs without a live terminal or window."
+  (declare (indent 0) (debug t))
+  `(let ((buf (generate-new-buffer " *ghostel-test-auto-leave*")))
+     (unwind-protect
+         (with-current-buffer buf
+           (ghostel-mode)
+           (insert "echo hi")
+           (setq-local ghostel--term 'fake)
+           (setq-local ghostel--cursor-char-pos (point-max))
+           (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+                     ((symbol-function 'ghostel--anchor-window) #'ignore))
+             ,@body))
+       (kill-buffer buf))))
+
+(ert-deftest ghostel-test-auto-leave-switches-to-copy ()
+  "Point leaving the live cursor in semi-char enters copy mode (the default)."
+  (ghostel-test--with-auto-leave-buffer
+    (let ((ghostel-point-leave-input-mode 'copy))
+      (goto-char (point-min))
+      (ghostel-maybe-leave-input)
+      (should (eq ghostel--input-mode 'copy)))))
+
+(ert-deftest ghostel-test-auto-leave-switches-to-emacs ()
+  "With the custom set to `emacs', point leaving enters Emacs mode."
+  (ghostel-test--with-auto-leave-buffer
+    (let ((ghostel-point-leave-input-mode 'emacs))
+      (goto-char (point-min))
+      (ghostel-maybe-leave-input)
+      (should (eq ghostel--input-mode 'emacs)))))
+
+(ert-deftest ghostel-test-auto-leave-stays-when-point-on-cursor ()
+  "Point coinciding with the live cursor keeps the buffer in semi-char."
+  (ghostel-test--with-auto-leave-buffer
+    (let ((ghostel-point-leave-input-mode 'copy))
+      (goto-char ghostel--cursor-char-pos)
+      (ghostel-maybe-leave-input)
+      (should (eq ghostel--input-mode 'semi-char)))))
+
+(ert-deftest ghostel-test-auto-leave-disabled-by-nil ()
+  "A nil custom disables the auto-switch even when point has moved."
+  (ghostel-test--with-auto-leave-buffer
+    (let ((ghostel-point-leave-input-mode nil))
+      (goto-char (point-min))
+      (ghostel-maybe-leave-input)
+      (should (eq ghostel--input-mode 'semi-char)))))
+
+(ert-deftest ghostel-test-auto-leave-only-from-semi-char ()
+  "The check is a no-op when not in semi-char (e.g. already in copy mode)."
+  (ghostel-test--with-auto-leave-buffer
+    (let ((ghostel-point-leave-input-mode 'copy))
+      (setq-local ghostel--input-mode 'copy)
+      (goto-char (point-min))
+      (ghostel-maybe-leave-input)
+      (should (eq ghostel--input-mode 'copy)))))
+
+(ert-deftest ghostel-test-auto-leave-skips-kbd-macro ()
+  "Executing a keyboard macro does not switch mode mid-playback."
+  (ghostel-test--with-auto-leave-buffer
+    (let ((ghostel-point-leave-input-mode 'copy)
+          (executing-kbd-macro [?x]))
+      (goto-char (point-min))
+      (ghostel-maybe-leave-input)
+      (should (eq ghostel--input-mode 'semi-char)))))
+
+(ert-deftest ghostel-test-auto-leave-preserves-point ()
+  "Switching modes leaves point where the jump landed it."
+  (ghostel-test--with-auto-leave-buffer
+    (let ((ghostel-point-leave-input-mode 'copy))
+      (goto-char 3)
+      (ghostel-maybe-leave-input)
+      (should (eq ghostel--input-mode 'copy))
+      (should (= (point) 3)))))
+
+(ert-deftest ghostel-test-auto-leave-isearch-hook-registered ()
+  "`ghostel-mode' wires the leave check into `isearch-mode-end-hook'."
+  (let ((buf (generate-new-buffer " *ghostel-test-auto-leave-hook*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (should (memq #'ghostel-maybe-leave-input
+                        (buffer-local-value 'isearch-mode-end-hook buf))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-anchor-window-emacs-mode-force ()
+  "`ghostel--anchor-window' anchors an Emacs-mode window only when FORCE is set.
+Auto-follow callers leave FORCE nil, so a buffer reading its scrollback in
+Emacs mode keeps its position.  Deliberate callers (paste/yank) pass FORCE to
+snap to the live cursor."
+  (let ((buf (generate-new-buffer " *ghostel-test-anchor-force*"))
+        (previous-buffer (window-buffer (selected-window))))
+    (unwind-protect
+        (progn
+          (set-window-buffer (selected-window) buf)
+          (with-current-buffer buf
+            (ghostel-mode)
+            (let ((rows (max 1 (window-body-height)))
+                  (inhibit-read-only t))
+              (dotimes (i (+ rows 20))
+                (insert (format "row-%02d\n" i))))
+            (setq ghostel--input-mode 'emacs)
+            (setq ghostel--cursor-char-pos (point-max))
+            (goto-char (point-min))
+            (set-window-start (selected-window) (point-min) t)
+            ;; Without FORCE: Emacs mode keeps its reading position.
+            (ghostel--anchor-window (selected-window))
+            (should (= (window-start (selected-window)) (point-min)))
+            ;; With FORCE: a deliberate anchor scrolls to the live cursor.
+            (ghostel--anchor-window (selected-window) t)
+            (should (> (window-start (selected-window)) (point-min)))))
+      (set-window-buffer (selected-window) previous-buffer)
+      (kill-buffer buf))))
+
 (provide 'ghostel-modes-test)
 ;;; ghostel-modes-test.el ends here


### PR DESCRIPTION
## What

The keyboard analog of the existing mouse/mark mode-switch: in semi-char mode, when point moves off the live terminal cursor, ghostel switches to a read-only mode (`ghostel-point-leave-input-mode`, default `copy`) so the navigated position is stable instead of the next redraw yanking point back to the prompt.

## Details

- New defcustom `ghostel-point-leave-input-mode` (`copy`/`emacs`/`nil`), a sibling of `ghostel-mouse-drag-input-mode` and `ghostel-mark-activation-input-mode`.
- New public command `ghostel-maybe-leave-input` — a no-op unless point has left the live cursor in semi-char; ignores its args so it works as a hook function or `:after` advice.
- Wired into `isearch-mode-end-hook` and (deferred) `minibuffer-exit-hook` (covers `consult-line` and other minibuffer jumps). Packages with no hook of their own (avy, flash) add `ghostel-maybe-leave-input` themselves — documented in the README.
- The deferred `minibuffer-exit` re-anchor now skips copy/Emacs buffers, so a minibuffer jump that switched modes isn't snapped back to the live cursor; semi-char/char/line still re-anchor as before. The guard lives on the auto-follow path rather than in `ghostel--anchor-window`, which intentionally anchors Emacs mode for deliberate input like paste (covered by `ghostel-test-emacs-mode-yank-scrolls-to-live-cursor`).

## Testing

- New ERT tests in `ghostel-modes-test.el`; `make -j8 all` green.
- Live-verified under elate (real shell in a ghostel buffer) across both `copy` and `emacs` targets for isearch, consult-line (deep + near-bottom), avy, and flash, plus the no-false-positive typing path.

README and CHANGELOG updated.