### PR TITLE
Stabilize Emacs PTY echo test

### DIFF
--- a/test/ghostel-spawn-test.el
+++ b/test/ghostel-spawn-test.el
@@ -491,7 +491,8 @@ former defaulted to t and throttled bursty TUI redraws."
   "The Emacs PTY path enables input echo before PROGRAM reads."
   :tags '(native)
   (skip-unless (file-executable-p "/bin/sh"))
-  (let ((ghostel-use-native-pty nil))
+  (let ((ghostel-use-native-pty nil)
+        (ghostel-kill-buffer-on-exit nil))
     (ghostel-test--with-terminal-buffer (buf term 8 80 200)
       (let ((proc (ghostel--spawn-pty
                    "/bin/sh"


### PR DESCRIPTION
## Summary
- keep the Emacs PTY echo test buffer alive after the short-lived child exits
- avoids racing process-exit cleanup before the final echoed token assertion

## Verification
- `emacs --batch -Q -L lisp -L test -l ert -l test/ghostel-test-helpers.el -l test/ghostel-spawn-test.el --eval "(ert-run-tests-batch-and-exit 'ghostel-test-spawn-emacs-pty-enables-input-echo)"`
- 100 repeated targeted runs of the same test
- `HOME=/private/tmp EVIL_DIR=/Users/emilsahlen/.cache/evil make .build/tests/native-ghostel-spawn-test.ok`
- `git diff --check`