### PR TITLE
Mark OSC 133 output and skip prompt regex on output rows

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3915,7 +3915,9 @@ pressing \\`C-a' gives the standard column-0 behaviour."
                 (and (> pos bol) (< pos eol) pos)))))
          ;; Regex fallback for shells/REPLs without OSC 133.
          (regex-target
-          (unless (or line-mode-target prop-target)
+          (unless (or line-mode-target
+                      prop-target
+                      (text-property-not-all bol eol 'ghostel-output nil))
             (ghostel--regex-prompt-end bol))))
     (cond
      (line-mode-target (goto-char line-mode-target))

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -78,6 +78,10 @@ pub fn redraw(self: *Self, force_full: bool) !void {
     defer self.unlockTerm();
 
     const env = emacs.current_env orelse return;
+    // A native process sees OSC 133 markers on its own thread; fold its flag in.
+    if (self.process) |proc| {
+        if (proc.semantic_output_enabled) self.renderer.semantic_output_enabled = true;
+    }
     const pre_size = .{ self.terminal.cols, self.terminal.rows };
     try self.renderer.redraw(self.alloc, env, force_full);
     _ = env.f("ghostel--kitty-clear", .{});
@@ -94,6 +98,11 @@ pub fn redraw(self: *Self, force_full: bool) !void {
             );
         }
     }
+}
+
+/// Mark that OSC 133 semantic markers have been seen (in-process case).
+pub fn enableSemanticOutput(self: *Self) void {
+    self.renderer.semantic_output_enabled = true;
 }
 
 /// Set default foreground color.

--- a/src/NativeProcess.zig
+++ b/src/NativeProcess.zig
@@ -31,6 +31,10 @@ wake_pipe: [2]posix.fd_t = .{ -1, -1 },
 quit: bool = false,
 thread: std.Thread,
 
+/// Whether OSC 133 semantic markers have been seen. Set and read under
+/// `term_mutex`; `GhostelTerm.redraw` folds it into the renderer.
+semantic_output_enabled: bool = false,
+
 pub fn init(
     self: *Self,
     alloc: Allocator,
@@ -52,6 +56,11 @@ pub fn init(
         .wake_pipe = pipe,
         .thread = try std.Thread.spawn(.{}, Self.run, .{self}),
     };
+}
+
+/// Mark that OSC 133 semantic markers have been seen (native case).
+pub fn enableSemanticOutput(self: *Self) void {
+    self.semantic_output_enabled = true;
 }
 
 pub fn lockTerm(self: *Self) void {

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -55,6 +55,11 @@ font_info: ?FontInfo = null,
 /// Bold text coloring configuration.
 bold_config: ?gt.Style.BoldColor = null,
 
+/// Whether OSC 133 semantic prompt markers have been seen for this terminal.
+/// Before this is true, `.output` is just libghostty's default cell semantic and
+/// should not become an Emacs text property.
+semantic_output_enabled: bool = false,
+
 /// Saved positions and pins for various buffer markers. Retained between
 /// rendering passes to avoid allocations.
 saved_markers: SavedBufferMarkers = .{},
@@ -313,10 +318,16 @@ fn createCellProps(
     props.hyperlink = resolveHyperlink(page, key.hyperlink_id);
     props.semantic_content = cell.raw.semantic_content;
 
-    return if (props.isDefault(
+    const is_default = props.isDefault(
         self.render_state.colors.foreground,
         self.render_state.colors.background,
-    )) null else props;
+    );
+
+    return if (is_default and
+        (props.semantic_content != .output or !self.semantic_output_enabled))
+        null
+    else
+        props;
 }
 
 /// Apply text properties to a region of the buffer.
@@ -388,6 +399,12 @@ fn applyProps(env: emacs.Env, start: i64, end: i64, props: CellProps) !void {
             start_val,
             end_val,
             s.@"ghostel-input",
+            env.t(),
+        }),
+        .output => _ = env.f("put-text-property", .{
+            start_val,
+            end_val,
+            s.@"ghostel-output",
             env.t(),
         }),
         else => {},

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -407,7 +407,6 @@ fn applyProps(env: emacs.Env, start: i64, end: i64, props: CellProps) !void {
             s.@"ghostel-output",
             env.t(),
         }),
-        else => {},
     }
 }
 

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -464,6 +464,7 @@ const interned_symbols = [_][:0]const u8{
     "ghostel-link-id",
     "ghostel-link-map",
     "ghostel-module",
+    "ghostel-output",
     "ghostel-prompt",
     "ghostel-wrap",
     "goto-char",

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -138,7 +138,7 @@ pub fn GhostelHandler(Context: type) type {
         /// PARAM is the raw options string from the OSC - elisp parses it on
         /// demand (e.g. `(string-to-number param)` for the 'D' exit code).
         fn handleSemanticPrompt(self: *Self, sp: gt.osc.Command.SemanticPrompt) void {
-            self.context.renderer.semantic_output_enabled = true;
+            self.context.enableSemanticOutput();
 
             const marker_char: u8 = switch (sp.action) {
                 .fresh_line_new_prompt, .new_command => 'A',

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -138,6 +138,8 @@ pub fn GhostelHandler(Context: type) type {
         /// PARAM is the raw options string from the OSC - elisp parses it on
         /// demand (e.g. `(string-to-number param)` for the 'D' exit code).
         fn handleSemanticPrompt(self: *Self, sp: gt.osc.Command.SemanticPrompt) void {
+            self.context.renderer.semantic_output_enabled = true;
+
             const marker_char: u8 = switch (sp.action) {
                 .fresh_line_new_prompt, .new_command => 'A',
                 .prompt_start => 'P',

--- a/test/ghostel-line-mode-test.el
+++ b/test/ghostel-line-mode-test.el
@@ -934,6 +934,24 @@ Without prop, marker, or regex, the command falls through to BOL."
               (should (= (current-column) 0)))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-beginning-of-input-or-line-output-skips-regex ()
+  "`C-a' on OSC 133-marked output ignores prompt-regexp false positives."
+  (let ((buf (generate-new-buffer " *ghostel-test-c-a-output*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (insert (propertize
+                   "[44/48] Removing docker-ce-cli 100% | 14.3 KiB/s"
+                   'ghostel-output t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore))
+              (ghostel-emacs-mode)
+              (search-backward "|")
+              (ghostel-beginning-of-input-or-line)
+              (should (= (current-column) 0)))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-beginning-of-input-or-line-regex-ps2-continuation ()
   "`C-a' on an empty PS2 continuation row lands past the prefix.
 The helper's `<=' check enables this — every fresh `RET' the user

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -1909,6 +1909,47 @@ scanner skips them."
                              (point-min) 'ghostel-input))))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-osc133-output-text-property ()
+  "Cells between OSC 133 C and D should be marked `ghostel-output'."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-osc133-output*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 80 100))
+                 (inhibit-read-only t)
+                 (output "[44/48] Removing docker-ce-cli 100% | 14.3 KiB/s"))
+            (ghostel--write-vt
+             term (concat "\e]133;A\e\\$ \e]133;B\e\\dnf update\r\n"
+                          "\e]133;C\e\\" output "\r\n\e]133;D;0\e\\"))
+            (ghostel--redraw term)
+            (goto-char (point-min))
+            (should (search-forward output nil t))
+            (let ((output-beg (- (point) (length output)))
+                  (output-end (point)))
+              (should (get-text-property output-beg 'ghostel-output))
+              (should (get-text-property (1- output-end) 'ghostel-output))
+              (should (null (get-text-property output-beg 'ghostel-prompt)))
+              (should (null (get-text-property output-beg 'ghostel-input))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-plain-output-has-no-output-text-property ()
+  "Without OSC 133, default output cells are not marked `ghostel-output'."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-plain-output*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 80 100))
+                 (inhibit-read-only t)
+                 (output ">>> import os"))
+            (ghostel--write-vt term output)
+            (ghostel--redraw term)
+            (goto-char (point-min))
+            (should (search-forward output nil t))
+            (should (null (get-text-property
+                           (- (point) (length output))
+                           'ghostel-output)))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-osc133-prompt-stops-at-input ()
   "`ghostel-prompt' must end where `ghostel-input' begins on the row.
 Without this, the historical prompt row carries `ghostel-prompt'


### PR DESCRIPTION
Fixes #430 

Shells with OSC 133 integration emit a C marker to delimit command output. Previously these output cells carried no Emacs text property, so `ghostel-beginning-of-input-or-line` (C-a) had no way to tell output apart from a prompt and fell back to `ghostel-prompt-regexp`. On output that happens to look prompt-like (e.g. a progress bar such as "[44/48] Removing docker-ce-cli 100% | 14.3 KiB/s") the regex matched mid-line and C-a jumped past real text instead of to column 0.

Propagate the cell's `.output` semantic content to a new `ghostel-output` text property and skip the regex fallback on any row carrying it.

Because libghostty's default cell semantic is `.output`, a guard (`semantic_output_enabled`) ensures the property is only applied once an OSC 133 marker has actually been seen, otherwise every cell on a plain shell would be marked as output.