### PR TITLE
Add blinking cursor support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ All notable changes to this project will be documented in this file.
   `ghostel-maybe-leave-input` to their after-jump hook or as `:after` advice.
   Mouse selection and region activation keep their independent
   `ghostel-mouse-drag-input-mode` / `ghostel-mark-activation-input-mode` knobs.
+- Blinking cursor support. A terminal app that requests a blinking cursor
+  (DECSCUSR `CSI 5/3/1 SP q`, i.e. mode 12) now blinks the cursor in the Emacs
+  buffer instead of rendering it steady. Works for the bar, block, and
+  underline shapes. Yields to the global `blink-cursor-mode` when that is
+  enabled (no double-blink); graphical frames only.
 
 ### Changed
 - Internal libghostty VT-parser warnings no longer leak to the module's

--- a/README.org
+++ b/README.org
@@ -578,7 +578,7 @@ read-only buffer (Emacs or copy).
 - *OSC 9 / OSC 777* - desktop notifications and ConEmu progress reports (see
   [[#notifications-and-progress][Notifications and Progress]]).
 - Text attributes: bold, italic, faint, underline (single/double/curly/dotted/dashed, with color), strikethrough, inverse.
-- Cursor styles: block, bar, underline, hollow block.
+- Cursor styles: block, bar, underline, hollow block - each steady or blinking.
 - Alternate screen buffer (for TUI apps like htop, vim, etc.).
 - Scrollback buffer (configurable, default 5 MB / ~5,000 lines, materialized
   into the Emacs buffer so =isearch= / =consult-line= work over history).
@@ -1806,7 +1806,8 @@ while ghostel and vterm trade a compile step for a C/Zig engine.
 | Underline styles              | 5 types | ❌       | curly    |
 | Colored underline             | ✅      | ❌       | ✅       |
 | Strikethrough                 | ✅      | ✅       | ✅       |
-| Cursor styles                 | 4       | 3        | 7        |
+| Cursor shapes                 | 4       | 3        | 3        |
+| Blinking cursor               | ✅      | partial  | ✅       |
 |-------------------------------+---------+----------+----------|
 | Kitty graphics (images)       | ✅      | ❌       | ❌       |
 | Sixel graphics                | ❌      | ❌       | ✅       |

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -169,7 +169,10 @@ ORIG-FN is the advised setter (STYLE, VISIBLE); deferred to in alt-screen."
   (if (and evil-ghostel-mode
            ghostel--term
            (not (ghostel--mode-enabled ghostel--term 1049)))
-      (evil-refresh-cursor)
+      ;; Evil owns the cursor now; end any terminal-driven blink that a
+      ;; full-screen app left running before we exited the alt-screen.
+      (progn (ghostel--cursor-blink-stop)
+             (evil-refresh-cursor))
     (funcall orig-fn)))
 
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1560,6 +1560,21 @@ Matches Ghostty 1.2.0's `bold-color' configuration."
 (defvar-local ghostel--cursor-pos nil
   "The terminal cursor as (COL . ROW) in viewport-relative coordinates.")
 
+(defvar-local ghostel--cursor-blinking nil
+  "Non-nil when the terminal requests a blinking cursor.
+Published by the renderer alongside `ghostel--cursor-style' and read by
+`ghostel--apply-cursor-style'.")
+
+(defvar-local ghostel--cursor-blink-timer nil
+  "Repeating timer blinking the terminal cursor, or nil when steady.")
+
+(defvar-local ghostel--cursor-blink-window nil
+  "Window whose cursor the blink timer last toggled.
+Tracked so the cursor can be restored there even after this buffer
+stops being displayed in it; `internal-show-cursor' sets a
+per-window flag, so a window left in the blink's \"off\" phase would
+otherwise hide its cursor for whatever buffer it shows next.")
+
 (defvar-local ghostel--cursor-char-pos nil
   "The position of the terminal cursor in the buffer.")
 
@@ -2833,6 +2848,7 @@ OSC 9;4 packet, and same-value packets must not fire FMLU."
 Saves the cursor style, re-enables `hl-line-mode' if it was
 suppressed, and sets the buffer read-only.  Does NOT cancel the
 redraw timer — that is the caller's job when freezing."
+  (ghostel--cursor-blink-stop)
   (setq ghostel--saved-cursor-type cursor-type)
   (setq cursor-type (default-value 'cursor-type))
   (when ghostel--saved-hl-line-mode
@@ -3547,6 +3563,7 @@ in line mode (the interactive entry validates these)."
       ;; running terminal app issued in semi-char/char mode.
       ;; `ghostel--apply-cursor-style' is a no-op in line mode, so
       ;; further terminal requests are ignored until teardown.
+      (ghostel--cursor-blink-stop)
       (setq ghostel--line-mode-saved-cursor-type (list cursor-type))
       (setq cursor-type (default-value 'cursor-type))
       ;; Force full redraws while line mode is active so the
@@ -5120,11 +5137,69 @@ Maps TITLE through `ghostel-buffer-name-function' and renames via
   (when ghostel-buffer-name-function
     (ghostel--rename-managed (funcall ghostel-buffer-name-function title))))
 
+(defun ghostel--cursor-blink-stop ()
+  "Cancel the blink timer, restore the cursor, and remove the blink hooks.
+Restores via `ghostel--cursor-blink-window' rather than this buffer's
+current window, which may already show another buffer."
+  (when ghostel--cursor-blink-timer
+    (cancel-timer ghostel--cursor-blink-timer)
+    (setq ghostel--cursor-blink-timer nil))
+  (when (window-live-p ghostel--cursor-blink-window)
+    (internal-show-cursor ghostel--cursor-blink-window t))
+  (setq ghostel--cursor-blink-window nil)
+  (remove-hook 'window-buffer-change-functions
+               #'ghostel--cursor-blink-restore-window t)
+  (remove-hook 'kill-buffer-hook #'ghostel--cursor-blink-stop t))
+
+(defun ghostel--cursor-blink-restore-window (window)
+  "Show WINDOW's cursor after this buffer enters or leaves it.
+A buffer-local `window-buffer-change-functions' entry.  The blink sets
+a per-window \"cursor off\" flag via `internal-show-cursor', which would
+hide the cursor of whatever buffer the window shows next.  The restore
+is deferred to a 0-delay timer because `internal-show-cursor' is inert
+during redisplay, which is when these functions run."
+  (run-at-time 0 nil
+               (lambda ()
+                 (when (window-live-p window)
+                   (internal-show-cursor window t)))))
+
+(defun ghostel--cursor-blink-tick (buffer)
+  "Toggle BUFFER's cursor visibility.
+Self-stops when BUFFER is no longer the selected window or has
+left terminal input mode, so the navigation cursor stays solid."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let ((win (get-buffer-window buffer)))
+        (if (and win
+                 (eq win (selected-window))
+                 (ghostel--buffer-editable-p))
+            (progn
+              (setq ghostel--cursor-blink-window win)
+              (internal-show-cursor win (not (internal-show-cursor-p win))))
+          (ghostel--cursor-blink-stop))))))
+
+(defun ghostel--cursor-blink-start ()
+  "Begin blinking the cursor.
+No-op on text terminals, when already blinking, or when the global
+`blink-cursor-mode' already drives the blink (avoids a double beat)."
+  (when (and (display-graphic-p)
+             (not ghostel--cursor-blink-timer)
+             (not blink-cursor-mode))
+    (add-hook 'kill-buffer-hook #'ghostel--cursor-blink-stop nil t)
+    ;; Restore the cursor when the blinked window switches buffers, so a window
+    ;; left in the blink's "off" phase never hides the next buffer's cursor.
+    (add-hook 'window-buffer-change-functions
+              #'ghostel--cursor-blink-restore-window nil t)
+    (setq ghostel--cursor-blink-window (selected-window))
+    (setq ghostel--cursor-blink-timer
+          (run-with-timer blink-cursor-interval blink-cursor-interval
+                          #'ghostel--cursor-blink-tick (current-buffer)))))
+
 (defun ghostel--apply-cursor-style ()
-  "Apply the terminal cursor style published by the native renderer.
-The renderer owns discovering terminal cursor state, but cursor
-application is intentionally kept in Elisp so input modes and
-integrations can decide whether `cursor-type' should change."
+  "Apply the cursor style and blink published by the native renderer.
+Kept in Elisp so input modes and integrations can decide whether
+`cursor-type' should change.  Reads the buffer-local
+`ghostel--cursor-style' and `ghostel--cursor-blinking'."
   (when (and (ghostel--buffer-editable-p)
              (not ghostel-ignore-cursor-change))
     (setq cursor-type
@@ -5134,7 +5209,10 @@ integrations can decide whether `cursor-type' should change."
 			(2 '(hbar . 2))      ; underline
 			(3 'hollow)          ; hollow block
 			('nil nil)
-			(_ 'box)))))
+			(_ 'box)))
+    (if (and ghostel--cursor-style ghostel--cursor-blinking)
+        (ghostel--cursor-blink-start)
+      (ghostel--cursor-blink-stop))))
 
 (defun ghostel--update-directory (dir)
   "Update `default-directory' from terminal's OSC 7 report.

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -937,6 +937,8 @@ fn renderCursor(self: *Self, env: emacs.Env) !void {
         _ = env.set("ghostel--cursor-pos", env.nil());
     }
 
+    _ = env.set("ghostel--cursor-blinking", if (self.render_state.cursor.blinking) env.t() else env.nil());
+
     if (self.render_state.cursor.visible) {
         env.set(
             "ghostel--cursor-style",

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -440,6 +440,7 @@ const interned_symbols = [_][:0]const u8{
     "fset",
     "get-buffer-window-list",
     "ghostel",
+    "ghostel--cursor-blinking",
     "ghostel--cursor-char-pos",
     "ghostel--cursor-pos",
     "ghostel--cursor-style",

--- a/test/ghostel-terminal-test.el
+++ b/test/ghostel-terminal-test.el
@@ -453,5 +453,47 @@ state from the wrong buffer after feeding output to the native module."
             (should (equal cursor-type 'box))))  ; unchanged
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-cursor-blink ()
+  "A blinking cursor request starts the blink timer; steady cancels it."
+  (let ((buf (generate-new-buffer " *ghostel-test-cursor-blink*")))
+    (unwind-protect
+        ;; Pretend we are on a graphical display and the user has the
+        ;; global blink off, so `ghostel--cursor-blink-start' engages.
+        (cl-letf (((symbol-function 'display-graphic-p) (lambda (&rest _) t)))
+          (with-current-buffer buf
+            (ghostel-mode)
+            (let ((blink-cursor-mode nil))
+              ;; Blinking block requested -> timer running, box shape,
+              ;; and both blink hooks installed buffer-locally.
+              (setq ghostel--cursor-blinking t)
+              (setq ghostel--cursor-style 1)
+              (ghostel--apply-cursor-style)
+              (should (equal cursor-type 'box))
+              (should (timerp ghostel--cursor-blink-timer))
+              (should (memq #'ghostel--cursor-blink-restore-window
+                            window-buffer-change-functions))
+              (should (memq #'ghostel--cursor-blink-stop kill-buffer-hook))
+              ;; Steady request -> timer cancelled and hooks removed.
+              (setq ghostel--cursor-blinking nil)
+              (setq ghostel--cursor-style 1)
+              (ghostel--apply-cursor-style)
+              (should-not ghostel--cursor-blink-timer)
+              (should-not (memq #'ghostel--cursor-blink-restore-window
+                                window-buffer-change-functions))
+              (should-not (memq #'ghostel--cursor-blink-stop kill-buffer-hook))
+              ;; Blinking again, then hidden cursor -> cancelled, hooks gone.
+              (setq ghostel--cursor-blinking t)
+              (setq ghostel--cursor-style 0)
+              (ghostel--apply-cursor-style)
+              (should (timerp ghostel--cursor-blink-timer))
+              (setq ghostel--cursor-style nil)
+              (ghostel--apply-cursor-style)
+              (should-not ghostel--cursor-blink-timer)
+              (should-not (memq #'ghostel--cursor-blink-restore-window
+                                window-buffer-change-functions)))))
+      ;; `kill-buffer' runs the buffer-local `kill-buffer-hook' that
+      ;; `ghostel--cursor-blink-start' installs, cancelling any timer.
+      (kill-buffer buf))))
+
 (provide 'ghostel-terminal-test)
 ;;; ghostel-terminal-test.el ends here


### PR DESCRIPTION
## Summary

Adds **blinking cursor support** — the one cursor capability ghostel was missing versus eat. ghostty's VT engine already computes the blink state (DECSCUSR mode 12), but the renderer was dropping it; now a terminal app that requests a blinking bar/block/underline actually blinks in the Emacs buffer instead of rendering steady.

## How it works

- **Renderer** forwards `render_state.cursor.blinking` to the buffer-local `ghostel--cursor-blinking` (threaded like `ghostel--cursor-pos`, so `ghostel--set-cursor-style` keeps its 2-arg signature — no churn for evil-ghostel's advice or existing tests).
- A **per-buffer timer** blinks the cursor with `internal-show-cursor` — the same cheap primitive Emacs's own `blink-cursor-mode` uses (no `redraw-frame`, unlike eat).
- **Yields to a globally-enabled `blink-cursor-mode`** to avoid a double beat, and only runs on graphical frames.

## Window-leak fix

`internal-show-cursor` sets a per-*window* "cursor off" flag, so a window the blink left mid-"off" would hide the cursor of whatever buffer it showed next (e.g. split the terminal's window, switch it to `*scratch*` → no cursor). The blinked window is restored both when the blink stops and on `window-buffer-change-functions` — deferred via `run-at-time 0` because `internal-show-cursor` is inert during redisplay, which is when those functions run. Both hooks are installed **only while actively blinking** and removed on stop (no per-command hooks).

## Other

- **evil-ghostel** ends any terminal-driven blink when evil reclaims the cursor on leaving the alt-screen.
- **Docs**: README feature comparison now splits "Cursor shapes" (ghostel 4, incl. hollow / vterm 3 / eat 3) from "Blinking cursor" (ghostel ✅ / vterm partial / eat ✅); CHANGELOG entry added.

## Testing

- Unit test `ghostel-test-cursor-blink` (timer start/stop + hook install/removal).
- Verified live in a GUI Emacs via elate: DECSCUSR `\e[5 q` starts a real toggling blink, `\e[2 q` goes steady, copy mode cancels it, and `C-x b *scratch*` from the blinked window leaves the cursor visible (the leak fix).
- `make -j8 all` green.
