### PR TITLE
Add GUI xctrace benchmark runner

### DIFF
--- a/bench/ghostel-bench.el
+++ b/bench/ghostel-bench.el
@@ -1263,14 +1263,10 @@ backend-include flags do not apply."
     "backend/plain/emacs"
     "backend/mixed/native"
     "backend/mixed/emacs"
-    "tui-frame/ghostel-incr/24x80"
-    "tui-frame/ghostel-full/24x80"
-    "tui-frame/ghostel-incr/40x120"
-    "tui-frame/ghostel-full/40x120"
-    "tui-partial/ghostel-incr/24x80"
-    "tui-partial/ghostel-full/24x80"
-    "tui-partial/ghostel-incr/40x120"
-    "tui-partial/ghostel-full/40x120"
+    "tui-frame/24x80"
+    "tui-frame/40x120"
+    "tui-partial/24x80"
+    "tui-partial/40x120"
     "e2e/plain/ghostel"
     "e2e/plain/ghostel-nodetect"
     "e2e/plain/vterm"
@@ -1354,20 +1350,12 @@ backend-include flags do not apply."
     (cons (string-to-number (car parts))
           (string-to-number (cadr parts)))))
 
-(defun ghostel-bench--case-full-redraw-p (backend)
-  "Return whether BACKEND names a full-redraw ghostel benchmark."
-  (cond
-   ((string= backend "ghostel-incr") nil)
-   ((string= backend "ghostel-full") t)
-   (t (error "Unsupported renderer benchmark backend: %s" backend))))
-
-(defun ghostel-bench--run-one-tui-frame (backend size)
-  "Run one TUI full-frame renderer benchmark for BACKEND and SIZE."
+(defun ghostel-bench--run-one-tui-frame (size)
+  "Run one TUI full-frame renderer benchmark for SIZE."
   (require 'ghostel)
   (let* ((dims (ghostel-bench--parse-size size))
          (rows (car dims))
          (cols (cdr dims))
-         (full (ghostel-bench--case-full-redraw-p backend))
          (raw-frame (ghostel-bench--gen-tui-frame rows cols))
          (frame (ghostel-bench--encode-for-backend raw-frame 'ghostel)))
     (message "\n--- TUI Frame Rendering (single case) ---")
@@ -1380,20 +1368,19 @@ backend-include flags do not apply."
            (inhibit-read-only t))
        (let ((result
               (ghostel-bench--measure
-               (format "tui-frame/%s/%s" backend size)
+               (format "tui-frame/%s" size)
                (string-bytes frame) ghostel-bench-iterations
                (lambda ()
                  (ghostel--write-vt term frame)
-                 (ghostel--redraw term full)))))
+                 (ghostel--redraw term nil)))))
          (message "    ^ %.0f fps" (/ 1000.0 (plist-get result :per-iter-ms))))))))
 
-(defun ghostel-bench--run-one-tui-partial (backend size)
-  "Run one TUI partial-update renderer benchmark for BACKEND and SIZE."
+(defun ghostel-bench--run-one-tui-partial (size)
+  "Run one TUI partial-update renderer benchmark for SIZE."
   (require 'ghostel)
   (let* ((dims (ghostel-bench--parse-size size))
          (rows (car dims))
          (cols (cdr dims))
-         (full (ghostel-bench--case-full-redraw-p backend))
          (static-frame (ghostel-bench--gen-tui-frame rows cols))
          (static (ghostel-bench--encode-for-backend static-frame 'ghostel))
          (status-template (format "\e[%d;1H\e[1;33;41m%%-%ds\e[0m" rows cols)))
@@ -1407,16 +1394,16 @@ backend-include flags do not apply."
            (inhibit-read-only t)
            (counter 0))
        (ghostel--write-vt term static)
-       (ghostel--redraw term t)
+       (ghostel--redraw term nil)
        (let ((result
               (ghostel-bench--measure
-               (format "tui-partial/%s/%s" backend size)
+               (format "tui-partial/%s" size)
                cols ghostel-bench-iterations
                (lambda ()
                  (cl-incf counter)
                  (ghostel--write-vt
                   term (format status-template (format "status #%d" counter)))
-                 (ghostel--redraw term full)))))
+                 (ghostel--redraw term nil)))))
          (message "    ^ %.0f fps" (/ 1000.0 (plist-get result :per-iter-ms))))))))
 
 (defun ghostel-bench--run-one-typing (backend)
@@ -1452,11 +1439,11 @@ Use `ghostel-bench-list-cases' to list valid case names."
     (`("backend" ,shape ,backend)
      (ghostel-bench--run-one-backend shape backend)
      (ghostel-bench--print-summary))
-    (`("tui-frame" ,backend ,size)
-     (ghostel-bench--run-one-tui-frame backend size)
+    (`("tui-frame" ,size)
+     (ghostel-bench--run-one-tui-frame size)
      (ghostel-bench--print-summary))
