### PR TITLE
Fix launching Bash remotely when shell integration is enabled

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4464,6 +4464,16 @@ run the shell on the remote host."
                                (ghostel--default-remote-shell-args
                                 shell remote-integration)))
                       integration-args))
+         ;; Bash does not recognize multi-character options that come after
+         ;; single-character ones, so move single-character options to the end.
+         (shell-args (if (eq shell-type 'bash)
+                        (cl-loop for arg in shell-args
+                                 if (and (string-prefix-p "-" arg)
+                                         (not (string-prefix-p "--" arg)))
+                                 collect arg into singles
+                                 else collect arg into others
+                                 finally return (append others singles))
+                      shell-args))
          (extra-env (append
                      (unless remote-p
                        (list (format "EMACS_GHOSTEL_PATH=%s" ghostel-dir)))

--- a/test/ghostel-spawn-test.el
+++ b/test/ghostel-spawn-test.el
@@ -245,7 +245,7 @@ A login bash ignores the `--rcfile' the bash integration relies on, so
                (default-directory "/ssh:host:/home/u/"))
           (ghostel--start-process)
           (should (equal "/bin/bash" (car spawn)))
-          (should (equal '("-i" "--rcfile" "/tmp/ghostel.bash") (cdr spawn)))
+          (should (equal '("--rcfile" "/tmp/ghostel.bash" "-i") (cdr spawn)))
           (should-not (member "-l" (cdr spawn))))))))
 
 (ert-deftest ghostel-test-start-process-remote-zsh-integration-login-interactive ()


### PR DESCRIPTION
Attempting to start ghostel for a remote Bash shell over TRAMP with `ghostel-tramp-shell-integration` set to `t` fails with:

```
=== Ghostel Debug Log ===

[14:05:49.706] RESIZE: 116x59 → 116x59 (0.1ms)
[14:05:53.763] RESIZE: 116x59 → 116x59 (0.0ms)
[14:05:55.842] RESIZE: 116x59 → 116x59 (0.1ms)
[14:05:55.901] FILTER: 7 bytes: "[H[2J"
[14:05:55.908] FILTER: 491 bytes: "/bin/bash: --: invalid option
Usage:	/bin/bash [GNU long option] [option] ...
..."
```

The failing command is roughly `/bin/bash -i --rcfile /tmp/ghostel.bash`.

Bash requires all multi-character (long) options come before any single-character options in order to be recognized. This change reorders `shell-args` to ensure that all single-character options are moved to the end. With the fix, the generated Bash command line looks like `/bin/bash --rcfile /tmp/ghostel.bash -i` and Bash launches cleanly.