### PR TITLE
evil-ghostel: anchor-inhibit hook so point can roam over an animated terminal (#454)

### DIFF
--- a/README.org
+++ b/README.org
@@ -1212,6 +1212,7 @@ tables below group them by area; defaults shown are the out-of-the-box values.
 | =ghostel-adaptive-fps=              | =t=       | Adaptive frame rate (shorter delay after idle, stop timer when idle).                                                                |
 | =ghostel-immediate-redraw-interval= | =0.05=    | Max seconds since last keystroke for immediate redraw.                                                                               |
 | =ghostel-inhibit-redraw-functions=  | =nil=     | Abnormal hook (each fn called with the buffer); if any returns non-nil the redraw is deferred.  Used by add-ons such as =ghostel-ime=. |
+| =ghostel-inhibit-anchor-functions=  | =nil=     | Abnormal hook (each fn called with WINDOW and FORCE); non-nil skips anchoring that window.  Used by add-ons such as =evil-ghostel=.    |
 | =ghostel-cell-pixel-scale=          | =auto=    | Physical:logical pixel ratio for cell-size reporting (=auto= derives from DPI).                                                        |
 | =ghostel-glyph-scale-floor=         | =0.0=     | Minimum scale for glyphs that don't fit the cell (=0.0= preserves grid alignment; =1.0= renders CJK at natural size).                    |
 

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -150,7 +150,12 @@ ORIG-FN is the advised function (TERM, FULL).  Skipped in alt-screen (1049)."
              (saved-ve (and visual-p (bound-and-true-p evil-visual-end)
                             (marker-position evil-visual-end))))
         (funcall orig-fn term full)
-        (when (memq evil-state '(insert emacs))
+        ;; Don't drag point to the cursor while the user reads scrollback;
+        ;; redisplay would yank the viewport back to the bottom each frame.
+        ;; (No window showing the buffer → treat as following.)
+        (when (and (memq evil-state '(insert emacs))
+                   (let ((win (get-buffer-window (current-buffer) t)))
+                     (or (null win) (ghostel--window-anchored-p win))))
           (evil-ghostel--reset-cursor-point))
         (when visual-p
           (let ((pmax (point-max)))

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -670,7 +670,7 @@ unless at end-of-input, where a right arrow would accept a suggestion."
 (defun evil-ghostel-paste-after (&optional count register yank-handler)
   "Paste after the cursor via bracketed paste COUNT times from REGISTER.
 YANK-HANDLER is used by Evil outside live terminal input.  Covers p."
-  (interactive "*P")
+  (interactive "P")
   (if (evil-ghostel--active-p)
       (evil-ghostel--do-paste count register t)
     (evil-paste-after count register yank-handler)))
@@ -678,7 +678,7 @@ YANK-HANDLER is used by Evil outside live terminal input.  Covers p."
 (defun evil-ghostel-paste-before (&optional count register yank-handler)
   "Paste before the cursor via bracketed paste COUNT times from REGISTER.
 YANK-HANDLER is used by Evil outside live terminal input.  Covers P."
-  (interactive "*P")
+  (interactive "P")
   (if (evil-ghostel--active-p)
       (evil-ghostel--do-paste count register nil)
     (evil-paste-before count register yank-handler)))

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -160,6 +160,16 @@ ORIG-FN is the advised function (TERM, FULL).  Skipped in alt-screen (1049)."
               (set-marker evil-visual-end (min saved-ve pmax))))))
     (funcall orig-fn term full)))
 