-    (`("tui-partial" ,backend ,size)
-     (ghostel-bench--run-one-tui-partial backend size)
+    (`("tui-partial" ,size)
+     (ghostel-bench--run-one-tui-partial size)
      (ghostel-bench--print-summary))
     (`("typing" ,backend)
      (ghostel-bench--run-one-typing backend))

--- a/bench/ghostel-bench.el
+++ b/bench/ghostel-bench.el
@@ -61,12 +61,29 @@ Always available since term is built into Emacs.")
 (defvar ghostel-bench-chunk-size 4096
   "Chunk size for streaming benchmarks.")
 
+(defvar ghostel-bench-force-gui-redisplay nil
+  "When non-nil, force Emacs redisplay after each measured iteration.
+This is intended for GUI profiling runs where the trace should include
+window redisplay/font/rendering work, not only terminal parsing and buffer
+mutation.")
+
+(defvar ghostel-bench-min-duration 0.5
+  "Minimum target duration in seconds for very fast benchmark cases.
+When the warmup trial shows a case is too fast to time reliably,
+`ghostel-bench--measure' raises the iteration count to target at least
+this many seconds.  Explicit `ghostel-bench-iterations' remains a floor.")
+
 ;; ---------------------------------------------------------------------------
 ;; Results accumulator
 ;; ---------------------------------------------------------------------------
 
 (defvar ghostel-bench--results nil
   "List of result plists from benchmark runs.")
+
+(defun ghostel-bench--maybe-redisplay ()
+  "Force redisplay when `ghostel-bench-force-gui-redisplay' is non-nil."
+  (when ghostel-bench-force-gui-redisplay
+    (redisplay t)))
 
 ;; ---------------------------------------------------------------------------
 ;; Data generators
@@ -216,22 +233,34 @@ Automatically increases iterations if the operation is too fast
 for reliable measurement."
   (garbage-collect)
   (funcall body-fn)  ; warm up
+  (ghostel-bench--maybe-redisplay)
   (garbage-collect)
   (let ((actual-iters iterations))
-    ;; Auto-scale fast operations
-    (let ((trial-start (float-time)))
-      (dotimes (_ (min 3 iterations))
-        (funcall body-fn))
+    ;; Auto-scale fast operations.
+    (let* ((trial-iters (min 3 iterations))
+           (trial-start (float-time)))
+      (dotimes (_ trial-iters)
+        (funcall body-fn)
+        (ghostel-bench--maybe-redisplay))
       (let ((trial-time (- (float-time) trial-start)))
-        (when (< trial-time 0.01)
-          (setq actual-iters (max iterations
-                                  (* 10 (ceiling (/ 0.5 (max trial-time 1e-6)))))))))
+        (when (< trial-time ghostel-bench-min-duration)
+          (setq actual-iters
+                (max iterations
+                     (ceiling (/ (* ghostel-bench-min-duration trial-iters)
+                                 (max trial-time 1e-6))))))))
     (garbage-collect)
