### PR TITLE
Harden flaky native process-lifecycle tests for slow CI

### DIFF
--- a/test/ghostel-compile-test.el
+++ b/test/ghostel-compile-test.el
@@ -1475,7 +1475,11 @@ declare that variable buffer-locally so the live buffer qualifies."
   (skip-unless (and (file-executable-p "/bin/sh")
                     (file-executable-p "/bin/sleep")))
   (let* ((buf-name "*ghostel-test-kill-compilation*")
-         (command "exec /bin/sleep 30")
+         ;; Print a readiness marker, then `exec' sleep so the PTY's
+         ;; foreground process group is the long-lived sleep.  Waiting
+         ;; for the marker before `kill-compilation' avoids racing
+         ;; SIGINT against process startup on a loaded CI host.
+         (command "printf '%s\\n' GHOSTEL_KILL_READY; exec /bin/sleep 30")
          (shell-file-name "/bin/sh")
          (inhibit-message t)
          (save-some-buffers-default-predicate (lambda () nil))
@@ -1487,6 +1491,11 @@ declare that variable buffer-locally so the live buffer qualifies."
         (let ((buf (ghostel-compile--start command buf-name
                                            default-directory)))
           (with-current-buffer buf
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda ()
+               (string-match-p "GHOSTEL_KILL_READY"
+                               (ghostel--copy-all-text ghostel--term))))
             (should (process-live-p ghostel--process))
             ;; The live buffer passes `compilation-buffer-p' — which is
             ;; the gate `kill-compilation' uses.

--- a/test/ghostel-test-helpers.el
+++ b/test/ghostel-test-helpers.el
@@ -91,11 +91,31 @@ even when the ghostel buffer is read-only."
   (ghostel-test--redraw term)
   ghostel--cursor-pos)
 
+(defconst ghostel-test--timeout-scale
+  ;; Gate on a *positive numeric* parse, not mere presence: `getenv'
+  ;; returns "" (non-nil) for a set-but-empty var, and
+  ;; `string-to-number' maps "" and garbage to 0 — which would zero
+  ;; every timeout and fail every wait instantly.  A bad override
+  ;; falls through to the CI/default logic instead.
+  (let* ((env (getenv "GHOSTEL_TEST_TIMEOUT_SCALE"))
+         (n (and env (string-to-number env))))
+    (cond ((and n (> n 0)) n)
+          ((getenv "CI") 4)             ; GitHub Actions et al. set CI=true
+          (t 1)))
+  "Multiplier applied to every polling-wait timeout.
+Heavily-loaded CI runners (`make -jN test-native' spawns a real PTY
+child per test file in parallel) can take far longer than the local
+default to reach a predicate.  The wait helpers early-exit the moment
+their predicate holds, so a larger ceiling costs nothing on a passing
+run; only a genuinely slow startup (or a failing predicate) waits the
+extra time.  Override with the `GHOSTEL_TEST_TIMEOUT_SCALE'
+environment variable (must parse to a positive number).")
+
 (defun ghostel-test--wait-for (proc pred &optional timeout)
   "Poll PROC until PRED returns non-nil, or TIMEOUT seconds (default 5).
 Signal an ERT failure if TIMEOUT is reached or PROC exits before PRED
-succeeds."
-  (let* ((timeout (or timeout 5))
+succeeds.  TIMEOUT is scaled by `ghostel-test--timeout-scale'."
+  (let* ((timeout (* (or timeout 5) ghostel-test--timeout-scale))
          (deadline (+ (float-time) timeout))
          result)
     (while (and (not (setq result (funcall pred)))
@@ -284,8 +304,9 @@ Return the matching payload.  PROCESS and TIMEOUT are passed to
 (defun ghostel-test--wait-until (pred &optional process timeout)
   "Poll until PRED returns non-nil, or TIMEOUT seconds elapse.
 PROCESS, when non-nil, is passed to `accept-process-output' so both
-Emacs PTY and native event output can be drained."
-  (let* ((timeout (or timeout 5))
+Emacs PTY and native event output can be drained.  TIMEOUT is scaled
+by `ghostel-test--timeout-scale'."
+  (let* ((timeout (* (or timeout 5) ghostel-test--timeout-scale))
          (deadline (+ (float-time) timeout))
          result)
     (while (and (not (setq result (funcall pred)))


### PR DESCRIPTION
Three native tests flake on the heavily-loaded GitHub runner, which runs `make -j$(nproc) test-native` — spawning a real PTY child per test file in parallel:

- `ghostel-test-exec-delete-process-kills-sighup-ignoring-child`
- `ghostel-test-exec-kill-buffer-leaves-sighup-ignoring-child-live`
- `ghostel-test-compile-kill-compilation-finds-live-buffer`

Two distinct causes:

### 1. Regression in `kill-compilation-finds-live-buffer`
The readiness handshake added in 36d95106 ("Harden flaky tests") was dropped in 9e8460a6 ("Make ghostel buffers read-only"). Without it, `kill-compilation` (SIGINT) races process startup: the signal can land before `/bin/sh -c "exec /bin/sleep 30"` has exec'd sleep / the PTY foreground process group has settled, so finalize may not happen within the wait. Restore the `GHOSTEL_KILL_READY` marker and wait for it before signalling.

### 2. Tight 5s startup waits under parallel CI load
The two exec SIGHUP tests are logically sound (verified both PTY backends: `kill-buffer` → SIGHUP which the child traps, `delete-process` → SIGKILL), but rely on a hard-coded 5s startup wait. That's too tight under `-j$(nproc)` load, made worse now that the native PTY backend runs them twice via `with-pty-matrix`. The same 5s recurs across osc/exec/spawn/shell/keys native tests.

Fix centrally: add `ghostel-test--timeout-scale` (1 locally, 4 when `CI` is set, overridable via `GHOSTEL_TEST_TIMEOUT_SCALE`) and apply it in `ghostel-test--wait-for` / `ghostel-test--wait-until`. Every polling wait routes through these two, so the whole suite gets headroom in one place. The helpers early-exit on their predicate, so the larger ceiling costs nothing on passing runs. The scale gates on a positive numeric parse, so an empty or malformed override falls through to the CI/default logic instead of zeroing every timeout.

The unscaled fixed-window/negative assertions (`accept-process-output proc 0.2`, etc.) are deliberately left alone — scaling a "nothing should happen within this window" guard would change its meaning.

## Verification
- Three named tests pass locally (scale=1) and under simulated CI (`CI=true`, scale=4), both fast.
- Scale resolution checked across unset / CI / empty / garbage / zero / valid / fractional overrides.
- `make -j8 all` → exit 0, all suites green. The changed helper is a prerequisite of every test stamp, so the full elisp + native suite re-ran under the new code.