### PR TITLE
Add ghostel-initial-input-mode to start in char or line mode

### DIFF
--- a/lisp/ghostel-line-mode.el
+++ b/lisp/ghostel-line-mode.el
@@ -26,6 +26,7 @@
 (declare-function ghostel--mode-line-tag-make "ghostel")
 (declare-function ghostel--open-link "ghostel")
 (declare-function ghostel--redraw "ghostel-module" (term &optional full))
+(declare-function ghostel--regex-prompt-end "ghostel")
 (declare-function ghostel--send-encoded "ghostel")
 (declare-function ghostel--uri-at-pos "ghostel")
 (declare-function ghostel--write-pty "ghostel-module")
@@ -161,6 +162,12 @@ duplicating the prefix when the shell echoes our line back.")
 Set by `ghostel--line-mode-enter'; tells `ghostel--line-mode-pre-redraw'
 not to auto-pause line mode merely because the alt screen is up.
 Cleared by `ghostel--line-mode-teardown'.")
+
+(defvar-local ghostel--pending-initial-line-mode nil
+  "Non-nil to enter line mode at the first prompt of a fresh terminal.
+Armed by `ghostel--apply-initial-input-mode' when
+`ghostel-initial-input-mode' is `line'; consumed by
+`ghostel--line-mode-maybe-enter-initial' once a prompt renders.")
 
 
 ;;; Keymap and commands
@@ -668,10 +675,41 @@ paints) so `ghostel-input-start-point' sees the
 post-TUI buffer state.  Re-attempts every redraw cycle until a
 prompt is locatable — covers the case where the shell prints its
 new prompt one or more redraws after libghostty leaves the alt
