### PR TITLE
Respect frame transparency in ghostel buffers

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3463,16 +3463,22 @@ the no-op case.")
 
 (defun ghostel--set-buffer-face (fg bg)
   "Set the buffer's default face to FG foreground and BG background.
-This ensures terminal text is visible regardless of the Emacs theme.
-No-op when FG/BG match the cached values from the previous call."
-  (let ((pair (cons fg bg)))
+This keeps terminal text legible regardless of the Emacs theme.  On a graphical
+frame BG is omitted when it already equals the frame `default' face background,
+so a semi-transparent frame shows through; an explicit BG is applied when
+`ghostel-default' has been customized to a different background.
+No-op when the effective spec is unchanged."
+  (let* ((default-bg (ghostel--face-hex-color 'default :background))
+         (effective-bg (unless (and (display-graphic-p) (equal bg default-bg))
+                         bg))
+         (pair (cons fg effective-bg)))
     (unless (equal pair ghostel--face-cookie-fg-bg)
       (when ghostel--face-cookie
         (face-remap-remove-relative ghostel--face-cookie))
       (setq ghostel--face-cookie
-            (face-remap-add-relative 'default
-                                     :foreground fg
-                                     :background bg))
+            (apply #'face-remap-add-relative 'default
+                   (append (list :foreground fg)
+                           (when effective-bg (list :background effective-bg)))))
       (setq ghostel--face-cookie-fg-bg pair))))
 
 (defun ghostel-buffer-name-by-title (title)

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -295,6 +295,15 @@ fn createCellProps(
     });
     props.bg = style.bg(&cell.raw, &self.render_state.colors.palette) orelse
         self.render_state.colors.background;
+    // Emit fg/bg only when the resolved color differs from the terminal
+    // default, so default cells inherit the buffer's default face and a
+    // transparent frame (`alpha-background') shows through.  Comparing the
+    // resolved color also covers bold remapping: `style.fg` already applies
+    // the bright/fixed bold color, so a bold default-fg cell still differs
+    // from the default and is emitted.  `props.bg` stays resolved even when
+    // unset because the faint dim color needs a concrete background.
+    props.fg_set = !std.meta.eql(props.fg, self.render_state.colors.foreground);
+    props.bg_set = !std.meta.eql(props.bg, self.render_state.colors.background);
     props.bold = style.flags.bold;
     props.italic = style.flags.italic;
     props.faint = style.flags.faint;
@@ -306,10 +315,7 @@ fn createCellProps(
     props.hyperlink = resolveHyperlink(page, key.hyperlink_id);
     props.semantic_content = cell.raw.semantic_content;
 
-    return if (props.isDefault(
-        self.render_state.colors.foreground,
-        self.render_state.colors.background,
-    )) null else props;
+    return if (props.isPlain()) null else props;
 }
 
 /// Apply text properties to a region of the buffer.

--- a/src/style_face.zig
+++ b/src/style_face.zig
@@ -45,10 +45,16 @@ pub const CellProps = struct {
     hyperlink: ?Hyperlink = null,
     semantic_content: gt.page.Cell.SemanticContent = .output,
 
-    /// True if these props match the default style for the given palette
-    /// (no face plist needs to be emitted).
-    pub fn isDefault(self: CellProps, default_fg: gt.color.RGB, default_bg: gt.color.RGB) bool {
-        return std.meta.eql(self, .{ .fg = default_fg, .bg = default_bg });
+    /// True when this run needs no text properties at all: no face
+    /// attributes, no hyperlink, and default (output) semantic content.
+    /// The renderer returns null for such runs so trailing blank cells
+    /// stay trimmable padding.
+    pub fn isPlain(self: CellProps) bool {
+        return !self.fg_set and !self.bg_set and !self.faint and
+            !self.bold and !self.italic and !self.inverse and
+            !self.strikethrough and !self.overline and
+            self.underline == .none and self.hyperlink == null and
+            self.semantic_content == .output;
     }
 };
 

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -646,6 +646,35 @@ new terminal. Regression guard against color flickering."
             (should (equal expected-bg (cadr call)))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-set-buffer-face-omits-matching-background ()
+  "Omit the buffer-face :background when it matches the graphical default.
+On a graphical frame a matching bg is dropped so a semi-transparent frame
+shows through; an explicit background is kept when `ghostel-default'
+differs, and always kept on a non-graphical (TTY) frame so text never ends
+up foreground-only on the terminal's own background."
+  (let ((default-bg (ghostel--face-hex-color 'default :background))
+        (fg (ghostel--face-hex-color 'default :foreground)))
+    ;; Graphical, un-customized: bg matches default → no :background.
+    (with-temp-buffer
+      (cl-letf (((symbol-function 'display-graphic-p) (lambda (&optional _) t)))
+        (ghostel--set-buffer-face fg default-bg))
+      (let ((spec (cadr (assq 'default face-remapping-alist))))
+        (should (equal fg (plist-get spec :foreground)))
+        (should-not (plist-member spec :background))))
+    ;; Graphical, customized to a different bg → explicit :background kept.
+    (with-temp-buffer
+      (let ((custom-bg (if (equal default-bg "#123456") "#654321" "#123456")))
+        (cl-letf (((symbol-function 'display-graphic-p) (lambda (&optional _) t)))
+          (ghostel--set-buffer-face fg custom-bg))
+        (let ((spec (cadr (assq 'default face-remapping-alist))))
+          (should (equal custom-bg (plist-get spec :background))))))
+    ;; Non-graphical (TTY): keep :background even when it matches default.
+    (with-temp-buffer
+      (cl-letf (((symbol-function 'display-graphic-p) (lambda (&optional _) nil)))
+        (ghostel--set-buffer-face fg default-bg))
+      (let ((spec (cadr (assq 'default face-remapping-alist))))
+        (should (equal default-bg (plist-get spec :background)))))))
+
 (ert-deftest ghostel-test-color-palette ()
   "Test setting a custom ANSI color palette via faces."
   :tags '(native)
@@ -2009,6 +2038,60 @@ the bright variant just like in `bright' mode."
             (let ((face (get-text-property (point) 'face)))
               (should (equal "#00ff00" (plist-get face :foreground)))
               (should (eq 'bold (plist-get face :weight))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-render-default-bg-omits-background ()
+  "Default-bg cells carry :foreground but no :background.
+A non-default fg with the default bg lets a transparent frame show
+through; fully default text carries no face at all."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-default-bg*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 40 100))
+                 (inhibit-read-only t))
+            (ghostel--write-vt term "\e[31mRED\e[0mX")
+            (ghostel--redraw term)
+            (goto-char (point-min))
+            (let ((face (get-text-property (point) 'face)))
+              (should (plist-get face :foreground))       ; colored fg present
+              (should-not (plist-get face :background)))   ; default bg omitted
+            ;; The trailing default 'X' needs no properties.
+            (should-not (get-text-property (+ (point-min) 3) 'face))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-render-explicit-bg-kept ()
+  "An explicit SGR background (48) is still emitted as :background."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-explicit-bg*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 40 100))
+                 (inhibit-read-only t))
+            (ghostel--write-vt term "\e[48;2;18;52;86mX\e[0m")
+            (ghostel--redraw term)
+            (goto-char (point-min))
+            (let ((face (get-text-property (point) 'face)))
+              (should (equal "#123456" (plist-get face :background))))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-render-inverse-omits-fg-bg ()
+  "Inverse video (7) on a default cell emits :inverse-video with no fg/bg.
+Emacs swaps the default face at display time, so theme colors and frame
+transparency are preserved instead of being baked into the cell."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-inverse*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 40 100))
+                 (inhibit-read-only t))
+            (ghostel--write-vt term "\e[7mINV\e[0m")
+            (ghostel--redraw term)
+            (goto-char (point-min))
+            (let ((face (get-text-property (point) 'face)))
+              (should (eq t (plist-get face :inverse-video)))
+              (should-not (plist-get face :foreground))
+              (should-not (plist-get face :background)))))
       (kill-buffer buf))))
 
 


### PR DESCRIPTION
## Problem

On semi-transparent frames (the GUI `alpha-background` frame parameter), ghostel buffers stayed fully **opaque** while the rest of Emacs showed the desktop through — unlike eat and vterm.

Root cause: Emacs's `alpha-background` only makes the *default face's* background transparent; any text or face with an explicit `:background` (even one whose color equals the frame background) is drawn opaque. Ghostel forced an explicit background in two places:

1. `ghostel--set-buffer-face` remapped the buffer `default` face with an explicit `:background` on every redraw → the whole buffer opaque, even blank cells.
2. The renderer filled every styled run's `:background` with the default color → colored output (e.g. `ls --color`, prompts) painted opaque rectangles.

## Fix

Both now omit the background for default-background content, matching what eat/vterm — and ghostel's own comint filter — already do:

- **`createCellProps`** sets `fg_set`/`bg_set` by comparing the *resolved* color against the terminal default, so default cells emit no fg/bg and a transparent frame shows through. Comparing the resolved color also preserves bold remapping (bright and fixed-color modes).
- **`isPlain`** replaces `isDefault` as the "needs no text properties" predicate, so trailing-blank trimming stays correct once `bg_set` can be `false`.
- **`ghostel--set-buffer-face`** drops `:background` only on a graphical frame when it matches the frame default. A customized `ghostel-default` background still renders opaque (opt-out), and a non-graphical (TTY) frame always keeps the background so text never ends up foreground-only on the terminal's own background.

On opaque frames the rendering is visually identical; explicit SGR backgrounds are always preserved.

## Testing

- `make -j8 all` green (all ERT suites, Zig tests, lint).
- New tests: per-cell default-bg omits `:background`, explicit bg kept, inverse-video emits `:inverse-video` only, and `ghostel--set-buffer-face` omits/keeps bg across graphical-match / custom-bg / TTY cases.
- Live-verified in a real ghostel+shell session: property-level checks plus a GUI pixel comparison on a translucent frame (ghostel region blended into the translucent frame; simulating the old code reproduced a distinct opaque rectangle).