### PR TITLE
Scale fallback glyphs with text scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ All notable changes to this project will be documented in this file.
   deleted directory, so neither the integration nor the user's own config
   loaded. Cleanup is now deferred to buffer-kill, past the shell's startup read
   and the session-long lifetime of the terminfo dir.
+- Emoji and other glyphs scaled into the terminal cell now follow buffer-local
+  text scaling.
 
 ## [0.37.0] — 2026-06-21
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4781,45 +4781,43 @@ Convenience wrapper to keep the five resize sites consistent."
                      (ghostel--reported-cell-width)
                      (ghostel--reported-cell-height)))
 
-(defun ghostel--adjust-size (window)
+(defun ghostel--adjust-size (window &optional force)
   "Resize the terminal to match WINDOW's buffer dimensions.
 If WINDOW was anchored to the live viewport before the size change,
 keep it anchored.  Redraw synchronously when the terminal size
-actually changes."
+actually changes.  When FORCE is non-nil, run the resize/redraw
+path even when the row/column count is unchanged."
   (when (ghostel--window-anchored-p
          window (window-old-body-pixel-height window))
     (ghostel--anchor-window window))
-  (let* ((adjust-fn (default-value 'window-adjust-process-window-size-function))
-         (adjust-fn (if (functionp adjust-fn)
-                        adjust-fn
-                      #'window-adjust-process-window-size-smallest))
-         (windows (get-buffer-window-list nil nil t))
-         (size (funcall adjust-fn ghostel--process windows))
-         (width (car size))
-         (height (cdr size)))
-    (when (and ghostel--term size)
-      (cond
-       ;; No change — skip entirely.
-       ((and (eql height ghostel--term-rows)
-             (eql width ghostel--term-cols))
-        (setq size nil))
-       ;; Don't resize on minibuffer-induced rows-only change.
-       ;; E.g. fish clears and re-emits its prompt on every SIGWINCH;
-       ;; a `consult-buffer'/`M-x' cycle that grows then shrinks the body
-       ;; would otherwise produce two prompt repaints in quick succession.
-       ;; Skip the deferral on the alt screen TUIs.
-       ((and (active-minibuffer-window)
-             (eql width ghostel--term-cols)
-             (not (ghostel--alt-screen-p ghostel--term)))
-        (setq size nil))
-       ;; Real resize — queue the terminal model resize and redraw.
-       (t
-        (ghostel--set-size-with-cell-dims
-         ghostel--term (max 1 height) (max 1 width))
+  (when-let* ((adjust-fn (or (default-value 'window-adjust-process-window-size-function)
+                             #'window-adjust-process-window-size-smallest))
+              (windows (get-buffer-window-list nil nil t))
+              (size (funcall adjust-fn ghostel--process windows))
+              (width (car size))
+              (height (cdr size)))
+    (let* ((same-size-p (and (eql height ghostel--term-rows)
+                             (eql width ghostel--term-cols)))
+           ;; Don't resize on minibuffer-induced rows-only change.
+           ;; E.g. fish clears and re-emits its prompt on every SIGWINCH; a
+           ;; `consult-buffer'/`M-x' cycle that grows then shrinks the body
+           ;; would otherwise produce two prompt repaints in quick succession.
+           ;; Skip the deferral on the alt screen TUIs.
+           (minibuffer-excepted-p (and (active-minibuffer-window)
+                                       (eql width ghostel--term-cols)
+                                       (not (ghostel--alt-screen-p ghostel--term)))))
+      (when (or force (and (not same-size-p) (not minibuffer-excepted-p)))
+        (ghostel--set-size-with-cell-dims ghostel--term (max 1 height) (max 1 width))
         (setq ghostel--force-next-redraw t)
         ;; Redraw synchronously so the buffer is updated before
         ;; Emacs displays the stale content at the new window size.
-        (ghostel--redraw-now (current-buffer)))))))
+        (ghostel--redraw-now (current-buffer))))))
+
+(defun ghostel--text-scale-changed ()
+  "Update terminal size and redraw after `text-scale-mode' changes the cell font."
+  (when (and ghostel--term (ghostel--terminal-live-p))
+    (when-let* ((window (get-buffer-window (current-buffer) t)))
+      (ghostel--adjust-size window t))))
 
 (defun ghostel--sync-tty-composition (window)
   "Sync `auto-composition-mode' with WINDOW's frame for ghostel buffers.
@@ -4926,6 +4924,7 @@ for both native and Emacs PTY paths."
   (add-hook 'window-buffer-change-functions #'ghostel--window-buffer-change nil t)
   (add-hook 'window-buffer-change-functions #'ghostel--sync-tty-composition nil t)
   (add-hook 'window-size-change-functions #'ghostel--adjust-size nil t)
+  (add-hook 'text-scale-mode-hook #'ghostel--text-scale-changed nil t)
   (add-hook 'minibuffer-exit-hook #'ghostel--minibuffer-exit)
   (add-hook 'minibuffer-exit-hook #'ghostel--minibuffer-exit-maybe-leave)
   (add-hook 'activate-mark-hook #'ghostel--mark-activated nil t)

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -234,6 +234,13 @@ fn updateFontInfo(self: *Self, alloc: Allocator, env: emacs.Env) bool {
 
 fn getDefaultFont(env: emacs.Env) emacs.Value {
     const s = emacs.sym;
+
+    const probe = env.f("propertize", .{ " ", s.face, s.default });
+    const remapped_font = env.f("font-at", .{ 0, env.f("selected-window", .{}), probe });
+    if (env.isNotNil(env.f("fontp", .{ remapped_font, s.@"font-object" }))) {
+        return remapped_font;
+    }
+
     const font = env.f("face-attribute", .{ s.default, s.@":font" });
     if (env.isNil(env.f("fontp", .{ font, s.@"font-object" }))) return env.nil();
     return font;

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -499,6 +499,7 @@ const interned_symbols = [_][:0]const u8{
     "process-live-p",
     "process-send-string",
     "process-tty-name",
+    "propertize",
     "provide",
     "put-text-property",
     "run-at-time",

--- a/test/ghostel-glyph-test.el
+++ b/test/ghostel-glyph-test.el
@@ -35,6 +35,8 @@ SPECS is a plist with these keys:
   :default-font        -- mock font (from `ghostel-test--make-font') returned by
                           `face-attribute' for the default face; its :metrics is
                           used by the `query-font' mock.
+  :remapped-default-font -- mock font returned by a synthetic-string `font-at'
+                          default-face probe, falling back to :default-font.
   :glyph-font          -- mock font returned by `font-at'; its :metrics and
                           shaped gstring are used by `query-font',
                           `composition-get-gstring', and `font-shape-gstring'.
@@ -48,6 +50,9 @@ SPECS is a plist with these keys:
           (--orig-find-composition (symbol-function 'find-composition))
           (--orig-composition-get-gstring (symbol-function 'composition-get-gstring))
           (--orig-font-shape-gstring (symbol-function 'font-shape-gstring)))
+     (ignore --orig-face-attribute --orig-fontp --orig-font-at --orig-query-font
+             --orig-font-has-char-p --orig-find-composition
+             --orig-composition-get-gstring --orig-font-shape-gstring)
      (cl-letf (,@(when-let* ((df (plist-get specs :default-font)))
                    `(((symbol-function 'face-attribute)
                       (lambda (face attr &rest args)
@@ -68,13 +73,20 @@ SPECS is a plist with these keys:
                         (or (and (ghostel-test--mock-font-p font)
                                  (plist-get (cdr font) :metrics))
                             (funcall --orig-query-font font))))))
+               ,@(let ((gf (plist-get specs :glyph-font))
+                       (default-probe-font (or (plist-get specs :remapped-default-font)
+                                               (plist-get specs :default-font))))
+                   (when (or gf default-probe-font)
+                     `(((symbol-function 'font-at)
+                        (lambda (pos &optional window string)
+                          (cond
+                           (string
+                            ,(or default-probe-font
+                                 '(funcall --orig-font-at pos window string)))
+                           ,@(when gf `(((>= pos (point-min)) ,gf)))
+                           (t (funcall --orig-font-at pos window string))))))))
                ,@(when-let* ((gf (plist-get specs :glyph-font)))
-                   `(((symbol-function 'font-at)
-                      (lambda (pos &optional window string)
-                        (if (>= pos (if string 0 (point-min)))
-                            ,gf
-                          (funcall --orig-font-at pos window string))))
-                     ((symbol-function 'composition-get-gstring)
+                   `(((symbol-function 'composition-get-gstring)
                       (lambda (from to font &optional string)
                         (or (and (ghostel-test--mock-font-p font)
                                  (ghostel-test--mock-font-gstring font))
@@ -115,6 +127,34 @@ SPECS is a plist with these keys:
       (should (eq (ghostel--query-font-cached font) metrics))
       (should (eq (ghostel--query-font-cached font) metrics))
       (should (= calls 1)))))
+
+(ert-deftest ghostel-test-glyph-adjust-uses-remapped-default-font ()
+  "Cell metrics come from the remapped default font, not `face-attribute'."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-glyph-remapped-default*")))
+    (unwind-protect
+        (save-window-excursion
+          (with-selected-window (display-buffer buf)
+            (ghostel-mode)
+            (let* ((term (ghostel--new 5 80 1000))
+                   (ghostel--term term)
+                   (ghostel--term-rows 5)
+                   (inhibit-read-only t)
+                   (base (ghostel-test--make-font ghostel-test--default-font-info))
+                   (remapped (ghostel-test--make-font
+                              ["MockRemappedDefault" "mock.ttf" 24 240 20 20 20 20 0]))
+                   (glyph-font (ghostel-test--make-font
+                                ["MockGlyph" "mock.ttf" 24 240 20 20 20 20 0]
+                                [[0 1 ?\u0100 0 20 0 0 20 20 0]])))
+              (ghostel--write-vt term "\u0100")
+              (ghostel-test--with-glyph-mocks
+               (:default-font base
+                              :remapped-default-font remapped
+                              :glyph-font glyph-font)
+               (ghostel--redraw term t)
+               (goto-char (point-min))
+               (should-not (get-text-property (point) 'display))))))
+      (kill-buffer buf))))
 
 (ert-deftest ghostel-test-glyph-adjust-uses-composition-gstring ()
   "A composed glyph uses `find-composition' metrics for adjustment."
@@ -464,7 +504,8 @@ Sets floor to 1.0 and feeds a glyph larger than the cell.  With floor
                      (mock-query-font (symbol-function 'query-font)))
                  (cl-letf (((symbol-function 'font-at)
                             (lambda (&rest args)
-                              (cl-incf font-at-calls)
+                              (unless (nth 2 args)
+                                (cl-incf font-at-calls))
                               (apply mock-font-at args)))
                            ((symbol-function 'query-font)
                             (lambda (font)
@@ -504,11 +545,13 @@ Sets floor to 1.0 and feeds a glyph larger than the cell.  With floor
               (ghostel-test--with-glyph-mocks
                (:default-font df)
                (cl-letf (((symbol-function 'font-at)
-                          (lambda (pos &optional _window _string)
-                            (if (eq (plist-get (get-text-property pos 'face) :weight)
-                                    'bold)
-                                bold-font
-                              normal-font)))
+                          (lambda (pos &optional _window string)
+                            (cond
+                             (string df)
+                             ((eq (plist-get (get-text-property pos 'face) :weight)
+                                  'bold)
+                              bold-font)
+                             (t normal-font))))
                          ((symbol-function 'composition-get-gstring)
                           (lambda (_from _to font &optional _string)
                             (ghostel-test--mock-font-gstring font)))
@@ -543,8 +586,10 @@ Sets floor to 1.0 and feeds a glyph larger than the cell.  With floor
               ;; would call `font-at', and the deliberately-broken stub below
               ;; would fail the test.
               (cl-letf (((symbol-function 'font-at)
-                         (lambda (&rest _)
-                           (error "font-at must not be called for covered glyphs"))))
+                         (lambda (&rest args)
+                           (when (null (nth 2 args))
+                             (error "font-at must not be called for covered glyphs"))
+                           nil)))
                 (ghostel-test--with-glyph-mocks
                  (:default-font df)
                  (ghostel--redraw term t)

--- a/test/ghostel-terminal-test.el
+++ b/test/ghostel-terminal-test.el
@@ -236,6 +236,41 @@ modes (47 / 1047 / 1049) are handled uniformly."
 		  (ghostel--adjust-size 'fake-window))
         (should-not set-size-called)))))
 
+(ert-deftest ghostel-test-resize-force-same-dims-still-runs ()
+  "Forced resize runs even when rows and cols are unchanged."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--process 'fake-proc)
+          (ghostel--term-rows 40)
+          (ghostel--term-cols 120)
+          (ghostel--force-next-redraw nil)
+          (set-size-args nil)
+          (redraw-called nil))
+      (cl-letf (((symbol-function 'ghostel--set-size-with-cell-dims)
+                 (lambda (term h w) (setq set-size-args (list term h w))))
+                ((symbol-function 'ghostel--redraw-now)
+                 (lambda (buffer)
+                   (should (eq buffer (current-buffer)))
+                   (setq redraw-called ghostel--force-next-redraw))))
+        (ghostel-test--with-resize-stubs '(120 . 40)
+		  (ghostel--adjust-size 'fake-window t))
+        (should (equal '(fake 40 120) set-size-args))
+        (should ghostel--force-next-redraw)
+        (should redraw-called)))))
+
+(ert-deftest ghostel-test-text-scale-change-forces-size-adjustment ()
+  "Text-scale changes use a forced size adjustment."
+  (with-temp-buffer
+    (let ((ghostel--term 'fake)
+          (ghostel--input-mode 'semi-char)
+          (adjust-args nil))
+      (cl-letf (((symbol-function 'get-buffer-window)
+                 (lambda (&rest _) 'fake-window))
+                ((symbol-function 'ghostel--adjust-size)
+                 (lambda (&rest args) (setq adjust-args args))))
+        (ghostel--text-scale-changed)
+        (should (equal '(fake-window t) adjust-args))))))
+
 (ert-deftest ghostel-test-resize-rows-only-during-minibuffer-suppressed ()
   "Rows-only resize while a minibuffer is active is deferred (#268).
 fish (and other shells with `fish_handle_reflow' on) clears and


### PR DESCRIPTION
## Summary
- make the renderer obtain the default font through a remapping-aware synthetic `font-at` probe
- force the normal resize/redraw path after `text-scale-mode` changes so renderer metrics and terminal sizing are refreshed
- add coverage for remapped default-font metrics and forced resize handling

Supersedes #453.
Fixes #429.

## Tests
- `zig build test`
- `make build`
- `emacs --batch -Q -L lisp --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile lisp/ghostel.el`
- `emacs --batch -Q -L lisp -L test --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile test/ghostel-glyph-test.el`
- `emacs --batch -Q -L lisp -L test --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile test/ghostel-terminal-test.el`
- `emacs --batch -Q -L lisp -L test -l ert -l test/ghostel-test-helpers.el -l test/ghostel-glyph-test.el --eval "(ert-run-tests-batch-and-exit '(tag native))"`
- `emacs --batch -Q -L lisp -L test -l ert -l test/ghostel-test-helpers.el -l test/ghostel-terminal-test.el --eval "(ert-run-tests-batch-and-exit '(not (tag native)))"`
- `zig fmt --check src/Renderer.zig src/emacs.zig`
- `git diff --check`