### PR TITLE
Make ghostel buffers read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,12 @@ normal Emacs buffer and *no* key gets sent to the terminal.
 Only after you finish typing a line and press enter, the whole line
 is sent at once.
 
-**emacs** (`C-c C-e`) and **copy mode** (`C-c C-t`) make the buffer temporarily
-a normal Emacs buffer that you can use to navigate, look around and copy text.
-The difference between the two is that **copy mode** freezes the
-terminal, so if you have continuous output nothing "scrolls away"
-while you try to select something. **emacs mode** is *live* so
-new output keeps coming in while you scroll/select.
+**emacs** (`C-c C-e`) and **copy mode** (`C-c C-t`) give you normal Emacs
+navigation over the read-only terminal buffer so you can look around and copy
+text. The difference between the two is that **copy mode** freezes the terminal,
+so if you have continuous output nothing "scrolls away" while you try to select
+something. **emacs mode** is *live* so new output keeps coming in while you
+scroll/select.
 
 Those read-only modes have by default `ghostel-readonly-fast-exit`
 set to true, which automatically exits those modes on most keys

--- a/README.org
+++ b/README.org
@@ -307,13 +307,13 @@ Ghostel offers five eat.el-style input modes.  You enter a ghostel buffer in
 *semi-char mode*; switch modes with the key bindings below and watch
 =mode-line-process= for the current mode indicator.
 
-| Mode      | Indicator | Terminal | Buffer    | Purpose                                      |
-|-----------+-----------+----------+-----------+----------------------------------------------|
-| semi-char | /(none)/    | live     | editable  | default - type to terminal, =C-c= reserved    |
-| char      | =:Char=     | live     | editable  | TUI apps - /all/ keys go to the terminal       |
-| Emacs     | =:Emacs=    | live     | read-only | search/read while the terminal keeps running |
-| copy      | =:Copy=     | frozen   | read-only | precise text selection without scroll churn  |
-| line      | =:Line=     | live     | editable  | compose input with Emacs keys, send on =RET=   |
+| Mode      | Indicator | Terminal | Input handling                               |
+|-----------+-----------+----------+----------------------------------------------|
+| semi-char | /(none)/    | live     | type to terminal, =C-c= reserved              |
+| char      | =:Char=     | live     | /all/ keys go to the terminal                 |
+| Emacs     | =:Emacs=    | live     | Emacs navigation/search/copy                 |
+| copy      | =:Copy=     | frozen   | Emacs navigation/search/copy, stable output  |
+| line      | =:Line=     | live     | compose input with Emacs keys, send on =RET=   |
 
 ** Mode-switch keybindings
 
@@ -1370,7 +1370,7 @@ Commands:
 | Command                         | Description                                                                |
 |---------------------------------+----------------------------------------------------------------------------|
 | =M-x ghostel-compile=             | Run a command in a read-only ghostel buffer (uses =compile-command=).        |
-| =C-u M-x ghostel-compile=         | Prompt for the command and run it in an /interactive/ (writable) buffer.     |
+| =C-u M-x ghostel-compile=         | Prompt for the command and run it with /interactive/ terminal input.        |
 | =M-x ghostel-recompile=           | Re-run the last command in its original directory (preserves launch mode). |
 | =M-x ghostel-compile-global-mode= | Route /all/ =compile=-style calls through ghostel (opt-in).                    |
 
@@ -1394,10 +1394,10 @@ process, so the "compile-mode" UX (read coloured output, kill with =C-c C-c=) is
 available even mid-run.
 
 Pass a prefix arg (=C-u M-x ghostel-compile=, mirroring =C-u M-x compile=) to launch
-in *interactive* mode instead - the buffer stays writable for the duration of the
-run, so programs like =htop= and =less=, test runners that prompt for input, or
-anything that wants live keystrokes work.  =ghostel-recompile= (=g=) preserves
-whichever mode the buffer was launched in.
+in *interactive* mode instead - keystrokes are forwarded to the running process,
+so programs like =htop= and =less=, test runners that prompt for input, or
+anything that wants live keystrokes work.  The rendered buffer remains read-only.
+=ghostel-recompile= (=g=) preserves whichever mode the buffer was launched in.
 
 When the command finishes, the live process and ghostel renderer are torn down
 and the buffer's major mode is switched to =ghostel-compile-view-mode= (derived
@@ -1412,8 +1412,8 @@ Two keys switch the buffer's state without restarting the process:
 
 | Key                   | Action                                        |
 |-----------------------+-----------------------------------------------|
-| =C-c C-j=               | Switch to interactive (writable terminal)     |
-| =C-c C-e= / =C-c C-t=     | Switch back to read-only / compile-mode-style |
+| =C-c C-j=               | Switch to interactive terminal input |
+| =C-c C-e= / =C-c C-t=     | Switch back to compilation-style navigation |
 
 (=C-c C-t= mirrors =ghostel-mode='s key for entering copy-mode, so the same muscle
 memory works in compile buffers.)  Both keys are bound by
@@ -1430,7 +1430,7 @@ buffers.  Subsequent recompiles preserve whichever state you last switched to.
 | =M-g n= / =M-g p=               | Standard =next-error= / =previous-error=               |
 | =C-c C-c=                     | =compile-goto-error= (same as RET)                   |
 | =C-c C-k=                     | =kill-compilation= - interrupt the running process   |
-| =C-c C-j= / =C-c C-e= / =C-c C-t= | Switch to interactive / read-only (see above)      |
+| =C-c C-j= / =C-c C-e= / =C-c C-t= | Switch interactive input / compilation-style navigation |
 
 These standard =compile= options are honoured: =compile-command= /
 =compile-history= (shared with =M-x compile=), =compilation-read-command=,

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -854,10 +854,10 @@ Enabling installs global advice while any buffer has the mode enabled."
         (evil-ghostel--escape-stay)
         ;; Evil owns selection here (visual state + the visual operators), so
         ;; opt this buffer out of ghostel's keyboard-mark->copy-mode switch:
