### PR TITLE
Fix ghostel-debug advice arity for redraw-now's FORCE argument

### DIFF
--- a/lisp/ghostel-debug.el
+++ b/lisp/ghostel-debug.el
@@ -325,24 +325,28 @@ computed viewport-start, and per-window ws/we/wp/body-height."
                        (plist-get w :wp) (plist-get w :body)))
    wins " | "))
 
-(defun ghostel-debug--log-redraw (orig-fn buffer)
+(defun ghostel-debug--log-redraw (orig-fn buffer &optional force)
   "Log redraw decisions: skip vs execute, DEC 2026 state, timing.
-ORIG-FN is `ghostel--redraw-now', BUFFER is the target buffer."
+ORIG-FN is `ghostel--redraw-now', BUFFER is the target buffer, FORCE is
+its optional force-past-synchronized-output argument (forwarded)."
   (when ghostel-debug--log-buffer
-    (let ((before (ghostel-debug--snapshot buffer))
-          (t0 (current-time)))
-      (funcall orig-fn buffer)
+    (let* ((before (ghostel-debug--snapshot buffer))
+           ;; `force' set via the snapshotted buffer-local flag OR passed as
+           ;; an argument both bypass the DEC 2026 skip in `ghostel--redraw-now'.
+           (force-in (or (plist-get before :force) force))
+           (t0 (current-time)))
+      (funcall orig-fn buffer force)
       (let* ((elapsed (* 1000 (float-time (time-subtract (current-time) t0))))
              (after (ghostel-debug--snapshot buffer)))
         (with-current-buffer ghostel-debug--log-buffer
           (goto-char (point-max))
-          (if (and (plist-get before :sync) (not (plist-get before :force)))
+          (if (and (plist-get before :sync) (not force-in))
               (insert (format "[%s] REDRAW: SKIPPED (DEC2026 active, force=nil)\n"
                               (format-time-string "%T.%3N")))
             (insert (format "[%s] REDRAW: %.1fms force=%s→%s dec2026=%s buf=%d→%d trailNL=%s→%s pt=%d→%d cursor=%S→%S cursor-char=%S→%S rows=%s vs=%s→%s\n"
                             (format-time-string "%T.%3N")
                             elapsed
-                            (plist-get before :force) (plist-get after :force)
+                            force-in (plist-get after :force)
                             (plist-get before :sync)
                             (plist-get before :buf-size) (plist-get after :buf-size)
                             (plist-get before :trailing-nl) (plist-get after :trailing-nl)
@@ -356,16 +360,17 @@ ORIG-FN is `ghostel--redraw-now', BUFFER is the target buffer."
             (insert (format "           wins-after:  %s\n"
                             (ghostel-debug--fmt-wins (plist-get after :wins))))))))))
 
-(defun ghostel-debug--log-resize (orig-fn window)
+(defun ghostel-debug--log-resize (orig-fn window &optional force)
   "Log resize events with old/new dimensions and timing.
-ORIG-FN is `ghostel--adjust-size'.  WINDOW is passed through."
+ORIG-FN is `ghostel--adjust-size'.  WINDOW and its optional FORCE
+argument are passed through."
   (let* ((buffer (and (window-live-p window) (window-buffer window)))
          (old-rows (and (buffer-live-p buffer)
                         (buffer-local-value 'ghostel--term-rows buffer)))
          (old-cols (and (buffer-live-p buffer)
                         (buffer-local-value 'ghostel--term-cols buffer)))
          (t0 (current-time))
-         (result (funcall orig-fn window))
+         (result (funcall orig-fn window force))
          (elapsed (* 1000 (float-time (time-subtract (current-time) t0))))
          (new-rows (and (buffer-live-p buffer)
                         (buffer-local-value 'ghostel--term-rows buffer)))
@@ -439,8 +444,9 @@ The latency breakdown shows:
             ghostel-debug--latency-log)
       (setq ghostel-debug--latency-send-time nil))))
 
-(defun ghostel-debug--latency-on-render (_buffer)
-  "Record render-completion time and finalize latency entry."
+(defun ghostel-debug--latency-on-render (_buffer &rest _)
+  "Record render-completion time and finalize latency entry.
+Ignores `ghostel--redraw-now's optional force argument."
   (when ghostel-debug--latency-active
     (let ((render-time (current-time)))
       ;; Complete the most recent entry that has no render time

--- a/test/ghostel-debug-test.el
+++ b/test/ghostel-debug-test.el
@@ -466,6 +466,37 @@ delta in the phase timings section."
                      #'ghostel-debug--capture-start-process)
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-debug-redraw-advices-tolerate-force ()
+  "Debug redraw/latency advices accept and forward `ghostel--redraw-now's FORCE.
+Regression for #460: adding the optional FORCE argument made the :around
+log advice and the :after latency advice receive an extra argument.  Both
+must tolerate it without `wrong-number-of-arguments', and the :around must
+forward FORCE to the real redraw."
+  (let ((log-buf (generate-new-buffer " *ghostel-test-redraw-advice*"))
+        (recorded nil))
+    (unwind-protect
+        (let ((ghostel-debug--log-buffer log-buf)
+              (ghostel-debug--latency-active nil))
+          (cl-letf* (((symbol-function 'ghostel--redraw-now)
+                      (lambda (_buffer &optional force) (push force recorded)))
+                     ;; Stub the snapshot so the log body needs no live terminal.
+                     ((symbol-function 'ghostel-debug--snapshot)
+                      (lambda (_buffer)
+                        (list :sync nil :force nil :buf-size 0 :trailing-nl nil
+                              :point 1 :cursor nil :cursor-char nil
+                              :term-rows 0 :vs 1 :wins nil))))
+            (advice-add 'ghostel--redraw-now :around #'ghostel-debug--log-redraw)
+            (advice-add 'ghostel--redraw-now :after #'ghostel-debug--latency-on-render)
+            (with-temp-buffer
+              (ghostel--redraw-now (current-buffer) t)
+              (ghostel--redraw-now (current-buffer)))
+            ;; Both calls returned without an arity error, and FORCE was
+            ;; forwarded: newest-first push records the bare then forced call.
+            (should (equal recorded '(nil t)))))
+      (advice-remove 'ghostel--redraw-now #'ghostel-debug--log-redraw)
+      (advice-remove 'ghostel--redraw-now #'ghostel-debug--latency-on-render)
+      (kill-buffer log-buf))))
+
 
 (ert-deftest ghostel-test-vt-warnings-do-not-leak-to-stderr ()
   "VT-parser warnings must not reach the module's stderr (#425).

--- a/test/ghostel-ime-test.el
+++ b/test/ghostel-ime-test.el
@@ -13,7 +13,7 @@
 (require 'ghostel-test-helpers)
 (require 'ghostel-ime)
 
-(declare-function ghostel--redraw-now "ghostel" (buffer))
+(declare-function ghostel--redraw-now "ghostel" (buffer &optional force))
 (declare-function ghostel--redraw "ghostel" (term &optional full))
 (declare-function ghostel--buffer-editable-p "ghostel")
 (declare-function ghostel--send-string "ghostel" (string))


### PR DESCRIPTION
## Problem

#460 gave `ghostel--redraw-now` an optional `FORCE` argument (`(buffer)` → `(buffer &optional force)`). Adding an `&optional` arg is safe for plain callers, but **advices capture arity** — and the `ghostel-debug` advices that wrap `ghostel--redraw-now` still declared the old single-argument form. When debug logging or latency profiling is active, the forced redraw paths (`ghostel-force-redraw`, the reappear hook `ghostel--window-buffer-change`) signal `wrong-number-of-arguments`:

- `ghostel-debug--log-redraw` (`:around`) received three args into a two-parameter lambda, and dropped `FORCE` when forwarding to the original.
- `ghostel-debug--latency-on-render` (`:after`) received two args into a one-parameter lambda.

This was reported in #456 (review of #460).

Beyond the regression, `ghostel-debug--log-resize` (`:around` on `ghostel--adjust-size`) had the **same latent bug** already: `ghostel--adjust-size` has taken an optional `FORCE` for a while (a text-scale change passes it), so the resize advice would crash there too.

Notably, this also blocks diagnosing the *other* open parts of #456: `ghostel-debug-start` installs these advices, so switching workspaces (→ forced reappear redraw) throws before any useful log is produced. This fix is a precondition for debugging the rest.

## Changes

- `ghostel-debug--log-redraw`: accept `&optional force`, forward it, and fold it into the skip prediction and the `force=…` log column so the log stays truthful for arg-forced redraws.
- `ghostel-debug--latency-on-render`: accept `&rest _` (ignores the arg).
- `ghostel-debug--log-resize`: accept and forward `&optional force` (the pre-existing latent bug).
- `test/ghostel-ime-test.el`: refresh the stale `declare-function` arity.
- `test/ghostel-debug-test.el`: regression test asserting both redraw-now advices tolerate **and** forward `FORCE`.

Only affects sessions with `ghostel-debug-start` / latency profiling active; normal sessions were unaffected.

`make -j8 all` is green.