### PR TITLE
Force redraw past synchronized output when a hidden buffer reappears

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4661,13 +4661,18 @@ for BUFFER; return nil to let the redraw proceed."
                           #'ghostel--redraw-now buffer))
     t))
 
-(defun ghostel--redraw-now (buffer)
+(defun ghostel--redraw-now (buffer &optional force)
   "Perform the actual redraw in BUFFER.
-The renderer preserves buffer positions while applying terminal
-mutations; this function anchors windows that were following the
-live viewport."
+The renderer preserves buffer positions while applying terminal mutations;
+this function anchors windows that were following the live viewport.
+
+With FORCE non-nil, redraw even while synchronized output (mode 2026)
+is open.  Use it for repaints that must happen now regardless of frame
+batching, such as a buffer reappearing in a window; leave it nil for
+opportunistic output redraws that may safely wait for the frame to end."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
+      (when force (setq ghostel--force-next-redraw t))
       (when ghostel--redraw-timer
         (cancel-timer ghostel--redraw-timer)
         (setq ghostel--redraw-timer nil))
@@ -4728,11 +4733,12 @@ live viewport."
         (ghostel--detect-password-prompt)))))
 
 (defun ghostel-force-redraw ()
-  "Force a full terminal redraw on the next display cycle.
-Cancels any pending redraw timer and schedules an immediate one.
+  "Force an immediate terminal redraw, bypassing synchronized-output batching.
+Repaints now even while the terminal program holds mode 2026 open, so a
+buffer left showing stale content (e.g. revealed mid-frame) recovers.
 Requires the buffer to be visible in a window; has no effect otherwise."
   (interactive)
-  (ghostel--redraw-now (current-buffer)))
+  (ghostel--redraw-now (current-buffer) t))
 
 
 ;;; Window resize
@@ -4838,7 +4844,11 @@ and the TTY display that needs it off keeps working in parallel)."
   (when (and (window-live-p window)
              (eq (window-buffer window) (current-buffer)))
     (ghostel--anchor-window window)
-    (ghostel--redraw-now (current-buffer))))
+    ;; While hidden the buffer renders nothing, so its content can be
+    ;; stale on reappear.  Force the repaint past any open synchronized
+    ;; output (mode 2026); otherwise the redraw is skipped and the stale
+    ;; content lingers until the next non-2026 output, which may never come.
+    (ghostel--redraw-now (current-buffer) t)))
 
 (defun ghostel--minibuffer-exit ()
   "Schedule anchoring of all the currently anchored Ghostel windows.

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -1519,6 +1519,71 @@ for new size inside BSU/ESU → verify buffer shows new content."
               (should-not (string-match-p "OLD-LINE" content)))))
       (kill-buffer buf))))
 
