### PR TITLE
Fix launching remote Bash with shell integration enabled

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -118,6 +118,9 @@ arguments passed to that executable.  For example:
 
   (setq ghostel-shell \\='(\"/bin/zsh\" \"--login\"))
 
+For bash, list long options (e.g. `--rcfile') before single-character
+ones (e.g. `-i'); bash rejects long options that follow short ones.
+
 On macOS, ghostel additionally wraps the shell via `login(1)' by
 default so the shell starts as a login shell (matching Apple's
 Terminal.app and Ghostty), which sources `~/.zprofile' /
@@ -241,7 +244,10 @@ When none are given, ghostel supplies a type-aware default: recognized shells
 source the user's rc/profile files, mirroring an interactive `ssh host' login.
 Unrecognized shells (e.g. /bin/sh) get no args.
 To override, list the arguments explicitly after FALLBACK,
-e.g. (\"ssh\" login-shell nil \"-i\")."
+e.g. (\"ssh\" login-shell nil \"-i\").
+
+For bash, list long options (e.g. `--rcfile') before single-character
+ones (e.g. `-i'); bash rejects long options that follow short ones."
   :type '(alist :key-type (choice string (const t))
                 :value-type
                 (list (choice :tag "Shell" string (const login-shell))
@@ -4434,11 +4440,11 @@ run the shell on the remote host."
          ;; adapts per shell (bash drops `-l' to keep `--rcfile').  Explicit
          ;; per-method args from `ghostel-tramp-shells' override the default.
          (shell-args (append
+                      integration-args
                       (or extra-shell-args
                           (and remote-p
                                (ghostel--default-remote-shell-args
-                                shell remote-integration)))
-                      integration-args))
+                                shell remote-integration)))))
          (extra-env (append
                      (unless remote-p
                        (list (format "EMACS_GHOSTEL_PATH=%s" ghostel-dir)))

--- a/test/ghostel-spawn-test.el
+++ b/test/ghostel-spawn-test.el
@@ -245,7 +245,9 @@ A login bash ignores the `--rcfile' the bash integration relies on, so
                (default-directory "/ssh:host:/home/u/"))
           (ghostel--start-process)
           (should (equal "/bin/bash" (car spawn)))
-          (should (equal '("-i" "--rcfile" "/tmp/ghostel.bash") (cdr spawn)))
+          ;; Bash rejects long options that follow short ones, so the
+          ;; integration's `--rcfile' must precede the `-i' default.
+          (should (equal '("--rcfile" "/tmp/ghostel.bash" "-i") (cdr spawn)))
           (should-not (member "-l" (cdr spawn))))))))
 
 (ert-deftest ghostel-test-start-process-remote-zsh-integration-login-interactive ()
@@ -429,8 +431,8 @@ pushed terminfo dir is needed for the whole session besides."
              (default-directory "/tmp/"))
         (ghostel--start-process)
         (should (equal "/bin/bash" (car spawn)))
-        ;; Extra args precede integration args.
-        (should (equal '("--login" "--posix") (cdr spawn)))))))
+        ;; Integration args precede extra args.
+        (should (equal '("--posix" "--login") (cdr spawn)))))))
 
 (ert-deftest ghostel-test-start-process-darwin-login-wrap-with-integration ()
   "Wrap + list shell + bash integration: all three layers compose correctly."
@@ -450,7 +452,7 @@ pushed terminfo dir is needed for the whole session besides."
           (should (equal "/usr/bin/login" (car spawn)))
           (should (equal '("-flp" "alice"
                            "/bin/bash" "--noprofile" "--norc"
-                           "-c" "exec -l /bin/bash --login --posix")
+                           "-c" "exec -l /bin/bash --posix --login")
                          (cdr spawn))))))))
 
 (ert-deftest ghostel-test-start-process-local-bash-integration-adds-env ()


### PR DESCRIPTION
## Problem

Starting a remote Bash shell over TRAMP with `ghostel-tramp-shell-integration` enabled fails at launch:

```
/bin/bash: --: invalid option
Usage:  /bin/bash [GNU long option] [option] ...
```

ghostel assembled the argv as `/bin/bash -i --rcfile FILE`. Bash requires all multi-character (long) options to come *before* any single-character options, so the long `--rcfile` following the short `-i` is rejected.

This is the same bug as #470; this PR fixes it at the source rather than with a post-hoc argument sort.

## Fix

`shell-args` is built by appending two groups: the login/interactive defaults (`-i`/`-l`) and the integration args (bash's `--rcfile`/`--posix`, fish's `-C`). The fix simply swaps the append order so the integration args lead:

```elisp
(shell-args (append
             integration-args
             (or extra-shell-args
                 (and remote-p
                      (ghostel--default-remote-shell-args
                       shell remote-integration)))))
```

For remote Bash this yields `/bin/bash --rcfile FILE -i`, which launches cleanly. The reorder is:

- **zsh** — a no-op (integration args are always `nil`),
- **fish** — harmless (no long-before-short rule; `-C` stays adjacent to its value),
- **local bash** — harmless (`--posix`/`--login` are order-independent).

User-supplied bash args are not reordered within their own list, so the long-before-short requirement is now documented in the `ghostel-shell` and `ghostel-tramp-shells` docstrings.

## Verification

- `make -j8 all` passes (build + tests + lint).
- Verified live over TRAMP/SSH against a real remote Bash 4.4.20 host: reproduced the `--: invalid option` failure without the change, and confirmed a clean interactive prompt with it.