+(defun evil-ghostel--anchor-inhibit (_window force)
+  "Veto ghostel's redraw anchor while point roams off the live cursor.
+A `ghostel-inhibit-anchor-functions' entry: returns non-nil in a motion-capable
+evil state with point off the cursor, unless FORCE."
+  (and (not force)
+       (evil-ghostel--active-p)
+       (memq evil-state '(normal visual operator motion))
+       ghostel--cursor-char-pos
+       (/= (point) ghostel--cursor-char-pos)))
+
 ;; Cursor style: let evil control cursor shape
 
 (defun evil-ghostel--override-cursor-style (orig-fn)
@@ -868,6 +878,10 @@ Enabling installs global advice while any buffer has the mode enabled."
         ;; states expect point to follow the terminal cursor.
         (add-hook 'evil-emacs-state-entry-hook
                   #'evil-ghostel--insert-state-entry nil t)
+        ;; Let normal/visual/operator/motion-state navigation roam point off
+        ;; the live cursor without the per-redraw anchor snapping it back.
+        (add-hook 'ghostel-inhibit-anchor-functions
+                  #'evil-ghostel--anchor-inhibit nil t)
         (advice-add 'ghostel--redraw :around #'evil-ghostel--around-redraw)
         (advice-add 'ghostel--apply-cursor-style :around
                     #'evil-ghostel--override-cursor-style)
@@ -876,6 +890,8 @@ Enabling installs global advice while any buffer has the mode enabled."
                  #'evil-ghostel--insert-state-entry t)
     (remove-hook 'evil-emacs-state-entry-hook
                  #'evil-ghostel--insert-state-entry t)
+    (remove-hook 'ghostel-inhibit-anchor-functions
+                 #'evil-ghostel--anchor-inhibit t)
     (kill-local-variable 'ghostel-mark-activation-input-mode)
     (unless (evil-ghostel--any-active-elsewhere-p (current-buffer))
       (advice-remove 'ghostel--redraw #'evil-ghostel--around-redraw)

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -325,6 +325,16 @@ buffer during transient states such as Emacs Lisp input-method
 composition."
   :type 'hook)
 
+(defcustom ghostel-inhibit-anchor-functions nil
+  "Abnormal hook to veto per-window anchoring after a redraw.
+Each function is called with (WINDOW FORCE), WINDOW's buffer current.
+A non-nil return skips anchoring WINDOW for this redraw - neither the
+viewport nor point moves - letting point roam off the live cursor while
+the buffer stays in a follow-capable input mode (e.g. evil normal-state
+motion over an animated terminal).  Honor FORCE (deliberate paste/yank
+and mode-switch anchors) by returning nil when it is set."
+  :type 'hook)
+
 (defcustom ghostel-adaptive-fps t
   "Use adaptive frame rate for terminal redraw.
 When non-nil, use a shorter initial delay for responsive interactive
@@ -2338,9 +2348,10 @@ Most keys are sent to the terminal; keys in
     (setq ghostel--mode-line-tag nil)
     (ghostel--mode-line-refresh)
     (when ghostel--term
-      ;; Snap the window to the live viewport so the user lands back
-      ;; at the prompt after exiting copy/emacs/line.
-      (ghostel--anchor-window)
+      ;; Snap the window to the live viewport so the user lands back at the
+      ;; prompt after exiting copy/emacs/line.  FORCE so a deliberate switch
+      ;; wins over any `ghostel-inhibit-anchor-functions' roaming veto.
+      (ghostel--anchor-window nil t)
       (setq ghostel--force-next-redraw t)
       (goto-char (point-max))
       (ghostel--invalidate))))
