### PR TITLE
Add Emacs bookmark support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Emacs bookmark support for ghostel buffers: `bookmark-set` (`C-x r m`) records
+  a terminal's working directory and name, and `bookmark-jump` (`C-x r b`)
+  reopens it — reusing a live ghostel buffer of that name or starting a fresh
+  shell in the bookmarked directory. The new `ghostel-bookmark-check-dir`
+  (default `t`) controls whether the directory is restored (`cd`'d into a reused
+  buffer that has since moved elsewhere).
+  Fixes [#447](https://github.com/dakra/ghostel/issues/447).
+
 ## [0.37.0] — 2026-06-21
 
 ### Added

--- a/README.org
+++ b/README.org
@@ -599,6 +599,23 @@ Remote TRAMP buffers still use Emacs process machinery so TRAMP can spawn the
 shell on the remote host and apply its file handlers.  The rendering and input
 APIs are shared by both paths.
 
+** Bookmarks
+:properties:
+:custom_id: bookmarks
+:end:
+
+Ghostel buffers work with Emacs's built-in bookmarks.  =bookmark-set= (=C-x r
+m=) records the terminal's working directory and buffer name; =bookmark-jump=
+(=C-x r b=) reopens it — reusing a live ghostel buffer of that name, or starting
+a fresh shell in the bookmarked directory when none exists.  Bookmarks capture
+the directory and name only (not scrollback or session contents), matching
+vterm.
+
+=ghostel-bookmark-check-dir= (default =t=) controls directory restoration: a
+fresh buffer starts its shell in the bookmarked directory, and a reused buffer
+that has since moved elsewhere gets a =cd= typed into its shell.  Set it to =nil=
+to leave the directory alone.
+
 ** Links and file detection
 :properties:
 :custom_id: links-and-file-detection
@@ -1149,6 +1166,7 @@ tables below group them by area; defaults shown are the out-of-the-box values.
 | =ghostel-exit-functions=           | =nil=                                           | Hook run with =(BUFFER EVENT)= when the terminal process exits.                                                 |
 | =ghostel-command-start-functions=  | =(ghostel--query-before-killing-on-cmd-start)=  | Hook run with =(BUFFER)= on OSC 133 C (command start).                                                          |
 | =ghostel-command-finish-functions= | =(ghostel--query-before-killing-on-cmd-finish)= | Hook run with =(BUFFER EXIT-STATUS)= on OSC 133 D (command finish).                                             |