+(defmacro ghostel-test--with-open-sync-output (spec &rest body)
+  "Run BODY in a displayed terminal buffer left mid synchronized output.
+SPEC is (BUFFER TERM).  Sets up a ghostel buffer showing BASELINE-CONTENT,
+then opens mode 2026 and mutates the grid to UPDATED-CONTENT *without*
+closing it - the state of a buffer hidden while a TUI streams a frame."
+  (declare (indent 1))
+  (pcase-let ((`(,buffer ,term) spec))
+    `(let ((,buffer (generate-new-buffer " *ghostel-test-open-sync-output*")))
+       (unwind-protect
+           (with-current-buffer ,buffer
+             (set-window-buffer (selected-window) (current-buffer))
+             (ghostel-mode)
+             (let* ((,term (ghostel--new 10 40 100))
+                    (ghostel--term ,term)
+                    (ghostel--term-rows 10)
+                    (ghostel--term-cols 40)
+                    (ghostel--force-next-redraw nil)
+                    (inhibit-read-only t))
+               ;; Baseline content, rendered into the buffer.
+               (ghostel--write-vt ,term "\e[H\e[2JBASELINE-CONTENT")
+               (ghostel--redraw ,term t)
+               (should (string-match-p "BASELINE-CONTENT" (buffer-string)))
+               ;; Open synchronized output and mutate the grid without closing
+               ;; it, as a streaming TUI does mid-frame.
+               (ghostel--write-vt ,term "\e[?2026h\e[H\e[2JUPDATED-CONTENT")
+               (should (ghostel--mode-enabled ,term 2026))
+               ,@body))
+         (kill-buffer ,buffer)))))
+
+(ert-deftest ghostel-test-redraw-now-force-bypasses-open-sync-output ()
+  "FORCE makes `ghostel--redraw-now' repaint even while mode 2026 is open.
+Without FORCE the redraw is correctly suppressed during synchronized
+output; with FORCE it repaints now (the contract the #456 fix relies on)."
+  :tags '(native)
+  (ghostel-test--with-open-sync-output (buf term)
+    ;; Unforced redraw is suppressed mid synchronized output: still baseline.
+    (ghostel--redraw-now buf)
+    (should (string-match-p "BASELINE-CONTENT" (buffer-string)))
+    (should-not (string-match-p "UPDATED-CONTENT" (buffer-string)))
+    ;; Forced redraw bypasses the skip and repaints now.
+    (ghostel--redraw-now buf t)
+    (should (string-match-p "UPDATED-CONTENT" (buffer-string)))
+    (should-not (string-match-p "BASELINE-CONTENT" (buffer-string)))))
+
+(ert-deftest ghostel-test-window-buffer-change-repaints-stale-reappear ()
+  "Regression for #456: a buffer reappearing repaints past open mode 2026.
+A hidden ghostel buffer renders nothing, so its content is stale on
+reappear.  `ghostel--window-buffer-change' must force the repaint instead
+of leaving the stale content until the next non-2026 output."
+  :tags '(native)
+  (ghostel-test--with-open-sync-output (_buf term)
+    (ghostel--window-buffer-change (selected-window))
+    (should (string-match-p "UPDATED-CONTENT" (buffer-string)))
+    (should-not (string-match-p "BASELINE-CONTENT" (buffer-string)))))
+
+(ert-deftest ghostel-test-force-redraw-recovers-during-sync-output ()
+  "`ghostel-force-redraw' recovers stale content even while mode 2026 is open.
+The user-facing recovery command must not be defeated by the same
+synchronized-output skip that stranded the content (#456)."
+  :tags '(native)
+  (ghostel-test--with-open-sync-output (_buf term)
+    (ghostel-force-redraw)
+    (should (string-match-p "UPDATED-CONTENT" (buffer-string)))
+    (should-not (string-match-p "BASELINE-CONTENT" (buffer-string)))))
+
 (ert-deftest ghostel-test-resize-width-change-full-repaint ()
   "After width change on alt screen, all rows repainted correctly.
 Matches the real htop scenario: width changes from wide to narrow,


### PR DESCRIPTION
Fixes #456.

## Symptom

A ghostel terminal goes blank/stale when its window is hidden and then
reappears while output is streaming — the buffer and process stay alive,
only the displayed content is wrong. Intermittent, and observed with
Claude Code under plain Emacs + bash (no persp-mode / Doom / fish — those
turned out to be red herrings; persp-mode's layout restore is atomic and
cannot race the redraw).

## Root cause

While a ghostel buffer is displayed in no window, `ghostel--redraw-now`
skips its render body (`ghostel--get-render-window` returns nil), so
streaming output accumulates in libghostty's grid but not the Emacs
buffer. On reappear, `ghostel--window-buffer-change` calls
`ghostel--redraw-now` **unforced**, which hits the synchronized-output
(DEC mode 2026) guard:

```elisp
(unless (and (not ghostel--force-next-redraw)
             (ghostel--mode-enabled ghostel--term 2026))
  …render…)
```

TUIs like Claude Code wrap their partial frame updates in mode 2026. If
the reappear lands inside an open 2026 block, the entire render is
skipped and the buffer keeps its stale pre-hide content until the next
non-2026 output — which may never come. `ghostel-force-redraw` was
defeated by the same guard, so the natural recovery didn't work either.

## Fix

- `ghostel--redraw-now` gains an optional `FORCE` arg that sets
  `ghostel--force-next-redraw` before the guard (and before the defer
  check, so it survives a deferred re-run). Default nil leaves
  opportunistic output redraws via `ghostel--invalidate` correctly
  skippable mid-frame.
- `ghostel--window-buffer-change` (reappear hook) and
  `ghostel-force-redraw` (recovery command) now force.

Incremental redraw is sufficient once it's allowed to run — it
reconstructs the viewport and backfills hidden scrollback — so no full
repaint is needed. When mode 2026 isn't open at reappear (the common
case), forcing is a no-op versus current behavior; only the buggy path
changes.

## Tests

Three native regression tests (one per fixed site) via a shared
`with-open-sync-output` helper that leaves a buffer mid-open-2026 with
pending grid changes: the forced-redraw contract, the reappear hook, and
the recovery command. `make -j8 all` passes clean.