@@ -2369,7 +2380,8 @@ Even keys listed in `ghostel-keymap-exceptions' (\\`C-c', \\`C-x',
     (setq ghostel--mode-line-tag (ghostel--mode-line-tag-make 'char ":Char"))
     (ghostel--mode-line-refresh)
     (when ghostel--term
-      (ghostel--anchor-window)
+      ;; FORCE: a deliberate switch wins over any roaming veto.
+      (ghostel--anchor-window nil t)
       (setq ghostel--force-next-redraw t)
       (goto-char (point-max))
       (ghostel--invalidate))
@@ -4599,6 +4611,7 @@ the bottom of WINDOW."
 In graphical frames, use Emacs's pixel layout for exact bottom alignment.
 In text frames, use line-count geometry with no vscroll.
 Do nothing unless WINDOW displays a live Ghostel terminal.
+A `ghostel-inhibit-anchor-functions' hook can veto anchoring a window.
 
 Copy mode is never anchored (the viewport is frozen).  Emacs mode is
 anchored only when FORCE is non-nil, reserved for deliberate anchors such
@@ -4613,7 +4626,12 @@ user's point, since its input region is user-owned."
                  (and (derived-mode-p 'ghostel-mode)
                       (if (eq ghostel--input-mode 'emacs)
                           force
-                        (ghostel--terminal-live-p))))))
+                        (ghostel--terminal-live-p))
+                      ;; Per-window veto: a consumer (e.g. evil-ghostel) can
+                      ;; keep point roaming off the live cursor while the
+                      ;; buffer stays in a follow-capable input mode.
+                      (not (run-hook-with-args-until-success
+                            'ghostel-inhibit-anchor-functions window force))))))
     (with-selected-window window
       (with-current-buffer buffer
         (let ((target (point-max))

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -1255,6 +1255,24 @@ line)."
          (evil-ghostel-paste-after 1))
        (should (equal "world" pasted))))))
 
+(ert-deftest evil-ghostel-test-paste-interactive-on-read-only ()
+  "Interactive p/P does not trip the read-only guard — paste goes via the PTY.
+Regression: `(interactive \"*P\")' barfed on the read-only ghostel buffer
+before the body ran, even though the live-terminal path writes nothing to it.
+`active-p' is stubbed so the test isolates the interactive spec, not the
+live-terminal detection."
+  (evil-ghostel-test--with-evil-buffer
+   (setq buffer-read-only t)
+   (let (pasted)
+     (cl-letf (((symbol-function 'evil-ghostel--active-p) (lambda () t))
+               ((symbol-function 'evil-ghostel--do-paste)
+                (lambda (&rest _) (setq pasted t))))
+       (call-interactively #'evil-ghostel-paste-after)
+       (should pasted)
+       (setq pasted nil)
+       (call-interactively #'evil-ghostel-paste-before)
+       (should pasted)))))
+
 ;; -----------------------------------------------------------------------
 ;; Test: insert-state Ctrl key passthrough
 ;; -----------------------------------------------------------------------

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -84,6 +84,8 @@ literal key."
    (should evil-ghostel-mode)
    (should (memq 'evil-ghostel--insert-state-entry
                  evil-insert-state-entry-hook))
+   (should (memq 'evil-ghostel--anchor-inhibit
+                 ghostel-inhibit-anchor-functions))
    (should (advice--p (advice--symbol-function 'ghostel--redraw)))
    (should (advice--p (advice--symbol-function 'ghostel--apply-cursor-style)))
    ;; Editing operators are bound via [remap evil-FOO] in normal state.
@@ -323,6 +325,40 @@ advice must not restore point or visual markers there."
      (evil-ghostel--around-redraw (symbol-function 'ghostel--redraw) nil))
    ;; Advice bypassed → the mock's point placement (point-min) wins.
    (should (= (point-min) (point)))))
+
+(ert-deftest evil-ghostel-test-anchor-inhibit-predicate ()
+  "`evil-ghostel--anchor-inhibit' vetoes only when roaming off the cursor.
+Fires only where evil-ghostel drives PTY input (`evil-ghostel--active-p':
+semi-char, outside alt-screen).  There: non-nil in a motion-capable state with
+point off the live cursor and no FORCE; nil on the cursor, under FORCE, or in
+insert state.  Inert (never vetoes) when not active, e.g. in alt-screen."
+  (evil-ghostel-test--with-evil-buffer
+   (insert "one\ntwo\nthree\n$ ")
+   (setq-local ghostel--term 'fake)
+   (setq-local ghostel--cursor-char-pos (point))
+   (let ((off (point-min)))
+     ;; Active: semi-char input mode, not alt-screen.
+     (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                (lambda (&rest _) nil)))
+       (let ((evil-state 'normal))
+         ;; Normal state, point off the cursor: veto, unless FORCE.
+         (goto-char off)
+         (should (evil-ghostel--anchor-inhibit nil nil))
+         (should-not (evil-ghostel--anchor-inhibit nil t))
+         ;; Point back on the live cursor: no veto.
+         (goto-char ghostel--cursor-char-pos)
+         (should-not (evil-ghostel--anchor-inhibit nil nil)))
+       ;; Insert state roams point off the cursor but still follows: no veto.
+       (let ((evil-state 'insert))
+         (goto-char off)
+         (should-not (evil-ghostel--anchor-inhibit nil nil))))
+     ;; Not active (alt-screen): ghostel owns the anchor, never vetoed even
+     ;; while roaming off the cursor in a motion state.
+     (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                (lambda (&rest _) t)))
+       (let ((evil-state 'normal))
+         (goto-char off)
+         (should-not (evil-ghostel--anchor-inhibit nil nil)))))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: reset-cursor-point

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -326,6 +326,55 @@ advice must not restore point or visual markers there."
    ;; Advice bypassed → the mock's point placement (point-min) wins.
    (should (= (point-min) (point)))))
 
+(ert-deftest evil-ghostel-test-around-redraw-keeps-point-in-scrollback ()
+  "Insert-state redraw keeps point put while reading scrollback (seam 2).
+When the window has scrolled off the live output, `evil-ghostel--around-redraw'
+must not drag point to the terminal cursor; when the window follows the bottom,
+it still snaps point to the cursor."
+  (let ((buf (generate-new-buffer " *evil-ghostel-test-seam2*"))
+        (previous-buffer (window-buffer (selected-window))))
+    (unwind-protect
+        (progn
+          (set-window-buffer (selected-window) buf)
+          (with-current-buffer buf
+            (ghostel-mode)
+            (evil-local-mode 1)
+            (evil-ghostel-mode 1)
+            (let ((rows (max 1 (window-body-height))))
+              (setq-local ghostel--term 'fake
+                          ghostel--term-rows rows)
+              (let ((inhibit-read-only t))
+                (dotimes (i (+ rows 20))
+                  (insert (format "row-%02d\n" i)))
+                (insert "$ ")))
+            (setq ghostel--cursor-char-pos (point))
+            ;; Viewport-relative cursor: last row, column past the prompt.
+            (setq ghostel--cursor-pos (cons (current-column) (1- ghostel--term-rows)))
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (&rest _) nil)))
+              ;; Bind `evil-state' directly: entering insert via
+              ;; `evil-insert-state' would fire entry hooks that touch the
+              ;; (fake) native term.
+              (let ((win (selected-window))
+                    (evil-state 'insert))
+                ;; Scrolled into scrollback: point must stay put.
+                (goto-char (point-min))
+                (set-window-start win (point-min) t)
+                (should-not (ghostel--window-anchored-p win))
+                (evil-ghostel--around-redraw #'ignore 'fake)
+                (should (= (point) (point-min)))
+                ;; Following the bottom: point snaps to the live cursor.
+                (goto-char (point-max))
+                (ghostel--anchor-window win)
+                (should (ghostel--window-anchored-p win))
+                (goto-char (point-min))
+                (evil-ghostel--around-redraw #'ignore 'fake)
+                (should (/= (point) (point-min)))))))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf (evil-ghostel-mode -1)))
+      (set-window-buffer (selected-window) previous-buffer)
+      (kill-buffer buf))))
+
 (ert-deftest evil-ghostel-test-anchor-inhibit-predicate ()
   "`evil-ghostel--anchor-inhibit' vetoes only when roaming off the cursor.
 Fires only where evil-ghostel drives PTY input (`evil-ghostel--active-p':

--- a/test/ghostel-scroll-test.el
+++ b/test/ghostel-scroll-test.el
@@ -617,5 +617,48 @@ rows in the viewport — with or without the trailing newline."
         (should (equal "hello" sent-text))
         (should (> (window-start) (point-min))))))
 
+(ert-deftest ghostel-test-anchor-window-inhibit-functions-veto ()
+  "`ghostel-inhibit-anchor-functions' vetoes anchoring per window.
+A non-nil-returning hook (honoring FORCE) leaves both point and the viewport
+put in semi-char mode, where the anchor would otherwise snap point to the live
+cursor and scroll to the bottom.  FORCE bypasses the veto."
+  (let ((buf (generate-new-buffer " *ghostel-test-anchor-inhibit*"))
+        (previous-buffer (window-buffer (selected-window))))
+    (unwind-protect
+        (progn
+          (set-window-buffer (selected-window) buf)
+          (with-current-buffer buf
+            (ghostel-mode)
+            (setq ghostel--term 'fake)
+            ;; Scrollback above the prompt so a bottom-anchor is observable.
+            (let ((rows (max 1 (window-body-height))))
+              (ghostel-test--with-rendered-output
+                (dotimes (i (+ rows 20))
+                  (insert (format "row-%02d\n" i)))))
+            ;; Prompt on the cursor's row; terminal cursor right after it.
+            (ghostel-test--insert-rendered "$ ")
+            (setq ghostel--cursor-char-pos (point))
+            (setq ghostel--cursor-pos (cons (current-column) 0))
+            (should (eq ghostel--input-mode 'semi-char))
+            (let* ((win (selected-window))
+                   ;; Park point up in the scrollback, off the live cursor.
+                   (parked (point-min))
+                   ;; Stub mirrors evil-ghostel: veto unless FORCE.
+                   (ghostel-inhibit-anchor-functions
+                    (list (lambda (_window force) (not force)))))
+              ;; Vetoed: neither point nor the viewport moves.
+              (goto-char parked)
+              (set-window-point win parked)
+              (set-window-start win (point-min) t)
+              (ghostel--anchor-window win)
+              (should (= (window-point win) parked))
+              (should (= (window-start win) (point-min)))
+              ;; FORCE bypasses the veto: point snaps, viewport scrolls.
+              (ghostel--anchor-window win t)
+              (should (= (window-point win) ghostel--cursor-char-pos))
+              (should (> (window-start win) (point-min))))))
+      (set-window-buffer (selected-window) previous-buffer)
+      (kill-buffer buf))))
+
 (provide 'ghostel-scroll-test)
 ;;; ghostel-scroll-test.el ends here


### PR DESCRIPTION
## Summary

Resolves #454. Under evil + an animated (~30 fps) terminal, ghostel's per-redraw
viewport anchor snapped point to the live terminal cursor on every frame, fighting
two interactions:

- **Normal-state roaming** — `hjkl` motion off the live cursor was yanked back ~30×/sec.
- **Insert-state scrollback** — a wheel-scroll into scrollback was immediately re-anchored to the bottom.

## Changes

**Core (`ghostel.el`)**
- New `ghostel-anchor-inhibit-functions` abnormal hook (mirrors `ghostel-inhibit-redraw-functions`): a non-nil return from any function skips anchoring that window — neither viewport nor point moves — for the redraw. FORCE anchors (paste/yank, mode switches) still win. This is the blessed extension point asked for in the issue, replacing the brittle `define-advice` workaround.
- The deliberate `ghostel-semi-char-mode` / `ghostel-char-mode` anchors now pass FORCE, so an explicit mode switch always snaps back to the prompt even mid-roam.

**evil-ghostel**
- Registers a buffer-local predicate (`evil-ghostel--anchor-inhibit`) that vetoes the anchor while point roams off the cursor in a motion-capable evil state, scoped to where evil-ghostel drives PTY input (`evil-ghostel--active-p`: semi-char, outside alt-screen) — so line/copy/emacs/alt-screen keep ghostel's own anchor handling.
- Insert/emacs-state point-follow in `evil-ghostel--around-redraw` now only re-syncs to the live cursor while the window still tracks live output, so scrolling into scrollback sticks instead of being yanked back every frame.
- Drops the read-only guard (`*`) on `p`/`P`: paste is sent over the PTY and writes nothing to the read-only buffer, so the guard wrongly errored "Buffer is read-only" in the common semi-char case (separate pre-existing bug found while testing; the fall-through to `evil-paste-*` still fails on its own when not driving the terminal).

## Testing

- Unit tests: hook veto + FORCE bypass, the predicate's truth table incl. the active-p/alt-screen scoping, the insert-state scrollback gate, and interactive `p`/`P` on a read-only buffer (the existing paste test called the command directly and missed the interactive `*` barf).
- Live-verified in a sandboxed evil + ghostel + fish session: normal-state roaming holds while an animated counter runs, auto-follow resumes on return to insert/cursor, insert-state scroll-into-scrollback sticks, and a mode switch snaps back to the prompt. Plus a general evil-ghostel regression sweep (operators, motions, insert/append, paste, undo, visual, escape/alt-screen routing, copy/emacs mode) — no regressions.
- `make all` green.
