### PR TITLE
Stabilize CI tool setup

### DIFF
--- a/.github/scripts/install-emacs.sh
+++ b/.github/scripts/install-emacs.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-${EMACS_VERSION:-}}"
+if [[ -z "$version" ]]; then
+  echo "usage: $0 <emacs-version> or set EMACS_VERSION" >&2
+  exit 2
+fi
+
+if [[ -z "${NIX_EMACS_CI_REF:-}" ]]; then
+  echo "NIX_EMACS_CI_REF must name the pinned purcell/nix-emacs-ci revision" >&2
+  exit 2
+fi
+
+attr="emacs-${version//./-}"
+flake_ref="github:purcell/nix-emacs-ci?rev=${NIX_EMACS_CI_REF}#${attr}"
+
+echo "Installing ${attr} from purcell/nix-emacs-ci@${NIX_EMACS_CI_REF}"
+nix profile install --accept-flake-config "$flake_ref"
+emacs --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+env:
+  NIX_EMACS_CI_REF: 868482a78575138aebb1b5c16a9266b95c800f2e
+
 jobs:
   byte-compile:
     runs-on: ubuntu-latest
@@ -17,9 +23,14 @@ jobs:
           - 'snapshot'
     steps:
       - uses: actions/checkout@v4
-      - uses: purcell/setup-emacs@master
+      - uses: cachix/install-nix-action@v31
         with:
-          version: ${{ matrix.emacs_version }}
+          github_access_token: ${{ github.token }}
+
+      - name: Install pinned Emacs
+        env:
+          EMACS_VERSION: ${{ matrix.emacs_version }}
+        run: bash .github/scripts/install-emacs.sh
 
       - name: Install compat
         run: git clone --depth 1 https://github.com/emacs-compat/compat.git /tmp/compat
@@ -34,9 +45,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: purcell/setup-emacs@master
+      - uses: cachix/install-nix-action@v31
         with:
-          version: '29.4'
+          github_access_token: ${{ github.token }}
+
+      - name: Install pinned Emacs
+        env:
+          EMACS_VERSION: '29.4'
+        run: bash .github/scripts/install-emacs.sh
 
       - name: Run package-lint, checkdoc, docquotes
         # `make package-lint' self-provisions its deps (package-lint +
@@ -67,9 +83,14 @@ jobs:
           - 'snapshot'
     steps:
       - uses: actions/checkout@v4
-      - uses: purcell/setup-emacs@master
+      - uses: cachix/install-nix-action@v31
         with:
-          version: ${{ matrix.emacs_version }}
+          github_access_token: ${{ github.token }}
+
+      - name: Install pinned Emacs
+        env:
+          EMACS_VERSION: ${{ matrix.emacs_version }}
+        run: bash .github/scripts/install-emacs.sh
 
       - name: Install fish
         run: sudo apt-get install -y fish
@@ -93,9 +114,14 @@ jobs:
           - 'snapshot'
     steps:
       - uses: actions/checkout@v4
-      - uses: purcell/setup-emacs@master
+      - uses: cachix/install-nix-action@v31
         with:
-          version: ${{ matrix.emacs_version }}
+          github_access_token: ${{ github.token }}
+
+      - name: Install pinned Emacs
+        env:
+          EMACS_VERSION: ${{ matrix.emacs_version }}
+        run: bash .github/scripts/install-emacs.sh
 
       - name: Install evil
         run: |
@@ -119,10 +145,10 @@ jobs:
           - os: ubuntu-latest
             platform: x86_64-linux
             suffix: .so
-          - os: macos-latest
+          - os: macos-26
             platform: aarch64-macos
             suffix: .dylib
-          - os: macos-latest
+          - os: macos-26
             platform: x86_64-macos
             suffix: .dylib
             target: x86_64-macos
@@ -142,6 +168,7 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          cache-key: ${{ matrix.platform }}-zig-0.15.2
 
       - name: Build native module
         run: |
@@ -173,20 +200,25 @@ jobs:
             platform: x86_64-linux
             suffix: .so
             emacs_version: 'snapshot'
-          - os: macos-latest
+          - os: macos-26
             platform: aarch64-macos
             suffix: .dylib
             emacs_version: '29.4'
-          - os: macos-latest
+          - os: macos-26
             platform: aarch64-macos
             suffix: .dylib
             emacs_version: 'snapshot'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: purcell/setup-emacs@master
+      - uses: cachix/install-nix-action@v31
         with:
-          version: ${{ matrix.emacs_version }}
+          github_access_token: ${{ github.token }}
+
+      - name: Install pinned Emacs
+        env:
+          EMACS_VERSION: ${{ matrix.emacs_version }}
+        run: bash .github/scripts/install-emacs.sh
 
       - name: Install zsh and fish
         if: runner.os == 'Linux'
@@ -218,9 +250,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: purcell/setup-emacs@master
+      - uses: cachix/install-nix-action@v31
         with:
-          version: '29.4'
+          github_access_token: ${{ github.token }}
+
+      - name: Install pinned Emacs
+        env:
+          EMACS_VERSION: '29.4'
+        run: bash .github/scripts/install-emacs.sh
 
       - name: Download native module
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Select Xcode 26.3 for Zig 0.15.2
+        if: runner.os == 'macOS'
+        run: |
+          sudo xcode-select --switch /Applications/Xcode_26.3.app/Contents/Developer
+          xcodebuild -version
+          xcrun --sdk macosx --show-sdk-path
+
       - name: Install Zig
         uses: mlugg/setup-zig@v2
         with:


### PR DESCRIPTION
## Summary
- install Emacs via a pinned purcell/nix-emacs-ci flake revision instead of resolving HEAD in every job
- install Nix explicitly with the GitHub token available to reduce GitHub API throttling
- pin macOS jobs to macos-26 and use platform-specific Zig cache keys

## Verification
- Ruby YAML parse for .github/workflows/ci.yml
- bash -n .github/scripts/install-emacs.sh
- git diff --check

Note: local sandbox blocks network, so the pinned flake fetch is left to CI.