-        ;; otherwise `v' activates the mark, `ghostel--mark-activated' flips the
-        ;; buffer to read-only copy mode, and the visual operators hit "Buffer
-        ;; is read-only".  Mouse selection stays governed by
-        ;; `ghostel-mouse-drag-input-mode', so it still picks its own mode.
+        ;; otherwise `v' activates the mark and `ghostel--mark-activated' flips
+        ;; the buffer to copy mode before Evil's terminal-aware operators run.
+        ;; Mouse selection stays governed by `ghostel-mouse-drag-input-mode',
+        ;; so it still picks its own mode.
         (setq-local ghostel-mark-activation-input-mode nil)
         (add-hook 'evil-insert-state-entry-hook
                   #'evil-ghostel--insert-state-entry nil t)

--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -37,13 +37,14 @@
 ;; ghostel terminal — a recompile (`g', `M-x ghostel-recompile')
 ;; discards it and starts fresh in the original `default-directory'.
 ;; When invoked from inside the compile buffer, recompile preserves
-;; the launch mode (read-only vs interactive); when invoked from an
-;; unrelated buffer it falls back to the global default (read-only).
+;; the launch mode (compilation-style vs interactive input); when invoked
+;; from an unrelated buffer it falls back to the global default
+;; (compilation-style).
 ;;
 ;; Enable `ghostel-compile-global-mode' to route `compile',
 ;; `recompile', `project-compile', ... through ghostel.
 ;; `MODE=t' (the comint variant — \\[universal-argument] \\[compile])
-;; becomes a writable ghostel terminal instead of comint.
+;; becomes an interactive ghostel terminal instead of comint.
 ;; `grep-mode' falls through to the stock implementation.
 ;;
 ;; Standard `compile' options honoured:
@@ -145,12 +146,13 @@ Nil means finalize falls back to the global
 `ghostel-compile-finished-major-mode'.")
 
 (defvar-local ghostel-compile--interactive nil
-  "Non-nil if this run was launched in interactive (writable) mode.
-Nil means the buffer is read-only and navigable like
-`compilation-mode' from the start; non-nil means the buffer behaves
-like an interactive ghostel terminal during the run (keystrokes are
-forwarded to the PTY).  `ghostel-recompile' reads this flag from the
-source buffer so a recompile preserves the launch mode.")
+  "Non-nil if this run was launched with interactive input.
+Nil means the buffer uses compilation-style navigation from the start;
+non-nil means the buffer behaves like an interactive ghostel terminal
+during the run (keystrokes are forwarded to the PTY).  The buffer
+itself remains renderer-owned and read-only in both cases.
+`ghostel-recompile' reads this flag from the source buffer so a
+recompile preserves the launch mode.")
 
 (defvar ghostel-compile-view-mode-map
   (let ((map (make-sparse-keymap)))
@@ -219,7 +221,7 @@ Matches the format used by `M-x compile'."
    (t              (format-seconds "%h:%02m:%02s" seconds))))
 
 (defun ghostel-compile--status-message (exit)
-  "Return the compile-style status message string for EXIT status."
+  "Return the compilation-style status message string for EXIT status."
   (cond
    ((and (numberp exit) (= exit 0)) "finished\n")
    ((numberp exit) (format "exited abnormally with code %d\n" exit))
@@ -556,16 +558,17 @@ Creates the terminal directly — no interactive shell is spawned —
 so there is no remote-integration round-trip on TRAMP buffers.
 
 When INTERACTIVE is non-nil the buffer keeps the regular
-`ghostel-mode' keymap so keystrokes reach the running process —
+`ghostel-semi-char-mode-map' so keystrokes reach the running process —
 the same UX a user gets from \\[universal-argument]
 \\[ghostel-compile] or from `compilation-start' under
 `ghostel-compile-global-mode' with `MODE=t'.  When INTERACTIVE is
-nil (the default) the buffer is made read-only and the local map is
-set to `ghostel-compile-view-mode-map' so it behaves like a
+nil (the default) the local map is set to
+`ghostel-compile-view-mode-map' so it behaves like a
 `compilation-mode' buffer.  Either way the major mode stays
 `ghostel-mode' during the run so the renderer, redraw timer, and
 resize hooks
-\(all gated on `derived-mode-p \\='ghostel-mode\\=') keep working."
+\(all gated on `derived-mode-p \\='ghostel-mode\\=') keep working;
+the rendered buffer remains read-only in both cases."
   (let ((existing (get-buffer name)))
     (when existing
       (with-current-buffer existing
@@ -621,8 +624,8 @@ resize hooks
       ;; as errors land, including in the interactive variant.
       (setq-local next-error-function #'compilation-next-error-function)
 
-      ;; In read-only (compile-style) mode, swap the local keymap to the
-      ;; compile-style one and lock the buffer.  Major mode stays `ghostel-mode'
+      ;; In compilation-style mode, swap only the local keymap.  Major mode stays
+      ;; `ghostel-mode'
       ;; so the renderer/timer/resize hooks (which all gate on `derived-mode-p
       ;; \\='ghostel-mode\\=') keep working; only input handling changes.
       (unless interactive
@@ -676,7 +679,7 @@ buffer into after finalize (overriding
 honour custom compile-mode subclasses the caller passed to
 `compilation-start'.
 
-INTERACTIVE, when non-nil, runs COMMAND in a writable ghostel terminal.
+INTERACTIVE, when non-nil, runs COMMAND with terminal input forwarding.
 
 COMPILATION-ARGS, when non-nil, is the list `(COMMAND MODE
 NAME-FUNCTION HIGHLIGHT-REGEXP)' that gets stored as
@@ -695,7 +698,7 @@ any other code that walks `compilation-arguments') re-runs via
       ;; (so the renderer/timer/resize hooks keep firing).  When
       ;; INTERACTIVE is non-nil, keystrokes reach the process for
       ;; programs like `htop', `less', or read prompts; otherwise the
-      ;; buffer is read-only with `compilation-mode'-style keys via
+      ;; buffer uses `compilation-mode'-style keys via
       ;; `ghostel-compile-view-mode-map' (see `--prepare-buffer').
       ;; Compile-mode error parsing kicks in at finalize when the
       ;; buffer is switched to `ghostel-compile-view-mode'.
@@ -787,10 +790,10 @@ scripts work exactly as in \\[shell-command].  No shell-integration
 setup is required — the process sentinel reports the real exit
 status.
 
-If optional second arg INTERACTIVE is non-nil the buffer is a
-writable ghostel terminal during the run.
-Otherwise (the default) the buffer is read-only and behaves like a
-`compilation-mode' buffer with `g' reruns, `n'/`p' walk errors, etc.
+If optional second arg INTERACTIVE is non-nil the buffer forwards
+keystrokes to the terminal during the run.
+Otherwise (the default) the buffer behaves like a `compilation-mode'
+buffer with `g' reruns, `n'/`p' walk errors, etc.
 
 Interactively, prompts for the command if option
 `compilation-read-command' is non-nil, otherwise uses
@@ -829,7 +832,7 @@ window showing it stays put.  This matches `M-x recompile' in a
 `ghostel-compile-buffer-name', and ultimately to `compile-command'
 with the current `default-directory' when no prior run exists.
 
-The launch mode (read-only vs interactive) is preserved from the
+The launch mode (compilation-style vs interactive input) is preserved from the
 source buffer's `ghostel-compile--interactive' flag, so a buffer
 launched with \\[universal-argument] reruns interactively."
   (interactive "P")
@@ -862,7 +865,7 @@ launched with \\[universal-argument] reruns interactively."
     (ghostel-compile--start cmd name dir nil launched-interactive)))
 
 
-;;; Live toggle: switch between read-only (compile-style) and interactive
+;;; Live toggle: switch between compilation-style and interactive input
 
 (defun ghostel-compile--assert-live-run ()
   "Signal a `user-error' unless the current buffer has a live compile run.
@@ -878,11 +881,11 @@ nothing to send keystrokes to, and a non-compile buffer has no
 
 (defun ghostel-compile-switch-to-interactive ()
   "Switch the current `ghostel-compile' run to interactive mode.
-The buffer becomes writable and `ghostel-mode's keymap is
-restored, so keystrokes reach the running process — useful when
-the command turned out to need input (a `read -p', a `git push'
-password prompt, an `htop'-style program).  No-op if the buffer is
-already interactive.
+`ghostel-semi-char-mode-map' is restored so keystrokes reach the running
+process — useful when the command turned out to need input (a
+`read -p', a `git push' password prompt, an `htop'-style program).
+The renderer-owned buffer remains read-only.  No-op if the buffer
+is already interactive.
 
 Bound to \\[ghostel-compile-switch-to-interactive] in
 `ghostel-compile-toggle-mode' (active in compile buffers)."
@@ -891,8 +894,8 @@ Bound to \\[ghostel-compile-switch-to-interactive] in
   (if ghostel-compile--interactive
       (message "ghostel-compile: already interactive")
     (setq ghostel-compile--interactive t)
-    (use-local-map ghostel-mode-map)
-    (setq buffer-read-only nil)
+    (use-local-map ghostel-semi-char-mode-map)
+    (setq buffer-read-only t)
     ;; Place point at the VT cursor so the user's first keystroke
     ;; lands at the prompt, not at wherever they happened to be
     ;; navigating in the read-only buffer.
@@ -905,46 +908,48 @@ Bound to \\[ghostel-compile-switch-to-interactive] in
     (when ghostel-compile-debug
       (message "ghostel-compile: switched to interactive"))))
 
-(defun ghostel-compile-switch-to-readonly ()
-  "Switch the current `ghostel-compile' run to read-only/compile-mode-style.
-Restores `ghostel-compile-view-mode-map' as the local map and
-locks the buffer, so `g' reruns, `n'/`p' walk errors, RET jumps —
-the normal `compilation-mode' UX — even while the command keeps
-running.  Subsequent recompiles will preserve this state.  No-op
-if the buffer is already read-only.
+(defun ghostel-compile-switch-to-compilation-style ()
+  "Switch the current `ghostel-compile' run to compilation-mode-style navigation.
+Restores `ghostel-compile-view-mode-map' as the local map, so `g'
+reruns, `n'/`p' walk errors, RET jumps — the normal
+`compilation-mode' UX — even while the command keeps running.
+Subsequent recompiles will preserve this state.  No-op if the buffer
+already uses compilation-style input.
 
-Bound to \\[ghostel-compile-switch-to-readonly] in
+Bound to \\[ghostel-compile-switch-to-compilation-style] in
 `ghostel-compile-toggle-mode' (active in compile buffers)."
   (interactive)
   (ghostel-compile--assert-live-run)
   (if (not ghostel-compile--interactive)
-      (message "ghostel-compile: already read-only")
+      (message "ghostel-compile: already compilation-style")
     (setq ghostel-compile--interactive nil)
     (use-local-map ghostel-compile-view-mode-map)
     (setq buffer-read-only t)
     (ghostel-compile--set-mode-line-running)
     (when ghostel-compile-debug
-      (message "ghostel-compile: switched to read-only"))))
+      (message "ghostel-compile: switched to compilation-style"))))
+
+(define-obsolete-function-alias 'ghostel-compile-switch-to-readonly
+  #'ghostel-compile-switch-to-compilation-style "0.38.0")
 
 (defvar ghostel-compile-toggle-mode-map
   (let ((m (make-sparse-keymap)))
     (define-key m (kbd "C-c C-j") #'ghostel-compile-switch-to-interactive)
-    (define-key m (kbd "C-c C-e") #'ghostel-compile-switch-to-readonly)
+    (define-key m (kbd "C-c C-e") #'ghostel-compile-switch-to-compilation-style)
     ;; Mirror `ghostel-mode's `C-c C-t' (= enter copy-mode, the
-    ;; navigable freeze).  Compile-mode read-only state is the
-    ;; closest analogue, so binding it to the same key carries the
-    ;; muscle memory across.
-    (define-key m (kbd "C-c C-t") #'ghostel-compile-switch-to-readonly)
+    ;; navigable freeze).  Compilation-style navigation is the closest
+    ;; analogue, so binding it to the same key carries the muscle
+    ;; memory across.
+    (define-key m (kbd "C-c C-t") #'ghostel-compile-switch-to-compilation-style)
     m)
   "Keymap for `ghostel-compile-toggle-mode'.
 \\<ghostel-compile-toggle-mode-map>\\[ghostel-compile-switch-to-interactive] switches to interactive
-\(writable terminal); \\[ghostel-compile-switch-to-readonly] switches
-back to read-only/compile-mode-style.  The latter is also bound to
-the same key `ghostel-mode' uses for entering copy-mode, so muscle
-memory carries across.  The minor-mode keymap takes precedence over
-both `ghostel-mode-map' and the buffer-local
-`ghostel-compile-view-mode-map', so the keys work regardless of
-which run state the buffer is in.")
+input; \\[ghostel-compile-switch-to-compilation-style] switches back to
+compilation-mode-style navigation.  The latter is also bound to the same
+key `ghostel-mode' uses for entering copy-mode, so muscle memory
+carries across.  The minor-mode keymap takes precedence over both
+the terminal-input and `ghostel-compile-view-mode-map' local maps,
+so the keys work regardless of which run state the buffer is in.")
 
 (define-minor-mode ghostel-compile-toggle-mode
   "Minor mode providing live mode-switching for `ghostel-compile' buffers.
@@ -983,9 +988,9 @@ Otherwise routes COMMAND through `ghostel-compile--start':
 
 - MODE is nil or `compilation-mode' - read-only ghostel buffer
 - MODE is t - `compilation-start's request for an interactive
-  comint buffer.  We honour the *interactive* part by spawning a
-  writable ghostel terminal (so programs that want a TTY still
-  work) instead of falling through to `comint-mode'.
+  comint buffer.  We honour the *interactive* part by forwarding
+  terminal input (so programs that want a TTY still work) instead
+  of falling through to `comint-mode'.
 - MODE is a `compilation-mode' subclass — read-only ghostel
   buffer; finalize switches to that subclass so its error-regexp,
   font-lock keywords, and keymap are honoured.
@@ -1044,8 +1049,8 @@ The default routing is read-only: a plain \\[compile] (or any caller
 passing `MODE=nil' / `MODE=compilation-mode') yields a read-only buffer
 that behaves like a `compilation-mode' buffer.  Callers asking for the
 comint variant \(\\[universal-argument] \\[compile], i.e. `MODE=t') are
-routed to a writable ghostel terminal - interactive throughout the run,
-so programs like `htop' or test prompts work - instead of falling
+routed to an interactive ghostel terminal throughout the run, so
+programs like `htop' or test prompts work - instead of falling
 through to `comint-mode'.  Note: this means `compilation-shell-minor-mode'
 is *not* enabled in the interactive variant - its keymap would shadow
 `ghostel-mode's input handlers and break key forwarding to the PTY.

--- a/lisp/ghostel-ime.el
+++ b/lisp/ghostel-ime.el
@@ -44,7 +44,7 @@
 
 (require 'ghostel)
 
-(declare-function ghostel--buffer-editable-p "ghostel")
+(declare-function ghostel--terminal-input-mode-p "ghostel")
 (declare-function ghostel--send-string "ghostel" (string))
 
 (defvar ghostel-ime-mode)
@@ -83,9 +83,9 @@ ignores GUI preedit overlays, which core ghostel handles separately."
 
 (defun ghostel-ime--wrap-input-method (key)
   "Translate KEY through the original input method.
-If the input method commits text by inserting into the current ghostel
-buffer, delete that transient insertion and forward the committed text
-to the PTY as UTF-8."
+If the input method commits text by inserting into a protected ghostel
+buffer, delete that transient insertion.  Forward the committed text
+to the PTY as UTF-8 only in terminal-input modes."
   (let ((ghostel-ime--composition-buffer (current-buffer))
         (original ghostel-ime--original-input-method-function)
         (before-point (point)))
@@ -94,16 +94,18 @@ to the PTY as UTF-8."
             ;; translator; calling it would silently skip composition.
             (eq original #'list))
         (list key)
-      (let ((events (funcall original key)))
+      (let ((events (let ((inhibit-read-only t))
+                      (funcall original key))))
         (let ((after-point (point)))
-          (when (and (> after-point before-point)
-                     (ghostel--buffer-editable-p))
+          (when (> after-point before-point)
             (let ((inserted (buffer-substring-no-properties
                              before-point after-point)))
-              (let ((inhibit-read-only t))
-                (delete-region before-point after-point))
-              (ghostel--send-string
-               (encode-coding-string inserted 'utf-8)))))
+              (when buffer-read-only
+                (let ((inhibit-read-only t))
+                  (delete-region before-point after-point)))
+              (when (ghostel--terminal-input-mode-p)
+                (ghostel--send-string
+                 (encode-coding-string inserted 'utf-8))))))
         events))))
 
 (defun ghostel-ime--install ()

--- a/lisp/ghostel-line-mode.el
+++ b/lisp/ghostel-line-mode.el
@@ -392,6 +392,9 @@ in line mode (the interactive entry validates these)."
       (pcase ghostel--input-mode
         ('copy  (ghostel--leave-readonly-state))
         ('emacs (ghostel--leave-readonly-state)))
+      ;; Line mode is the one user-editable ghostel state.  The rendered
+      ;; scrollback is still protected below with read-only text properties.
+      (setq buffer-read-only nil)
       ;; Copy mode froze the redraw timer; line mode is live, so the
       ;; timer must be running again before we exit this function or
       ;; the prompt sits there with no scheduled redraw until the next
@@ -582,11 +585,12 @@ which discards any type-ahead and runs inside `ghostel--redraw-now'."
         (ghostel--write-pty ghostel--term input))))
   (ghostel--line-mode-delete-input)
   ;; Drop the `read-only' and `rear-nonsticky' properties that
-  ;; protected the scrollback region during line mode so the buffer
-  ;; is editable again.
+  ;; protected the scrollback region during line mode; after this teardown
+  ;; the whole ghostel buffer returns to the default renderer-owned lock.
   (let ((inhibit-read-only t))
     (remove-text-properties (point-min) (point-max)
                             '(read-only nil rear-nonsticky nil)))
+  (setq buffer-read-only t)
   (when (markerp ghostel--line-input-start)
     (set-marker ghostel--line-input-start nil))
   (when (markerp ghostel--line-input-end)

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1119,10 +1119,11 @@ is non-nil."
 
 ;;; Input mode predicates
 
-(defsubst ghostel--buffer-editable-p ()
-  "Non-nil when typed keys are forwarded to the terminal.
-True in semi-char and char modes.  In Emacs, copy, and line modes
-the buffer is either read-only or consumes keys locally."
+(defsubst ghostel--terminal-input-mode-p ()
+  "Non-nil when user input should be forwarded to the terminal.
+True in semi-char and char modes.  This is independent of
+`buffer-read-only': ghostel buffers are protected by default because
+the rendered buffer is owned by the terminal, not by editing commands."
   (memq ghostel--input-mode '(semi-char char)))
 
 (defsubst ghostel--terminal-live-p ()
@@ -1831,7 +1832,7 @@ pasted using bracketed paste."
 (defun ghostel--forward-scroll-event (event button)
   "Try to forward a scroll EVENT as mouse BUTTON to the terminal.
 Return non-nil if the event was forwarded (mouse tracking is active)."
-  (when (and event (ghostel--buffer-editable-p))
+  (when (and event (ghostel--terminal-input-mode-p))
     (let* ((posn (event-start event))
            (col-row (posn-col-row posn))
            (col (car col-row))
@@ -2222,29 +2223,27 @@ OSC 9;4 packet, and same-value packets must not fire FMLU."
       (force-mode-line-update))))
 
 (defun ghostel--enter-readonly-state ()
-  "Common setup when entering a read-only mode (copy or Emacs).
-Saves the cursor style, re-enables `hl-line-mode' if it was
-suppressed, and sets the buffer read-only.  Does NOT cancel the
-redraw timer — that is the caller's job when freezing."
+  "Common setup when entering copy or Emacs mode.
+Saves the cursor style and re-enables `hl-line-mode' if it was
+suppressed.  Does NOT cancel the redraw timer — that is the
+caller's job when freezing."
   (ghostel--cursor-blink-stop)
   (setq ghostel--saved-cursor-type cursor-type)
   (setq cursor-type (default-value 'cursor-type))
   (when ghostel--saved-hl-line-mode
     (hl-line-mode 1))
-  (setq buffer-read-only t)
   (add-hook 'pre-redisplay-functions #'ghostel--fake-cursor-update nil t))
 
 (defun ghostel--leave-readonly-state ()
-  "Common teardown when leaving a read-only mode.
-Restores the cursor style, deactivates the mark, disables
-`hl-line-mode' again, and clears `buffer-read-only'."
+  "Common teardown when leaving copy or Emacs mode.
+Restores the cursor style, deactivates the mark, and disables
+`hl-line-mode' again."
   (remove-hook 'pre-redisplay-functions #'ghostel--fake-cursor-update t)
   (ghostel--fake-cursor-clear)
   (setq cursor-type ghostel--saved-cursor-type)
   (deactivate-mark)
   (when ghostel--saved-hl-line-mode
-    (hl-line-mode -1))
-  (setq buffer-read-only nil))
+    (hl-line-mode -1)))
 
 (defun ghostel--freeze-terminal ()
   "Cancel the redraw timer so new output stops updating the buffer."
@@ -3541,7 +3540,7 @@ left terminal input mode, so the navigation cursor stays solid."
       (let ((win (get-buffer-window buffer)))
         (if (and win
                  (eq win (selected-window))
-                 (ghostel--buffer-editable-p))
+                 (ghostel--terminal-input-mode-p))
             (progn
               (setq ghostel--cursor-blink-window win)
               (internal-show-cursor win (not (internal-show-cursor-p win))))
@@ -3569,7 +3568,7 @@ No-op on text terminals, when already blinking, or when the global
 Kept in Elisp so input modes and integrations can decide whether
 `cursor-type' should change.  Reads the buffer-local
 `ghostel--cursor-style' and `ghostel--cursor-blinking'."
-  (when (and (ghostel--buffer-editable-p)
+  (when (and (ghostel--terminal-input-mode-p)
              (not ghostel-ignore-cursor-change))
     (setq cursor-type
 		  (pcase ghostel--cursor-style
@@ -4909,7 +4908,9 @@ for both native and Emacs PTY paths."
   ;; whether font-lock ends up on.  `ghostel-mode' has no keywords, so
   ;; skipping unfontify has no other effect.
   (setq-local font-lock-unfontify-region-function #'ignore)
-  (setq buffer-read-only nil)
+  ;; The terminal renderer owns the buffer contents.  User-editable
+  ;; modes are exceptional and must opt in explicitly.
+  (setq buffer-read-only t)
   (setq-local scroll-margin 0)
   (setq-local auto-hscroll-mode nil)
   (setq-local hscroll-margin 0)
@@ -5012,6 +5013,9 @@ spawn after initialization."
       (cancel-timer ghostel--redraw-timer))
     (when ghostel--plain-link-detection-timer
       (cancel-timer ghostel--plain-link-detection-timer))
+    ;; Reinitialization may reuse an existing ghostel buffer that was in
+    ;; line mode; reset it to the renderer-owned default before erasing.
+    (setq buffer-read-only t)
     (let ((inhibit-read-only t))
       (erase-buffer))
     (setq ghostel--term nil

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -8,6 +8,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'ert)
 (require 'evil)
 (require 'ghostel)
@@ -16,6 +17,11 @@
 ;; -----------------------------------------------------------------------
 ;; Helper: set up a ghostel buffer with evil
 ;; -----------------------------------------------------------------------
+
+(defun evil-ghostel-test--insert (&rest args)
+  "Insert ARGS as renderer-owned test setup text."
+  (let ((inhibit-read-only t))
+    (apply #'insert args)))
 
 (defmacro evil-ghostel-test--with-buffer (rows cols text &rest body)
   "Create a ghostel buffer with ROWS x COLS, feed TEXT, render, then run BODY.
@@ -36,7 +42,9 @@ Requires the native module; without it the test is skipped
              (evil-ghostel-mode 1)
              (let ((inhibit-read-only t))
                (ghostel--redraw term t))
-             ,@body)
+             (cl-macrolet ((insert (&rest args)
+                             `(evil-ghostel-test--insert ,@args)))
+               ,@body))
          (when (buffer-live-p buf)
            (kill-buffer buf))))))
 
@@ -54,7 +62,9 @@ Uses mocks for native functions."
      (setq-local ghostel--term-rows 100)
      (evil-local-mode 1)
      (evil-ghostel-mode 1)
-     ,@body))
+     (cl-macrolet ((insert (&rest args)
+                     `(evil-ghostel-test--insert ,@args)))
+       ,@body)))
 
 ;; -----------------------------------------------------------------------
 ;; Test: mode activation
@@ -114,13 +124,13 @@ overwrite the position evil assigns at operator/visual completion."
                      evil-insert-state-entry-hook))))
 
 (ert-deftest evil-ghostel-test-visual-inhibits-mark-copy-mode ()
-  "Entering evil visual must not flip ghostel into read-only copy mode.
+  "Entering evil visual must not flip ghostel into copy mode.
 `ghostel-mode' wires `ghostel--mark-activated' onto `activate-mark-hook',
-which (for vanilla users) switches semi-char -> read-only `copy' mode when
-the mark activates.  Evil's `v' activates the mark, so without suppression
-the buffer goes read-only and the visual operators hit \"Buffer is
-read-only\".  `evil-ghostel-mode' sets `ghostel-mark-activation-input-mode'
-to nil buffer-locally so that chain yields to evil's own selection model."
+which (for vanilla users) switches semi-char -> copy mode when the mark
+activates.  Evil's `v' activates the mark, so without suppression copy mode
+would take over before Evil's terminal-aware visual operators run.
+`evil-ghostel-mode' sets `ghostel-mark-activation-input-mode' to nil
+buffer-locally so that chain yields to evil's own selection model."
   (evil-ghostel-test--with-evil-buffer
    ;; Preconditions the major mode established (mirrors a live buffer):
    (should (eq ghostel--input-mode 'semi-char))
@@ -131,7 +141,7 @@ to nil buffer-locally so that chain yields to evil's own selection model."
    (let (copied)
      (cl-letf (((symbol-function 'ghostel-copy-mode)
                 (lambda (&rest _) (setq copied t))))
-       ;; Opted out -> activating the mark is a no-op, mode stays editable.
+       ;; Opted out -> activating the mark is a no-op, mode stays semi-char.
        (ghostel--mark-activated)
        (should-not copied)
        ;; With the default knob restored, the hook switches modes.
@@ -232,7 +242,8 @@ The mock erases and reinserts the same text so these tests exercise
 `evil-ghostel--around-redraw' independent of renderer marker handling."
   `(cl-letf (((symbol-function 'ghostel--redraw)
               (lambda (_term &optional _full)
-                (let ((text (buffer-string)))
+                (let ((text (buffer-string))
+                      (inhibit-read-only t))
                   (erase-buffer)
                   (insert text))))
              ((symbol-function 'ghostel--mode-enabled)
@@ -302,7 +313,8 @@ advice must not restore point or visual markers there."
    (search-forward "three")
    (cl-letf (((symbol-function 'ghostel--redraw)
               (lambda (_term &optional _full)
-                (let ((text (buffer-string)))
+                (let ((text (buffer-string))
+                      (inhibit-read-only t))
                   (erase-buffer)
                   (insert text)
                   (goto-char (point-min)))))
@@ -1194,6 +1206,7 @@ become `ghostel--line-input-start' / `--line-input-end'."
   `(evil-ghostel-test--with-evil-buffer
     (setq-local ghostel--term t)
     (setq-local ghostel--input-mode 'line)
+    (setq buffer-read-only nil)
     (insert ,input-text)
     (setq-local ghostel--line-input-start (copy-marker ,input-start nil))
     (setq-local ghostel--line-input-end (copy-marker ,input-end t))
@@ -2047,7 +2060,8 @@ does not push BEG up to the cursor and collapse the range."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "$ command")
-   (put-text-property 1 3 'ghostel-prompt t)
+   (let ((inhibit-read-only t))
+     (put-text-property 1 3 'ghostel-prompt t))
    (cl-letf (((symbol-function 'ghostel--mode-enabled) (lambda (&rest _) nil)))
      (evil-normal-state)
      (goto-char (point-max))

--- a/test/ghostel-compile-test.el
+++ b/test/ghostel-compile-test.el
@@ -734,7 +734,7 @@ override with the default `ghostel-compile-view-mode'."
     (should-not ghostel-called)))
 
 (ert-deftest ghostel-test-compile-global-mode-routes-mode-t-to-interactive ()
-  "MODE=t routes to a writable ghostel terminal, not stock comint.
+  "MODE=t routes to an interactive ghostel terminal, not stock comint.
 This is the user-facing target for `\\[universal-argument] \\[compile]':
 the caller is asking for an interactive buffer, and we honour that
 by spawning a ghostel terminal (so a real TTY is still available)
@@ -779,7 +779,7 @@ instead of falling through to `comint-mode'."
       (should-not captured-interactive))))
 
 (ert-deftest ghostel-test-compile-interactive-form-c-u ()
-  "\\[universal-argument] \\[ghostel-compile] → INTERACTIVE=t (writable terminal)."
+  "\\[universal-argument] \\[ghostel-compile] → INTERACTIVE=t."
   (let ((captured-interactive 'unset)
         (compile-command "make")
         (current-prefix-arg '(4)))                               ; C-u
@@ -848,7 +848,7 @@ launched read-only reruns read-only."
   "Default (read-only) run: buffer is locked, compile keys are bound.
 
 The buffer is in `ghostel-mode' (so the renderer keeps working) but
-`buffer-read-only' is set and the local map is the compile-style
+`buffer-read-only' is set and the local map is the compilation-style
 `ghostel-compile-view-mode-map' — `g' reruns, `n'/`p' walk errors,
 attempts to mutate the buffer signal `buffer-read-only'."
   :tags '(native)
@@ -872,7 +872,7 @@ attempts to mutate the buffer signal `buffer-read-only'."
             (should (eq major-mode 'ghostel-mode))
             ;; Buffer is read-only.
             (should buffer-read-only)
-            ;; Local map is the compile-style one.
+            ;; Local map is the compilation-style one.
             (should (eq (current-local-map) ghostel-compile-view-mode-map))
             ;; `g' is bound to ghostel-recompile (not to ghostel's
             ;; self-insert), `n'/`p' walk errors.
@@ -1038,16 +1038,21 @@ custom MODE / NAME-FUNCTION / HIGHLIGHT-REGEXP survive a revert."
         (when (get-buffer buf-name)
           (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name)))))))
 
+(ert-deftest ghostel-test-compile-switch-to-readonly-alias ()
+  "The old public readonly switch name remains as a compatibility alias."
+  (should (eq (indirect-function 'ghostel-compile-switch-to-readonly)
+              (indirect-function 'ghostel-compile-switch-to-compilation-style))))
+
 (ert-deftest ghostel-test-compile-toggle-mode-keymap-bindings ()
   "`ghostel-compile-toggle-mode-map' binds the switch commands.
-`switch-to-readonly' has two bindings — the second mirrors
+`switch-to-compilation-style' has two bindings — the second mirrors
 `ghostel-mode's copy-mode key, since both are navigable/frozen
 states."
   (should (eq #'ghostel-compile-switch-to-interactive
               (lookup-key ghostel-compile-toggle-mode-map (kbd "C-c C-j"))))
-  (should (eq #'ghostel-compile-switch-to-readonly
+  (should (eq #'ghostel-compile-switch-to-compilation-style
               (lookup-key ghostel-compile-toggle-mode-map (kbd "C-c C-e"))))
-  (should (eq #'ghostel-compile-switch-to-readonly
+  (should (eq #'ghostel-compile-switch-to-compilation-style
               (lookup-key ghostel-compile-toggle-mode-map (kbd "C-c C-t")))))
 
 (ert-deftest ghostel-test-compile-switch-errors-without-process ()
@@ -1062,8 +1067,25 @@ Post-finalize the keys remain bound but the commands refuse to act
                 ghostel--process nil)
           (should-error (ghostel-compile-switch-to-interactive)
                         :type 'user-error)
-          (should-error (ghostel-compile-switch-to-readonly)
+          (should-error (ghostel-compile-switch-to-compilation-style)
                         :type 'user-error))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-compile-switch-to-interactive-restores-terminal-input-map ()
+  "Switching a live compile run to interactive restores terminal key input."
+  (let ((buf (generate-new-buffer " *ghostel-test-switch-input-map*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq ghostel-compile--command "make"
+                ghostel-compile--interactive nil
+                ghostel--process 'fake-process)
+          (use-local-map ghostel-compile-view-mode-map)
+          (cl-letf (((symbol-function 'process-live-p) (lambda (_process) t)))
+            (ghostel-compile-switch-to-interactive))
+          (should ghostel-compile--interactive)
+          (should buffer-read-only)
+          (should (eq (current-local-map) ghostel-semi-char-mode-map)))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-compile-switch-errors-in-non-compile-buffer ()
@@ -1075,7 +1097,7 @@ Post-finalize the keys remain bound but the commands refuse to act
           ;; No `ghostel-compile--command' — not a compile buffer.
           (should-error (ghostel-compile-switch-to-interactive)
                         :type 'user-error)
-          (should-error (ghostel-compile-switch-to-readonly)
+          (should-error (ghostel-compile-switch-to-compilation-style)
                         :type 'user-error))
       (kill-buffer buf))))
 
@@ -1090,14 +1112,15 @@ Post-finalize the keys remain bound but the commands refuse to act
       (should (equal ":run/i" (cadr (car mode-line-process)))))))
 
 (ert-deftest ghostel-test-compile-switch-flips-state ()
-  "End-to-end: spawn a long sleep read-only, switch to interactive and back.
+  "End-to-end: spawn a long sleep, switch to interactive input and back.
 
-After `\\[ghostel-compile-switch-to-interactive]' the buffer must
-become writable, the local map must drop the compile-style one for
-`ghostel-mode-map', and `mode-line-process' must show `:run/i'.
-After `\\[ghostel-compile-switch-to-readonly]' the buffer must lock
-back, install `ghostel-compile-view-mode-map', and the mode-line
-must read `:run' again."
+After `\\[ghostel-compile-switch-to-interactive]' the local map must
+drop the compilation-style one for `ghostel-semi-char-mode-map', and
+`mode-line-process' must show `:run/i'.  The buffer remains
+read-only because the renderer owns it.  After
+`\\[ghostel-compile-switch-to-compilation-style]' the buffer must install
+`ghostel-compile-view-mode-map', and the mode-line must read `:run'
+again."
   :tags '(native)
   (skip-unless (file-executable-p "/bin/sh"))
   (let* ((buf-name "*ghostel-test-toggle-flip*")
@@ -1119,23 +1142,23 @@ must read `:run' again."
             (should buffer-read-only)
             (should-not ghostel-compile--interactive)
             (should (equal ":run" (cadr (car mode-line-process))))
-            ;; Switch to interactive.
+            ;; Switch to interactive input.
             (ghostel-compile-switch-to-interactive)
             (should ghostel-compile--interactive)
-            (should-not buffer-read-only)
-            (should (eq (current-local-map) ghostel-mode-map))
+            (should buffer-read-only)
+            (should (eq (current-local-map) ghostel-semi-char-mode-map))
             (should (equal ":run/i" (cadr (car mode-line-process))))
             ;; No-op when already interactive.
             (ghostel-compile-switch-to-interactive)
             (should ghostel-compile--interactive)        ; unchanged
             ;; Switch back to read-only.
-            (ghostel-compile-switch-to-readonly)
+            (ghostel-compile-switch-to-compilation-style)
             (should-not ghostel-compile--interactive)
             (should buffer-read-only)
             (should (eq (current-local-map) ghostel-compile-view-mode-map))
             (should (equal ":run" (cadr (car mode-line-process))))
-            ;; No-op when already read-only.
-            (ghostel-compile-switch-to-readonly)
+            ;; No-op when already compilation-style.
+            (ghostel-compile-switch-to-compilation-style)
             (should-not ghostel-compile--interactive)    ; unchanged
             ;; Cleanup.
             (let ((p ghostel--process))
@@ -1152,7 +1175,7 @@ must read `:run' again."
   "`ghostel-compile-toggle-mode' is auto-enabled in compile buffers.
 The minor-mode keymap takes precedence over the local map and the
 major-mode map, so `\\[ghostel-compile-switch-to-interactive]' /
-`\\[ghostel-compile-switch-to-readonly]' work in both run states."
+`\\[ghostel-compile-switch-to-compilation-style]' work in both run states."
   :tags '(native)
   (skip-unless (file-executable-p "/bin/sh"))
   (let* ((buf-name "*ghostel-test-toggle-mode-active*")
@@ -1173,15 +1196,15 @@ major-mode map, so `\\[ghostel-compile-switch-to-interactive]' /
             (should (eq (key-binding (kbd "C-c C-j"))
                         #'ghostel-compile-switch-to-interactive))
             (should (eq (key-binding (kbd "C-c C-e"))
-                        #'ghostel-compile-switch-to-readonly))
+                        #'ghostel-compile-switch-to-compilation-style))
             ;; Switch and re-check: keys still bound (minor-mode wins
-            ;; over `ghostel-mode-map' too).
+            ;; over the semi-char local map too).
             (ghostel-compile-switch-to-interactive)
             (should ghostel-compile-toggle-mode)
             (should (eq (key-binding (kbd "C-c C-j"))
                         #'ghostel-compile-switch-to-interactive))
             (should (eq (key-binding (kbd "C-c C-e"))
-                        #'ghostel-compile-switch-to-readonly))
+                        #'ghostel-compile-switch-to-compilation-style))
             ;; Cleanup.
             (let ((p ghostel--process))
               (when (process-live-p p)
@@ -1212,20 +1235,20 @@ is no live process."
                   :type 'user-error)))
 
 (ert-deftest ghostel-test-compile-allows-interactive-input-during-run ()
-  "Regression: when launched interactively, the buffer must accept input.
+  "Regression: when launched interactively, keys must reach the process.
 
 When `ghostel-compile--start' is called with INTERACTIVE non-nil
 \(via \\[universal-argument] \\[ghostel-compile], or
 `compilation-start' with MODE=t under `ghostel-compile-global-mode'),
-the live buffer must remain writable: `compilation-minor-mode' must
-not be enabled on it, and the local map must keep `ghostel-mode's
-self-insert so letters like `q', `a', `g' reach the process (this
-is what makes `htop', `less', read prompts etc. work).  And
-`--spawn' must set `ghostel--process' so `ghostel--self-insert' has
-a process to send keystrokes to.
+the live buffer must keep `ghostel-mode's local map and must not enable
+`compilation-minor-mode', so letters like `q', `a', `g' reach the
+process (this is what makes `htop', `less', read prompts etc. work).
+The buffer itself remains renderer-owned and read-only.  `--spawn'
+must set `ghostel--process' so `ghostel--self-insert' has a process
+to send keystrokes to.
 
-Run a small interactive echo loop, verify both conditions, then
-send bytes through the process to confirm they land in the buffer."
+Run a small interactive echo loop, verify both conditions, then send
+bytes through the process to confirm they land in the buffer."
   :tags '(native)
   (skip-unless (file-executable-p "/bin/sh"))
   (let* ((buf-name "*ghostel-test-interactive-compile*")
@@ -1258,8 +1281,8 @@ send bytes through the process to confirm they land in the buffer."
             ;; minor mode stealing keys.
             (should (eq major-mode 'ghostel-mode))
             (should-not (bound-and-true-p compilation-minor-mode))
-            ;; Buffer is writable in interactive mode.
-            (should-not buffer-read-only)
+            ;; The buffer remains protected even though keys reach the PTY.
+            (should buffer-read-only)
             ;; Plain letters route through ghostel-mode's self-insert,
             ;; not through compilation-mode's navigation commands.
             (should (eq (key-binding "q") #'ghostel--self-insert))
@@ -1449,9 +1472,10 @@ calls `compilation-find-buffer' -> `compilation-buffer-internal-p',
 which is `(local-variable-p 'compilation-locs)'.  `prepare-buffer' must
 declare that variable buffer-locally so the live buffer qualifies."
   :tags '(native)
-  (skip-unless (file-executable-p "/bin/sh"))
+  (skip-unless (and (file-executable-p "/bin/sh")
+                    (file-executable-p "/bin/sleep")))
   (let* ((buf-name "*ghostel-test-kill-compilation*")
-         (command "printf '%s\\n' GHOSTEL_KILL_READY; exec sleep 30")
+         (command "exec /bin/sleep 30")
          (shell-file-name "/bin/sh")
          (inhibit-message t)
          (save-some-buffers-default-predicate (lambda () nil))
@@ -1463,11 +1487,7 @@ declare that variable buffer-locally so the live buffer qualifies."
         (let ((buf (ghostel-compile--start command buf-name
                                            default-directory)))
           (with-current-buffer buf
-            (ghostel-test--wait-for
-             ghostel--process
-             (lambda ()
-               (string-match-p "GHOSTEL_KILL_READY"
-                               (ghostel--copy-all-text ghostel--term))))
+            (should (process-live-p ghostel--process))
             ;; The live buffer passes `compilation-buffer-p' — which is
             ;; the gate `kill-compilation' uses.
             (should (compilation-buffer-p buf))

--- a/test/ghostel-ime-test.el
+++ b/test/ghostel-ime-test.el
@@ -15,7 +15,7 @@
 
 (declare-function ghostel--redraw-now "ghostel" (buffer))
 (declare-function ghostel--redraw "ghostel" (term &optional full))
-(declare-function ghostel--buffer-editable-p "ghostel")
+(declare-function ghostel--terminal-input-mode-p "ghostel")
 (declare-function ghostel--send-string "ghostel" (string))
 
 ;; `quail-overlay' is defined by quail.el, which is not loaded in batch.
@@ -119,16 +119,16 @@ It waits for the activation hook to deliver a genuine translator."
 (ert-deftest ghostel-test-ime-wrap-forwards-cjk-buffer-commits ()
   "Buffer-inserted CJK commits are forwarded to the PTY and removed locally."
   (ghostel-test--with-compile-buffer buf
-    (setq buffer-read-only nil)
     (dolist (text '("한" "あ" "中"))
-      (erase-buffer)
+      (let ((inhibit-read-only t))
+        (erase-buffer))
       (let (sent observed-composing)
         (setq-local ghostel-ime--original-input-method-function
                     (lambda (_key)
                       (setq observed-composing (ghostel-ime-lisp-composing-p))
                       (insert text)
                       nil))
-        (cl-letf (((symbol-function 'ghostel--buffer-editable-p)
+        (cl-letf (((symbol-function 'ghostel--terminal-input-mode-p)
                    (lambda () t))
                   ((symbol-function 'ghostel--send-string)
                    (lambda (string) (push string sent))))
@@ -138,6 +138,48 @@ It waits for the activation hook to deliver a genuine translator."
         (should (equal (buffer-string) ""))
         (should (equal sent
                        (list (encode-coding-string text 'utf-8))))))))
+
+(ert-deftest ghostel-test-ime-wrap-discards-cjk-commits-in-protected-non-input-modes ()
+  "Buffer-inserted IME commits in protected non-input modes are removed."
+  (ghostel-test--with-compile-buffer buf
+    (let (sent)
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert "base"))
+      (goto-char (point-max))
+      (setq-local ghostel-ime--original-input-method-function
+                  (lambda (_key)
+                    (insert "한")
+                    nil))
+      (cl-letf (((symbol-function 'ghostel--terminal-input-mode-p)
+                 (lambda () nil))
+                ((symbol-function 'ghostel--send-string)
+                 (lambda (string) (push string sent))))
+        (should (null (ghostel-ime--wrap-input-method ?x))))
+      (should (equal (buffer-string) "base"))
+      (should-not sent))))
+
+(ert-deftest ghostel-test-ime-wrap-keeps-line-mode-commits ()
+  "Buffer-inserted IME commits in line mode stay in the writable input."
+  (ghostel-test--with-compile-buffer buf
+    (let (sent)
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (insert "base"))
+      (setq-local ghostel--input-mode 'line)
+      (setq-local buffer-read-only nil)
+      (goto-char (point-max))
+      (setq-local ghostel-ime--original-input-method-function
+                  (lambda (_key)
+                    (insert "한")
+                    nil))
+      (cl-letf (((symbol-function 'ghostel--terminal-input-mode-p)
+                 (lambda () nil))
+                ((symbol-function 'ghostel--send-string)
+                 (lambda (string) (push string sent))))
+        (should (null (ghostel-ime--wrap-input-method ?x))))
+      (should (equal (buffer-string) "base한"))
+      (should-not sent))))
 
 (ert-deftest ghostel-test-ime-composing-p-detects-quail-overlay ()
   "A live non-empty `quail-overlay' marks Lisp IME composition active."

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -397,7 +397,8 @@ side effects have to happen explicitly inside the command."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert "hello world")
+          (let ((inhibit-read-only t))
+            (insert "hello world"))
           (goto-char (point-min))
           (set-mark (point))
           (goto-char (point-max))

--- a/test/ghostel-line-mode-test.el
+++ b/test/ghostel-line-mode-test.el
@@ -22,7 +22,7 @@ native module."
      (unwind-protect
          (with-current-buffer buf
            (ghostel-mode)
-           (let ((inhibit-read-only t))
+           (ghostel-test--with-rendered-output
              (insert (propertize ,prompt 'ghostel-prompt t))
              (insert ,input))
            (setq ghostel--term 'fake)
@@ -45,8 +45,7 @@ not clobbered."
     (setq ghostel--process 'fake-proc)
     ;; First prompt with OSC 133 A/B markers.
     (ghostel--write-vt term "\e]133;A\e\\$ \e]133;B\e\\")
-    (let ((inhibit-read-only t))
-      (ghostel--redraw term t))
+    (ghostel-test--redraw term t)
     (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
               ((symbol-function 'ghostel--write-pty) #'ignore)
               ((symbol-function 'ghostel--invalidate) #'ignore))
@@ -110,12 +109,12 @@ available (unit tests, native module not loaded)."
     (should-not (ghostel-input-start-point))
     ;; With prompt property
     (erase-buffer)
-    (insert (propertize "$ " 'ghostel-prompt t))
+    (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
     (insert "")  ; cursor right after prompt
     (should (= (ghostel-input-start-point) 3))
     ;; With prompt property followed by user-typed content
     (erase-buffer)
-    (insert (propertize "$ " 'ghostel-prompt t))
+    (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
     (insert "ls -la")
     (should (= (ghostel-input-start-point) 3))))
 
@@ -126,7 +125,7 @@ cursor sits at the end of the `>>> ' prompt the REPL printed."
   (let ((buf (generate-new-buffer " *ghostel-test-line-cursor*")))
     (unwind-protect
         (with-current-buffer buf
-          (insert ">>> \n")
+          (ghostel-test--insert-rendered ">>> \n")
           (setq ghostel--term 'fake)
           (setq ghostel--term-rows 1)
           (setq ghostel--cursor-char-pos 5)
@@ -146,10 +145,10 @@ onto the bash prompt."
     (unwind-protect
         (with-current-buffer buf
           ;; 3 renderer rows: bash row + 2 python rows.
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (insert "python3\n")
           (insert "Python 3.x\n")
-          (insert ">>> \n")
+          (ghostel-test--insert-rendered ">>> \n")
           (setq ghostel--term 'fake)
           (setq ghostel--term-rows 3)
           (setq ghostel--cursor-char-pos (1- (point-max)))
@@ -173,7 +172,7 @@ have a usable input boundary."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (let ((inhibit-read-only t))
+          (ghostel-test--with-rendered-output
             ;; Line has no prompt prefix and no prompt char anywhere —
             ;; `ghostel-prompt-regexp' can't match, so the cursor wins.
             (insert "plain text line"))
@@ -190,7 +189,7 @@ have a usable input boundary."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (let ((inhibit-read-only t))
+          (ghostel-test--with-rendered-output
             ;; Python REPL line — no prop, but `>>> ' matches the regex.
             (insert ">>> hello"))
           (setq ghostel--term 'fake)
@@ -207,8 +206,7 @@ have a usable input boundary."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (let ((inhibit-read-only t))
-            (insert "λ ls"))
+          (ghostel-test--insert-rendered "λ ls")
           (setq ghostel--term 'fake)
           (setq ghostel--term-rows 1)
           (setq ghostel--cursor-char-pos (point))
@@ -227,13 +225,13 @@ result must be 2 to prove the prop branch is consulted first."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (let ((inhibit-read-only t))
+          (ghostel-test--with-rendered-output
             ;; Prop ONLY on the `$' — not the space.  The walk-back in
             ;; `ghostel-input-start-point' stops as soon as it finds any
             ;; `ghostel-prompt' char, so it returns the position right after
             ;; the `$' (= 2).  The regex would match `$ ' (end = 3).
             ;; Different answers → precedence matters.
-            (insert (propertize "$" 'ghostel-prompt t))
+            (ghostel-test--insert-rendered (propertize "$" 'ghostel-prompt t))
             (insert " ls"))
           (setq ghostel--term 'fake)
           (setq ghostel--term-rows 1)
@@ -248,7 +246,7 @@ result must be 2 to prove the prop branch is consulted first."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (let ((inhibit-read-only t))
+          (ghostel-test--with-rendered-output
             (insert ">>> hello"))
           (setq ghostel--term 'fake)
           (setq ghostel--term-rows 1)
@@ -286,9 +284,9 @@ Also verifies the documented nil-return when no cursor is available."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (let ((inhibit-read-only t))
+          (ghostel-test--with-rendered-output
             (insert "first line\n")
-            (insert (propertize "$ " 'ghostel-prompt t))
+            (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
             (insert "second"))
           (setq ghostel--term 'fake)
           (setq ghostel--term-rows 2)
@@ -321,7 +319,7 @@ without waiting for another PTY byte."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert ">>> \n")
+          (ghostel-test--insert-rendered ">>> \n")
           (setq ghostel--term 'fake)
           (setq ghostel--term-rows 1)
           (setq ghostel--process 'fake-proc)
@@ -353,7 +351,7 @@ the hot path."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert ">>> \n")
+          (ghostel-test--insert-rendered ">>> \n")
           (setq ghostel--term 'fake)
           (setq ghostel--term-rows 1)
           (setq ghostel--process 'fake-proc)
@@ -383,7 +381,7 @@ sentinel and enters line mode for real once the TUI exits."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
                        (lambda (_term mode) (= mode 1049))))
@@ -408,7 +406,7 @@ preserved."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((alt-on nil)
                 (ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
@@ -448,7 +446,7 @@ restored."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((alt-on nil)
                 (ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
@@ -487,7 +485,7 @@ restored."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((alt-on nil)
                 (ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
@@ -506,7 +504,7 @@ restored."
               ;; Drop the prompt before alt-screen-off — simulates
               ;; a redraw cycle where the new post-TUI prompt has
               ;; not been painted yet.
-              (let ((inhibit-read-only t)) (erase-buffer))
+              (ghostel-test--with-rendered-output (erase-buffer))
               (setq alt-on nil)
               (ghostel--line-mode-post-redraw)
               ;; Still paused (sentinel intact), mode still semi-char.
@@ -515,7 +513,7 @@ restored."
               (should (equal (plist-get ghostel--line-mode-paused :input) ""))
               ;; Add the new prompt and run another post-redraw —
               ;; resume succeeds.
-              (insert (propertize "$ " 'ghostel-prompt t))
+              (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
               (ghostel--line-mode-post-redraw)
               (should (eq ghostel--input-mode 'line))
               (should-not ghostel--line-mode-paused)
@@ -528,7 +526,7 @@ restored."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((alt-on t)
                 (ghostel--term 'fake))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -555,7 +553,7 @@ a literal newline."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -598,8 +596,8 @@ a literal newline."
         (with-current-buffer buf
           (ghostel-mode)
           ;; Scrollback line carrying a help-echo (linkified).
-          (insert (propertize "see ./README.md\n" 'help-echo "fileref:./README.md"))
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "see ./README.md\n" 'help-echo "fileref:./README.md"))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -630,7 +628,7 @@ pi), the trailing encoded `return' is the submit and any embedded
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -661,8 +659,8 @@ pi), the trailing encoded `return' is the submit and any embedded
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert "scrollback line\n")
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered "scrollback line\n")
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -691,7 +689,7 @@ pi), the trailing encoded `return' is the submit and any embedded
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -729,10 +727,10 @@ a duplicated line."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           ;; Adopted input as the renderer would have painted it for
           ;; chars typed via the PTY in a previous mode.
-          (insert (propertize "ls -la" 'ghostel-input t))
+          (ghostel-test--insert-rendered (propertize "ls -la" 'ghostel-input t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -775,7 +773,7 @@ a duplicated line."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -809,8 +807,8 @@ should land at the position right after the prompt prefix."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
-          (insert "ls -la")
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered "ls -la")
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -843,8 +841,8 @@ back to the active prompt's input area."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert "scrollback line one\nscrollback line two\n")
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered "scrollback line one\nscrollback line two\n")
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -883,7 +881,7 @@ prefix on a Python REPL line."
         (with-current-buffer buf
           (ghostel-mode)
           ;; No prop — the line just looks like a Python REPL line.
-          (insert ">>> import os")
+          (ghostel-test--insert-rendered ">>> import os")
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore))
@@ -900,7 +898,7 @@ prefix on a Python REPL line."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert "λ ls")
+          (ghostel-test--insert-rendered "λ ls")
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore))
@@ -918,7 +916,7 @@ Without prop, marker, or regex, the command falls through to BOL."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert ">>> import os")
+          (ghostel-test--insert-rendered ">>> import os")
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc)
                 (ghostel-prompt-regexp nil))
@@ -941,7 +939,7 @@ types produces a row like `> ' with no trailing input, and pressing
           (ghostel-mode)
           ;; Empty continuation row — bash/zsh PS2 default is `> '.
           ;; No `ghostel-prompt' prop, no trailing input.
-          (insert "> ")
+          (ghostel-test--insert-rendered "> ")
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore))
@@ -984,7 +982,7 @@ on every empty prompt the user pressed `RET' to.)"
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1017,7 +1015,7 @@ user can continue editing at the shell prompt."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1044,7 +1042,7 @@ user can continue editing at the shell prompt."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1066,7 +1064,7 @@ user can continue editing at the shell prompt."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1098,8 +1096,8 @@ normally."
         (with-current-buffer buf
           (ghostel-mode)
           ;; Buffer: some previous output, then a prompt.
-          (insert "earlier output\n")
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered "earlier output\n")
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1134,8 +1132,8 @@ normally."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert "earlier output\n")
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered "earlier output\n")
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1165,7 +1163,7 @@ normally."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1191,8 +1189,8 @@ normally."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert "earlier output\n")
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered "earlier output\n")
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1220,8 +1218,8 @@ normally."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert "earlier output\n")
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered "earlier output\n")
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc)
                 (ghostel-line-mode-completion-at-point-functions
@@ -1267,7 +1265,7 @@ ambiguous)."
           (with-current-buffer buf
             (setq default-directory tmpdir)
             (ghostel-mode)
-            (insert (propertize "$ " 'ghostel-prompt t))
+            (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
             (let ((ghostel--term 'fake)
                   (ghostel--process 'fake-proc)
                   (ghostel-line-mode-use-bash-completion nil)
@@ -1295,7 +1293,7 @@ ambiguous)."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc)
                 (ghostel-line-mode-use-bash-completion nil)
@@ -1319,8 +1317,8 @@ ambiguous)."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert "earlier output\n")
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered "earlier output\n")
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc)
                 (ghostel-line-mode-use-bash-completion nil)
@@ -1347,7 +1345,7 @@ ambiguous)."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc)
                 (ghostel-line-mode-use-bash-completion nil)
@@ -1402,7 +1400,7 @@ ambiguous)."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1433,7 +1431,7 @@ ambiguous)."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1459,7 +1457,7 @@ ambiguous)."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1473,10 +1471,10 @@ ambiguous)."
                 ;; would re-emit the prompt at a (potentially new)
                 ;; position.  Erase and rebuild with a longer
                 ;; preamble.
-                (let ((inhibit-read-only t))
+                (ghostel-test--with-rendered-output
                   (erase-buffer)
                   (insert "background line\n")
-                  (insert (propertize "$ " 'ghostel-prompt t)))
+                  (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t)))
                 (should (ghostel--line-mode-restore snap))
                 ;; Input is back, marker points at the new prompt-end.
                 (should (equal (ghostel--line-mode-input-text) "command"))
@@ -1506,7 +1504,7 @@ not get linkified (which would steal RET from line-mode-send)."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1517,9 +1515,9 @@ not get linkified (which would steal RET from line-mode-send)."
               (insert "cd src/main.rs")
               (let ((snap (ghostel--line-mode-snapshot)))
                 ;; Simulate redraw rewriting buffer with same prompt.
-                (let ((inhibit-read-only t))
+                (ghostel-test--with-rendered-output
                   (erase-buffer)
-                  (insert (propertize "$ " 'ghostel-prompt t)))
+                  (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t)))
                 (should (ghostel--line-mode-restore snap))
                 ;; Every char in the input region carries `ghostel-input'.
                 (let ((start (marker-position
@@ -1540,8 +1538,8 @@ snapshot/restore must leave the status-bar text untouched."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
-          (insert "\n--- status ---\n")
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered "\n--- status ---\n")
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1582,9 +1580,9 @@ instead of being discarded."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           ;; Pre-existing typed chars marked with `ghostel-input'.
-          (insert (propertize "cd src" 'ghostel-input t))
+          (ghostel-test--insert-rendered (propertize "cd src" 'ghostel-input t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1611,8 +1609,8 @@ running through a redraw cycle."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
-          (insert "\n[status: ok]\n")
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered "\n[status: ok]\n")
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1633,7 +1631,7 @@ running through a redraw cycle."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc)
                 (ghostel-full-redraw nil))
@@ -1664,7 +1662,7 @@ Entering line mode forces the editor default; teardown restores the saved value.
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (cl-letf (((symbol-function 'ghostel--mode-enabled)
@@ -1696,7 +1694,7 @@ enter at that prompt instead of arming."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (setq ghostel--cursor-char-pos (point))
@@ -1725,7 +1723,7 @@ it would scrape garbage.  It arms a deferred sentinel instead."
         (with-current-buffer buf
           (ghostel-mode)
           ;; vim-like row: plain text, no prompt prop.
-          (let ((inhibit-read-only t))
+          (ghostel-test--with-rendered-output
             (insert "~ NORMAL line one"))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
@@ -1751,7 +1749,7 @@ cursor to anchor on, a prefix arg bypasses the gate and enters."
         (with-current-buffer buf
           (ghostel-mode)
           ;; No prompt prop — only a cursor anchors the boundary.
-          (let ((inhibit-read-only t))
+          (ghostel-test--with-rendered-output
             (insert "bash-5.2$ "))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc)
@@ -1781,7 +1779,7 @@ rather than leave the mode unchanged."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (let ((inhibit-read-only t))
+          (ghostel-test--with-rendered-output
             (insert "no prompt here"))
           (let ((ghostel--term 'fake)
                 (ghostel--cursor-char-pos nil))
@@ -1802,7 +1800,7 @@ alt-screen is still on, making the whole entry a no-op."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (setq ghostel--cursor-char-pos (point))
@@ -1830,7 +1828,7 @@ transition pauses as before (type-ahead discarded)."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((alt-on nil)
                 (ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
@@ -1865,17 +1863,17 @@ the `ghostel-prompt' prop is present."
         (with-current-buffer buf
           (ghostel-mode)
           ;; Row matches `ghostel-prompt-regexp' (`$ ') but has no prop.
-          (let ((inhibit-read-only t))
+          (ghostel-test--with-rendered-output
             (insert "$ ls -la"))
           (setq ghostel--term 'fake)
           (setq ghostel--cursor-char-pos (point))
           (should (ghostel--regex-prompt-end ghostel--cursor-char-pos))
           (should-not (ghostel--line-mode-prompt-on-screen-p))
           ;; Now add a real prop on the cursor row → non-nil.
-          (let ((inhibit-read-only t))
+          (ghostel-test--with-rendered-output
             (erase-buffer)
-            (insert (propertize "$ " 'ghostel-prompt t))
-            (insert "ls -la"))
+            (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
+            (ghostel-test--insert-rendered "ls -la"))
           (setq ghostel--cursor-char-pos (point))
           (should (ghostel--line-mode-prompt-on-screen-p)))
       (kill-buffer buf))))
@@ -1897,7 +1895,7 @@ the saved `ghostel-full-redraw' state captured on first entry."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (setq ghostel--cursor-char-pos (point))
@@ -1946,7 +1944,7 @@ the flag must not keep suppressing the pause forever."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           (let ((ghostel--term 'fake)
                 (ghostel--process 'fake-proc))
             (setq ghostel--cursor-char-pos (point))
@@ -1981,7 +1979,7 @@ the flag must not keep suppressing the pause forever."
   "`ghostel--apply-initial-input-mode' arms deferred entry for `line'.
 The buffer stays in semi-char until a prompt renders."
   :tags '(native)
-  (ghostel-test--with-terminal-buffer (buf term 5 80 1000)
+  (ghostel-test--with-terminal-buffer (buf _term 5 80 1000)
     (with-current-buffer buf
       (let ((ghostel-initial-input-mode 'line))
         (ghostel--apply-initial-input-mode))
@@ -1991,7 +1989,7 @@ The buffer stays in semi-char until a prompt renders."
 (ert-deftest ghostel-test-initial-input-mode-char-applies-immediately ()
   "`ghostel-initial-input-mode' = `char' enters char mode at startup."
   :tags '(native)
-  (ghostel-test--with-terminal-buffer (buf term 5 80 1000)
+  (ghostel-test--with-terminal-buffer (buf _term 5 80 1000)
     (set-window-buffer (selected-window) buf)
     (with-current-buffer buf
       (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore))
@@ -2065,14 +2063,13 @@ snap-to-`ghostel--cursor-char-pos' behaviour is preserved for the other modes."
             (ghostel-mode)
             (setq ghostel--term 'fake)
             ;; Scrollback above the prompt so a bottom-anchor is observable.
-            (let ((rows (max 1 (window-body-height)))
-                  (inhibit-read-only t))
-              (dotimes (i (+ rows 20))
-                (insert (format "row-%02d\n" i))))
+            (let ((rows (max 1 (window-body-height))))
+              (ghostel-test--with-rendered-output
+                (dotimes (i (+ rows 20))
+                  (insert (format "row-%02d\n" i)))))
             ;; A prompt carrying `ghostel-prompt' on the cursor's row, with the
             ;; terminal cursor (= the input boundary) right after it.
-            (let ((inhibit-read-only t))
-              (insert (propertize "$ " 'ghostel-prompt t)))
+            (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
             (setq ghostel--cursor-char-pos (point))
             (setq ghostel--cursor-pos (cons (current-column) 0))
             ;; Enter line mode: markers now wrap the (empty) input region.
@@ -2081,8 +2078,7 @@ snap-to-`ghostel--cursor-char-pos' behaviour is preserved for the other modes."
             (should (markerp ghostel--line-input-start))
             ;; Type input locally; the end marker grows to include it.
             (goto-char (marker-position ghostel--line-input-end))
-            (let ((inhibit-read-only t))
-              (insert "echo hello world"))
+            (insert "echo hello world")
             (should (equal (ghostel--line-mode-input-text) "echo hello world"))
             (let* ((win (selected-window))
                    (start (marker-position ghostel--line-input-start))

--- a/test/ghostel-line-mode-test.el
+++ b/test/ghostel-line-mode-test.el
@@ -310,6 +310,44 @@ Also verifies the documented nil-return when no cursor is available."
               (should-error (ghostel-line-mode) :type 'user-error))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-line-mode-enters-without-osc133 ()
+  "Line mode enters successfully in a REPL with no shell integration.
+Reproduces the python3 case: no `ghostel-prompt' chars anywhere,
+but the cursor is at the end of the REPL's prompt."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-nointegration*"))
+        (sent nil)
+        (encoded nil))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (ghostel-test--insert-rendered ">>> \n")
+          (setq ghostel--term 'fake)
+          (setq ghostel--term-rows 1)
+          (setq ghostel--process 'fake-proc)
+          (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                     (lambda (&rest _) nil))
+                    (ghostel--cursor-char-pos 4)
+                    ((symbol-function 'process-live-p) (lambda (_p) t))
+                    ((symbol-function 'ghostel--write-pty)
+                     (lambda (_term s) (setq sent s)))
+                    ((symbol-function 'ghostel--send-encoded)
+                     (lambda (key _mods &optional _utf8)
+                       (setq encoded key)))
+                    ((symbol-function 'ghostel--redraw) #'ignore)
+                    ((symbol-function 'ghostel--invalidate) #'ignore))
+            (ghostel-line-mode)
+            (should (eq ghostel--input-mode 'line))
+            (should-not buffer-read-only)
+            (goto-char (marker-position ghostel--line-input-end))
+            (insert "1+1")
+            (ghostel-line-mode-send)
+            (should-not buffer-read-only)
+            (ghostel-semi-char-mode)
+            (should buffer-read-only)
+            (should (equal sent "1+1"))
+            (should (equal encoded "return"))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-copy-to-line-restarts-redraw-timer ()
   "Copy → line transition re-arms the redraw timer.
 Copy mode freezes the timer; line mode is live, so redraws must resume

--- a/test/ghostel-line-mode-undo-test.el
+++ b/test/ghostel-line-mode-undo-test.el
@@ -24,8 +24,7 @@ previous undo."
 Stubs the process predicates so `ghostel-line-mode' runs without a
 live PTY.  Leaves the buffer in line mode with point at the input."
   (ghostel--write-vt term "\e]133;A\e\\$ \e]133;B\e\\")
-  (let ((inhibit-read-only t))
-    (ghostel--redraw term t))
+  (ghostel-test--redraw term t)
   (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
             ((symbol-function 'ghostel--write-pty) #'ignore)
             ((symbol-function 'ghostel--invalidate) #'ignore))
@@ -61,7 +60,7 @@ live PTY.  Leaves the buffer in line mode with point at the input."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert (propertize "$ " 'ghostel-prompt t))
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
           ;; Fresh ghostel-mode buffer: recording off.
           (should (eq buffer-undo-list t))
           (let ((ghostel--term 'fake)
@@ -92,8 +91,7 @@ start, so an undo can never delete the prompt or earlier output."
     (setq ghostel--process 'fake-proc)
     ;; Some prior output to form scrollback, then a fresh prompt.
     (ghostel--write-vt term "hello\r\nworld\r\n\e]133;A\e\\$ \e]133;B\e\\")
-    (let ((inhibit-read-only t))
-      (ghostel--redraw term t))
+    (ghostel-test--redraw term t)
     (cl-letf (((symbol-function 'process-live-p) (lambda (_p) t))
               ((symbol-function 'ghostel--write-pty) #'ignore)
               ((symbol-function 'ghostel--invalidate) #'ignore))

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -20,8 +20,7 @@ unlike semi-char mode where it tracks the terminal cursor."
 				      (dotimes (i 10)
 					(ghostel--write-vt term
 							   (format "row-%02d\r\n" i)))
-				      (let ((inhibit-read-only t))
-					(ghostel--redraw term t))
+				      (ghostel-test--redraw term t)
 				      ;; Enter emacs mode and navigate to the top.
 				      (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore))
 					(ghostel-emacs-mode))
@@ -47,8 +46,7 @@ unlike semi-char mode where it tracks the terminal cursor."
 				      (dotimes (i 3)
 					(ghostel--write-vt term
 							   (format "initial-%d\r\n" i)))
-				      (let ((inhibit-read-only t))
-					(ghostel--redraw term t))
+				      (ghostel-test--redraw term t)
 				      (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore))
 					(ghostel-copy-mode))
 				      (let ((snapshot (buffer-substring-no-properties
@@ -65,8 +63,7 @@ unlike semi-char mode where it tracks the terminal cursor."
 				      ;; Exiting copy mode lets the redraw catch up.
 				      (cl-letf (((symbol-function 'ghostel--anchor-window) #'ignore))
 					(ghostel-readonly-exit))
-				      (let ((inhibit-read-only t))
-					(ghostel--redraw term t))
+				      (ghostel-test--redraw term t)
 				      (let ((content (buffer-substring-no-properties
 						      (point-min) (point-max))))
 					(should (string-match-p "frozen-2" content)))))
@@ -371,10 +368,10 @@ unlike semi-char mode where it tracks the terminal cursor."
         (with-current-buffer buf
           (ghostel-mode)
           (let ((ghostel--input-mode 'copy)
-                (ghostel--term 'fake-term)
-                (inhibit-read-only t))
-            (insert (mapconcat #'number-to-string (number-sequence 1 20) "\n"))
-            (insert "   \n\n")
+                (ghostel--term 'fake-term))
+            (ghostel-test--with-rendered-output
+              (insert (mapconcat #'number-to-string (number-sequence 1 20) "\n"))
+              (insert "   \n\n"))
             (goto-char (point-min))
             (ghostel-readonly-end-of-buffer)
             (should (looking-back "20" (line-beginning-position)))))
@@ -389,32 +386,44 @@ unlike semi-char mode where it tracks the terminal cursor."
           (should (eq ghostel--input-mode 'semi-char))
           (should (eq (current-local-map) ghostel-semi-char-mode-map))
           (should (null mode-line-process))
-          (should (ghostel--buffer-editable-p))
+          (should (ghostel--terminal-input-mode-p))
+          (should buffer-read-only)
           (should (ghostel--terminal-live-p))
           (should-not (ghostel--terminal-frozen-p)))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-default-buffer-is-protected ()
+  "Renderer-owned ghostel buffers reject ordinary editing commands."
+  (let ((buf (generate-new-buffer " *ghostel-test-mode-protected*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (ghostel-test--insert-rendered "one\ntwo\n")
+          (goto-char (point-min))
+          (should-error (transpose-lines 1) :type 'buffer-read-only))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-input-mode-predicates ()
   "The ghostel--*-p predicates reflect the current `ghostel--input-mode'."
   (let ((ghostel--input-mode 'semi-char))
-    (should (ghostel--buffer-editable-p))
+    (should (ghostel--terminal-input-mode-p))
     (should (ghostel--terminal-live-p))
     (should-not (ghostel--terminal-frozen-p)))
   (let ((ghostel--input-mode 'char))
-    (should (ghostel--buffer-editable-p))
+    (should (ghostel--terminal-input-mode-p))
     (should (ghostel--terminal-live-p))
     (should-not (ghostel--terminal-frozen-p)))
   (let ((ghostel--input-mode 'emacs))
-    (should-not (ghostel--buffer-editable-p))
+    (should-not (ghostel--terminal-input-mode-p))
     (should (ghostel--terminal-live-p)))
   (let ((ghostel--input-mode 'copy))
-    (should-not (ghostel--buffer-editable-p))
+    (should-not (ghostel--terminal-input-mode-p))
     (should-not (ghostel--terminal-live-p))
     (should (ghostel--terminal-frozen-p)))
   ;; Line mode keeps the terminal live: redraws still run, with the
   ;; snapshot/restore path preserving the user's in-progress input.
   (let ((ghostel--input-mode 'line))
-    (should-not (ghostel--buffer-editable-p))
+    (should-not (ghostel--terminal-input-mode-p))
     (should (ghostel--terminal-live-p))
     (should-not (ghostel--terminal-frozen-p))))
 
@@ -439,7 +448,7 @@ unlike semi-char mode where it tracks the terminal cursor."
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-emacs-mode-enter-exit ()
-  "Emacs mode sets read-only, swaps map, and exits cleanly."
+  "Emacs mode swaps map, updates the mode line, and exits cleanly."
   (let ((buf (generate-new-buffer " *ghostel-test-emacs-mode*")))
     (unwind-protect
         (with-current-buffer buf
@@ -454,10 +463,8 @@ unlike semi-char mode where it tracks the terminal cursor."
                               ghostel-readonly-fast-exit-mode-map
                             ghostel-readonly-mode-map)))
               (should (equal mode-line-process ":Emacs"))
-              (should buffer-read-only)
               (ghostel-semi-char-mode)
               (should (eq ghostel--input-mode 'semi-char))
-              (should-not buffer-read-only)
               (should (null mode-line-process)))))
       (kill-buffer buf))))
 
@@ -632,7 +639,7 @@ scrollback."
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-copy-to-emacs-transition ()
-  "Copy → Emacs unfreezes the terminal without re-toggling read-only."
+  "Copy → Emacs unfreezes the terminal."
   (let ((buf (generate-new-buffer " *ghostel-test-copy-to-emacs*")))
     (unwind-protect
         (with-current-buffer buf
@@ -644,18 +651,15 @@ scrollback."
                       ((symbol-function 'ghostel--anchor-window) #'ignore))
               (ghostel-copy-mode)
               (should (eq ghostel--input-mode 'copy))
-              (should buffer-read-only)
               (ghostel-emacs-mode)
               (should (eq ghostel--input-mode 'emacs))
-              (should buffer-read-only)               ; still read-only
-              (should (ghostel--terminal-live-p))     ; but now unfrozen
+              (should (ghostel--terminal-live-p))
               (ghostel-semi-char-mode)
-              (should (eq ghostel--input-mode 'semi-char))
-              (should-not buffer-read-only))))
+              (should (eq ghostel--input-mode 'semi-char)))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-emacs-to-copy-transition ()
-  "Emacs → copy freezes the terminal without re-toggling read-only."
+  "Emacs → copy freezes the terminal."
   (let ((buf (generate-new-buffer " *ghostel-test-emacs-to-copy*")))
     (unwind-protect
         (with-current-buffer buf
@@ -667,10 +671,8 @@ scrollback."
                   (progn
                     (ghostel-emacs-mode)
                     (should (eq ghostel--input-mode 'emacs))
-                    (should buffer-read-only)
                     (ghostel-copy-mode)
                     (should (eq ghostel--input-mode 'copy))
-                    (should buffer-read-only)
                     (should (ghostel--terminal-frozen-p))
                     (should (null ghostel--redraw-timer)))
                 (when (and ghostel--redraw-timer
@@ -729,7 +731,6 @@ Exiting returns to whatever mode the user was in beforehand, mirroring
               (should (eq ghostel--input-mode 'emacs))
               (ghostel-emacs-mode)
               (should (eq ghostel--input-mode 'semi-char))
-              (should-not buffer-read-only)
               ;; char → emacs → (toggle) char
               (ghostel-char-mode)
               (ghostel-emacs-mode)
@@ -773,9 +774,7 @@ Exiting returns to whatever mode the user was in beforehand, mirroring
               (ghostel-copy-mode)  (should (eq ghostel--input-mode 'copy))
               (ghostel-char-mode)  (should (eq ghostel--input-mode 'char))
               (ghostel-semi-char-mode)
-              (should (eq ghostel--input-mode 'semi-char))
-              ;; Read-only flag is consistently off after returning.
-              (should-not buffer-read-only))))
+              (should (eq ghostel--input-mode 'semi-char)))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-mark-activation-enters-copy-mode ()
@@ -793,7 +792,7 @@ Exiting returns to whatever mode the user was in beforehand, mirroring
                 (transient-mark-mode t))
             (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
                       ((symbol-function 'ghostel--anchor-window) #'ignore))
-              (insert "some terminal output")
+              (ghostel-test--insert-rendered "some terminal output")
               (goto-char 5)
               ;; Any mark-activating command works; C-SPC's is the canonical one.
               (set-mark-command nil)
@@ -906,7 +905,7 @@ semi-char."
                 (this-command 'ghostel-mouse-press-or-copy-mode))
             (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
                       ((symbol-function 'ghostel--anchor-window) #'ignore))
-              (insert "some terminal output")
+              (ghostel-test--insert-rendered "some terminal output")
               ;; An empty region (point == mark), like a window-selecting click.
               (push-mark (point) t t)
               (should (eq ghostel--input-mode 'semi-char)))))
@@ -931,7 +930,7 @@ but the cursor is at the end of the REPL's prompt."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
-          (insert ">>> \n")
+          (ghostel-test--insert-rendered ">>> \n")
           (setq ghostel--term 'fake)
           (setq ghostel--term-rows 1)
           (setq ghostel--process 'fake-proc)
@@ -948,9 +947,13 @@ but the cursor is at the end of the REPL's prompt."
                     ((symbol-function 'ghostel--invalidate) #'ignore))
             (ghostel-line-mode)
             (should (eq ghostel--input-mode 'line))
+            (should-not buffer-read-only)
             (goto-char (marker-position ghostel--line-input-end))
             (insert "1+1")
             (ghostel-line-mode-send)
+            (should-not buffer-read-only)
+            (ghostel-semi-char-mode)
+            (should buffer-read-only)
             (should (equal sent "1+1"))
             (should (equal encoded "return"))))
       (kill-buffer buf))))
@@ -967,7 +970,7 @@ so copy/Emacs mode entry runs without a live terminal or window."
      (unwind-protect
          (with-current-buffer buf
            (ghostel-mode)
-           (insert "echo hi")
+           (ghostel-test--insert-rendered "echo hi")
            (setq-local ghostel--term 'fake)
            (setq-local ghostel--cursor-char-pos (point-max))
            (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
@@ -1056,10 +1059,10 @@ snap to the live cursor."
           (set-window-buffer (selected-window) buf)
           (with-current-buffer buf
             (ghostel-mode)
-            (let ((rows (max 1 (window-body-height)))
-                  (inhibit-read-only t))
-              (dotimes (i (+ rows 20))
-                (insert (format "row-%02d\n" i))))
+            (let ((rows (max 1 (window-body-height))))
+              (ghostel-test--with-rendered-output
+                (dotimes (i (+ rows 20))
+                  (insert (format "row-%02d\n" i)))))
             (setq ghostel--input-mode 'emacs)
             (setq ghostel--cursor-char-pos (point-max))
             (goto-char (point-min))

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -920,44 +920,6 @@ global mark command, whose activation `ghostel--mark-activated' handles."
   (dolist (key '("C-SPC" "C-@"))
     (should (functionp (lookup-key ghostel-char-mode-map (kbd key))))))
 
-(ert-deftest ghostel-test-line-mode-enters-without-osc133 ()
-  "Line mode enters successfully in a REPL with no shell integration.
-Reproduces the python3 case: no `ghostel-prompt' chars anywhere,
-but the cursor is at the end of the REPL's prompt."
-  (let ((buf (generate-new-buffer " *ghostel-test-line-nointegration*"))
-        (sent nil)
-        (encoded nil))
-    (unwind-protect
-        (with-current-buffer buf
-          (ghostel-mode)
-          (ghostel-test--insert-rendered ">>> \n")
-          (setq ghostel--term 'fake)
-          (setq ghostel--term-rows 1)
-          (setq ghostel--process 'fake-proc)
-          (cl-letf (((symbol-function 'ghostel--mode-enabled)
-                     (lambda (&rest _) nil))
-                    (ghostel--cursor-char-pos 4)
-                    ((symbol-function 'process-live-p) (lambda (_p) t))
-                    ((symbol-function 'ghostel--write-pty)
-                     (lambda (_term s) (setq sent s)))
-                    ((symbol-function 'ghostel--send-encoded)
-                     (lambda (key _mods &optional _utf8)
-                       (setq encoded key)))
-                    ((symbol-function 'ghostel--redraw) #'ignore)
-                    ((symbol-function 'ghostel--invalidate) #'ignore))
-            (ghostel-line-mode)
-            (should (eq ghostel--input-mode 'line))
-            (should-not buffer-read-only)
-            (goto-char (marker-position ghostel--line-input-end))
-            (insert "1+1")
-            (ghostel-line-mode-send)
-            (should-not buffer-read-only)
-            (ghostel-semi-char-mode)
-            (should buffer-read-only)
-            (should (equal sent "1+1"))
-            (should (equal encoded "return"))))
-      (kill-buffer buf))))
-
 ;;; Auto-leave: switch out of semi-char when point leaves the input point
 
 (defmacro ghostel-test--with-auto-leave-buffer (&rest body)

--- a/test/ghostel-shell-test.el
+++ b/test/ghostel-shell-test.el
@@ -50,8 +50,7 @@ newest-first list aligns with the buffer-order regions."
 
 (defun ghostel-test--rendered-terminal-text ()
   "Redraw the current ghostel terminal and return its text."
-  (let ((inhibit-read-only t))
-    (ghostel--redraw ghostel--term t))
+  (ghostel-test--redraw ghostel--term t)
   (ghostel-test--terminal-text))
 
 (ert-deftest ghostel-test-shell-integration ()
@@ -837,7 +836,7 @@ a successful submission."
           (setq ghostel--term-rows 5)
           (setq ghostel--process 'fake-proc)
           (setq ghostel--password-mode-p t)
-          (ghostel--redraw ghostel--term)
+          (ghostel-test--redraw ghostel--term)
           (let ((ghostel-password-prompt-functions
                  (list (lambda (_row) nil) (lambda (_row) nil))))
             (cl-letf (((symbol-function 'ghostel--write-pty)
@@ -862,7 +861,7 @@ not the debounce window itself (covered separately)."
           (ghostel-mode)
           (setq ghostel--term (ghostel--new 5 80 1000))
           (setq ghostel--term-rows 5)
-          (ghostel--redraw ghostel--term)
+          (ghostel-test--redraw ghostel--term)
           (let ((ghostel-password-prompt-functions
                  (list (lambda (_row) (cl-incf calls) nil)))
                 (ghostel-password-prompt-debounce 0))
@@ -943,7 +942,7 @@ is re-confirmed (mirrors ghostty's ~200 ms termios polling cadence)."
           (ghostel-mode)
           (setq ghostel--term (ghostel--new 5 80 1000))
           (setq ghostel--term-rows 5)
-          (ghostel--redraw ghostel--term)
+          (ghostel-test--redraw ghostel--term)
           (let ((ghostel-password-prompt-functions
                  (list (lambda (_row) (cl-incf calls) "x")))
                 (ghostel-password-prompt-debounce 0.1))
@@ -974,7 +973,7 @@ window never reaches the user."
           (ghostel-mode)
           (setq ghostel--term (ghostel--new 5 80 1000))
           (setq ghostel--term-rows 5)
-          (ghostel--redraw ghostel--term)
+          (ghostel-test--redraw ghostel--term)
           (let ((ghostel-password-prompt-functions
                  (list (lambda (_row) (cl-incf calls) "x")))
                 (ghostel-password-prompt-debounce 0.5))

--- a/test/ghostel-spawn-test.el
+++ b/test/ghostel-spawn-test.el
@@ -597,7 +597,7 @@ not the old ones — verified on both PTY backends."
                         (lambda () (ghostel-test--latest-winsize "INIT")) proc 6)))
         ;; Stage a new size and commit it with a redraw, which fires SIGWINCH.
         (ghostel--set-size-with-cell-dims ghostel--term 30 100)
-        (ghostel--redraw ghostel--term t)
+        (ghostel-test--redraw ghostel--term t)
         ;; The child's SIGWINCH handler must report the new size, not the old.
         (should (ghostel-test--wait-until
                  (lambda () (equal '(30 . 100)

--- a/test/ghostel-test-helpers.el
+++ b/test/ghostel-test-helpers.el
@@ -67,9 +67,28 @@ through the production `ghostel--create' path."
   (string-match-p (concat "\\(?:\\`\\|\n\\)[[:blank:]]*" (regexp-quote prefix))
                   (or text (ghostel-test--terminal-text))))
 
+(defmacro ghostel-test--with-rendered-output (&rest body)
+  "Run BODY while mutating fake renderer-owned buffer text."
+  (declare (indent 0) (debug t))
+  `(let ((inhibit-read-only t))
+     ,@body))
+
+(defun ghostel-test--insert-rendered (&rest args)
+  "Insert ARGS as fake renderer-owned output in the current buffer."
+  (ghostel-test--with-rendered-output
+    (apply #'insert args)))
+
+(defun ghostel-test--redraw (term &optional full)
+  "Redraw TERM as renderer-owned test output.
+When FULL is non-nil, request a full redraw.  This mirrors
+`ghostel--redraw-now', which allows terminal renderer mutations
+even when the ghostel buffer is read-only."
+  (ghostel-test--with-rendered-output
+    (ghostel--redraw term full)))
+
 (defun ghostel-test--cursor (term)
   "Return (COL . ROW) cursor position for TERM via redraw."
-  (ghostel--redraw term)
+  (ghostel-test--redraw term)
   ghostel--cursor-pos)
 
 (defun ghostel-test--wait-for (proc pred &optional timeout)
@@ -296,7 +315,7 @@ PROCESS and TIMEOUT are passed to `ghostel-test--wait-until'."
 ROWS, COLS, and TIMEOUT control the fresh terminal and wait.
 Return the terminal text after TEXT appears.  Dynamic process-spawn
 bindings from the caller are honored."
-  (ghostel-test--with-terminal-buffer (buf term (or rows 24) (or cols 80) 1000)
+  (ghostel-test--with-terminal-buffer (buf _term (or rows 24) (or cols 80) 1000)
     (let ((proc (ghostel--start-process)))
       (ghostel-test--wait-for-text text proc timeout)
       (ghostel-test--terminal-text))))


### PR DESCRIPTION
This prevents modifications by commands such as transpose-lines