### PR TITLE
Start remote shells as login+interactive shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ All notable changes to this project will be documented in this file.
   method.
   Fixes [#444](https://github.com/dakra/ghostel/issues/444).
 
+### Fixed
+- Remote shell integration: the per-session temp files (zsh `ZDOTDIR`, bash
+  `--rcfile`, fish init script, and the pushed terminfo dir) were deleted
+  immediately after the asynchronous spawn, racing the remote shell that had
+  not yet read them. The shell would then start with `ZDOTDIR` pointing at a
+  deleted directory, so neither the integration nor the user's own config
+  loaded. Cleanup is now deferred to buffer-kill, past the shell's startup read
+  and the session-long lifetime of the terminfo dir.
+
 ## [0.37.0] — 2026-06-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ All notable changes to this project will be documented in this file.
   buffer that has since moved elsewhere).
   Fixes [#447](https://github.com/dakra/ghostel/issues/447).
 
+### Changed
+- Remote (TRAMP) shells now start as login+interactive shells by default for
+  recognized shells (bash, zsh, fish), so they reliably source the user's
+  rc/profile files (`.zshrc`, `.zprofile`, …) like an interactive `ssh host`
+  login. Previously remote shells were spawned with no flags: they were never
+  login shells (so `.zprofile`/`.zlogin` were skipped), and interactivity was
+  left to the shell's own tty auto-detection — which doesn't hold on every
+  TRAMP method, so `.zshrc` could be skipped too. Passing `-l -i` explicitly
+  restores login semantics and makes interactivity reliable. This also applies
+  when remote shell integration (`ghostel-tramp-shell-integration`) is enabled,
+  so the user's own config (prompt, aliases, …) loads alongside the integration;
+  bash uses `-i` only there, since a login bash would ignore the `--rcfile` the
+  integration relies on. Unrecognized shells (e.g. `/bin/sh`) are left
+  unchanged. `ghostel-tramp-shells` entries gained an optional trailing args
+  slot — `(METHOD SHELL [FALLBACK [ARG...]])` — to override the default per
+  method.
+  Fixes [#444](https://github.com/dakra/ghostel/issues/444).
+
 ## [0.37.0] — 2026-06-21
 
 ### Added

--- a/README.org
+++ b/README.org
@@ -925,9 +925,25 @@ ghostel= spawns a shell on the remote host via TRAMP's process machinery.  The
         ("docker" "/bin/sh")))       ; fixed shell for containers
 #+end_src
 
-Each entry is =(METHOD SHELL [FALLBACK])=.  =SHELL= can be a path like ="/bin/bash"=
-or the symbol =login-shell= to auto-detect the remote user's login shell via
-=getent passwd=.  =FALLBACK= is used when detection fails.
+Each entry is =(METHOD SHELL [FALLBACK [ARG...]])=.  =SHELL= can be a path like
+="/bin/bash"= or the symbol =login-shell= to auto-detect the remote user's login
+shell via =getent passwd=.  =FALLBACK= is used when detection fails.
+
+Any elements after =FALLBACK= are extra arguments for the shell.  When none are
+given, ghostel supplies a type-aware default: recognized shells (bash, zsh,
+fish) are started as login+interactive shells (=-l -i=) so they source the
+user's rc/profile files, mirroring an interactive =ssh host= login; unrecognized
+shells (e.g. =/bin/sh=) get no args.  This default also applies when remote shell
+integration (see below) is enabled, so your own config still loads alongside it
+— except bash uses =-i= only there, since a login bash ignores the =--rcfile= the
+integration relies on.  To override, list the arguments explicitly after
+=FALLBACK=:
+
+#+begin_src emacs-lisp
+(setq ghostel-tramp-shells
+      '(("ssh" login-shell nil "-i")    ; interactive only, no login
+        ("docker" "/bin/sh")))
+#+end_src
 
 OSC 7 directory tracking is TRAMP-aware: when the shell reports a remote
 hostname, =default-directory= is set to the corresponding TRAMP path, reusing the

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -228,17 +228,25 @@ README for the full design and per-call escape hatch."
     ("scp" login-shell)
     ("docker" "/bin/sh"))
   "Shell to use for remote TRAMP connections, per method.
