### PR TITLE
Keep point in line mode when ghostel--anchor-window scrolls

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4576,7 +4576,9 @@ Copy mode is never anchored (the viewport is frozen).  Emacs mode is
 anchored only when FORCE is non-nil, reserved for deliberate anchors such
 as paste/yank that should scroll to the live cursor even in Emacs mode;
 auto-follow callers leave FORCE nil so a buffer reading its scrollback in
-Emacs mode keeps its position.  Semi-char/char/line always anchor."
+Emacs mode keeps its position.  Semi-char/char always anchor and snap
+point to the live cursor; line mode anchors the viewport but keeps the
+user's point, since its input region is user-owned."
   (when-let* ((window (or window (selected-window)))
               (buffer (window-buffer window))
               ((with-current-buffer buffer
@@ -4586,7 +4588,10 @@ Emacs mode keeps its position.  Semi-char/char/line always anchor."
                         (ghostel--terminal-live-p))))))
     (with-selected-window window
       (with-current-buffer buffer
-        (let ((target (point-max)))
+        (let ((target (point-max))
+              ;; Line mode's input region is user-owned; keep point instead of
+              ;; snapping it to the terminal cursor.
+              (orig (point)))
           (if-let* ((anchor (and (display-graphic-p (window-frame window))
                                  ghostel--pixel-anchor-supported-p
                                  (ghostel--pixel-anchor window target))))
@@ -4598,7 +4603,9 @@ Emacs mode keeps its position.  Semi-char/char/line always anchor."
               (forward-line (- (floor lines)))
               (set-window-start window (point))
               (ghostel--set-window-vscroll window 0 t t)))
-          (set-window-point window (or ghostel--cursor-char-pos target)))))))
+          (set-window-point window (if (eq ghostel--input-mode 'line)
+                                       orig
+                                     (or ghostel--cursor-char-pos target))))))))
 
 (defun ghostel--maybe-defer-redraw (buffer)
   "Defer BUFFER's redraw if a `ghostel-inhibit-redraw-functions' hook asks.

--- a/test/ghostel-line-mode-test.el
+++ b/test/ghostel-line-mode-test.el
@@ -2046,5 +2046,68 @@ prompt and engages on the redraw that exposes one."
       (should (eq ghostel--input-mode 'char))
       (should-not ghostel--pending-initial-line-mode))))
 
+(ert-deftest ghostel-test-anchor-window-line-mode-keeps-point ()
+  "`ghostel--anchor-window' anchors the line-mode viewport but keeps point.
+In line mode the input region between `ghostel--line-input-start' and
+`ghostel--line-input-end' is user-owned, so an anchor (minibuffer grow, window
+resize, redisplay) must scroll the viewport to the bottom WITHOUT snapping point
+to the terminal cursor.  The semi-char control sub-case proves the
+snap-to-`ghostel--cursor-char-pos' behaviour is preserved for the other modes."
+  (let ((buf (generate-new-buffer " *ghostel-test-anchor-line*"))
+        (previous-buffer (window-buffer (selected-window))))
+    (unwind-protect
+        ;; No native module: stub the alt-screen DEC-mode query so line-mode
+        ;; entry takes the primary-screen path.
+        (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                   (lambda (&rest _) nil)))
+          (set-window-buffer (selected-window) buf)
+          (with-current-buffer buf
+            (ghostel-mode)
+            (setq ghostel--term 'fake)
+            ;; Scrollback above the prompt so a bottom-anchor is observable.
+            (let ((rows (max 1 (window-body-height)))
+                  (inhibit-read-only t))
+              (dotimes (i (+ rows 20))
+                (insert (format "row-%02d\n" i))))
+            ;; A prompt carrying `ghostel-prompt' on the cursor's row, with the
+            ;; terminal cursor (= the input boundary) right after it.
+            (let ((inhibit-read-only t))
+              (insert (propertize "$ " 'ghostel-prompt t)))
+            (setq ghostel--cursor-char-pos (point))
+            (setq ghostel--cursor-pos (cons (current-column) 0))
+            ;; Enter line mode: markers now wrap the (empty) input region.
+            (ghostel-line-mode)
+            (should (eq ghostel--input-mode 'line))
+            (should (markerp ghostel--line-input-start))
+            ;; Type input locally; the end marker grows to include it.
+            (goto-char (marker-position ghostel--line-input-end))
+            (let ((inhibit-read-only t))
+              (insert "echo hello world"))
+            (should (equal (ghostel--line-mode-input-text) "echo hello world"))
+            (let* ((win (selected-window))
+                   (start (marker-position ghostel--line-input-start))
+                   ;; Point mid-input: distinct from `ghostel--cursor-char-pos'
+                   ;; (= input start) and from `point-max' (= input end).
+                   (mid (+ start 5)))
+              (should (= ghostel--cursor-char-pos start))
+              (should (< start mid))
+              (should (< mid (point-max)))
+              ;; Park point mid-input and scroll the window off the bottom.
+              (goto-char mid)
+              (set-window-point win mid)
+              (set-window-start win (point-min) t)
+              ;; Line mode anchors the viewport but leaves point put.
+              (ghostel--anchor-window win)
+              (should (= (window-point win) mid))
+              (should (> (window-start win) (point-min)))
+              ;; Control: semi-char mode still snaps point to the live cursor.
+              (setq ghostel--input-mode 'semi-char)
+              (set-window-start win (point-min) t)
+              (ghostel--anchor-window win)
+              (should (= (window-point win) ghostel--cursor-char-pos))
+              (should (> (window-start win) (point-min))))))
+      (set-window-buffer (selected-window) previous-buffer)
+      (kill-buffer buf))))
+
 (provide 'ghostel-line-mode-test)
 ;;; ghostel-line-mode-test.el ends here


### PR DESCRIPTION
In line mode the input region between ghostel--line-input-start and
ghostel--line-input-end is user-owned, but ghostel--anchor-window
unconditionally snapped point to the terminal cursor
(ghostel--cursor-char-pos) after scrolling to the bottom.  Any re-anchor
-- growing the minibuffer with M-x, a window resize, or a redisplay --
therefore yanked point off the user's in-progress edit back to the
prompt.

Capture point before scrolling and, in line mode, restore it instead of
snapping to the cursor; semi-char/char/emacs modes still snap as before.
Add a regression test covering the line-mode and semi-char paths.

Fixes #436