-screen."
+screen.  Also drives the deferred startup entry when
+`ghostel-initial-input-mode' is `line'."
   (when (and ghostel--line-mode-paused
              (not (ghostel--line-mode-alt-screen-p)))
-    (ghostel--line-mode-try-resume)))
+    (ghostel--line-mode-try-resume))
+  (ghostel--line-mode-maybe-enter-initial))
+
+(defun ghostel--line-mode-startup-prompt-ready-p ()
+  "Non-nil when the cursor row shows a real prompt (OSC 133 prop or regex).
+Gates the deferred startup entry so line mode skips a blank pre-prompt screen.
+Unlike `ghostel-input-start-point', the bare cursor does not count as a prompt."
+  (when-let* ((cursor-pos ghostel--cursor-char-pos))
+    (save-excursion
+      (goto-char cursor-pos)
+      (let ((row-start (line-beginning-position))
+            (pos cursor-pos))
+        (while (and (> pos row-start)
+                    (not (get-text-property (1- pos) 'ghostel-prompt)))
+          (setq pos (1- pos)))
+        (or (and (> pos row-start)
+                 (get-text-property (1- pos) 'ghostel-prompt))
+            (ghostel--regex-prompt-end cursor-pos))))))
+
+(defun ghostel--line-mode-maybe-enter-initial ()
+  "Enter line mode once the first prompt renders, if armed at startup.
+Armed by `ghostel-initial-input-mode' = `line'.  Runs each redraw cycle until a
+prompt appears, then enters and disarms.  A manual mode switch during startup
+wins: a non-semi-char buffer drops the flag without entering."
+  (when ghostel--pending-initial-line-mode
+    (cond
+     ((not (eq ghostel--input-mode 'semi-char))
+      (setq ghostel--pending-initial-line-mode nil))
+     ((ghostel--line-mode-startup-prompt-ready-p)
+      (setq ghostel--pending-initial-line-mode nil)
+      (ghostel-line-mode)))))
 
 (defun ghostel-line-mode-send ()
   "Send the current in-progress input line to the shell.

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -746,6 +746,15 @@ Customize the faces `ghostel-fake-cursor' and
 `ghostel-fake-cursor-box' to tune the appearance."
   :type 'boolean)
 
+(defcustom ghostel-initial-input-mode 'semi-char
+  "Input mode a freshly started `ghostel' terminal begins in.
+One of `semi-char' (default), `char', or `line'.  `line' engages on
+the first redraw that exposes a prompt, because it needs a prompt to
+anchor the input region.  Has no effect on `ghostel-exec'."
+  :type '(choice (const :tag "Semi-char (default)" semi-char)
+                 (const :tag "Char mode" char)
+                 (const :tag "Line mode" line)))
+
 (defcustom ghostel-mouse-drag-input-mode 'copy
   "Input mode to switch to after a left-button mouse click or selection.
 
@@ -5866,6 +5875,14 @@ buffer creation time — see `ghostel--buffer-identity'."
                           identity)))
             (buffer-list)))
 
+(defun ghostel--apply-initial-input-mode ()
+  "Switch a new `ghostel' terminal to `ghostel-initial-input-mode'.
+`char' applies now; `line' is deferred to the first prompt;
+`semi-char' needs nothing."
+  (pcase ghostel-initial-input-mode
+    ('char (ghostel-char-mode))
+    ('line (setq ghostel--pending-initial-line-mode t))))
+
 ;;;###autoload
 (defun ghostel (&optional arg)
   "Start a new Ghostel terminal.  If the buffer already exists, switch to it.
@@ -5897,7 +5914,8 @@ Returns the buffer."
       (with-current-buffer buffer
         (setq ghostel--managed-buffer-name (buffer-name))
         (setq ghostel--buffer-identity (or identity (buffer-name)))
-        (ghostel--start-process)))
+        (ghostel--start-process)
+        (ghostel--apply-initial-input-mode)))
     buffer))
 
 (defun ghostel-exec (buffer program &optional args)

--- a/test/ghostel-line-mode-test.el
+++ b/test/ghostel-line-mode-test.el
@@ -1975,5 +1975,76 @@ the flag must not keep suppressing the pause forever."
               (should ghostel--line-mode-paused))))
       (kill-buffer buf))))
 
+;;; Initial input mode (ghostel-initial-input-mode)
+
+(ert-deftest ghostel-test-initial-input-mode-line-arms-deferred-entry ()
+  "`ghostel--apply-initial-input-mode' arms deferred entry for `line'.
+The buffer stays in semi-char until a prompt renders."
+  :tags '(native)
+  (ghostel-test--with-terminal-buffer (buf term 5 80 1000)
+    (with-current-buffer buf
+      (let ((ghostel-initial-input-mode 'line))
+        (ghostel--apply-initial-input-mode))
+      (should ghostel--pending-initial-line-mode)
+      (should (eq ghostel--input-mode 'semi-char)))))
+
+(ert-deftest ghostel-test-initial-input-mode-char-applies-immediately ()
+  "`ghostel-initial-input-mode' = `char' enters char mode at startup."
+  :tags '(native)
+  (ghostel-test--with-terminal-buffer (buf term 5 80 1000)
+    (set-window-buffer (selected-window) buf)
+    (with-current-buffer buf
+      (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore))
+        (let ((ghostel-initial-input-mode 'char))
+          (ghostel--apply-initial-input-mode)))
+      (should (eq ghostel--input-mode 'char))
+      (should-not ghostel--pending-initial-line-mode))))
+
+(ert-deftest ghostel-test-initial-line-mode-defers-until-prompt ()
+  "`ghostel-initial-input-mode' = `line' waits for the first prompt, then enters.
+The deferred entry stays armed across redraws with no detectable
+prompt and engages on the redraw that exposes one."
+  :tags '(native)
+  (ghostel-test--with-terminal-buffer (buf term 5 80 1000)
+    (setq ghostel-detect-password-prompts nil)
+    (set-window-buffer (selected-window) buf)
+    (setq ghostel--process 'fake-proc)
+    ;; Arm exactly as `ghostel--apply-initial-input-mode' would.
+    (setq ghostel--pending-initial-line-mode t)
+    (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+              ((symbol-function 'ghostel--write-pty) #'ignore)
+              ((symbol-function 'ghostel--invalidate) #'ignore))
+      ;; Output with no prompt yet — must not enter line mode.
+      (ghostel--write-vt term "starting up...\r\n")
+      (ghostel--redraw-now buf)
+      (should ghostel--pending-initial-line-mode)
+      (should (eq ghostel--input-mode 'semi-char))
+      ;; First prompt arrives — the next redraw enters line mode.
+      (ghostel--write-vt term "\e]133;A\e\\$ \e]133;B\e\\")
+      (ghostel--redraw-now buf)
+      (should (eq ghostel--input-mode 'line))
+      (should-not ghostel--pending-initial-line-mode)
+      (should (markerp ghostel--line-input-start)))))
+
+(ert-deftest ghostel-test-initial-line-mode-respects-manual-override ()
+  "A manual mode switch before the first prompt cancels deferred line entry."
+  :tags '(native)
+  (ghostel-test--with-terminal-buffer (buf term 5 80 1000)
+    (setq ghostel-detect-password-prompts nil)
+    (set-window-buffer (selected-window) buf)
+    (setq ghostel--process 'fake-proc)
+    (setq ghostel--pending-initial-line-mode t)
+    (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
+              ((symbol-function 'ghostel--write-pty) #'ignore)
+              ((symbol-function 'ghostel--invalidate) #'ignore))
+      ;; User switches to char mode before any prompt.
+      (ghostel-char-mode)
+      (should (eq ghostel--input-mode 'char))
+      ;; Prompt arrives; deferred entry must not override the user's choice.
+      (ghostel--write-vt term "\e]133;A\e\\$ \e]133;B\e\\")
+      (ghostel--redraw-now buf)
+      (should (eq ghostel--input-mode 'char))
+      (should-not ghostel--pending-initial-line-mode))))
+
 (provide 'ghostel-line-mode-test)
 ;;; ghostel-line-mode-test.el ends here


### PR DESCRIPTION
Closes #435.

## What

Adds a `ghostel-initial-input-mode` defcustom (`semi-char` (default) / `char` / `line`) that sets the input mode a freshly started `ghostel` terminal begins in, so users coming from `shell` can start directly in line mode without the `sleep-for` + `ghostel-line-mode 'force` advice from the issue.

## How

- `char` applies immediately at process start.
- `line` cannot engage until the shell prints its first prompt to anchor the input region, so `ghostel--apply-initial-input-mode` arms a buffer-local flag and the existing per-redraw `ghostel--line-mode-post-redraw` path enters line mode on the first redraw that exposes a real prompt. The new `ghostel--line-mode-startup-prompt-ready-p` gates on an OSC 133 prompt property or `ghostel-prompt-regexp` (not the bare cursor), so it skips a blank pre-prompt screen. No timer/sleep.
- A manual mode switch during startup wins (the flag is dropped without entering).
- Scoped to the interactive `ghostel` entry point, not `ghostel-exec`.

## Testing

- `make -j8 all` passes (build, Zig, native, elisp, lint).
- 4 new native tests in `test/ghostel-line-mode-test.el`: deferral-then-entry, `char` immediate, `line` arming, manual-override-cancels.
- Live-verified in a real bash session: `line` defers then enters on the first prompt (~0.5s) with end-to-end editing + send; `char` enters immediately; `semi-char` unchanged.