-Each entry is (TRAMP-METHOD SHELL [FALLBACK]).  TRAMP-METHOD is a
+Each entry is (TRAMP-METHOD SHELL [FALLBACK [ARG...]]).  TRAMP-METHOD is a
 method string such as \"ssh\" or \"docker\", or t as a catch-all default.
 
-SHELL is either a path string like \"/bin/bash\" or the symbol
-`login-shell' to auto-detect the remote user's login shell via
-`getent passwd'.  FALLBACK, when present, is used when login-shell
-detection fails."
+SHELL is either a path string like \"/bin/bash\" or the symbol `login-shell'
+to auto-detect the remote user's login shell via `getent passwd'.
+FALLBACK, when present, is used when login-shell detection fails.
+
+Any elements after FALLBACK are extra arguments passed to the shell.
+When none are given, ghostel supplies a type-aware default: recognized shells
+\(bash, zsh, fish) are started as login+interactive shells (`-l -i') so they
+source the user's rc/profile files, mirroring an interactive `ssh host' login.
+Unrecognized shells (e.g. /bin/sh) get no args.
+To override, list the arguments explicitly after FALLBACK,
+e.g. (\"ssh\" login-shell nil \"-i\")."
   :type '(alist :key-type (choice string (const t))
                 :value-type
-                (list (choice string (const login-shell))
-                      (choice (const :tag "No fallback" nil) string))))
+                (list (choice :tag "Shell" string (const login-shell))
+                      (choice :tag "Fallback" (const :tag "None" nil) string)
+                      (repeat :inline t :tag "Extra arguments" string))))
 
 (defcustom ghostel-max-scrollback (* 5 1024 1024)  ; 5MB
   "Maximum scrollback size in bytes.
@@ -3801,26 +3809,34 @@ EVENT is the state-change description passed by Emacs."
              host nil nil
              (car (split-string (system-name) "\\.")) nil nil t))))
 
-(defun ghostel--tramp-get-shell (method)
-  "Get the shell for TRAMP METHOD from `ghostel-tramp-shells'.
-METHOD is a TRAMP method string or t for the default."
+(defun ghostel--tramp-shell-spec (method)
+  "Return (PROGRAM . EXTRA-ARGS) for TRAMP METHOD from `ghostel-tramp-shells'.
+METHOD is a TRAMP method string or t for the default.
+PROGRAM is the shell path: either the configured string or, for the
+`login-shell' symbol, the remote user's login shell auto-detected
+via `getent passwd' \(falling back to the entry's FALLBACK).
+EXTRA-ARGS are the optional arguments listed after the FALLBACK slot.
+Returns nil when no program resolves for METHOD."
   (let* ((specs (cdr (assoc method ghostel-tramp-shells)))
          (first (car specs))
-         (second (cadr specs)))
-    (if (eq first 'login-shell)
-        (let* ((entry (ignore-errors
-                        (with-output-to-string
-                          (with-current-buffer standard-output
-                            (unless (= 0 (process-file-shell-command
-                                          "getent passwd $LOGNAME"
-                                          nil (current-buffer) nil))
-                              (error "Unexpected return value"))
-                            (when (> (count-lines (point-min) (point-max)) 1)
-                              (error "Unexpected output"))))))
-               (shell (when entry
-                        (nth 6 (split-string entry ":" nil "[ \t\n\r]+")))))
-          (or shell second))
-      first)))
+         (second (cadr specs))
+         (args (cddr specs))
+         (program
+          (if (eq first 'login-shell)
+              (let* ((entry (ignore-errors
+                              (with-output-to-string
+                                (with-current-buffer standard-output
+                                  (unless (= 0 (process-file-shell-command
+                                                "getent passwd $LOGNAME"
+                                                nil (current-buffer) nil))
+                                    (error "Unexpected return value"))
+                                  (when (> (count-lines (point-min) (point-max)) 1)
+                                    (error "Unexpected output"))))))
+                     (shell (when entry
+                              (nth 6 (split-string entry ":" nil "[ \t\n\r]+")))))
+                (or shell second))
+            first)))
+    (and program (cons program args))))
 
 (defun ghostel--shell-program-and-args (spec)
   "Split a `ghostel-shell'-style SPEC into (PROGRAM . ARGS).
@@ -3832,30 +3848,33 @@ element is the program path and the remaining elements are arguments."
     (cons (car spec) (cdr spec)))
    (t (error "Invalid ghostel-shell value: %S" spec))))
 
