### PR TITLE
Move the setting of ghostel--term-cols/rows to Renderer

### DIFF
--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -728,8 +728,7 @@ any other code that walks `compilation-arguments') re-runs via
         (let ((oh (max 1 (with-selected-window outwin
                            (floor (window-screen-lines)))))
               (ow (max 1 (window-max-chars-per-line outwin))))
-          (ghostel--set-size ghostel--term oh ow)
-          (setq ghostel--term-rows oh)))
+          (ghostel--set-size ghostel--term oh ow)))
       ;; Render the compilation header into the terminal before spawning
       ;; the command, so the user sees the "Compilation started at ..."
       ;; banner *during* the run rather than only when it finishes (the

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1519,12 +1519,14 @@ entry points so tests run without the module present."
   "Handle to the native terminal instance.")
 
 (defvar-local ghostel--term-rows nil
-  "Row count of the native terminal, for viewport/scrollback arithmetic.
-Updated whenever the terminal is created or resized.")
+  "Committed row count of the native terminal.
+Used for viewport/scrollback arithmetic.  Updated by the native
+renderer when the terminal is created or a resize is committed.")
 
 (defvar-local ghostel--term-cols nil
-  "Column count of the native terminal.
-Updated whenever the terminal is created or resized.")
+  "Committed column count of the native terminal.
+Updated by the native renderer when the terminal is created or a
+resize is committed.")
 
 (defcustom ghostel-bold-color nil
   "Configure how bold text is colored.
@@ -6440,12 +6442,10 @@ actually changes."
              (eql width ghostel--term-cols)
              (not (ghostel--alt-screen-p ghostel--term)))
         (setq size nil))
-       ;; Real resize — update the terminal model and redraw.
+       ;; Real resize — queue the terminal model resize and redraw.
        (t
         (ghostel--set-size-with-cell-dims
          ghostel--term (max 1 height) (max 1 width))
-        (setq ghostel--term-rows height)
-        (setq ghostel--term-cols width)
         (setq ghostel--force-next-redraw t)
         ;; Redraw synchronously so the buffer is updated before
         ;; Emacs displays the stale content at the new window size.
@@ -6663,8 +6663,6 @@ spawn after initialization."
                           ghostel-max-scrollback
                           ghostel-kitty-graphics-storage-limit
                           (ghostel--kitty-mediums-bits)))
-      (setq ghostel--term-rows height)
-      (setq ghostel--term-cols width)
       ;; Seed libghostty's cell dimensions before the process starts —
       ;; otherwise kitty graphics placements arriving in the very first
       ;; output (e.g. timg's transmit-and-place) compute grid_rows=0

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -27,7 +27,7 @@ renderer: Renderer,
 process: ?*NativeProcess = null,
 
 /// Create a new terminal with the given dimensions and scrollback.
-pub fn init(alloc: Allocator, cols: u16, rows: u16, max_scrollback: usize) !*Self {
+pub fn init(alloc: Allocator, env: emacs.Env, cols: u16, rows: u16, max_scrollback: usize) !*Self {
     if (cols == 0 or rows == 0) return error.InvalidSize;
 
     const opts = gt.Terminal.Options{
@@ -54,7 +54,7 @@ pub fn init(alloc: Allocator, cols: u16, rows: u16, max_scrollback: usize) !*Sel
     term.stream = .initAlloc(alloc, .init(term, &term.terminal));
     errdefer term.stream.deinit();
 
-    term.renderer = try .init(alloc, &term.terminal);
+    term.renderer = try .init(alloc, &term.terminal, env);
 
     return term;
 }
@@ -405,7 +405,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                     (std.math.cast(u32, env.cast(i64, args[4])) orelse 0)
                 else
                     0;
-                const term = try init(module_alloc, cols, rows, max_scrollback);
+                const term = try init(module_alloc, env, cols, rows, max_scrollback);
                 errdefer term.deinit();
                 // Set default colors (light gray on black)
                 term.setColorForeground(.{ .r = 204, .g = 204, .b = 204 });

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -81,7 +81,7 @@ const FontInfo = struct {
     }
 };
 
-pub fn init(alloc: Allocator, term: *gt.Terminal) !Self {
+pub fn init(alloc: Allocator, term: *gt.Terminal, env: emacs.Env) !Self {
     var renderer = Self{
         .term = term,
         .render_state = gt.RenderState.empty,
@@ -91,7 +91,7 @@ pub fn init(alloc: Allocator, term: *gt.Terminal) !Self {
         .rendered_screen = term.screens.active,
         .pending_resize = .{ .cols = term.cols, .rows = term.rows, .cell_w = 1, .cell_h = 1 },
     };
-    try renderer.commitResize(alloc);
+    try renderer.commitResize(alloc, env);
     return renderer;
 }
 
@@ -149,7 +149,7 @@ pub fn redraw(self: *Self, alloc: Allocator, env: emacs.Env, force_full_arg: boo
     // If we have a pending resize, commit it now and just rerender the active
     // since the scrollback is already up to date.
     if (self.pending_resize != null) {
-        try self.commitResize(alloc);
+        try self.commitResize(alloc, env);
         self.gotoActiveStart(env);
         try self.render(alloc, env, self.term.screens.active.pages.getTopLeft(.active));
         self.evictScrollback(alloc, env);
@@ -958,7 +958,7 @@ fn renderToEnd(self: *Self, alloc: Allocator, env: emacs.Env, start_pin: gt.Pin)
     }
 }
 
-fn commitResize(self: *Self, alloc: Allocator) !void {
+fn commitResize(self: *Self, alloc: Allocator, env: emacs.Env) !void {
     if (self.pending_resize) |rz| {
         try self.term.resize(alloc, rz.cols, rz.rows);
         self.term.width_px = std.math.mul(u32, rz.cols, rz.cell_w) catch
@@ -966,6 +966,8 @@ fn commitResize(self: *Self, alloc: Allocator) !void {
         self.term.height_px = std.math.mul(u32, rz.rows, rz.cell_h) catch
             std.math.maxInt(u32);
         self.pending_resize = null;
+        env.set("ghostel--term-rows", self.term.rows);
+        env.set("ghostel--term-cols", self.term.cols);
     }
 }
 
@@ -997,7 +999,7 @@ fn clear(self: *Self, alloc: Allocator, env: emacs.Env) !void {
     self.render_pin = null;
 
     // Commit any pending resize since we're doing a rebuild anyway.
-    try self.commitResize(alloc);
+    try self.commitResize(alloc, env);
 
     self.rendered_screen = self.term.screens.active;
     if (!self.rendered_screen.no_scrollback) {

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -456,6 +456,8 @@ const interned_symbols = [_][:0]const u8{
     "ghostel--process",
     "ghostel--query-font-cached",
     "ghostel--rendered-font",
+    "ghostel--term-cols",
+    "ghostel--term-rows",
     "ghostel--set-buffer-face",
     "ghostel--set-title",
     "ghostel--update-directory",

--- a/test/ghostel-compile-test.el
+++ b/test/ghostel-compile-test.el
@@ -1381,8 +1381,6 @@ the same dimensions so PTY and VT always agree."
               (let ((vt-size (car set-size-calls))
                     (pty-size (car spawn-calls)))
                 (should (equal vt-size pty-size)))
-              ;; `ghostel--term-rows' tracks the final reconciled height.
-              (should (= (car (car set-size-calls)) ghostel--term-rows))
               ;; Clean up the fake process.
               (let ((p ghostel--process))
                 (when (process-live-p p)

--- a/test/ghostel-project-test.el
+++ b/test/ghostel-project-test.el
@@ -166,8 +166,8 @@ proves the project-prefixed binding actually took effect."
             (ghostel--init-buffer buf 7 33))
           (with-current-buffer buf
             (should (eq ghostel--term 'new-term))
-            (should (= ghostel--term-rows 7))
-            (should (= ghostel--term-cols 33))
+            (should-not ghostel--term-rows)
+            (should-not ghostel--term-cols)
             (should (equal ghostel--managed-buffer-name "managed"))
             (should (equal ghostel--buffer-identity "identity"))))
       (kill-buffer buf))))