-    (let ((start (float-time)))
-      (dotimes (_ actual-iters)
-        (funcall body-fn))
-      (let* ((elapsed (- (float-time) start))
-             (per-iter (/ elapsed actual-iters))
+    (let ((start (float-time))
+          (done-iters 0)
+          (elapsed 0.0))
+      (while (or (< done-iters actual-iters)
+                 (and (> ghostel-bench-min-duration 0)
+                      (< elapsed ghostel-bench-min-duration)))
+        (funcall body-fn)
+        (ghostel-bench--maybe-redisplay)
+        (cl-incf done-iters)
+        (setq elapsed (- (float-time) start)))
+      (setq actual-iters done-iters)
+      (let* ((per-iter (/ elapsed actual-iters))
              (throughput (if (> elapsed 0)
                              (/ (* data-size actual-iters) elapsed (expt 1024.0 2))
                            0.0))
@@ -1228,6 +1257,210 @@ backend-include flags do not apply."
   (ghostel-bench--print-header)
   (ghostel-bench--run-backend-scenarios)
   (ghostel-bench--print-summary))
+
+(defconst ghostel-bench-cases
+  '("backend/plain/native"
+    "backend/plain/emacs"
+    "backend/mixed/native"
+    "backend/mixed/emacs"
+    "tui-frame/ghostel-incr/24x80"
+    "tui-frame/ghostel-full/24x80"
+    "tui-frame/ghostel-incr/40x120"
+    "tui-frame/ghostel-full/40x120"
+    "tui-partial/ghostel-incr/24x80"
+    "tui-partial/ghostel-full/24x80"
+    "tui-partial/ghostel-incr/40x120"
+    "tui-partial/ghostel-full/40x120"
+    "e2e/plain/ghostel"
+    "e2e/plain/ghostel-nodetect"
+    "e2e/plain/vterm"
+    "e2e/plain/eat"
+    "e2e/plain/term"
+    "e2e/urls/ghostel"
+    "e2e/urls/ghostel-nodetect"
+    "e2e/urls/vterm"
+    "e2e/urls/eat"
+    "e2e/urls/term"
+    "e2e/mixed/ghostel"
+    "e2e/mixed/ghostel-nodetect"
+    "e2e/mixed/vterm"
+    "e2e/mixed/eat"
+    "e2e/mixed/term"
+    "typing/native"
+    "typing/emacs")
+  "Named benchmark cases accepted by `ghostel-bench-run-one'.")
+
+(defun ghostel-bench-list-cases ()
+  "Print and return the benchmark cases accepted by `ghostel-bench-run-one'."
+  (interactive)
+  (dolist (case ghostel-bench-cases)
+    (message "%s" case))
+  ghostel-bench-cases)
+
+(defun ghostel-bench--case-generator (shape)
+  "Return the data generator for benchmark SHAPE."
+  (or (cdr (assoc shape `(("plain" . ghostel-bench--gen-plain-ascii)
+                          ("urls" . ghostel-bench--gen-urls-and-paths)
+                          ("mixed" . ghostel-bench--gen-mixed-emoji-cjk-ascii))))
+      (error "Unknown benchmark data shape: %s" shape)))
+
+(defun ghostel-bench--run-one-e2e (shape backend)
+  "Run one end-to-end benchmark for data SHAPE and BACKEND."
+  (ghostel-bench--load-backends)
+  (let ((data-file (ghostel-bench--write-data-file
+                    (ghostel-bench--case-generator shape)))
+        (case-name (format "e2e/%s/%s" shape backend)))
+    (unwind-protect
+        (ghostel-bench--measure
+         case-name ghostel-bench-data-size ghostel-bench-iterations
+         (lambda ()
+           (cond
+            ((string= backend "ghostel")
+             (ghostel-bench--e2e-ghostel data-file t))
+            ((string= backend "ghostel-nodetect")
+             (ghostel-bench--e2e-ghostel data-file nil))
+            ((and (string= backend "vterm") ghostel-bench-include-vterm)
+             (ghostel-bench--e2e-vterm data-file))
+            ((and (string= backend "eat") ghostel-bench-include-eat)
+             (ghostel-bench--e2e-eat data-file))
+            ((and (string= backend "term") ghostel-bench-include-term)
+             (ghostel-bench--e2e-term data-file))
+            (t (error "Unsupported or unavailable e2e backend: %s" backend)))))
+      (delete-file data-file))))
+
+(defun ghostel-bench--run-one-backend (shape backend)
+  "Run one native-vs-Emacs PTY backend benchmark for data SHAPE and BACKEND."
+  (require 'ghostel)
+  (unless (member shape '("plain" "mixed"))
+    (error "Unsupported backend benchmark data shape: %s" shape))
+  (let ((data-file (ghostel-bench--write-data-file
+                    (ghostel-bench--case-generator shape)))
+        (native-p (cond
+                   ((string= backend "native") t)
+                   ((string= backend "emacs") nil)
+                   (t (error "Unknown backend benchmark backend: %s" backend)))))
+    (unwind-protect
+        (ghostel-bench--measure
+         (format "backend/%s/%s" shape backend)
+         ghostel-bench-data-size ghostel-bench-iterations
+         (lambda () (ghostel-bench--spawn-cat data-file native-p)))
+      (delete-file data-file))))
+
+(defun ghostel-bench--parse-size (size)
+  "Parse a ROWSxCOLS benchmark SIZE string."
+  (unless (string-match-p "\\`[0-9]+x[0-9]+\\'" size)
+    (error "Invalid benchmark size: %s" size))
+  (let ((parts (split-string size "x")))
+    (cons (string-to-number (car parts))
+          (string-to-number (cadr parts)))))
+
+(defun ghostel-bench--case-full-redraw-p (backend)
+  "Return whether BACKEND names a full-redraw ghostel benchmark."
+  (cond
+   ((string= backend "ghostel-incr") nil)
+   ((string= backend "ghostel-full") t)
+   (t (error "Unsupported renderer benchmark backend: %s" backend))))
+
+(defun ghostel-bench--run-one-tui-frame (backend size)
+  "Run one TUI full-frame renderer benchmark for BACKEND and SIZE."
+  (require 'ghostel)
+  (let* ((dims (ghostel-bench--parse-size size))
+         (rows (car dims))
+         (cols (cdr dims))
+         (full (ghostel-bench--case-full-redraw-p backend))
+         (raw-frame (ghostel-bench--gen-tui-frame rows cols))
+         (frame (ghostel-bench--encode-for-backend raw-frame 'ghostel)))
+    (message "\n--- TUI Frame Rendering (single case) ---")
+    (message "  %-50s %5s  %8s  %10s  %8s" "SCENARIO" "ITERS" "TOTAL(s)" "ITER(ms)" "fps")
+    (message "  %s" (make-string 90 ?-))
+    (ghostel-bench--with-bench-buffer
+     (let ((term (ghostel-bench--make-ghostel rows cols))
+           (ghostel-enable-url-detection nil)
+           (ghostel-enable-file-detection nil)
+           (inhibit-read-only t))
+       (let ((result
+              (ghostel-bench--measure
+               (format "tui-frame/%s/%s" backend size)
+               (string-bytes frame) ghostel-bench-iterations
+               (lambda ()
+                 (ghostel--write-vt term frame)
+                 (ghostel--redraw term full)))))
+         (message "    ^ %.0f fps" (/ 1000.0 (plist-get result :per-iter-ms))))))))
+
+(defun ghostel-bench--run-one-tui-partial (backend size)
+  "Run one TUI partial-update renderer benchmark for BACKEND and SIZE."
+  (require 'ghostel)
+  (let* ((dims (ghostel-bench--parse-size size))
+         (rows (car dims))
+         (cols (cdr dims))
+         (full (ghostel-bench--case-full-redraw-p backend))
+         (static-frame (ghostel-bench--gen-tui-frame rows cols))
+         (static (ghostel-bench--encode-for-backend static-frame 'ghostel))
+         (status-template (format "\e[%d;1H\e[1;33;41m%%-%ds\e[0m" rows cols)))
+    (message "\n--- TUI Partial Update (single case) ---")
+    (message "  %-50s %5s  %8s  %10s  %8s" "SCENARIO" "ITERS" "TOTAL(s)" "ITER(ms)" "fps")
+    (message "  %s" (make-string 90 ?-))
+    (ghostel-bench--with-bench-buffer
+     (let ((term (ghostel-bench--make-ghostel rows cols))
+           (ghostel-enable-url-detection nil)
+           (ghostel-enable-file-detection nil)
+           (inhibit-read-only t)
+           (counter 0))
+       (ghostel--write-vt term static)
+       (ghostel--redraw term t)
+       (let ((result
+              (ghostel-bench--measure
+               (format "tui-partial/%s/%s" backend size)
+               cols ghostel-bench-iterations
+               (lambda ()
+                 (cl-incf counter)
+                 (ghostel--write-vt
+                  term (format status-template (format "status #%d" counter)))
+                 (ghostel--redraw term full)))))
+         (message "    ^ %.0f fps" (/ 1000.0 (plist-get result :per-iter-ms))))))))
+
+(defun ghostel-bench--run-one-typing (backend)
+  "Run one typing latency benchmark for BACKEND."
+  (require 'ghostel)
+  (message "\n--- Typing Latency (real pipeline, send -> rendered; %d keystrokes) ---"
+           ghostel-bench-typing-count)
+  (message "  %-8s  %5s  %8s  %8s  %8s  %8s" "BACKEND" "n" "min" "median" "p99" "max")
+  (message "  %s" (make-string 56 ?-))
+  (ghostel-bench--typing-report
+   backend
+   (ghostel-bench--typing-latency-spawn
+    ghostel-bench-typing-count
+    (cond
+     ((string= backend "native") t)
+     ((string= backend "emacs") nil)
+     (t (error "Unknown typing backend: %s" backend)))))
+  (message ""))
+
+(defun ghostel-bench-run-one (case)
+  "Run exactly one named benchmark CASE.
+Use `ghostel-bench-list-cases' to list valid case names."
+  (interactive
+   (list (completing-read "Benchmark case: " ghostel-bench-cases nil t)))
+  (unless (member case ghostel-bench-cases)
+    (error "Unknown benchmark case: %s" case))
+  (setq ghostel-bench--results nil)
+  (ghostel-bench--print-header)
+  (pcase (split-string case "/")
+    (`("e2e" ,shape ,backend)
+     (ghostel-bench--run-one-e2e shape backend)
+     (ghostel-bench--print-summary))
+    (`("backend" ,shape ,backend)
+     (ghostel-bench--run-one-backend shape backend)
+     (ghostel-bench--print-summary))
+    (`("tui-frame" ,backend ,size)
+     (ghostel-bench--run-one-tui-frame backend size)
+     (ghostel-bench--print-summary))
+    (`("tui-partial" ,backend ,size)
+     (ghostel-bench--run-one-tui-partial backend size)
+     (ghostel-bench--print-summary))
+    (`("typing" ,backend)
+     (ghostel-bench--run-one-typing backend))
+    (_ (error "Invalid benchmark case: %s" case))))
 
 
 ;; ---------------------------------------------------------------------------

--- a/bench/run-bench.sh
+++ b/bench/run-bench.sh
@@ -76,7 +76,7 @@ Examples:
   $(basename "$0") --backends     # Only native-vs-Emacs PTY comparison
   $(basename "$0") --typing       # Only typing-latency comparison
   $(basename "$0") --case backend/plain/native
-  $(basename "$0") --case tui-partial/ghostel-incr/40x120
+  $(basename "$0") --case tui-partial/40x120
   $(basename "$0") --ghostty      # Include ghostty comparison data
 EOF
     exit 0

--- a/bench/run-bench.sh
+++ b/bench/run-bench.sh
@@ -10,6 +10,8 @@ EMACS="${EMACS:-emacs}"
 MODE="all"
 SIZE=""
 ITERS=""
+MIN_DURATION=""
+CASE=""
 INCLUDE_VTERM="t"
 INCLUDE_EAT="t"
 INCLUDE_TERM="t"
@@ -52,6 +54,8 @@ Options:
                    with --quick, --size, --iterations)
   --typing         Run only the typing-latency comparison (native vs Emacs
                    PTY); --quick uses fewer keystrokes
+  --case CASE      Run exactly one benchmark case, e.g.
+                   backend/plain/native or e2e/urls/ghostel
   --no-vterm       Skip vterm benchmarks
   --no-eat         Skip eat benchmarks
   --no-term        Skip Emacs built-in term benchmarks
@@ -59,6 +63,7 @@ Options:
   --output FILE    Tee output to FILE
   --size N         Data size in bytes (default: 1048576)
   --iterations N   Override iteration count (default: 5)
+  --min-duration S Target at least S seconds for auto-scaled fast cases
   --vterm-dir DIR  Path to vterm package directory
   --eat-dir DIR    Path to eat package directory
   -h, --help       Show this help
@@ -70,6 +75,8 @@ Examples:
   $(basename "$0") --quick --e2e  # Quick end-to-end-only run
   $(basename "$0") --backends     # Only native-vs-Emacs PTY comparison
   $(basename "$0") --typing       # Only typing-latency comparison
+  $(basename "$0") --case backend/plain/native
+  $(basename "$0") --case tui-partial/ghostel-incr/40x120
   $(basename "$0") --ghostty      # Include ghostty comparison data
 EOF
     exit 0
@@ -82,6 +89,7 @@ while [[ $# -gt 0 ]]; do
         --e2e)        SECTION="e2e"; shift ;;
         --backends)   SECTION="backends"; shift ;;
         --typing)     SECTION="typing"; shift ;;
+        --case)       if [ $# -lt 2 ]; then echo "ERROR: --case requires an argument" >&2; exit 1; fi; CASE="$2"; shift 2 ;;
         --no-vterm)   INCLUDE_VTERM="nil"; shift ;;
         --no-eat)     INCLUDE_EAT="nil"; shift ;;
         --no-term)    INCLUDE_TERM="nil"; shift ;;
@@ -89,12 +97,18 @@ while [[ $# -gt 0 ]]; do
         --output)     OUTPUT="$2"; shift 2 ;;
         --size)       SIZE="$2"; shift 2 ;;
         --iterations) ITERS="$2"; shift 2 ;;
+        --min-duration) MIN_DURATION="$2"; shift 2 ;;
         --vterm-dir)  VTERM_DIR="$2"; shift 2 ;;
         --eat-dir)    EAT_DIR="$2"; shift 2 ;;
         -h|--help)    usage ;;
         *)            echo "Unknown option: $1"; usage ;;
     esac
 done
+
+if [ -n "$CASE" ] && [[ ! "$CASE" =~ ^[A-Za-z0-9_./-]+$ ]]; then
+    echo "ERROR: invalid benchmark case syntax: $CASE" >&2
+    exit 1
+fi
 
 # Verify ghostel module exists
 MODULE=""
@@ -139,10 +153,16 @@ LOAD_PATH="-L $GHOSTEL_DIR/lisp"
 EVAL="(progn"
 [ -n "$SIZE" ] && EVAL="$EVAL (setq ghostel-bench-data-size $SIZE)"
 [ -n "$ITERS" ] && EVAL="$EVAL (setq ghostel-bench-iterations $ITERS)"
+[ -n "$MIN_DURATION" ] && EVAL="$EVAL (setq ghostel-bench-min-duration $MIN_DURATION)"
 EVAL="$EVAL (setq ghostel-bench-include-vterm $INCLUDE_VTERM)"
 EVAL="$EVAL (setq ghostel-bench-include-eat $INCLUDE_EAT)"
 EVAL="$EVAL (setq ghostel-bench-include-term $INCLUDE_TERM)"
-if [ "$SECTION" = "e2e" ]; then
+if [ -n "$CASE" ]; then
+    if [ "$MODE" = "quick" ]; then
+        EVAL="$EVAL (setq ghostel-bench-data-size (* 100 1024) ghostel-bench-iterations 2 ghostel-bench-typing-count 50)"
+    fi
+    EVAL="$EVAL (ghostel-bench-run-one \"$CASE\"))"
+elif [ "$SECTION" = "e2e" ]; then
     if [ "$MODE" = "quick" ]; then
         EVAL="$EVAL (setq ghostel-bench-data-size (* 100 1024) ghostel-bench-iterations 2)"
     fi

--- a/bench/run-gui-xctrace.sh
+++ b/bench/run-gui-xctrace.sh
@@ -57,7 +57,7 @@ Options:
 Examples:
   $(basename "$0") --case backend/plain/native
   $(basename "$0") --case e2e/urls/ghostel --size 1048576 --iterations 5
-  $(basename "$0") --case tui-partial/ghostel-incr/40x120 --min-duration 10
+  $(basename "$0") --case tui-partial/40x120 --min-duration 10
   $(basename "$0") --case backend/mixed/native --redisplay
 EOF
     exit 0

--- a/bench/run-gui-xctrace.sh
+++ b/bench/run-gui-xctrace.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# Run one ghostel benchmark case inside GUI Emacs while recording an xctrace
+# Time Profiler trace attached to that Emacs process.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GHOSTEL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -x /Applications/Emacs.app/Contents/MacOS/Emacs ]; then
+    DEFAULT_EMACS=/Applications/Emacs.app/Contents/MacOS/Emacs
+else
+    DEFAULT_EMACS=emacs
+fi
+
+EMACS_BIN="${EMACS_GUI:-${EMACS:-$DEFAULT_EMACS}}"
+EMACSCLIENT="${EMACSCLIENT:-emacsclient}"
+TEMPLATE="Time Profiler"
+CASE=""
+SIZE=""
+ITERS=""
+MIN_DURATION=""
+COUNT=""
+OUTPUT_DIR="$GHOSTEL_DIR/bench/profiles"
+OPEN_TRACE=false
+REDISPLAY="nil"
+INCLUDE_VTERM="t"
+INCLUDE_EAT="t"
+INCLUDE_TERM="t"
+VTERM_DIR=""
+EAT_DIR=""
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") --case CASE [OPTIONS]
+
+Options:
+  --case CASE       Benchmark case to run, e.g. backend/plain/native
+                   or e2e/urls/ghostel
+  --quick           100KB data, 2 iterations, 50 typing samples
+  --size N          Data size in bytes
+  --iterations N    Iteration count floor
+  --min-duration S  Target at least S seconds for auto-scaled fast cases
+  --count N         Typing sample count
+  --redisplay       Force GUI redisplay after each measured iteration
+  --template NAME   xctrace template (default: Time Profiler)
+  --output-dir DIR  Directory for .trace and .log files
+  --open            Open the resulting .trace in Instruments
+  --emacs PATH      GUI Emacs executable
+  --emacsclient PATH
+  --vterm-dir DIR   Path to vterm package directory
+  --eat-dir DIR     Path to eat package directory
+  --no-vterm        Skip/disable vterm
+  --no-eat          Skip/disable eat
+  --no-term         Skip/disable term
+  -h, --help        Show this help
+
+Examples:
+  $(basename "$0") --case backend/plain/native
+  $(basename "$0") --case e2e/urls/ghostel --size 1048576 --iterations 5
+  $(basename "$0") --case tui-partial/ghostel-incr/40x120 --min-duration 10
+  $(basename "$0") --case backend/mixed/native --redisplay
+EOF
+    exit 0
+}
+
+need_arg() {
+    if [ $# -lt 2 ] || [ -z "${2-}" ]; then
+        echo "ERROR: $1 requires an argument" >&2
+        exit 1
+    fi
+}
+
+QUICK=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --case)        need_arg "$1" "${2-}"; CASE="$2"; shift 2 ;;
+        --quick)       QUICK=true; shift ;;
+        --size)        need_arg "$1" "${2-}"; SIZE="$2"; shift 2 ;;
+        --iterations)  need_arg "$1" "${2-}"; ITERS="$2"; shift 2 ;;
+        --min-duration) need_arg "$1" "${2-}"; MIN_DURATION="$2"; shift 2 ;;
+        --count)       need_arg "$1" "${2-}"; COUNT="$2"; shift 2 ;;
+        --redisplay)   REDISPLAY="t"; shift ;;
+        --template)    need_arg "$1" "${2-}"; TEMPLATE="$2"; shift 2 ;;
+        --output-dir)  need_arg "$1" "${2-}"; OUTPUT_DIR="$2"; shift 2 ;;
+        --open)        OPEN_TRACE=true; shift ;;
+        --emacs)       need_arg "$1" "${2-}"; EMACS_BIN="$2"; shift 2 ;;
+        --emacsclient) need_arg "$1" "${2-}"; EMACSCLIENT="$2"; shift 2 ;;
+        --vterm-dir)   need_arg "$1" "${2-}"; VTERM_DIR="$2"; shift 2 ;;
+        --eat-dir)     need_arg "$1" "${2-}"; EAT_DIR="$2"; shift 2 ;;
+        --no-vterm)    INCLUDE_VTERM="nil"; shift ;;
+        --no-eat)      INCLUDE_EAT="nil"; shift ;;
+        --no-term)     INCLUDE_TERM="nil"; shift ;;
+        -h|--help)     usage ;;
+        *)             echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+if [ -z "$CASE" ]; then
+    echo "ERROR: --case is required" >&2
+    usage
+fi
+if [[ ! "$CASE" =~ ^[A-Za-z0-9_./-]+$ ]]; then
+    echo "ERROR: invalid benchmark case syntax: $CASE" >&2
+    exit 1
+fi
+
+if ! command -v xcrun >/dev/null 2>&1; then
+    echo "ERROR: xcrun not found" >&2
+    exit 1
+fi
+if ! command -v notifyutil >/dev/null 2>&1; then
+    echo "ERROR: notifyutil not found" >&2
+    exit 1
+fi
+if ! command -v "$EMACSCLIENT" >/dev/null 2>&1; then
+    echo "ERROR: emacsclient not found: $EMACSCLIENT" >&2
+    exit 1
+fi
+
+TMPDIR="$(mktemp -d "/tmp/ghostel-gui-xctrace.XXXXXX")"
+cleanup() {
+    local status=$?
+    if [ -n "${NOTIFY_PID:-}" ] && kill -0 "$NOTIFY_PID" 2>/dev/null; then
+        kill "$NOTIFY_PID" 2>/dev/null || true
+    fi
+    if [ -n "${EMACS_PID:-}" ] && kill -0 "$EMACS_PID" 2>/dev/null; then
+        kill "$EMACS_PID" 2>/dev/null || true
+    fi
+    if [ -n "${XCTRACE_PID:-}" ] && kill -0 "$XCTRACE_PID" 2>/dev/null; then
+        kill "$XCTRACE_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMPDIR"
+    exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+if ! xcrun xctrace list templates >/dev/null 2>"$TMPDIR/xctrace-check.err"; then
+    echo "ERROR: xctrace is not usable. It usually requires full Xcode, not only Command Line Tools." >&2
+    cat "$TMPDIR/xctrace-check.err" >&2
+    exit 1
+fi
+
+# Verify ghostel module exists before launching Emacs.
+MODULE=""
+for ext in dylib so; do
+    if [ -f "$GHOSTEL_DIR/ghostel-module.$ext" ]; then
+        MODULE="$GHOSTEL_DIR/ghostel-module.$ext"
+        break
+    fi
+done
+if [ -z "$MODULE" ]; then
+    echo "ERROR: ghostel native module not found. Run zig build -Doptimize=ReleaseFast first." >&2
+    exit 1
+fi
+
+# Try to find optional comparison backends.
+if [ "$INCLUDE_VTERM" = "t" ] && [ -z "$VTERM_DIR" ]; then
+    for dir in "$GHOSTEL_DIR/../vterm" \
+               "$HOME/.emacs.d/lib/vterm" \
+               "$HOME/.emacs.d/elpa/vterm"*/ \
+               "$HOME/.emacs.d/straight/build/vterm"; do
+        if [ -f "$dir/vterm.el" ] 2>/dev/null; then
+            VTERM_DIR="$(cd "$dir" && pwd)"
+            break
+        fi
+    done
+fi
+if [ "$INCLUDE_EAT" = "t" ] && [ -z "$EAT_DIR" ]; then
+    for dir in "$GHOSTEL_DIR/../eat" \
+               "$HOME/.emacs.d/lib/eat" \
+               "$HOME/.emacs.d/elpa/eat"*/ \
+               "$HOME/.emacs.d/straight/build/eat"; do
+        if [ -f "$dir/eat.el" ] 2>/dev/null; then
+            EAT_DIR="$(cd "$dir" && pwd)"
+            break
+        fi
+    done
+fi
+[ "$INCLUDE_VTERM" = "t" ] && [ -z "$VTERM_DIR" ] && INCLUDE_VTERM="nil"
+[ "$INCLUDE_EAT" = "t" ] && [ -z "$EAT_DIR" ] && INCLUDE_EAT="nil"
+
+mkdir -p "$OUTPUT_DIR"
+SAFE_CASE="${CASE//\//-}"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+BASE="$OUTPUT_DIR/$STAMP-$SAFE_CASE"
+TRACE_PATH="$BASE.trace"
+BENCH_LOG="$BASE.log"
+EMACS_LOG="$BASE.emacs.log"
+XCTRACE_LOG="$BASE.xctrace.log"
+SERVER_SOCKET="$TMPDIR/server"
+NOTIFY="com.ghostel.xctrace.started.$STAMP.$$"
+
+elisp_string() {
+    python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$1"
+}
+
+GHOSTEL_LISP_EL="$(elisp_string "$GHOSTEL_DIR/lisp")"
+BENCH_FILE_EL="$(elisp_string "$SCRIPT_DIR/ghostel-bench.el")"
+CASE_EL="$(elisp_string "$CASE")"
+BENCH_LOG_EL="$(elisp_string "$BENCH_LOG")"
+VTERM_DIR_EL="$(elisp_string "$VTERM_DIR")"
+EAT_DIR_EL="$(elisp_string "$EAT_DIR")"
+SERVER_SOCKET_EL="$(elisp_string "$SERVER_SOCKET")"
+
+SERVER_EVAL="(progn (setq enable-dir-local-variables nil) (require 'server) (setq server-name $SERVER_SOCKET_EL) (server-start))"
+pushd "$TMPDIR" >/dev/null
+"$EMACS_BIN" -Q -L "$GHOSTEL_DIR/lisp" --eval "$SERVER_EVAL" >"$EMACS_LOG" 2>&1 &
+EMACS_PID=$!
+popd >/dev/null
+
+for _ in $(seq 1 200); do
+    if "$EMACSCLIENT" -s "$SERVER_SOCKET" --eval t >/dev/null 2>&1; then
+        break
+    fi
+    if ! kill -0 "$EMACS_PID" 2>/dev/null; then
+        echo "ERROR: GUI Emacs exited before its server became ready; see $EMACS_LOG" >&2
+        cat "$EMACS_LOG" >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+if ! "$EMACSCLIENT" -s "$SERVER_SOCKET" --eval t >/dev/null 2>&1; then
+    echo "ERROR: timed out waiting for GUI Emacs server; see $EMACS_LOG" >&2
+    cat "$EMACS_LOG" >&2
+    exit 1
+fi
+
+notifyutil -1 "$NOTIFY" >/dev/null &
+NOTIFY_PID=$!
+
+xcrun xctrace record \
+    --template "$TEMPLATE" \
+    --output "$TRACE_PATH" \
+    --attach "$EMACS_PID" \
+    --no-prompt \
+    --notify-tracing-started "$NOTIFY" \
+    >"$XCTRACE_LOG" 2>&1 &
+XCTRACE_PID=$!
+
+TRACING_STARTED=false
+for _ in $(seq 1 300); do
+    if ! kill -0 "$NOTIFY_PID" 2>/dev/null; then
+        TRACING_STARTED=true
+        break
+    fi
+    if ! kill -0 "$XCTRACE_PID" 2>/dev/null; then
+        wait "$XCTRACE_PID" || true
+        echo "ERROR: xctrace exited before tracing started" >&2
+        cat "$XCTRACE_LOG" >&2
+        exit 1
+    fi
+    sleep 0.1
+done
+if [ "$TRACING_STARTED" != true ]; then
+    echo "ERROR: timed out waiting for xctrace to start" >&2
+    cat "$XCTRACE_LOG" >&2
+    exit 1
+fi
+wait "$NOTIFY_PID" 2>/dev/null || true
+NOTIFY_PID=""
+
+RUN_EVAL="
+(condition-case err
+    (progn
+      (setq enable-dir-local-variables nil)
+      (add-to-list 'load-path $GHOSTEL_LISP_EL)
+      (when (> (length $VTERM_DIR_EL) 0)
+        (add-to-list 'load-path $VTERM_DIR_EL))
+      (when (> (length $EAT_DIR_EL) 0)
+        (add-to-list 'load-path $EAT_DIR_EL))
+      (load $BENCH_FILE_EL nil t)
+      (setq ghostel-bench-include-vterm $INCLUDE_VTERM
+            ghostel-bench-include-eat $INCLUDE_EAT
+            ghostel-bench-include-term $INCLUDE_TERM
+            ghostel-bench-force-gui-redisplay $REDISPLAY)
+      $(if $QUICK; then echo "(setq ghostel-bench-data-size (* 100 1024) ghostel-bench-iterations 2 ghostel-bench-typing-count 50)"; fi)
+      $(if [ -n "$SIZE" ]; then echo "(setq ghostel-bench-data-size $SIZE)"; fi)
+      $(if [ -n "$ITERS" ]; then echo "(setq ghostel-bench-iterations $ITERS)"; fi)
+      $(if [ -n "$MIN_DURATION" ]; then echo "(setq ghostel-bench-min-duration $MIN_DURATION)"; fi)
+      $(if [ -n "$COUNT" ]; then echo "(setq ghostel-bench-typing-count $COUNT)"; fi)
+      (ghostel-bench-run-one $CASE_EL)
+      (with-current-buffer \"*Messages*\"
+        (write-region (point-min) (point-max) $BENCH_LOG_EL nil 'silent))
+      'ok)
+  (error
+   (message \"ERROR: %s\" (error-message-string err))
+   (with-current-buffer \"*Messages*\"
+     (write-region (point-min) (point-max) $BENCH_LOG_EL nil 'silent))
+   (error \"%s\" (error-message-string err))))"
+
+set +e
+"$EMACSCLIENT" -s "$SERVER_SOCKET" --eval "$RUN_EVAL"
+BENCH_STATUS=$?
+set -e
+
+"$EMACSCLIENT" -s "$SERVER_SOCKET" --eval '(kill-emacs 0)' >/dev/null 2>&1 || true
+wait "$EMACS_PID" 2>/dev/null || true
+EMACS_PID=""
+
+set +e
+wait "$XCTRACE_PID"
+XCTRACE_STATUS=$?
+set -e
+
+if [ "$BENCH_STATUS" -ne 0 ]; then
+    echo "ERROR: benchmark failed; see $BENCH_LOG" >&2
+    exit "$BENCH_STATUS"
+fi
+if [ "$XCTRACE_STATUS" -ne 0 ]; then
+    echo "ERROR: xctrace failed; see $XCTRACE_LOG" >&2
+    exit "$XCTRACE_STATUS"
+fi
+
+echo "trace: $TRACE_PATH"
+echo "bench log: $BENCH_LOG"
+echo "emacs log: $EMACS_LOG"
+echo "xctrace log: $XCTRACE_LOG"
+
+if $OPEN_TRACE; then
+    open -a Instruments "$TRACE_PATH"
+fi


### PR DESCRIPTION
## Summary
- add single-case benchmark entry points for targeted profiling
- add a GUI Emacs xctrace wrapper with duration-based runs and optional auto-open
- expose incremental TUI renderer cases without forced-full variants

## Verification
- `bash -n bench/run-bench.sh`
- `bash -n bench/run-gui-xctrace.sh`
- `bash bench/run-bench.sh --case tui-partial/24x80 --no-vterm --no-eat --no-term --iterations 10 --min-duration 0.1`