### PR TITLE
Clean up stale comments and docstrings

### DIFF
--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -77,9 +77,8 @@ buffer with \\[evil-ghostel-toggle-send-escape]."
                  (const :tag "Always to evil" evil)))
 
 (defcustom evil-ghostel-sync-render-max-iterations 10
-  "Iteration cap for the drain loop in `evil-ghostel--sync-render'.
-Each iteration waits up to 50 ms, bounding the total wait at ~500 ms so a
-runaway shell can't hang the caller."
+  "Iteration cap for waiting on terminal output to settle.
+Each iteration waits up to 50 ms, bounding the total wait at ~500 ms."
   :type 'integer)
 
 ;; Apply at load: a plain `setq' before load skips the `:set' above.
@@ -301,12 +300,7 @@ Loops `accept-process-output' (capped by
 
 (defun evil-ghostel-goto-input-position (pos)
   "Drive the terminal cursor and Emacs point to buffer position POS.
-Returns t when the cursor reached POS.  Sends arrow keys to move the
-shell's line editor toward POS (analogous to `vterm-goto-char'), then
-snaps point to POS.  On rightward moves it detects and recovers from two
-inner-program echoes — literal \"^[[C\" arrow echo, and autosuggest
-accept-on-right-arrow — returning nil if either fired (see comments).
-Only meaningful in semi-char mode."
+Returns t when the cursor reached POS.  Only meaningful in semi-char mode."
   (when (and ghostel--term ghostel--cursor-pos)
     (let* ((start-char-pos ghostel--cursor-char-pos)
            (start-cursor ghostel--cursor-pos)
@@ -366,8 +360,7 @@ the delete lands when the shell echoes it.  Semi-char only."
       (evil-ghostel-goto-input-position end)
       (dotimes (_ count)
         (ghostel--send-encoded "backspace" ""))
-      ;; Drain so `ghostel--cursor-pos' reflects the post-backspace position
-      ;; before any caller (e.g. `evil-ghostel-insert' for cc / cw) reads it.
+      ;; Keep cursor state current for commands that continue editing.
       (evil-ghostel--sync-render)
       (goto-char beg))
     count))
@@ -385,9 +378,7 @@ STRING through bracketed paste.  Only meaningful in `semi-char' mode."
 ;; Motions (the few that must be prompt-aware)
 
 (evil-define-motion evil-ghostel-first-non-blank ()
-  "Move point to the first input character after the prompt.
-On a prompt row, jumps past the prompt prefix; otherwise falls through
-to `evil-first-non-blank'."
+  "Move to the first input character after the prompt."
   :type exclusive
   (if (or (evil-ghostel--active-p)
           (evil-ghostel--line-mode-active-p))
@@ -410,9 +401,7 @@ $ would walk into non-typed cells).  Off the cursor row, unchanged."
       (goto-char (1- input-end)))))
 
 (evil-define-motion evil-ghostel-next-line (count)
-  "Move COUNT lines down, but not past the terminal cursor's row.
-Prevents `j' from stranding the user on empty renderer rows below the
-live prompt.  Falls through to `evil-next-line' outside semi-char."
+  "Move COUNT lines down, but not past the terminal cursor's row."
   :type line
   (if (not (evil-ghostel--active-p))
       (evil-next-line count)
@@ -431,9 +420,7 @@ live prompt.  Falls through to `evil-next-line' outside semi-char."
         (move-to-column col)))))
 
 (defun evil-ghostel-goto-cursor ()
-  "Move point to the live terminal cursor.
-Replaces `evil-goto-line' (G) in ghostel buffers — the natural \"go to
-the prompt\" gesture.  Outside semi-char, runs `evil-goto-line'."
+  "Move point to the live terminal cursor."
   (interactive)
   (if (not (evil-ghostel--active-p))
       (call-interactively #'evil-goto-line)
@@ -443,9 +430,7 @@ the prompt\" gesture.  Outside semi-char, runs `evil-goto-line'."
 ;; Insert / Append
 
 (defun evil-ghostel-insert ()
-  "Enter insert state at point, driving the shell cursor to match.
-Off the cursor row, snap to `ghostel-input-start-point'; on it, drive to
-point clamped to `evil-ghostel--input-end'.  Outside semi-char, `evil-insert'."
+  "Enter insert state at point, driving the shell cursor to match."
   (interactive)
   (cond
    ((not (evil-ghostel--active-p))
@@ -461,9 +446,7 @@ point clamped to `evil-ghostel--input-end'.  Outside semi-char, `evil-insert'."
     (evil-insert-state 1))))
 
 (defun evil-ghostel-insert-line ()
-  "Move to the start of input on the current line, then enter insert.
-Drives the shell cursor to `ghostel-input-start-point' (semi-char) or
-jumps to `ghostel--line-input-start' (line mode); else `evil-insert-line'."
+  "Move to the start of input on the current line, then enter insert."
   (interactive)
   (cond
    ((evil-ghostel--active-p)
@@ -476,10 +459,7 @@ jumps to `ghostel--line-input-start' (line mode); else `evil-insert-line'."
    (t (call-interactively #'evil-insert-line))))
 
 (defun evil-ghostel-append ()
-  "Append after point, driving the shell cursor to match.
-Target is one cell right of point (clamped to `evil-ghostel--input-end'),
-or point itself when point is at/past the cursor on a blank/eol cell.  Off
-the cursor row, snap to `ghostel-input-start-point'; else `evil-append'."
+  "Append after point, driving the shell cursor to match."
   (interactive)
   (cond
    ((not (evil-ghostel--active-p))
@@ -502,9 +482,7 @@ the cursor row, snap to `ghostel-input-start-point'; else `evil-append'."
     (evil-insert-state 1))))
 
 (defun evil-ghostel-append-line ()
-  "Move to the end of input on the current line, then enter insert.
-Symmetric to `evil-ghostel-insert-line': drives the cursor to
-`evil-ghostel--input-end' (semi-char) or `ghostel--line-input-end' (line)."
+  "Move to the end of input on the current line, then enter insert."
   (interactive)
   (cond
    ((evil-ghostel--active-p)
@@ -521,10 +499,9 @@ Symmetric to `evil-ghostel-insert-line': drives the cursor to
 
 (evil-define-operator evil-ghostel-delete
   (beg end type register yank-handler)
-  "Delete BEG..END via the PTY (semi-char), else run `evil-delete'.
-`evil-ghostel--clamp' trims the range to live input so overshoot (e.g.
-`dw' on the last word) can't over-delete; block deletes go per row.
-Covers d, dd, x, X."
+  "Delete BEG..END through the terminal when editing live input.
+Ranges are limited to the current input, including per-row handling for
+block deletes.  Covers d, dd, x, and X."
   (interactive "<R><x><y>")
   (if (not (evil-ghostel--active-p))
       (evil-delete beg end type register yank-handler)
@@ -673,18 +650,16 @@ unless at end-of-input, where a right arrow would accept a suggestion."
         (ghostel--paste-text text)))))
 
 (defun evil-ghostel-paste-after (&optional count register yank-handler)
-  "Paste after the cursor via bracketed paste.  Covers p.
-COUNT repeats; REGISTER selects a register; YANK-HANDLER is forwarded to
-`evil-paste-after' in the fall-through path."
+  "Paste after the cursor via bracketed paste COUNT times from REGISTER.
+YANK-HANDLER is used by Evil outside live terminal input.  Covers p."
   (interactive "*P")
   (if (evil-ghostel--active-p)
       (evil-ghostel--do-paste count register t)
     (evil-paste-after count register yank-handler)))
 
 (defun evil-ghostel-paste-before (&optional count register yank-handler)
-  "Paste before the cursor via bracketed paste.  Covers P.
-COUNT repeats; REGISTER selects a register; YANK-HANDLER is forwarded to
-`evil-paste-before' in the fall-through path."
+  "Paste before the cursor via bracketed paste COUNT times from REGISTER.
+YANK-HANDLER is used by Evil outside live terminal input.  Covers P."
   (interactive "*P")
   (if (evil-ghostel--active-p)
       (evil-ghostel--do-paste count register nil)
@@ -694,8 +669,7 @@ COUNT repeats; REGISTER selects a register; YANK-HANDLER is forwarded to
 ;; Undo / Redo
 
 (defun evil-ghostel-undo (count)
-  "Send Ctrl-_ (readline undo) COUNT times.  Covers u.
-Falls through to `evil-undo' outside semi-char."
+  "Send Ctrl-_ (readline undo) COUNT times.  Covers u."
   (interactive "p")
   (if (not (evil-ghostel--active-p))
       (evil-undo count)
@@ -703,8 +677,7 @@ Falls through to `evil-undo' outside semi-char."
       (ghostel--send-encoded "_" "ctrl"))))
 
 (defun evil-ghostel-redo (count)
-  "Redo is not supported in the terminal.
-COUNT is forwarded to `evil-redo' in the fall-through path."
+  "Run Evil redo COUNT times when not editing live terminal input."
   (interactive "p")
   (if (not (evil-ghostel--active-p))
       (evil-redo count)
@@ -868,12 +841,11 @@ Decides whether the global advice can be removed on the last disable."
 
 ;;;###autoload
 (define-minor-mode evil-ghostel-mode
-  "Minor mode for evil integration in ghostel terminal buffers.
-Binds the `evil-ghostel-*' operators in `evil-ghostel-mode-map' and syncs
-the terminal cursor with point across evil state transitions.  It also advises
-`ghostel--redraw' and `ghostel--apply-cursor-style' (to preserve point and the
-evil cursor style); since the mode is buffer-local but the advice global,
-the advice is installed on first enable and removed on the last disable."
+  "Minor mode for Evil integration in ghostel terminal buffers.
+Binds Evil operators to terminal-aware variants and keeps point aligned
+with the terminal cursor across Evil state transitions.
+
+Enabling installs global advice while any buffer has the mode enabled."
   :lighter nil
   :keymap evil-ghostel-mode-map
   (if evil-ghostel-mode
@@ -893,8 +865,6 @@ the advice is installed on first enable and removed on the last disable."
         ;; states expect point to follow the terminal cursor.
         (add-hook 'evil-emacs-state-entry-hook
                   #'evil-ghostel--insert-state-entry nil t)
-        ;; `advice-add' is idempotent per (symbol, fn), so re-adding on
-        ;; every enable is safe — no separate install flag needed.
         (advice-add 'ghostel--redraw :around #'evil-ghostel--around-redraw)
         (advice-add 'ghostel--apply-cursor-style :around
                     #'evil-ghostel--override-cursor-style)

--- a/lisp/ghostel-comint.el
+++ b/lisp/ghostel-comint.el
@@ -125,9 +125,8 @@ For full coverage disable `font-lock-mode' in the comint buffer."
   "Preoutput filter: hand STRING to ghostel's VT parser, return propertized text.
 Suitable for `comint-preoutput-filter-functions'.
 
-When the host buffer has `font-lock-mode' enabled, rewrites `face' text
-properties to `font-lock-face' so font-lock's unfontify pass doesn't
-strip our colours (see `ghostel-comint--face-to-font-lock-face')."
+When the host buffer has `font-lock-mode' enabled, protects the
+terminal colours from font-lock's unfontify pass."
   (unless ghostel-comint--state
     (ghostel--load-module)
     (setq ghostel-comint--state (ghostel--comint-make-state))
@@ -149,7 +148,6 @@ Adds `ghostel-comint-filter' as the first entry of the buffer-local
 `ansi-color-process-output' from `comint-output-filter-functions' so the
 two don't double-process bytes.
 
-See the file commentary for what's gained and what's not.
 
 For performance, xterm-color recommends disabling font-locking in
 shell-mode buffers — the same advice applies here.  Add this to your

--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -40,12 +40,10 @@
 ;; the launch mode (read-only vs interactive); when invoked from an
 ;; unrelated buffer it falls back to the global default (read-only).
 ;;
-;; Enable `ghostel-compile-global-mode' to route *all* `compile',
-;; `recompile', `project-compile', ... calls through ghostel.  It
-;; advises `compilation-start' so every caller benefits without any
-;; further configuration.  `compilation-start' callers asking for
+;; Enable `ghostel-compile-global-mode' to route `compile',
+;; `recompile', `project-compile', ... through ghostel.
 ;; `MODE=t' (the comint variant — \\[universal-argument] \\[compile])
-;; are routed to a writable ghostel terminal instead of comint.
+;; becomes a writable ghostel terminal instead of comint.
 ;; `grep-mode' falls through to the stock implementation.
 ;;
 ;; Standard `compile' options honoured:
@@ -708,11 +706,8 @@ any other code that walks `compilation-arguments') re-runs via
             ghostel-compile--finalized nil
             ghostel-compile--view-mode-override finished-mode
             ghostel-compile--interactive interactive)
-      ;; Make `revert-buffer' (and third-party code that walks
-      ;; `compilation-arguments') restart the run via `compilation-start'.
-      ;; Direct callers don't pass a tuple — synthesize one that records
-      ;; the launch mode in the MODE slot so a revert routes through the
-      ;; advice and lands back on the same variant.
+      ;; Preserve the launch mode for `revert-buffer' and code that reads
+      ;; `compilation-arguments'.
       (setq-local compilation-arguments
                   (or compilation-args
                       (list command (and interactive t) nil nil)))
@@ -1002,10 +997,7 @@ error highlighting in all cases."
    ((or continue (memq mode ghostel-compile-global-mode-excluded-modes))
     (funcall orig-fn command mode name-function highlight-regexp continue))
    ((eq mode t)
-    ;; Mirror stock `compilation-start': name-of-mode is "compilation"
-    ;; when MODE is t.  Spawn a writable ghostel terminal — same UX
-    ;; the legacy `ghostel-compile' had, so callers asking for an
-    ;; interactive buffer still get one (just rendered by ghostel).
+    ;; MODE=t means interactive comint-style compilation.
     (let* ((buf-name (compilation-buffer-name "compilation" t name-function))
            (buffer (ghostel-compile--start
                     command buf-name default-directory nil t

--- a/lisp/ghostel-debug.el
+++ b/lisp/ghostel-debug.el
@@ -163,12 +163,9 @@ fired but the underlying signal vanished by the time we looked again
 ;;;###autoload
 (defun ghostel-debug-password-events-show ()
   "Display recent password-prompt rising edges.
-Shows every fire of `ghostel--detect-password-prompt' along with the
-arm that triggered it (libghostty heuristic / regex on remote / regex
-on unobservable tty), the cursor row text at the moment, and the
-buffer's remote-shell state.  Use this to diagnose spurious
-`read-passwd' prompts: the entry that opened the unwanted minibuffer
-will identify which detection arm misfired."
+Shows which detection arm fired, the cursor row text at the time,
+and whether the buffer was in a remote shell.  Use this to diagnose
+spurious `read-passwd' prompts."
   (interactive)
   (let ((out (get-buffer-create "*ghostel-debug-password*")))
     (with-current-buffer out
@@ -1369,18 +1366,8 @@ ghostel produces (rendered locally in the `Key encoding' section)."
 (defun ghostel-debug-ghostel (&optional arg)
   "Like `ghostel', but capture spawn diagnostics into the new buffer.
 
-The new buffer carries a snapshot of:
-- the wrapper script as sent to `make-process' (with the on-remote
-  TERM preamble for TRAMP spawns — the smoking gun for #224-class
-  bugs)
-- the `process-environment' that ghostel was about to push
-- phase timestamps: `ghostel--start-process' entry, `ghostel--spawn-pty'
-  entry, first PTY byte received.  The deltas isolate where time goes
-  per spawn (elisp prep / TRAMP+ssh / remote shell startup) — useful
-  for diagnosing remote-spawn slowness.
-- the first ~16 KB of PTY output (did the shell start?  Send a
-  prompt?  Garbage?)
-- the first ~64 keystrokes you typed
+The capture includes the wrapper script, process environment, phase
+timestamps, early PTY output, and the first keystrokes typed.
 
 ARG is forwarded to `ghostel' (same prefix-argument conventions).
 View the capture with \\[ghostel-debug-info]."
@@ -1560,10 +1547,8 @@ command, where KIND is `:write-pty' or `:send-string').")
 After you press one key, a report appears in *ghostel-debug-keypress*
 suitable for pasting into a GitHub issue.
 
-Captures the raw event, the resolved keymap binding, every byte that
-flowed through `ghostel--send-string' or `ghostel--write-pty' during
-the command, terminal mode flags (DECCKM, DECKPAM, bracketed paste,
-mouse modes, alt screen, sync output), and process state."
+Captures the raw event, resolved key binding, terminal bytes emitted
+during the command, terminal mode flags, and process state."
   (interactive)
   (unless (derived-mode-p 'ghostel-mode)
     (user-error "Not in a ghostel buffer"))

--- a/lisp/ghostel-line-mode.el
+++ b/lisp/ghostel-line-mode.el
@@ -187,7 +187,7 @@ literal newline in the input for multi-line prompts."
   "<remap> <self-insert-command>" #'ghostel-line-mode-self-insert)
 
 (defun ghostel-line-mode-send-or-open-link ()
-  "Open the hyperlink at point, or send the input line if there is none."
+  "Follow the link at point, or send the current line-mode input."
   (interactive)
   (let ((url (ghostel--uri-at-pos (point))))
     (if url
@@ -196,14 +196,9 @@ literal newline in the input for multi-line prompts."
 
 (defun ghostel-line-mode-self-insert (&optional n)
   "Self-insert N times, snapping point back to the input region first.
-When point sits in the read-only scrollback portion of a line-mode
-buffer, jump to the end of the in-progress input
-\(`ghostel--line-input-end') and self-insert there.  When point is
-already inside `[ghostel--line-input-start, ghostel--line-input-end]'
-this is just `self-insert-command'.
-
-The prefix argument N is forwarded to `self-insert-command' so
-\\[universal-argument] still works as expected."
+When point is in read-only scrollback, insert at the end of the
+in-progress input instead.  The prefix argument N is forwarded to
+`self-insert-command' so \\[universal-argument] works as expected."
   (interactive "p")
   (let ((start (and (markerp ghostel--line-input-start)
                     (marker-position ghostel--line-input-start)))
@@ -471,35 +466,19 @@ in line mode (the interactive entry validates these)."
 
 (defun ghostel-line-mode (&optional force)
   "Switch to line mode — edit input locally, send to shell on RET.
-The user types into an editable region between the last prompt
-and `point-max'.  Full Emacs editing (yank, `kill-word',
-transpose, etc.) works.  Pressing \\[ghostel-line-mode-send]
-sends the entire line to the shell in one write; bash echoes and
-executes it normally.
+The user types into an editable region between the last prompt and
+`point-max'.  Full Emacs editing (yank, `kill-word', transpose,
+etc.) works.  Pressing \\[ghostel-line-mode-send] sends the input
+to the shell in one write.
 
-The terminal stays live: output streaming in around the prompt
-keeps rendering, and the snapshot/restore path in
-`ghostel--redraw-now' preserves the user's in-progress input
-across each redraw cycle.  After RET, line mode stays active so
-the user just keeps editing at the next prompt.
+Completion runs against the editable input and follows OSC 7 / TRAMP
+directory tracking.  The terminal stays live while output streams
+around the prompt.  After RET, line mode stays active for the next
+prompt.
 
-\\<ghostel-line-mode-map>\\[ghostel-line-mode-complete-at-point]
-runs `completion-at-point' against the input region — filenames,
-env vars, executables on \\=`PATH\\=', and whatever \\=`pcomplete\\='
-extensions are loaded.  Install the `bash-completion' package and
-set `ghostel-line-mode-use-bash-completion' to layer real bash
-programmable completion (git subcommands, ssh hosts, …) on top.
-
-Uses the terminal cursor as the input-area boundary, so REPLs
-without OSC 133 (python3, irb, sqlite3, …) work too.  When OSC
-133 markers are present on the cursor's row, the prompt prefix is
-recognised and the input boundary lands right after it.
-
-On the alt screen, line mode enters at an inner shell prompt whose
-OSC 133 markers reach Ghostel (tmux/screen passthrough); over a raw
-TUI (vim, less) it instead arms and resumes when the TUI exits.  A
-prefix arg (FORCE) forces immediate entry regardless — use it at an
-inner prompt whose OSC 133 does not pass through the multiplexer."
+On the alt screen, line mode enters at a shell prompt whose OSC 133
+markers reach Ghostel; over a raw TUI (vim, less) it arms and resumes
+when the TUI exits.  A prefix arg FORCE forces immediate entry."
   (interactive "P")
   (unless ghostel--term
     (user-error "No terminal in this buffer"))
@@ -696,20 +675,11 @@ screen."
 
 (defun ghostel-line-mode-send ()
   "Send the current in-progress input line to the shell.
-Reads the text between the line-input marker and `point-max',
-deletes it locally, sends the input to the PTY as a single write,
-then submits via an encoded `return' keypress so the running app
-sees Enter the same way semi-char mode would have produced it.
+Deletes the local input, writes it to the PTY, then submits Return.
 
-The encoded Return matters for TUI apps that distinguish a
-literal newline (Shift-Enter) from a submit (e.g. claude-code,
-pi).  They expect CR or a kitty-keyboard-protocol-encoded Enter,
-not a raw \\n; bash readline accepts CR as `accept-line' too, so
-the same code path works for shells.
-
-Stays in line mode: the next redraw cycle picks up the shell's
-echo and command output, and the snapshot/restore path moves the
-input marker to wherever the new prompt lands."
+The encoded Return matters for TUI apps that distinguish a literal
+newline (Shift-Enter) from submit (e.g. claude-code, pi).  Shells
+accept the same CR as `accept-line'."
   (interactive)
   (unless (eq ghostel--input-mode 'line)
     (user-error "Not in line mode"))
@@ -738,9 +708,7 @@ input marker to wherever the new prompt lands."
 
 (defun ghostel-line-mode-interrupt ()
   "Discard local input and send SIGINT (\\`C-c') to the shell.
-Stays in line mode; the next redraw cycle picks up the shell's
-new prompt and the snapshot/restore path repositions the input
-marker."
+Stays in line mode for the next prompt."
   (interactive)
   (ghostel--line-mode-delete-input)
   (setq ghostel--line-mode-history-index nil)
@@ -835,23 +803,10 @@ point is idempotent)."
     (ignore-errors (bash-completion-require-process))))
 
 (defun ghostel-line-mode-complete-at-point ()
-  "Complete the input at point against the line-mode capf stack.
-Narrows to `[ghostel--line-input-start, ghostel--line-input-end)'
-before delegating to `completion-at-point' so that comint/shell
-completion functions parse only the user's typed input — the
-prompt and surrounding scrollback are invisible to them.
-
-When point sits in the read-only scrollback, snaps to the input
-end first (mirrors `ghostel-line-mode-self-insert').
-
-Refreshes `comint-file-name-prefix' from `default-directory' on
-each call so completions follow OSC 7 / TRAMP directory tracking
-when it flips between local and remote.
-
-The capf list comes from `ghostel--line-mode-effective-capfs',
-which combines `ghostel-line-mode-completion-at-point-functions'
-with optional `bash-completion' integration controlled by
-`ghostel-line-mode-use-bash-completion'."
+  "Complete the line-mode input at point.
+Completion sees only the editable input, not the prompt or scrollback.
+When point is in read-only scrollback, completion starts at the end of
+the input instead."
   (interactive)
   (let ((start (and (markerp ghostel--line-input-start)
                     (marker-position ghostel--line-input-start)))

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3221,21 +3221,8 @@ when nothing can locate a position (no cursor and no detection)."
 
 (defun ghostel-beginning-of-input-or-line ()
   "Move point to the start of input on a prompt row, else `beginning-of-line'.
-On a line that carries the `ghostel-prompt' text property over its
-leading characters, point moves to the position right after the
-last contiguous prompt character — i.e. where the user's input
-begins on that prompt row.  In line mode the active input marker
-\(`ghostel--line-input-start') wins over the property scan so an
-empty fresh prompt still goes to the marker position.
-
-Without the property (no OSC 133 shell integration), consult
-`ghostel-prompt-regexp' so the command still finds the prompt
-prefix on lines from raw shells, Python REPL, and similar.
-
-On any other line — scrollback, output, a prompt-continuation row
-that has no content past the prefix — falls through to
-`move-beginning-of-line', so navigating up into history and
-pressing \\`C-a' gives the standard column-0 behaviour."
+On prompt rows, point moves to the first input character after the
+prompt prefix.  On other rows, point moves to the line beginning."
   (interactive "^")
   (let* ((bol (line-beginning-position))
          (eol (line-end-position))
@@ -3456,7 +3443,6 @@ Wraps to `point-max' when no link is found before point."
   (dotimes (_ (or n 1))
     (ghostel--goto-hyperlink 'previous)))
 
-;; Make the ghostel-*-hyperlink play nice with eldoc.
 (eldoc-add-command #'ghostel-next-hyperlink #'ghostel-previous-hyperlink)
 
 (defun ghostel--detect-urls-skip-p (pos active-bounds)
@@ -3798,9 +3784,8 @@ is preserved.  Mirrors the landing position used by
 
 (defun ghostel-imenu-setup ()
   "Wire OSC 133 prompts as imenu entries in the current buffer.
-Sets `imenu-create-index-function' and `imenu-default-goto-function',
-and registers the cwd-stamping hook on
-`ghostel-command-start-functions'."
+Prompt labels include the command and, when known, the command's
+working directory."
   (setq-local imenu-create-index-function #'ghostel--imenu-create-index)
   (setq-local imenu-default-goto-function #'ghostel--imenu-goto)
   (add-hook 'ghostel-command-start-functions
@@ -4130,9 +4115,8 @@ back to `message' when alert isn't installed.  TITLE is the
 notification summary; when empty (iTerm2-style OSC 9) the buffer
 name is used.  BODY is the notification text.
 
-Runs deferred off the VT-parser callpath by
-`ghostel--handle-notification' with the originating ghostel buffer
-current, so `buffer-name' here gives the terminal buffer's name."
+Runs with the originating ghostel buffer current, so an empty
+TITLE falls back to that buffer's name."
   (let ((summary (if (or (null title) (string-empty-p title))
                      (buffer-name)
                    title)))
@@ -4142,12 +4126,9 @@ current, so `buffer-name' here gives the terminal buffer's name."
 
 (defun ghostel-default-progress (state progress)
   "Default handler for OSC 9;4 ConEmu progress reports.
-Updates `ghostel--mode-line-progress' (and refreshes
-`mode-line-process') to show the current STATE and PROGRESS (an
-integer 0-100 or nil).  STATE is one of the symbols `remove',
-`set', `error', `indeterminate', `pause'.  The input-mode tag in
-`ghostel--mode-line-tag' is composed alongside, so progress
-updates do not clobber labels like \":Char\" or \":Line\"."
+Shows STATE and PROGRESS in `mode-line-process'.  STATE is one of
+`remove', `set', `error', `indeterminate', or `pause'; PROGRESS is
+an integer 0-100 or nil."
   (let ((new-val
          (pcase state
            ('remove        nil)
@@ -4171,9 +4152,7 @@ updates do not clobber labels like \":Char\" or \":Line\"."
 (defun ghostel--spinner-stop ()
   "Stop this buffer's progress spinner, if any.
 Safe to call when no spinner is running.  Errors from spinner.el
-\(e.g. on a half-torn-down buffer) are swallowed — this is
-teardown.  Refreshes `mode-line-process' so the spinner construct
-no longer renders alongside the input-mode tag."
+\(e.g. on a half-torn-down buffer) are swallowed during teardown."
   (when ghostel--spinner-active
     (ignore-errors (spinner-stop))
     (setq ghostel--spinner-active nil)
@@ -4188,9 +4167,7 @@ STATE is one of those symbols; PROGRESS is an integer 0-100 or nil.
 
 Requires spinner.el to be available; signals a `user-error' on
 the first call if it is not.  The spinner style is controlled by
-`ghostel-spinner-type'.  The input-mode tag (`:Char', `:Line',
-…) is preserved across spinner transitions via
-`ghostel--mode-line-refresh'."
+`ghostel-spinner-type'."
   (unless (require 'spinner nil t)
     (user-error
      "Cannot run `ghostel-spinner-progress' without spinner.el — install it \
@@ -5926,14 +5903,13 @@ Returns the buffer."
 (defun ghostel-exec (buffer program &optional args)
   "Run PROGRAM with ARGS as a ghostel terminal in BUFFER.
 
-BUFFER is switched into `ghostel-mode' (if not already) and a new
-terminal is created sized to the window displaying BUFFER, or
-80x24 if BUFFER is not currently displayed.  No shell integration is applied.
-PROGRAM and ARGS are passed as distinct argv entries, so shell metacharacters
-are not interpreted; pass extra tokens via ARGS, a list of strings.  Returns
-the lifecycle process object for the selected PTY path.
+BUFFER is switched into `ghostel-mode' and sized to its displayed
+window, or 80x24 if BUFFER is not displayed.  PROGRAM and ARGS are
+passed as distinct argv entries, so shell metacharacters are not
+interpreted.  Shell integration is not applied.
 
-Signals `user-error' if BUFFER already has a live ghostel process."
+Returns the lifecycle process object.  Signals `user-error' if BUFFER
+already has a live ghostel process."
   (ghostel--load-module t)
   (when (with-current-buffer buffer
           (process-live-p ghostel--process))

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -134,8 +134,7 @@ to nil buffer-locally so that chain yields to evil's own selection model."
        ;; Opted out -> activating the mark is a no-op, mode stays editable.
        (ghostel--mark-activated)
        (should-not copied)
-       ;; Control (proves the test is not vacuous): restore the default knob
-       ;; and the same hook DOES switch -> the nil knob is exactly what gates it.
+       ;; With the default knob restored, the hook switches modes.
        (let ((ghostel-mark-activation-input-mode 'copy))
          (ghostel--mark-activated)
          (should copied))))))
@@ -205,9 +204,7 @@ wrapper from every other ghostel buffer."
       (customize-set-variable 'evil-ghostel-initial-state orig))))
 
 (ert-deftest evil-ghostel-test-mode-activation-preserves-initial-state ()
-  "Enabling `evil-ghostel-mode' must not clobber the initial-state setting.
-Regression guard: the minor-mode body used to call
-`evil-set-initial-state' on every activation, overriding user config."
+  "Enabling `evil-ghostel-mode' must not clobber the initial-state setting."
   (let ((orig evil-ghostel-initial-state))
     (unwind-protect
         (progn
@@ -961,8 +958,7 @@ then enters insert state.  Same vterm-style shape as `dd'."
        (should (= 5 (cl-count '("backspace" . "") keys-sent :test #'equal)))
        (should-not (cl-find '("e" . "ctrl") keys-sent :test #'equal))
        (should-not (cl-find '("u" . "ctrl") keys-sent :test #'equal))
-       ;; Bug fix: point lands at input-start (pos 3, just after "$ "),
-       ;; NOT at column 0 of the buffer line.
+       ;; Point lands at input-start (pos 3, just after "$ ").
        (should (= 3 (point)))
        (should (eq evil-state 'insert))))))
 
@@ -1112,10 +1108,6 @@ line)."
                       (push (cons k mods) keys-sent))))
            (evil-ghostel--passthrough-ctrl key))
          (should (cl-find (cons key "ctrl") keys-sent :test #'equal)))))))
-
-;; (Removed: evil-ghostel-test-ctrl-passthrough-invalidates-shadow.
-;; The shadow-cursor model is gone — the new architecture reads
-;; `ghostel--cursor-pos' directly each time.)
 
 (ert-deftest evil-ghostel-test-ctrl-passthrough-sends-in-alt-screen ()
   "Insert-state Ctrl passthrough remains active in alt-screen TUIs.
@@ -1480,25 +1472,12 @@ rather than silently dropping the keystroke."
      (should (eq 'normal evil-state)))))
 
 ;; -----------------------------------------------------------------------
-;; Test: beginning-of-line lands at input start, not column 0
-;; -----------------------------------------------------------------------
-
-;; (Removed: evil-ghostel-test-shadow-cursor-tracks-cursor-to-point and
-;; evil-ghostel-test-shadow-cursor-tracks-delete-region.  The shadow-cursor
-;; model is gone — the new operators read `ghostel--cursor-pos' directly
-;; each time and don't rely on a queued-key projection.  See the
-;; "Shadow-cursor: drop" analysis in plans/evil-rewrite-plan.md.)
-
-;; -----------------------------------------------------------------------
 ;; Test: cw doesn't emit redundant left arrows after delete
 ;; -----------------------------------------------------------------------
 
 (ert-deftest evil-ghostel-test-delete-word-with-trailing-space ()
-  "Regression: `dw' over `\"word \"' sends 5 backspaces, not 4.
-Trailing whitespace in single-line ranges is real user content.
-\(With the old per-line stripping heuristic applied to single-line
-ranges, `dw' over `\"word word word\" + ESC bb' would send only 4
-backspaces — leaving a stray `w' behind.)"
+  "`dw' over `\"word \"' sends 5 backspaces, not 4.
+Trailing whitespace in single-line ranges is real user content."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "word word word")
@@ -1955,12 +1934,9 @@ uniform color distinct from the typed char."
       (kill-buffer buf))))
 
 (ert-deftest evil-ghostel-test-input-end-keeps-input-when-cursor-at-start ()
-  "Trailing colored input is NOT mistaken for a suggestion at the line start.
-After deleting the first word the cursor sits at the input start over
-recolored real input (fish repaints it red).  With no typed text before
-the cursor there can be no suggestion, so the whole line stays editable —
-the luminance test used to compare the red input against the white prompt
-space and collapse the region."
+  "Trailing colored input is not mistaken for a suggestion at the line start.
+After deleting the first word, the cursor sits at the input start over
+recolored real input; the whole line remains editable."
   (let ((buf (generate-new-buffer " *eg-no-suggest-at-start*")))
     (unwind-protect
         (with-current-buffer buf

--- a/test/ghostel-glyph-test.el
+++ b/test/ghostel-glyph-test.el
@@ -149,11 +149,8 @@ SPECS is a plist with these keys:
 (ert-deftest ghostel-test-glyph-adjust-clamps-on-ascent ()
   "An oversized glyph is clamped by its ascent when only the ascent overflows.
 The default font is 10 ascent / 10 descent.  This glyph's ascent (20)
-exceeds the default ascent while its descent (5) fits, so the row would
-grow above the baseline.  The scale must bound the ascent side
-\(10/20 = 0.5\), which is stricter than the sum ratio
-\(20/25 = 0.8\) the old height-based code used and which would have left
-the ascent over the line."
+exceeds the default ascent while its descent (5) fits.  The scale must
+bound the ascent side (10/20 = 0.5)."
   :tags '(native)
   (let ((buf (generate-new-buffer " *ghostel-test-glyph-ascent*")))
     (unwind-protect

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -430,9 +430,7 @@ instead of running Emacs commands like `forward-sexp'."
 
 (ert-deftest ghostel-test-control-punct-key-bindings ()
   "Control + non-letter keys route to `ghostel--send-event' in semi-char.
-C-] and C-/ previously fell through to Emacs (C-] = `abort-recursive-edit',
-C-/ = `undo') instead of reaching the shell/readline.  Only the keys that
-the ghostty encoder maps to a terminal byte are forwarded."
+Only keys that the ghostty encoder maps to a terminal byte are forwarded."
   (dolist (key-str '("C-]" "C-/"))
     (should (eq (lookup-key ghostel-semi-char-mode-map (kbd key-str))
                 #'ghostel--send-event)))

--- a/test/ghostel-line-mode-test.el
+++ b/test/ghostel-line-mode-test.el
@@ -264,9 +264,8 @@ result must be 2 to prove the prop branch is consulted first."
 Also verifies the documented nil-return when no cursor is available."
   (ghostel-test--with-input-fixture "$ " "hello"
     (let ((cursor-pos ghostel--cursor-char-pos))
-      ;; Move point away from the cursor and verify the function still
-      ;; returns the cursor position — proves it reads
-      ;; `ghostel--cursor-char-pos', not `(point)'.
+      ;; Move point away from the cursor; the function still returns the
+      ;; terminal cursor position.
       (goto-char (point-min))
       (should-not (= (point) cursor-pos))
       (should (= cursor-pos (ghostel-cursor-point))))
@@ -315,11 +314,8 @@ Also verifies the documented nil-return when no cursor is available."
 
 (ert-deftest ghostel-test-copy-to-line-restarts-redraw-timer ()
   "Copy → line transition re-arms the redraw timer.
-Copy mode froze the timer via `ghostel--freeze-terminal'; line
-mode is live, so the redraw cycle must be running again on exit
-or the prompt sits stuck until the next PTY byte arrives.
-Regression: `ghostel--line-mode-enter' previously cleared
-`buffer-read-only' but never called `ghostel--invalidate'."
+Copy mode freezes the timer; line mode is live, so redraws must resume
+without waiting for another PTY byte."
   (let ((buf (generate-new-buffer " *ghostel-test-copy-to-line*"))
         (invalidate-calls 0))
     (unwind-protect
@@ -1663,10 +1659,7 @@ running through a redraw cycle."
 
 (ert-deftest ghostel-test-line-mode-restores-cursor-when-terminal-hid-it ()
   "Line mode shows the editor's cursor regardless of CSI ?25l from the TUI.
-Bug: a TUI that hides the cursor (e.g. claude-code) leaves
-`cursor-type' nil, and line mode previously inherited that — so
-moving point produced no visible cursor.  Entering line mode must
-force the editor default; teardown must restore the saved value."
+Entering line mode forces the editor default; teardown restores the saved value."
   (let ((buf (generate-new-buffer " *ghostel-test-line-cursor*")))
     (unwind-protect
         (with-current-buffer buf

--- a/test/ghostel-line-mode-undo-test.el
+++ b/test/ghostel-line-mode-undo-test.el
@@ -2,10 +2,9 @@
 
 ;;; Commentary:
 
-;; Undo in line mode: recording is armed for the user's input-region
-;; edits, the renderer and the snapshot/restore helpers are shielded so
-;; their mutations never pollute the undo list, and recording is
-;; disabled again outside line mode.  See plans/line-mode-undo.md.
+;; Undo in line mode records user edits in the input region only.
+;; Renderer mutations and snapshot/restore bookkeeping stay out of the
+;; undo list, and recording is disabled outside line mode.
 
 ;;; Code:
 
@@ -126,13 +125,8 @@ start, so an undo can never delete the prompt or earlier output."
                        scrollback-before))))))
 
 ;; 6.4 — a redraw firing between edits does not corrupt undo.
-;; This is the central test for the renderer shield and the
-;; stale-position risk (plan §5 / open question 1).  The renderer
-;; shield keeps the grid rewrites out of the undo list; the restore
-;; re-arms an empty history because the input was re-inserted at a moved
-;; prompt and the old undo positions are stale.  An undo AFTER the
-;; redraw must therefore act on the input's CURRENT location, never on
-;; the renderer's output that now sits where the input used to be.
+;; Redraw rewrites must stay out of undo history.  After a prompt moves,
+;; new edits should undo at the input's current position.
 (ert-deftest ghostel-test-line-mode-redraw-between-edits-no-undo-pollution ()
   "A redraw mid-edit preserves the input and leaves undo well-formed.
 The renderer's mutations never enter the undo list, the stale
@@ -151,14 +145,11 @@ correctly against the input's new position."
     ;; (line mode forces full redraws).
     (ghostel--write-vt term "some output\r\n\e]133;A\e\\$ \e]133;B\e\\")
     (ghostel--redraw-now buf)
-    ;; (a) Regression guard: the input survived snapshot/restore.
+    ;; The input survived snapshot/restore.
     (should (equal (ghostel--line-mode-input-text) "foo"))
-    ;; (b) The renderer's whole-viewport delete/insert storm did NOT
-    ;; pollute undo: the only thing left is the empty re-armed history.
+    ;; Renderer rewrites did not pollute undo.
     (should (null buffer-undo-list))
-    ;; (c) A new edit after the redraw undoes correctly — proving the
-    ;; history refers to the input's CURRENT position, not the stale
-    ;; pre-redraw one (which would have deleted renderer output).
+    ;; A new edit after the redraw undoes at the input's current position.
     (let ((scrollback-before (buffer-substring-no-properties
                               (point-min)
                               (marker-position ghostel--line-input-start))))

--- a/test/ghostel-links-test.el
+++ b/test/ghostel-links-test.el
@@ -781,9 +781,8 @@ to step past more than one run before landing on a different id."
             (put-text-property p (point) 'ghostel-link-id "other"))
           (insert " DDD")                ; 24..27
 
-          ;; Forward from inside A1: dedup loop must step PAST A2 (shared id)
-          ;; before landing on `other'.  This is the path that proves the
-          ;; loop actually iterates more than once.
+          ;; Forward from inside A1: dedup skips A2 (shared id) and lands
+          ;; on `other'.
           (should (equal 19 (ghostel--find-next-link 5)))
           ;; Forward from inside A2 also dedupes; lands on `other'.
           (should (equal 19 (ghostel--find-next-link 12)))

--- a/test/ghostel-module-test.el
+++ b/test/ghostel-module-test.el
@@ -134,10 +134,7 @@ file mmap'd keeps a valid mapping (issue #247)."
         (delete-directory dir t)))))
 
 (ert-deftest ghostel-test-download-module-creates-missing-directory ()
-  "`ghostel--download-module' creates DIR before writing the module.
-Regression for the auto-install path: setting `ghostel-module-directory'
-to a path that does not yet exist used to fail silently because the
-temp-file write under that directory errored out."
+  "`ghostel--download-module' creates DIR before writing the module."
   (let* ((parent (make-temp-file "ghostel-dl-parent-" t))
          (dir (expand-file-name "sub/dir/" parent))
          (asset "ghostel-module-x86_64-linux.so"))

--- a/test/ghostel-mouse-paste-test.el
+++ b/test/ghostel-mouse-paste-test.el
@@ -1318,14 +1318,7 @@ binding wins."
               (lookup-key ghostel-readonly-mode-map (kbd "<return>")))))
 
 (ert-deftest ghostel-test-scroll-intercept-unselected-window ()
-  "Wheel events on an unselected ghostel window must not loop.
-
-Regression test: previously `ghostel--redispatch-scroll-event' set
-the buffer-local intercept flag in `current-buffer', which for wheel
-events on an unselected window is the *selected* window's buffer —
-not the ghostel buffer.  The flag therefore stayed t in the ghostel
-buffer and the re-dispatched event was intercepted again, hanging
-Emacs until `C-g'."
+  "Wheel events on an unselected ghostel window must not loop."
   (let ((ghostel-buf (generate-new-buffer " *ghostel-test-unsel*"))
         (other-buf (generate-new-buffer " *other-test-unsel*")))
     (unwind-protect

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -499,11 +499,7 @@ exits, so a regression here would leak the timer past the buffer's life."
         (should (= 1 stop-calls))))))
 
 (ert-deftest ghostel-test-progress-preserves-input-mode-tag ()
-  "Progress updates compose with `ghostel--mode-line-tag', not clobber it.
-Regression test: the previous implementation overwrote
-`mode-line-process' directly, so OSC 9;4 progress reports erased
-input-mode labels like \":Char\" or \":Line\".  The composed
-`mode-line-process' must contain both the tag and the progress."
+  "Progress updates compose with the input-mode tag in `mode-line-process'."
   (with-temp-buffer
     (setq ghostel--mode-line-tag ":Line")
     (ghostel--mode-line-refresh)
@@ -534,10 +530,7 @@ the spinner is active."
       (should (equal ":Char" mode-line-process)))))
 
 (ert-deftest ghostel-test-mode-line-refresh-skips-fmlu-when-unchanged ()
-  "Refresh skips FMLU when the composed mode-line value is unchanged.
-Regression: the previous `ghostel--mode-line-refresh' always
-fired `force-mode-line-update', defeating the no-spam contract
-that motivated the face-cache fix on the progress callpath."
+  "Refresh skips FMLU when the composed mode-line value is unchanged."
   (let ((fmlu-calls 0))
     (cl-letf (((symbol-function #'force-mode-line-update)
                (lambda (&rest _) (cl-incf fmlu-calls))))
@@ -566,14 +559,8 @@ that motivated the face-cache fix on the progress callpath."
 
 (ert-deftest ghostel-test-osc-partial-does-not-starve-later ()
   "A partial OSC must not cannibalize a following complete OSC.
-Input \"\\e]7;PARTIAL\\e]52;c;aGVsbG8=\\a\" used to be treated as
-two distinct OSCs by ghostel's own scanner: the partial OSC 7 was
-dropped and OSC 52 dispatched.  ghostty-vt's OSC parser treats the
-intervening \\e] as the end of the OSC 7 (truncating its payload to
-\"PARTIAL\") and then starts OSC 52 fresh — both dispatch, and the
-truncated OSC 7 lands as PWD = \"PARTIAL\".  This test pins the new
-behavior so a regression toward the old reject-partial logic would
-be caught."
+The parser dispatches the truncated OSC 7 payload and then starts OSC 52
+fresh."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
     (ghostel-test--with-raw-cat-buffer (buf proc)

--- a/test/ghostel-project-test.el
+++ b/test/ghostel-project-test.el
@@ -28,9 +28,7 @@
       (should-not (string-match-p "\\*\\*" (cdr result))))))
 
 (ert-deftest ghostel-test-project-universal-arg ()
-  "`ghostel-project' forwards the prefix arg AND binds `ghostel-buffer-name'.
-The captured value of `ghostel-buffer-name' at `ghostel' call time
-proves the project-prefixed binding actually took effect."
+  "`ghostel-project' forwards the prefix arg and binds `ghostel-buffer-name'."
   (require 'project)
   ;; Numeric prefix arg (C-5 M-x ghostel-project)
   (let ((ghostel-buffer-name "*ghostel*")

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -792,11 +792,7 @@ This is the vterm-style growing-buffer model that lets `isearch' and
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-scrollback-bootstrap-not-blank ()
-  "First-time scrollback materialization must contain actual content.
-Regression test: when the initial (mostly empty) viewport was rendered
-and then a burst of output overflowed the screen, the promotion
-optimisation incorrectly kept the stale empty rows as scrollback
-instead of fetching the real content from libghostty."
+  "First-time scrollback materialization must contain actual content."
   :tags '(native)
   (let ((buf (generate-new-buffer " *ghostel-test-sb-bootstrap*")))
     (unwind-protect
@@ -1336,10 +1332,7 @@ the written content; all remaining lines must be empty."
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-resize-no-blank-flash ()
-  "Buffer keeps old content after resize; redraw replaces it atomically.
-Regression test: fnSetSize used to call `erase-buffer' synchronously,
-leaving the buffer visibly empty until the next timer-driven redraw.
-Now the erasure is deferred into redraw() under `inhibit-redisplay'."
+  "Buffer keeps old content after resize; redraw replaces it atomically."
   :tags '(native)
   (let ((buf (generate-new-buffer " *ghostel-test-resize-no-blank*")))
     (unwind-protect

--- a/test/ghostel-shell-test.el
+++ b/test/ghostel-shell-test.el
@@ -154,12 +154,7 @@ newest-first list aligns with the buffer-order regions."
 				      (should-not (string-match-p "abc" state)))))))
 
 (ert-deftest ghostel-test-fish-auto-inject-loads-integration ()
-  "Fish auto-inject shim chains to ghostel.fish and cleans XDG_DATA_DIRS.
-Regression test: the vendor_conf.d shim previously (a) inlined a
-partial copy of the integration and silently dropped the outbound
-\\='ssh' wrapper, and (b) used a temp variable name (\\='xdg_data_dirs')
-that collided with a fish-internal local variable, leaking
-\\='/fish'-suffixed paths back to exported XDG_DATA_DIRS."
+  "Fish auto-inject shim chains to ghostel.fish and cleans XDG_DATA_DIRS."
   :tags '(:fish)
   (skip-unless (executable-find "fish"))
   (let* ((ghostel-dir (or (ghostel--resource-root)


### PR DESCRIPTION
Remove history/narration-style comments, shorten over-detailed docstrings, and keep public docs focused on current behavior.