-(defun ghostel--get-shell ()
-  "Get the shell program to run, respecting TRAMP remote connections.
-When `default-directory' is a remote TRAMP path, consult
-`ghostel-tramp-shells' for the appropriate shell.  Returns the
-executable path as a string.  When `ghostel-shell' is a list,
-only its first element (the program) is returned; use
-`ghostel--resolve-shell-spec' to also obtain the extra arguments."
-  (let ((value
-         (if (file-remote-p default-directory)
-             (with-parsed-tramp-file-name default-directory nil
-               (or (ghostel--tramp-get-shell method)
-                   (ghostel--tramp-get-shell t)
-                   (with-connection-local-variables shell-file-name)
-                   ghostel-shell))
-           ghostel-shell)))
-    (car (ghostel--shell-program-and-args value))))
+(defun ghostel--default-remote-shell-args (program &optional integration)
+  "Return default extra args for a remote shell PROGRAM.
+Recognized shells (bash, zsh, fish) start login+interactive (`-l -i') so
+remote sessions source the user's rc/profile files; unrecognized shells
+\(e.g. /bin/sh) get no args.  With INTEGRATION active, bash uses `-i'
+only (a login bash ignores the integration's `--rcfile')."
+  (pcase (ghostel--detect-shell program)
+    ('bash (if integration '("-i") '("-l" "-i")))
+    ((or 'zsh 'fish) '("-l" "-i"))
+    (_ nil)))
 
 (defun ghostel--resolve-shell-spec ()
   "Return (PROGRAM . EXTRA-ARGS) for the shell to spawn.
 For local sessions, splits `ghostel-shell' (string or list).
-For remote (TRAMP) sessions, defers to `ghostel--get-shell',
-which always returns a string — no extra args."
+For remote (TRAMP) sessions, resolves PROGRAM via `ghostel-tramp-shells'
+\(see `ghostel--tramp-shell-spec') and returns any explicit per-method
+EXTRA-ARGS configured there.  When no explicit args are configured the
+caller supplies a type-aware default; see
+`ghostel--default-remote-shell-args'."
   (if (file-remote-p default-directory)
-      (cons (ghostel--get-shell) nil)
+      (with-parsed-tramp-file-name default-directory nil
+        (let ((spec (or (ghostel--tramp-shell-spec method)
+                        (ghostel--tramp-shell-spec t))))
+          (cons (or (car spec)
+                    (with-connection-local-variables shell-file-name)
+                    (car (ghostel--shell-program-and-args ghostel-shell)))
+                (cdr spec))))
     (ghostel--shell-program-and-args ghostel-shell)))
 
 (defun ghostel--resolve-local-executable (program)
@@ -4414,7 +4433,16 @@ run the shell on the remote host."
                             ((and (eq shell-type 'bash) integration-env)
                              (list "--posix"))
                             (t nil)))
-         (shell-args (append extra-shell-args integration-args))
+         ;; Start recognized remote shells login+interactive so they (and the
+         ;; user's rc/profile) load.  When integration is active the default
+         ;; adapts per shell (bash drops `-l' to keep `--rcfile'.  Explicit
+         ;; per-method args from `ghostel-tramp-shells' override the default.
+         (shell-args (append
+                      (or extra-shell-args
+                          (and remote-p
+                               (ghostel--default-remote-shell-args
+                                shell remote-integration)))
+                      integration-args))
          (extra-env (append
                      (unless remote-p
                        (list (format "EMACS_GHOSTEL_PATH=%s" ghostel-dir)))

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4435,7 +4435,7 @@ run the shell on the remote host."
                             (t nil)))
          ;; Start recognized remote shells login+interactive so they (and the
          ;; user's rc/profile) load.  When integration is active the default
-         ;; adapts per shell (bash drops `-l' to keep `--rcfile'.  Explicit
+         ;; adapts per shell (bash drops `-l' to keep `--rcfile').  Explicit
          ;; per-method args from `ghostel-tramp-shells' override the default.
          (shell-args (append
                       (or extra-shell-args
@@ -4460,9 +4460,11 @@ run the shell on the remote host."
          (proc (ghostel--spawn-pty spawn-program spawn-args
                                    extra-env remote-p)))
     (when remote-integration
-      (ghostel--cleanup-temp-paths
-       (plist-get remote-integration :temp-files)
-       (plist-get remote-integration :temp-dirs)))
+      (let ((files (plist-get remote-integration :temp-files))
+            (dirs (plist-get remote-integration :temp-dirs)))
+        (add-hook 'kill-buffer-hook
+                  (lambda () (ghostel--cleanup-temp-paths files dirs))
+                  nil t)))
     proc))
 
 

--- a/test/ghostel-spawn-test.el
+++ b/test/ghostel-spawn-test.el
@@ -270,6 +270,41 @@ user's `.zprofile'/`.zshrc' load alongside it."
           (should (equal "/usr/bin/zsh" (car spawn)))
           (should (equal '("-l" "-i") (cdr spawn))))))))
 
+(ert-deftest ghostel-test-start-process-remote-defers-temp-cleanup ()
+  "Remote integration temp paths are cleaned on buffer-kill, not at spawn.
+Deleting them at spawn time would race the just-spawned async remote
+shell, which has not yet read its bootstrap (ZDOTDIR/.zshenv etc.); the
+pushed terminfo dir is needed for the whole session besides."
+  (let (cleaned)
+    (cl-letf (((symbol-function 'ghostel--setup-remote-integration)
+               (lambda (_type)
+                 (list :env nil :args nil
+                       :temp-files '("/tmp/ghostel-x.zsh")
+                       :temp-dirs '("/tmp/ghostel-zdot"))))
+              ((symbol-function 'ghostel--cleanup-temp-paths)
+               (lambda (files dirs) (setq cleaned (list files dirs))))
+              ((symbol-function 'ghostel--spawn-pty) (lambda (&rest _) nil)))
+      (let ((buf (generate-new-buffer " *ghostel-test-defer*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer buf
+                (setq-local ghostel--term-rows 24
+                            ghostel--term-cols 80)
+                (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+                       (ghostel-tramp-shells '(("ssh" "/usr/bin/zsh")))
+                       (ghostel-shell-integration t)
+                       (ghostel-tramp-shell-integration t)
+                       (ghostel-macos-login-shell nil)
+                       (default-directory "/ssh:host:/home/u/"))
+                  (ghostel--start-process)))
+              ;; Not deleted at spawn time.
+              (should-not cleaned)
+              ;; Buffer-kill triggers the deferred cleanup with the paths.
+              (kill-buffer buf)
+              (should (equal cleaned
+                             '(("/tmp/ghostel-x.zsh") ("/tmp/ghostel-zdot")))))
+          (when (buffer-live-p buf) (kill-buffer buf)))))))
+
 (ert-deftest ghostel-test-macos-login-wrap-basic ()
   "Login wrap produces /usr/bin/login + bash shim with exec -l <prog>."
   (cl-letf (((symbol-function 'user-login-name) (lambda (&optional _) "alice"))

--- a/test/ghostel-spawn-test.el
+++ b/test/ghostel-spawn-test.el
@@ -104,12 +104,6 @@ written by `ghostel-test--pty-winsize-script'."
             start (match-end 0)))
     last))
 
-(ert-deftest ghostel-test-get-shell-local ()
-  "Test that local shell resolution returns `ghostel-shell'."
-  (let ((default-directory "/tmp/")
-        (ghostel-shell "/bin/zsh"))
-    (should (equal "/bin/zsh" (ghostel--get-shell)))))
-
 (ert-deftest ghostel-test-shell-program-and-args-string ()
   "String SPEC splits into (PROGRAM . nil)."
   (should (equal '("/bin/zsh") (ghostel--shell-program-and-args "/bin/zsh"))))
@@ -127,11 +121,154 @@ written by `ghostel-test--pty-winsize-script'."
   (should-error (ghostel--shell-program-and-args '()))
   (should-error (ghostel--shell-program-and-args '(nil "foo"))))
 
-(ert-deftest ghostel-test-get-shell-local-returns-program-from-list ()
-  "When `ghostel-shell' is a list, `ghostel--get-shell' returns just the program."
-  (let ((default-directory "/tmp/")
-        (ghostel-shell '("/bin/zsh" "--login")))
-    (should (equal "/bin/zsh" (ghostel--get-shell)))))
+;;; Remote shell spec resolution (issue #444)
+
+(ert-deftest ghostel-test-default-remote-shell-args-recognized ()
+  "Recognized remote shells default to login+interactive args."
+  (should (equal '("-l" "-i") (ghostel--default-remote-shell-args "/bin/zsh")))
+  (should (equal '("-l" "-i") (ghostel--default-remote-shell-args "/bin/bash")))
+  (should (equal '("-l" "-i") (ghostel--default-remote-shell-args "/usr/bin/fish")))
+  ;; NixOS-style path: detection keys off the basename.
+  (should (equal '("-l" "-i")
+                 (ghostel--default-remote-shell-args
+                  "/run/current-system/sw/bin/zsh"))))
+
+(ert-deftest ghostel-test-default-remote-shell-args-unrecognized ()
+  "Unrecognized remote shells get no default args (they may reject -l)."
+  (should-not (ghostel--default-remote-shell-args "/bin/sh"))
+  (should-not (ghostel--default-remote-shell-args "/bin/dash")))
+
+(ert-deftest ghostel-test-default-remote-shell-args-integration ()
+  "With integration active, bash drops `-l'; zsh/fish keep login+interactive."
+  ;; Bash: `-l' would make login bash ignore integration's `--rcfile'.
+  (should (equal '("-i") (ghostel--default-remote-shell-args "/bin/bash" t)))
+  ;; Zsh and fish compose cleanly with `-l -i'.
+  (should (equal '("-l" "-i") (ghostel--default-remote-shell-args "/usr/bin/zsh" t)))
+  (should (equal '("-l" "-i") (ghostel--default-remote-shell-args "/usr/bin/fish" t)))
+  ;; Unrecognized shells still get nothing.
+  (should-not (ghostel--default-remote-shell-args "/bin/sh" t)))
+
+(ert-deftest ghostel-test-tramp-shell-spec-explicit-args ()
+  "Explicit args after the fallback slot are returned in the spec."
+  (let ((ghostel-tramp-shells '(("ssh" "/bin/zsh" nil "-i" "-l"))))
+    (should (equal '("/bin/zsh" "-i" "-l") (ghostel--tramp-shell-spec "ssh")))))
+
+(ert-deftest ghostel-test-tramp-shell-spec-no-args ()
+  "An entry without an args slot yields no extra args."
+  (let ((ghostel-tramp-shells '(("docker" "/bin/sh"))))
+    (should (equal '("/bin/sh") (ghostel--tramp-shell-spec "docker"))))
+  (let ((ghostel-tramp-shells '(("ssh" "/bin/zsh"))))
+    (should (equal '("/bin/zsh") (ghostel--tramp-shell-spec "ssh")))))
+
+(ert-deftest ghostel-test-tramp-shell-spec-unknown-method ()
+  "An unknown method resolves to nil."
+  (let ((ghostel-tramp-shells '(("ssh" "/bin/zsh"))))
+    (should-not (ghostel--tramp-shell-spec "docker"))))
+
+(ert-deftest ghostel-test-tramp-shell-spec-login-shell-fallback-args ()
+  "Login-shell detection failure falls back, preserving explicit args."
+  (cl-letf (((symbol-function 'process-file-shell-command)
+             (lambda (&rest _) 1)))     ; simulate getent failure
+    (let ((ghostel-tramp-shells '(("ssh" login-shell "/bin/sh" "-i"))))
+      (should (equal '("/bin/sh" "-i") (ghostel--tramp-shell-spec "ssh"))))))
+
+(ert-deftest ghostel-test-resolve-shell-spec-remote-default-no-args ()
+  "Remote resolve returns the program alone when no explicit args are configured.
+The type-aware default is applied later, at spawn time."
+  (let ((default-directory "/ssh:host:/home/u/")
+        (ghostel-tramp-shells '(("ssh" "/bin/zsh"))))
+    (should (equal '("/bin/zsh") (ghostel--resolve-shell-spec)))))
+
+(ert-deftest ghostel-test-start-process-remote-adds-login-interactive ()
+  "A recognized remote shell is started login+interactive by default."
+  (ghostel-test--with-spawn-capture spawn
+    (with-temp-buffer
+      (setq-local ghostel--term-rows 24
+                  ghostel--term-cols 80)
+      (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+             (ghostel-tramp-shells '(("ssh" "/bin/zsh")))
+             (ghostel-shell-integration nil)
+             (ghostel-macos-login-shell nil)
+             (default-directory "/ssh:host:/home/u/"))
+        (ghostel--start-process)
+        (should (equal "/bin/zsh" (car spawn)))
+        (should (equal '("-l" "-i") (cdr spawn)))))))
+
+(ert-deftest ghostel-test-start-process-remote-unrecognized-no-args ()
+  "An unrecognized remote shell gets no auto args."
+  (ghostel-test--with-spawn-capture spawn
+    (with-temp-buffer
+      (setq-local ghostel--term-rows 24
+                  ghostel--term-cols 80)
+      (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+             (ghostel-tramp-shells '(("ssh" "/bin/sh")))
+             (ghostel-shell-integration nil)
+             (ghostel-macos-login-shell nil)
+             (default-directory "/ssh:host:/home/u/"))
+        (ghostel--start-process)
+        (should (equal "/bin/sh" (car spawn)))
+        (should-not (cdr spawn))))))
+
+(ert-deftest ghostel-test-start-process-remote-explicit-args-override ()
+  "Explicit per-method args replace the type-aware default."
+  (ghostel-test--with-spawn-capture spawn
+    (with-temp-buffer
+      (setq-local ghostel--term-rows 24
+                  ghostel--term-cols 80)
+      (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+             (ghostel-tramp-shells '(("ssh" "/bin/zsh" nil "-i")))
+             (ghostel-shell-integration nil)
+             (ghostel-macos-login-shell nil)
+             (default-directory "/ssh:host:/home/u/"))
+        (ghostel--start-process)
+        (should (equal "/bin/zsh" (car spawn)))
+        (should (equal '("-i") (cdr spawn)))))))
+
+(ert-deftest ghostel-test-start-process-remote-bash-integration-interactive-no-login ()
+  "Bash integration: shell is made interactive (`-i') but not login.
+A login bash ignores the `--rcfile' the bash integration relies on, so
+`-l' must be omitted; `-i' is still added so the rcfile (and the user's
+`~/.bashrc') loads on TRAMP methods where the remote stdin isn't a tty."
+  (cl-letf (((symbol-function 'ghostel--setup-remote-integration)
+             (lambda (_type)
+               (list :env nil :args '("--rcfile" "/tmp/ghostel.bash")
+                     :temp-files nil :temp-dirs nil))))
+    (ghostel-test--with-spawn-capture spawn
+      (with-temp-buffer
+        (setq-local ghostel--term-rows 24
+                    ghostel--term-cols 80)
+        (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+               (ghostel-tramp-shells '(("ssh" "/bin/bash")))
+               (ghostel-shell-integration t)
+               (ghostel-tramp-shell-integration t)
+               (ghostel-macos-login-shell nil)
+               (default-directory "/ssh:host:/home/u/"))
+          (ghostel--start-process)
+          (should (equal "/bin/bash" (car spawn)))
+          (should (equal '("-i" "--rcfile" "/tmp/ghostel.bash") (cdr spawn)))
+          (should-not (member "-l" (cdr spawn))))))))
+
+(ert-deftest ghostel-test-start-process-remote-zsh-integration-login-interactive ()
+  "Zsh integration: the shell still starts login+interactive (`-l -i').
+`-l -i' composes cleanly with the ZDOTDIR-based zsh integration, so the
+user's `.zprofile'/`.zshrc' load alongside it."
+  (cl-letf (((symbol-function 'ghostel--setup-remote-integration)
+             (lambda (_type)
+               (list :env '("ZDOTDIR=/tmp/ghostel-zdot") :args nil
+                     :temp-files nil :temp-dirs nil))))
+    (ghostel-test--with-spawn-capture spawn
+      (with-temp-buffer
+        (setq-local ghostel--term-rows 24
+                    ghostel--term-cols 80)
+        (let* ((process-environment '("PATH=/usr/bin:/bin" "HOME=/tmp"))
+               (ghostel-tramp-shells '(("ssh" "/usr/bin/zsh")))
+               (ghostel-shell-integration t)
+               (ghostel-tramp-shell-integration t)
+               (ghostel-macos-login-shell nil)
+               (default-directory "/ssh:host:/home/u/"))
+          (ghostel--start-process)
+          (should (equal "/usr/bin/zsh" (car spawn)))
+          (should (equal '("-l" "-i") (cdr spawn))))))))
 
 (ert-deftest ghostel-test-macos-login-wrap-basic ()
   "Login wrap produces /usr/bin/login + bash shim with exec -l <prog>."


### PR DESCRIPTION
## Summary

Remote (TRAMP) shells were spawned with no extra args: they were never login shells (skipping `.zprofile`/`.zlogin`), and interactivity was left to the shell's tty auto-detection, which doesn't hold on every TRAMP method (so `.zshrc` could be skipped too).

This passes `-l -i` by default for recognized shells (bash, zsh, fish) so remote sessions reliably source the user's rc/profile files, mirroring an interactive `ssh host` login. Unrecognized shells (e.g. `/bin/sh`) are left unchanged.

`ghostel-tramp-shells` entries gain an optional trailing args slot — `(METHOD SHELL [FALLBACK [ARG...]])` — to override the default per method.

Fixes #444.

## Implementation

- `ghostel--tramp-get-shell` → `ghostel--tramp-shell-spec`: now returns `(PROGRAM . EXTRA-ARGS)`, parsing the optional per-method args after the fallback slot. Program resolution (incl. `login-shell` `getent` detection) is unchanged.
- New `ghostel--default-remote-shell-args`: returns `("-l" "-i")` for bash/zsh/fish (detected by basename, so NixOS-style paths work), `nil` otherwise.
- `ghostel--resolve-shell-spec` surfaces explicit per-method args for remote sessions; the type-aware default is applied in `ghostel--start-process` only when remote shell integration is **off** — integration owns startup-file loading via its own invocation (e.g. bash `--rcfile`, which a login shell would ignore), so the default must not be appended on top of it. Local and integration-on paths are unchanged.

## Testing

- `make -j8 all` is green; 10 new ERT tests cover arg parsing, the type-aware default, and spawn composition (including a guard that integration doesn't get a stray `-l`).
- Verified live by driving a ghostel terminal to a real remote host (`/ssh:<host>:` with zsh), non-destructively:
  - **Before:** `… exec /usr/bin/zsh` → `interactive=on login=off`
  - **After:** `… exec /usr/bin/zsh -l -i` → `interactive=on login=on`

  (On that host interactivity was already auto-detected from the PTY; the observable delta there was the login flag. Passing `-i` explicitly makes interactivity reliable on TRAMP methods where the remote stdin isn't a tty — the original report's case, where `.zshrc` wasn't loading.)
