### PR TITLE
Fix queued link detection in read-only buffers

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2905,11 +2905,13 @@ Skips regions that already have a `help-echo' property (e.g. from OSC 8)
 and the user's active input on the current prompt line.
 Bounding the scan keeps streaming output from re-scanning the entire
 materialized scrollback on every redraw.
-Binds `inhibit-read-only' so the scan can attach text properties even
-when called from the deferred-detection timer outside the redraw scope."
+Binds `inhibit-read-only' and suppresses modification hooks so the scan
+can attach text properties when called from the deferred-detection timer
+outside the redraw scope."
   (let* ((begin (or begin (point-min)))
          (end (or end (point-max)))
          (inhibit-read-only t)
+         (inhibit-modification-hooks t)
          ;; `ghostel--cursor-char-pos' is the live terminal cursor after a redraw;
          ;; its line is the prompt the user is currently editing.  Capture as
          ;; buffer-position bounds so the per-match skip check is O(1).

--- a/test/ghostel-links-test.el
+++ b/test/ghostel-links-test.el
@@ -623,7 +623,26 @@ E.g. `compilation-mode' error loci in `ghostel-compile-view-mode'."
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-detect-urls-allows-read-only-buffers ()
-  "Plain-text link detection should still work in read-only buffers."
+  "Plain-text link detection should still work silently in read-only buffers."
+  (with-temp-buffer
+    (let* ((url "https://example.com")
+           (hook-ran nil))
+      (insert "see " url " here\n")
+      (put-text-property 5 (+ 5 (length url))
+                         'modification-hooks
+                         (list (lambda (&rest _)
+                                 (setq hook-ran t)
+                                 (barf-if-buffer-read-only))))
+      (setq buffer-read-only t)
+      (let ((ghostel-enable-url-detection t)
+            (ghostel-enable-file-detection nil)
+            (ghostel-plain-link-detection-delay 0))
+        (should (eq 'ok
+                    (ignore-errors
+                      (ghostel--queue-plain-link-detection (point-min) (point-max))
+                      'ok)))
+        (should-not hook-ran)
+        (should (equal url (get-text-property 5 'help-echo))))))
   (let* ((root (ghostel--resource-root))
          (test-file (file-relative-name
                      (expand-file-name "lisp/ghostel.el" root)


### PR DESCRIPTION
## Summary
- suppress modification hooks while queued plain-link detection adds link text properties
- add regression coverage for read-only buffers with modification hooks on link spans

## Testing
- `make .build/tests/elisp-ghostel-links-test.ok .build/tests/native-ghostel-links-test.ok`