@@ -184,8 +184,8 @@ proves the project-prefixed binding actually took effect."
           (with-current-buffer buf
             (should (derived-mode-p 'ghostel-mode))
             (should (eq ghostel--term 'fake-term))
-            (should (= ghostel--term-rows 7))
-            (should (= ghostel--term-cols 33))
+            (should-not ghostel--term-rows)
+            (should-not ghostel--term-cols)
             (should-not ghostel--buffer-identity)))
       (when (buffer-live-p buf)
         (kill-buffer buf)))))

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -41,6 +41,23 @@ The `ghostel-test-clean' property is placed by
 
 ;;; Redraw harness and buffer invariants
 
+(ert-deftest ghostel-test-size-vars-follow-committed-resize ()
+  "`ghostel--term-rows' and `ghostel--term-cols' update when resize commits."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-size-vars*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let ((term (ghostel--new 5 40 1000)))
+            (should (= ghostel--term-rows 5))
+            (should (= ghostel--term-cols 40))
+            (ghostel--set-size term 7 30)
+            (should (= ghostel--term-rows 5))
+            (should (= ghostel--term-cols 40))
+            (ghostel--redraw term)
+            (should (= ghostel--term-rows 7))
+            (should (= ghostel--term-cols 30))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-redraw-preserves-mark ()
   "`ghostel--redraw' must keep `mark' stable across the destructive ops.
 Full redraws call `eraseBuffer' and partial redraws `deleteRegion',

--- a/test/ghostel-terminal-test.el
+++ b/test/ghostel-terminal-test.el
@@ -288,9 +288,7 @@ dimensions otherwise."
 		  (ghostel--adjust-size 'fake-window))
         (should (equal '(32 120) set-size-args))
         (should ghostel--force-next-redraw)
-        (should redraw-called)
-        (should (= 32 ghostel--term-rows))
-        (should (= 120 ghostel--term-cols))))))
+        (should redraw-called)))))
 
 (ert-deftest ghostel-test-resize-rows-only-outside-minibuffer-still-resizes ()
   "Rows-only resize with no minibuffer active goes through the normal path.
@@ -314,9 +312,7 @@ shell so $LINES stays accurate."
 		  (ghostel--adjust-size 'fake-window))
         (should (equal '(32 120) set-size-args))
         (should ghostel--force-next-redraw)
-        (should redraw-called)
-        (should (= 32 ghostel--term-rows))
-        (should (= 120 ghostel--term-cols))))))
+        (should redraw-called)))))
 
 (ert-deftest ghostel-test-resize-cols-change-during-minibuffer-still-resizes ()
   "Cols change during a minibuffer still goes through the normal path.
@@ -341,9 +337,7 @@ minibuffer state."
 		  (ghostel--adjust-size 'fake-window))
         (should (equal '(40 100) set-size-args))
         (should ghostel--force-next-redraw)
-        (should redraw-called)
-        (should (= 40 ghostel--term-rows))
-        (should (= 100 ghostel--term-cols))))))
+        (should redraw-called)))))
 
 (ert-deftest ghostel-test-cleanup-temp-paths-handles-files-and-dirs ()
   "`ghostel--cleanup-temp-paths' deletes files and recursively deletes dirs.


### PR DESCRIPTION
It's the entity responsible for resize so this keeps it in sync