### PR TITLE
Resolve local PTY programs via exec-path

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -5427,6 +5427,17 @@ which always returns a string — no extra args."
       (cons (ghostel--get-shell) nil)
     (ghostel--shell-program-and-args ghostel-shell)))
 
+(defun ghostel--resolve-local-executable (program)
+  "Return the absolute local executable path for PROGRAM.
+Bare program names are resolved via variable `exec-path'.  PROGRAM with a
+directory component is expanded relative to `default-directory'."
+  (let ((resolved (if (file-name-directory program)
+                      (expand-file-name program)
+                    (executable-find program))))
+    (unless (and resolved (file-executable-p resolved))
+      (error "Searching for program: No such file or directory, %s" program))
+    resolved))
+
 (defun ghostel--macos-login-wrap (program args)
   "Wrap PROGRAM/ARGS via `/usr/bin/login' to produce a macOS login shell.
 Returns (LOGIN-PROGRAM . LOGIN-ARGS).  Mirrors Ghostty's wrap:
@@ -5815,13 +5826,17 @@ for the native child process."
 
 (defun ghostel--spawn-process (program program-args remote-p)
   "Dispatch the spawn of PROGRAM (with PROGRAM-ARGS) to native or Emacs.
+Local PROGRAM is resolved to an absolute path before backend dispatch.
 Local buffers use the native PTY path when `ghostel-use-native-pty'
 is non-nil; remote (REMOTE-P) buffers always go through Emacs so
 TRAMP can manage the remote shell."
-  (setq ghostel--process
-        (if (and ghostel-use-native-pty (not remote-p))
-            (ghostel--spawn-via-native (cons program program-args))
-          (ghostel--spawn-via-emacs program program-args remote-p))))
+  (let ((program (if remote-p
+                     program
+                   (ghostel--resolve-local-executable program))))
+    (setq ghostel--process
+          (if (and ghostel-use-native-pty (not remote-p))
+              (ghostel--spawn-via-native (cons program program-args))
+            (ghostel--spawn-via-emacs program program-args remote-p)))))
 
 (defun ghostel--spawn-via-emacs (program program-args &optional remote-p)
   "Spawn PROGRAM with PROGRAM-ARGS through Emacs process machinery.

--- a/src/PtyProcess.zig
+++ b/src/PtyProcess.zig
@@ -166,22 +166,21 @@ pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: Proc
     }
 
     // This is the child
-    var stderr_buf: [1024]u8 = undefined;
-    const stderr_writer = std.fs.File.stderr().writer(&stderr_buf);
-    var stderr = stderr_writer.interface;
-
     self.pty.setupReplica() catch |err| {
-        stderr.print("Failed to set up PTY replica: {s}", .{@errorName(err)}) catch {};
+        _ = posix.write(posix.STDERR_FILENO, "Failed to set up PTY replica: ") catch {};
+        _ = posix.write(posix.STDERR_FILENO, @errorName(err)) catch {};
         std.c._exit(1);
     };
 
     if (params.cwd) |cwd| posix.chdir(cwd) catch |err| {
-        stderr.print("Failed to change working directory: {s}", .{@errorName(err)}) catch {};
+        _ = posix.write(posix.STDERR_FILENO, "Failed to change working directory: ") catch {};
+        _ = posix.write(posix.STDERR_FILENO, @errorName(err)) catch {};
     };
 
     const err = posix.execvpeZ(params.file, args, env);
     // The above never returns on success, if we're here it means we failed
-    stderr.print("Failed to start subprocess: {s}", .{@errorName(err)}) catch {};
+    _ = posix.write(posix.STDERR_FILENO, "Failed to start subprocess: ") catch {};
+    _ = posix.write(posix.STDERR_FILENO, @errorName(err)) catch {};
     std.c._exit(1);
 }
 

--- a/test/ghostel-spawn-test.el
+++ b/test/ghostel-spawn-test.el
@@ -329,6 +329,39 @@ former defaulted to t and throttled bursty TUI redraws."
         (should (string-match-p "GHOSTEL_ECHO_TOKEN"
                                 (ghostel-test--terminal-text)))))))
 
+(ert-deftest ghostel-test-spawn-process-resolves-bare-program-from-exec-path ()
+  "A bare local PROGRAM resolves via variable `exec-path' before backend dispatch.
+This deliberately makes variable `exec-path' and the child PATH disagree: the
+probe program exists only on variable `exec-path', not in `process-environment'."
+  :tags '(native)
+  (let* ((dir (file-name-as-directory (make-temp-file "ghostel-path-" t)))
+         (exec-dir (directory-file-name dir))
+         (program-name "ghostel-path-probe")
+         (program-path (expand-file-name program-name dir)))
+    (unwind-protect
+        (progn
+          (with-temp-file program-path
+            (insert "#!/bin/sh\nprintf 'GHOSTEL_PATH_PROBE:%s\\n' \"$0\"\n"))
+          (set-file-modes program-path #o755)
+          (ghostel-test--with-pty-matrix backend
+            (let* ((child-path (string-join '("/usr/bin" "/bin")
+                                             path-separator))
+                   (process-environment `(,(format "PATH=%s" child-path) "HOME=/tmp"))
+                   (exec-path (list exec-dir "/usr/bin" "/bin"))
+                   (ghostel-kill-buffer-on-exit nil)
+                   (default-directory "/tmp/"))
+              (should-not (member exec-dir
+                                  (split-string (getenv "PATH") path-separator t)))
+              (let ((found (executable-find program-name)))
+                (should found)
+                (should (file-equal-p program-path found)))
+              (ghostel-test--with-terminal-buffer (buf term 24 80 1000)
+                (let ((proc (ghostel--spawn-process program-name nil nil)))
+                  (ghostel-test--wait-for-text "GHOSTEL_PATH_PROBE:" proc 3)
+                  (should (ghostel-test--terminal-text-line-p
+                           (format "GHOSTEL_PATH_PROBE:%s" program-path))))))))
+      (delete-directory dir t))))
+
 (ert-deftest ghostel-test-spawn-initial-winsize-reaches-child ()
   "The child PTY is sized to the terminal dimensions at spawn.
 On the native path the PTY is opened at the term's rows/cols; on the


### PR DESCRIPTION
## Summary

- resolve local spawned programs to an absolute executable through Emacs `exec-path` before PTY backend dispatch
- pass the resolved program consistently to both Emacs and native PTY backends
- keep native fork-child error reporting async-signal-safe with direct `posix.write` calls
- add a regression test where `exec-path` and child `PATH` disagree

Fixes #433.

## Test plan

- [x] `make lisp/ghostel.elc`
- [x] `emacs --batch -Q -L lisp -L test -l ert -l test/ghostel-test-helpers.el -l test/ghostel-spawn-test.el --eval "(ert-run-tests-batch-and-exit 'ghostel-test-spawn-process-resolves-bare-program-from-exec-path)"`