### PR TITLE
Fix C-a jumping to stray prompt char in command output

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -828,7 +828,7 @@ before sending the input."
   :type 'boolean)
 
 (defcustom ghostel-prompt-regexp
-  "^[^#$%>λ❯→➜\n]*[#$%>λ❯→➜]+ *"
+  "^[^#$%>λ❯→➜\n]\\{0,60\\}[#$%>λ❯→➜]+ *"
   "Regexp matching a prompt prefix at the beginning of a line.
 Consulted as a fallback by `ghostel-input-start-point' and
 `ghostel-beginning-of-input-or-line' when the row has no
@@ -840,10 +840,13 @@ The default recognizes:
 - Themed prompts: `λ ', `❯ ' (Starship/Pure/Powerlevel10k),
   `➜ ' (oh-my-zsh robbyrussell), `→ '
 
-The negated character class `[^#$%>λ❯→➜\\n]*' forces the match to
-stop at the *first* prompt character on the line, so command lines
-echoed into scrollback (e.g. `$ echo $foo') are detected by their
-leading prompt prefix rather than a `$' deeper in the line.
+The negated character class `[^#$%>λ❯→➜\\n]\\{0,60\\}' forces the match to
+stop at the *first* prompt character on the line, so command lines echoed into
+scrollback (e.g. `$ echo $foo') are detected by their leading prompt prefix
+rather than a `$' deeper in the line.  The `\\{0,60\\}' bound caps that prefix
+at 60 columns: a prompt character only counts near the start of a line, so
+a stray `%'/`#' deep in command output (e.g. the `%' in a `100%' progress line)
+is treated as output, not a prompt.
 
 Trade-off: any line that *starts* with one of these characters is
 treated as a prompt line.  Diff output (`> excluded'), markdown
@@ -2679,9 +2682,16 @@ prompt prefix.  On other rows, point moves to the line beginning."
                             (get-text-property pos 'ghostel-prompt))
                   (setq pos (1+ pos)))
                 (and (> pos bol) (< pos eol) pos)))))
-         ;; Regex fallback for shells/REPLs without OSC 133.
+         ;; Regex fallback for shells/REPLs without OSC 133.  Suppressed
+         ;; when OSC 133 is active and a real prompt sits below point:
+         ;; this property-less line is then command output, not a prompt, so
+         ;; prefer BOL over a stray mid-line %/>/#.  During a live REPL/tmux
+         ;; session, the bottom line has no prompt and the regex still fires.
          (regex-target
-          (unless (or line-mode-target prop-target)
+          (unless (or line-mode-target prop-target
+                      (and ghostel--prompt-positions
+                           (text-property-not-all (point) (point-max)
+                                                  'ghostel-prompt nil)))
             (ghostel--regex-prompt-end bol))))
     (cond
      (line-mode-target (goto-char line-mode-target))

--- a/test/ghostel-shell-test.el
+++ b/test/ghostel-shell-test.el
@@ -1487,6 +1487,52 @@ input already typed at the prompt)."
       (kill-buffer buf))))
 
 
+(ert-deftest ghostel-test-regex-prompt-end-rejects-late-stray-char ()
+  "A stray `%' deep in command output is not treated as a prompt.
+The 60-column bound in `ghostel-prompt-regexp' stops the prefix from
+reaching the `%' in a `100%' progress line (here past column 60)."
+  (with-temp-buffer
+    (insert "[44/48] Removing docker-ce-cli-1:29.5.3-1.fc43.x86_64     100% | done")
+    (goto-char (point-min))
+    (should-not (ghostel--regex-prompt-end (point)))))
+
+(ert-deftest ghostel-test-regex-prompt-end-keeps-short-prompt ()
+  "A normal `$ ' prompt within the column bound is still detected."
+  (with-temp-buffer
+    (insert "$ ls -la")
+    (goto-char (point-min))
+    ;; Prompt prefix `$ ' ends at position 3.
+    (should (= (ghostel--regex-prompt-end (point)) 3))))
+
+(ert-deftest ghostel-test-beginning-of-input-lookahead-skips-output-line ()
+  "On an output line above a real prompt, `C-a' goes to BOL.
+The line has no `ghostel-prompt' property and starts with a stray `>',
+but a real OSC 133 prompt sits below, so the regex fallback is
+suppressed in favour of `beginning-of-line'."
+  (with-temp-buffer
+    (let ((out-bol (point)))
+      (insert "> some diff line\n")
+      (insert (propertize "$ " 'ghostel-prompt t))
+      (insert "ls")
+      (setq ghostel--prompt-positions '((1 . nil)))
+      ;; Point on the output line, after the `>'.
+      (goto-char (+ out-bol 5))
+      (ghostel-beginning-of-input-or-line)
+      (should (= (point) out-bol)))))
+
+(ert-deftest ghostel-test-beginning-of-input-repl-prompt-still-works ()
+  "A `>>> ' REPL prompt with no OSC 133 prompt below still gets `C-a'.
+The directional look-ahead must not suppress the regex on the live
+prompt line (no `ghostel-prompt' property exists after point)."
+  (with-temp-buffer
+    (insert ">>> print(1)")
+    (setq ghostel--prompt-positions nil)
+    (goto-char (point-max))
+    (ghostel-beginning-of-input-or-line)
+    ;; `>>> ' ends at position 5.
+    (should (= (point) 5))))
+
+
 (ert-deftest ghostel-test-local-host-p ()
   "Test local hostname detection."
   (should (ghostel--local-host-p nil))


### PR DESCRIPTION
Two complementary fixes for ghostel-beginning-of-input-or-line:

1. Cap the prompt-prefix scan at 60 columns in ghostel-prompt-regexp.
   Real prompts put their symbol near BOL; a prompt char found deep in
   a line (e.g. the % in a dnf "100%" progress line) is command output,
   not a prompt.  Replace the unbounded [^…]* with [^…]\{0,60\} so the
   fallback regex cannot match past the first 60 columns.

2. Suppress the regex fallback when OSC 133 is active and a real
   ghostel-prompt property exists after point.  On a property-less
   output line that sits above a real prompt the regex is unreliable;
   prefer BOL.  The check is directional (after point only) so inner
   REPLs and tmux/screen prompts — which are the live bottom line with
   no prompt below — are unaffected.

Closes #430