### PR TITLE
Fix scrollback accounting across page splits

### DIFF
--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -66,6 +66,13 @@ const MaterializedPage = struct {
     serial: PageSerial,
     char_len: usize = 0,
     rows: usize = 0,
+
+    pub fn next(self: *@This()) ?*@This() {
+        return if (self.node.next) |n|
+            @fieldParentPtr("node", n)
+        else
+            null;
+    }
 };
 
 const FontInfo = struct {
@@ -818,6 +825,11 @@ pub fn render(
             else => 0,
         };
 
+        var page = if (self.term.screens.active.no_scrollback)
+            null
+        else
+            try self.getOrAddPage(alloc, pin.node.serial);
+
         var i: usize = 0;
         const row_dirty = self.render_state.row_data.items(.dirty);
         while (i < self.render_state.rows) : ({
@@ -827,18 +839,19 @@ pub fn render(
         }) {
             if (i < skip) continue;
 
+            const row = self.render_state.row_data.get(i);
+            if (page) |p| {
+                if (p.serial != row.pin.node.serial) {
+                    page = p.next() orelse try self.addPage(alloc, row.pin.node.serial);
+                    std.debug.assert(page != null);
+                    std.debug.assert(page.?.serial == row.pin.node.serial);
+                }
+            }
+
             const dirty_row = self.render_state.dirty == .full or row_dirty[i];
             // Only process dirty rows, or there's no existing row
             const eob = env.isNotNil(env.f("eobp", .{}));
             if (dirty_row or eob) {
-                const row = self.render_state.row_data.get(i);
-
-                // We don't track pages when we have no scrollback
-                const page: ?*MaterializedPage = if (self.rendered_screen.no_scrollback)
-                    null
-                else
-                    try self.getOrAddLastPage(alloc, row.pin.node.serial);
-
                 const cursor_col = blk: {
                     if (self.render_state.cursor.viewport) |vp| {
                         if (vp.y == i) break :blk vp.x;
@@ -959,12 +972,17 @@ fn gotoActiveStart(self: *Self, env: emacs.Env) void {
     _ = env.f("forward-line", .{-@as(i64, @intCast(self.term.rows))});
 }
 
-fn getOrAddLastPage(self: *Self, alloc: Allocator, serial: PageSerial) !*MaterializedPage {
-    if (self.pages_in_buffer.last) |node| {
-        const page: *MaterializedPage = @fieldParentPtr("node", node);
+fn getOrAddPage(self: *Self, alloc: Allocator, serial: PageSerial) !*MaterializedPage {
+    var node = self.pages_in_buffer.last;
+    while (node) |n| : (node = n.prev) {
+        const page: *MaterializedPage = @fieldParentPtr("node", n);
         if (page.serial == serial) return page;
     }
 
+    return self.addPage(alloc, serial);
+}
+
+fn addPage(self: *Self, alloc: Allocator, serial: PageSerial) !*MaterializedPage {
     const page = try alloc.create(MaterializedPage);
     page.* = .{ .serial = serial };
     self.pages_in_buffer.append(&page.node);

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -1734,6 +1734,13 @@ When the buffer reappears, it is immediately redrawn."
 ;; the feature-oriented sections above and have an obvious home for
 ;; future additions.
 
+(defun ghostel-test--numbered-lines (count width)
+  "Return COUNT numbered lines with WIDTH x characters per line."
+  (with-temp-buffer
+    (dotimes (i count)
+      (insert (format "%05d: " i) (make-string width ?x) "\n"))
+    (buffer-string)))
+
 (ert-deftest ghostel-test-page-eviction-before-redraw ()
   "Regression: page-serial underflow when initial active area scrolls off entirely.
 Scenario (from Hypothesis failure): 1×136 terminal, render once while
@@ -1773,6 +1780,26 @@ subtracts old_line_len from the newly-created page whose char_len is
             (should (string-match-p "x"
                                     (buffer-substring-no-properties
                                      (point-min) (point-max))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-resize-eviction-char-count-stays-in-buffer-bounds ()
+  "Regression: resizing must not stale scrollback char counts.
+A row-count resize between materialized scrollback and later eviction
+left page character accounting larger than the actual buffer, so the
+next eviction called `delete-region' beyond `point-max'."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-resize-evict*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let ((term (ghostel--new 1 90 16384))
+                (inhibit-read-only t))
+            (ghostel--write-vt term (ghostel-test--numbered-lines 400 20))
+            (ghostel--set-size term 10 90)
+            (ghostel--redraw term)
+            (ghostel--set-size term 11 90)
+            (ghostel--redraw term)
+            (ghostel--write-vt term (ghostel-test--numbered-lines 800 20))
+            (ghostel--redraw term)))
       (kill-buffer buf))))
 
 


### PR DESCRIPTION
## Summary

- Track materialized page accounting across active-area page splits instead of assuming the active area is covered by the last materialized page.
- Preserve ordered page advancement semantics and assert when an unexpected page is encountered.
- Add a native regression for resize + later scrollback eviction deleting past buffer bounds.

## Test plan

- [x] `make build`
- [x] `emacs --batch -Q -L lisp -L test -l ert -l test/ghostel-test-helpers.el -l test/ghostel-render-test.el --eval "(ert-run-tests-batch-and-exit 'ghostel-test-resize-eviction-char-count-stays-in-buffer-bounds)"`