+| =ghostel-bookmark-check-dir=       | =t=                                             | Restore the working directory when jumping to a ghostel [[#bookmarks][bookmark]] (=cd= into a reused buffer that moved).      |
 
 ** Native module
 
@@ -1828,6 +1846,7 @@ while ghostel and vterm trade a compile step for a C/Zig engine.
 | Elisp eval from shell         | ✅      | ✅       | ❌       |
 | TRAMP remote terminals        | ✅      | ✅       | ✅       |
 | Eshell integration            | ✅      | ❌       | ✅       |
+| Bookmark support              | ✅      | ✅       | ❌       |
 |-------------------------------+---------+----------+----------|
 | Input modes (char/semi/emacs) | ✅      | partial  | ✅       |
 | Line mode (local editing)     | ✅      | ❌       | ✅       |

--- a/lisp/ghostel-bookmark.el
+++ b/lisp/ghostel-bookmark.el
@@ -1,0 +1,81 @@
+;;; ghostel-bookmark.el --- Bookmark support for ghostel -*- lexical-binding: t; -*-
+
+;; Author: Daniel Kraus <daniel@kraus.my>
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;;; Commentary:
+
+;; Integrate ghostel buffers with Emacs's built-in bookmark facility
+;; (`bookmark-set' / `bookmark-jump', i.e. `C-x r m' / `C-x r b').  A
+;; bookmark records the buffer's working directory and name; jumping to
+;; it reuses a live ghostel buffer of that name, or starts a fresh shell
+;; in the bookmarked directory when none exists.
+;;
+;; `ghostel-mode' wires up `bookmark-make-record-function' to point at
+;; `ghostel--bookmark-make-record' (a quoted symbol, so ghostel.el needs
+;; no load-time dependency on this file).  Both the record maker and the
+;; handler are autoloaded, so a bookmark saved in one session restores in
+;; a fresh Emacs the first time it is used.
+
+;;; Code:
+
+(require 'bookmark)
+(require 'ghostel)
+
+(defcustom ghostel-bookmark-check-dir t
+  "When non-nil, restoring a ghostel bookmark also restores its directory.
+For a freshly created buffer the shell starts in the bookmarked
+directory; for a reused live buffer that has since moved elsewhere,
+a `cd' to the bookmarked directory is typed into the shell."
+  :type 'boolean
+  :group 'ghostel)
+
+;;;###autoload
+(defun ghostel--bookmark-make-record ()
+  "Return a bookmark record for the current ghostel buffer.
+Notes the working directory and buffer name.
+See `ghostel--bookmark-handler' for how they are restored."
+  `(nil
+    (handler . ghostel--bookmark-handler)
+    (thisdir . ,default-directory)
+    (buf-name . ,(buffer-name))
+    (defaults . nil)))
+
+;;;###autoload
+(defun ghostel--bookmark-handler (bmk)
+  "Restore the ghostel bookmark BMK.
+Reuse a live ghostel buffer of the bookmarked name, or create one with a shell
+started in the bookmarked directory.  When a reused buffer's directory differs
+and `ghostel-bookmark-check-dir' is non-nil, type a `cd' into the shell."
+  (ghostel--load-module t)
+  (let* ((thisdir (bookmark-prop-get bmk 'thisdir))
+         (buf-name (bookmark-prop-get bmk 'buf-name))
+         (buf (get-buffer buf-name))
+         (mode (and buf (buffer-local-value 'major-mode buf))))
+    ;; Create branch: the shell starts directly in THISDIR (no `cd').
+    (when (or (not buf) (not (eq mode 'ghostel-mode)))
+      (let ((default-directory (if ghostel-bookmark-check-dir
+                                   thisdir
+                                 default-directory)))
+        (setq buf (ghostel--create buf-name))
+        (with-current-buffer buf
+          (setq ghostel--managed-buffer-name (buffer-name)
+                ghostel--buffer-identity buf-name)
+          (ghostel--start-process)
+          (ghostel--apply-initial-input-mode))))
+    ;; Reuse branch: `cd' if the live buffer has wandered elsewhere.
+    (with-current-buffer buf
+      (when (and ghostel-bookmark-check-dir
+                 ghostel--term
+                 (not (string-equal default-directory thisdir)))
+        (when (memq ghostel--input-mode '(copy emacs))
+          (ghostel-readonly-exit))
+        ;; Ghostel records remote dirs as TRAMP paths, so strip the TRAMP prefix
+        ;; with `file-local-name', and quote so paths with spaces survive.
+        (ghostel-send-string
+         (concat "cd " (shell-quote-argument (file-local-name thisdir))))
+        (ghostel-send-key "return")))
+    (set-buffer buf)))
+
+(provide 'ghostel-bookmark)
+;;; ghostel-bookmark.el ends here

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -999,6 +999,9 @@ Used when `cursor-in-non-selected-windows' resolves to box.")
 (declare-function spinner-start "spinner")
 (declare-function spinner-stop "spinner")
 
+;; Lazily loaded on first bookmark use; see ghostel-bookmark.el.
+(declare-function ghostel--bookmark-make-record "ghostel-bookmark")
+
 
 ;;; Automatic download and compilation of native module
 
@@ -5701,6 +5704,8 @@ for both native and Emacs PTY paths."
   (setq-local line-spacing 0)
   ;; expose cwd to buffer-menu/ibuffer
   (setq-local list-buffers-directory (expand-file-name default-directory))
+  ;; bookmark this buffer's cwd (loads ghostel-bookmark.el lazily on use)
+  (setq-local bookmark-make-record-function #'ghostel--bookmark-make-record)
   (setq ghostel--input-mode 'semi-char)
   (setq ghostel--scroll-intercept-active t)
   ;; Let C-g reach the keymap instead of triggering keyboard-quit.

--- a/test/ghostel-bookmark-test.el
+++ b/test/ghostel-bookmark-test.el
@@ -1,0 +1,102 @@
+;;; ghostel-bookmark-test.el --- Tests for ghostel: bookmarks -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Emacs bookmark integration: the `bookmark-make-record-function' maker and
+;; the jump handler.  The maker tests are pure elisp (a `ghostel-mode' buffer
+;; spawns no process).  The handler tests need the native module: they spawn a
+;; real shell and observe OSC 7 directory tracking, so they are tagged
+;; `native'.
+
+;;; Code:
+
+(require 'ghostel-test-helpers)
+(require 'ghostel-bookmark)
+
+(ert-deftest ghostel-test-bookmark-make-record ()
+  "`ghostel--bookmark-make-record' captures handler, dir, and buffer name."
+  (ghostel-test--with-compile-buffer buf
+    (let* ((default-directory "/tmp/ghostel-bookmark-make-record/")
+           (record (ghostel--bookmark-make-record)))
+      (should (eq (bookmark-prop-get record 'handler)
+                  'ghostel--bookmark-handler))
+      (should (equal (bookmark-prop-get record 'thisdir)
+                     "/tmp/ghostel-bookmark-make-record/"))
+      (should (equal (bookmark-prop-get record 'buf-name) (buffer-name))))))
+
+(ert-deftest ghostel-test-bookmark-mode-wires-record-function ()
+  "`ghostel-mode' wires `bookmark-make-record-function'; the record round-trips.
+`bookmark-make-record' is the entry point bookmark.el itself uses on
+`bookmark-set'; the handler and buffer name must survive its post-processing."
+  (ghostel-test--with-compile-buffer buf
+    (should (eq bookmark-make-record-function #'ghostel--bookmark-make-record))
+    (let ((record (bookmark-make-record)))
+      (should (eq (bookmark-prop-get record 'handler)
+                  'ghostel--bookmark-handler))
+      (should (equal (bookmark-prop-get record 'buf-name) (buffer-name))))))
+
+(defun ghostel-test--bookmark-record (buf-name thisdir)
+  "Return a ghostel bookmark record for BUF-NAME pointing at THISDIR."
+  `(,buf-name
+    (handler . ghostel--bookmark-handler)
+    (thisdir . ,thisdir)
+    (buf-name . ,buf-name)
+    (defaults . nil)))
+
+(ert-deftest ghostel-test-bookmark-handler-creates-buffer ()
+  "Jumping to a bookmark with no live buffer starts a fresh shell in its dir."
+  :tags '(native)
+  (let* ((ghostel-macos-login-shell nil)
+         (dir (file-name-as-directory (make-temp-file "ghostel-bm-create" t)))
+         (buf-name (generate-new-buffer-name " *ghostel-bm-create*"))
+         (buf nil))
+    (unwind-protect
+        (progn
+          (ghostel--bookmark-handler
+           (ghostel-test--bookmark-record buf-name dir))
+          (setq buf (get-buffer buf-name))
+          (should (buffer-live-p buf))
+          (with-current-buffer buf
+            (should (eq major-mode 'ghostel-mode))
+            (should (process-live-p ghostel--process))
+            ;; `file-equal-p' tolerates OSC 7 / symlink-resolved variants.
+            (should (file-equal-p default-directory dir))))
+      (when (buffer-live-p (get-buffer buf-name))
+        (ghostel-test--cleanup-exec-buffer (get-buffer buf-name)))
+      (ignore-errors (delete-directory dir t)))))
+
+(ert-deftest ghostel-test-bookmark-handler-reuse-cd ()
+  "Reusing a live buffer in a different dir types a TRAMP-stripped, quoted `cd'.
+Asserts the exact bytes the handler sends rather than the shell's OSC 7
+round-trip (that is ghostel's own directory tracking, covered elsewhere, and
+too timing-sensitive to drive a real shell through here).  With
+`ghostel-bookmark-check-dir' nil, nothing is typed."
+  :tags '(native)
+  ;; `ghostel-test--with-terminal-buffer' gives a live `ghostel--term' (so the
+  ;; reuse-branch guard passes) without a process; we stub the send functions.
+  (ghostel-test--with-terminal-buffer (buf term 24 80 1000)
+    (let ((sent nil)
+          (default-directory "/tmp/ghostel-bm-here/")
+          ;; A remote dir with a space exercises both departures from vterm:
+          ;; TRAMP-prefix stripping and shell quoting.
+          (remote "/ssh:host:/remote dir/"))
+      (cl-letf (((symbol-function 'ghostel-send-string)
+                 (lambda (s) (push (cons 'string s) sent)))
+                ((symbol-function 'ghostel-send-key)
+                 (lambda (k &rest _) (push (cons 'key k) sent))))
+        ;; Enabled + differing dir: a quoted `cd' with the TRAMP prefix stripped.
+        (ghostel--bookmark-handler
+         (ghostel-test--bookmark-record (buffer-name) remote))
+        (should (equal (nreverse sent)
+                       `((string . ,(concat "cd " (shell-quote-argument
+                                                   (file-local-name remote))))
+                         (key . "return"))))
+        ;; Disabled: nothing is typed even though the dirs differ.
+        (setq sent nil)
+        (let ((ghostel-bookmark-check-dir nil))
+          (ghostel--bookmark-handler
+           (ghostel-test--bookmark-record (buffer-name) "/tmp/elsewhere/")))
+        (should-not sent)))))
+
+(provide 'ghostel-bookmark-test)
+;;; ghostel-bookmark-test.el ends here


### PR DESCRIPTION
Adds Emacs's built-in bookmark support to ghostel buffers (#447). vterm has
this; eat does not — the reporter called it "about the only thing preventing
me from using Ghostel exclusively."

## Behavior (vterm parity)
- `ghostel-mode` sets `bookmark-make-record-function`, so `bookmark-set`
  (`C-x r m`) records a terminal's working directory and buffer name.
- `bookmark-jump` (`C-x r b`) reopens it:
  - **No live buffer of that name** → create one and start the shell directly
    in the bookmarked directory (no `cd` injection — the shell is born there).
  - **Live buffer that wandered elsewhere** → type `cd <dir>` + RET into the
    shell.
- New `ghostel-bookmark-check-dir` (default `t`) gates directory restoration;
  set it `nil` to restore only the buffer, not the directory.
- Bookmarks capture directory + name only (not scrollback/session), matching
  vterm.

## Implementation
- Self-contained, autoloaded `lisp/ghostel-bookmark.el` (loads lazily on first
  bookmark use; a bookmark saved in one session restores in a fresh Emacs).
  `ghostel.el` references the record maker by symbol, so there's no load cycle
  and no eager `require`.
- Two deliberate departures from vterm, both needed for ghostel:
  - the injected `cd` uses `file-local-name` + `shell-quote-argument` (ghostel
    records remote dirs as TRAMP paths via its OSC 7 handler; a bare TRAMP
    prefix isn't a valid `cd` arg, and unquoted paths break on spaces);
  - the injection is guarded on a live terminal so a dead shell isn't typed
    into.

## Testing
- `test/ghostel-bookmark-test.el`: 2 elisp tests (record maker + `bookmark.el`
  round-trip / mode wiring) and 2 native tests (create-in-dir branch; reuse +
  `cd` round-trip verified through real OSC 7 directory tracking, plus the
  `check-dir nil` suppression).
- `make -j8 all` green (build + elisp/native/zig/evil + lint).
- Live-verified end to end in a real Emacs: `M-x ghostel` → `cd` → `C-x r m` →
  kill buffer → `bookmark-jump` reopens a shell in the bookmarked dir; reuse
  branch `cd`s a wandered buffer back; `check-dir nil` suppresses it.

Fixes #447.