### PR TITLE
Remove full redraw user option

### DIFF
--- a/README.org
+++ b/README.org
@@ -1211,7 +1211,6 @@ tables below group them by area; defaults shown are the out-of-the-box values.
 | =ghostel-timer-delay=               | =0.033=   | Base redraw delay in seconds (~30 fps).                                                                                              |
 | =ghostel-adaptive-fps=              | =t=       | Adaptive frame rate (shorter delay after idle, stop timer when idle).                                                                |
 | =ghostel-immediate-redraw-interval= | =0.05=    | Max seconds since last keystroke for immediate redraw.                                                                               |
-| =ghostel-full-redraw=               | =nil=     | Always do full redraws instead of incremental updates.                                                                               |
 | =ghostel-inhibit-redraw-functions=  | =nil=     | Abnormal hook (each fn called with the buffer); if any returns non-nil the redraw is deferred.  Used by add-ons such as =ghostel-ime=. |
 | =ghostel-cell-pixel-scale=          | =auto=    | Physical:logical pixel ratio for cell-size reporting (=auto= derives from DPI).                                                        |
 | =ghostel-glyph-scale-floor=         | =0.0=     | Minimum scale for glyphs that don't fit the cell (=0.0= preserves grid alignment; =1.0= renders CJK at natural size).                    |

--- a/bench/ghostel-bench.el
+++ b/bench/ghostel-bench.el
@@ -721,7 +721,7 @@ terminal engine with periodic redraws, all in a tight loop."
                  (setq offset end)
                  (cl-incf chunk-count)
                  (when (zerop (% chunk-count redraw-every))
-                   (ghostel--redraw term ghostel-full-redraw)))))))))
+                   (ghostel--redraw term nil)))))))))
     ;; vterm
     (when ghostel-bench-include-vterm
       (ghostel-bench--with-bench-buffer

--- a/lisp/ghostel-line-mode.el
+++ b/lisp/ghostel-line-mode.el
@@ -40,7 +40,6 @@
 (defvar ghostel--input-mode)
 (defvar ghostel--mode-line-tag)
 (defvar ghostel--term)
-(defvar ghostel-full-redraw)
 (defvar ghostel-semi-char-mode-map)
 
 
@@ -133,12 +132,6 @@ Most recent first.")
 (defvar-local ghostel--line-mode-history-index nil
   "Current index into `ghostel--line-mode-history' while browsing history.
 Nil when not browsing.")
-
-(defvar-local ghostel--line-mode-saved-full-redraw nil
-  "Saved `ghostel-full-redraw' state from before line mode entry.
-Cons (BUFFER-LOCAL-P . VALUE).  Restored by
-`ghostel--line-mode-teardown' so toggling the mode does not
-permanently override the user's setting.")
 
 (defvar-local ghostel--line-mode-saved-cursor-type nil
   "Saved `cursor-type' from before line mode entry, as a singleton list.
@@ -411,15 +404,6 @@ in line mode (the interactive entry validates these)."
       (ghostel--cursor-blink-stop)
       (setq ghostel--line-mode-saved-cursor-type (list cursor-type))
       (setq cursor-type (default-value 'cursor-type))
-      ;; Force full redraws while line mode is active so the
-      ;; snapshot/restore path always rebuilds the prompt row
-      ;; (otherwise dirty-row diff could skip it and the input would
-      ;; be re-inserted at a stale marker position).  Restore the
-      ;; previous setting on teardown.
-      (setq ghostel--line-mode-saved-full-redraw
-            (cons (local-variable-p 'ghostel-full-redraw)
-                  ghostel-full-redraw))
-      (setq-local ghostel-full-redraw t)
       ;; If the user already typed something at this prompt via the
       ;; PTY (e.g. before switching from semi-char to line mode), the
       ;; renderer painted those cells with `ghostel-input'.  Adopt
@@ -564,8 +548,7 @@ have already handled the input themselves (like
 `ghostel-line-mode-send' and `ghostel-line-mode-interrupt') delete
 it from the buffer before calling this, so no double-send happens.
 
-Restores `ghostel-full-redraw' to the value captured on entry, and
-forces a final redraw so the buffer truncation done at entry is
+Forces a final redraw so the buffer truncation done at entry is
 re-materialized from libghostty.
 
 When PAUSE is non-nil, skip forwarding pending input to the PTY,
@@ -600,12 +583,6 @@ which discards any type-ahead and runs inside `ghostel--redraw-now'."
   (setq ghostel--line-mode-history-index nil)
   (setq ghostel--line-mode-adopted-count nil)
   (setq ghostel--line-mode-on-alt-screen nil)
-  (when ghostel--line-mode-saved-full-redraw
-    (if (car ghostel--line-mode-saved-full-redraw)
-        (setq-local ghostel-full-redraw
-                    (cdr ghostel--line-mode-saved-full-redraw))
-      (kill-local-variable 'ghostel-full-redraw))
-    (setq ghostel--line-mode-saved-full-redraw nil))
   (when ghostel--line-mode-saved-cursor-type
     (setq cursor-type (car ghostel--line-mode-saved-cursor-type))
     (setq ghostel--line-mode-saved-cursor-type nil))

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -338,12 +338,6 @@ Output arriving within this interval of a `ghostel--send-string'
 call is considered interactive echo and redrawn immediately."
   :type 'number)
 
-(defcustom ghostel-full-redraw nil
-  "When non-nil, always perform full redraws instead of incremental updates.
-Full redraws are more robust with TUI apps like Claude Code that do
-aggressive partial screen updates, but may use more CPU."
-  :type 'boolean)
-
 (defcustom ghostel-buffer-name "*ghostel*"
   "Default buffer name for ghostel terminals."
   :type 'string)
@@ -4699,7 +4693,10 @@ opportunistic output redraws that may safely wait for the frame to end."
                                            (* gc-cons-threshold 3)))
                    (ghostel--query-font-cache (make-hash-table :test 'eq)))
               (with-selected-window render-win
-                (ghostel--redraw ghostel--term ghostel-full-redraw))
+                ;; Line mode snapshots editable input out of the buffer;
+                ;; redraw fully so the prompt row is always rebuilt
+                ;; before restoring input at its fresh marker position.
+                (ghostel--redraw ghostel--term (eq ghostel--input-mode 'line)))
               (ghostel--apply-cursor-style)
 
               (dolist (win anchored) (ghostel--anchor-window win))

--- a/test/ghostel-line-mode-test.el
+++ b/test/ghostel-line-mode-test.el
@@ -1663,36 +1663,6 @@ running through a redraw cycle."
                                       (buffer-string))))))
       (kill-buffer buf))))
 
-(ert-deftest ghostel-test-line-mode-saves-restores-full-redraw ()
-  "Entering line mode forces full redraws; teardown restores the prior setting."
-  (let ((buf (generate-new-buffer " *ghostel-test-line-fullredraw*")))
-    (unwind-protect
-        (with-current-buffer buf
-          (ghostel-mode)
-          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
-          (let ((ghostel--term 'fake)
-                (ghostel--process 'fake-proc)
-                (ghostel-full-redraw nil))
-            (cl-letf (((symbol-function 'ghostel--mode-enabled)
-                       (lambda (&rest _) nil))
-                      ((symbol-function 'ghostel--redraw) #'ignore)
-                      ((symbol-function 'ghostel--invalidate) #'ignore)
-                      ((symbol-function 'ghostel--anchor-window) #'ignore))
-              ;; Was nil, no buffer-local override.
-              (should-not (local-variable-p 'ghostel-full-redraw))
-              (ghostel-line-mode)
-              ;; Entry sets buffer-local override to t.
-              (should (local-variable-p 'ghostel-full-redraw))
-              (should (eq ghostel-full-redraw t))
-              ;; Saved-state cons records "was not buffer-local".
-              (should (equal ghostel--line-mode-saved-full-redraw
-                             '(nil . nil)))
-              (ghostel-semi-char-mode)
-              ;; Teardown killed the buffer-local override.
-              (should-not (local-variable-p 'ghostel-full-redraw))
-              (should-not ghostel--line-mode-saved-full-redraw))))
-      (kill-buffer buf))))
-
 (ert-deftest ghostel-test-line-mode-restores-cursor-when-terminal-hid-it ()
   "Line mode shows the editor's cursor regardless of CSI ?25l from the TUI.
 Entering line mode forces the editor default; teardown restores the saved value."
@@ -1926,8 +1896,7 @@ must clear that sentinel, otherwise the alt-screen-off `post-redraw'
 would call
 `ghostel--line-mode-try-resume' on top of the already-active line
 mode — re-running `ghostel--line-mode-enter', wiping the user's
-typed input (it restores the empty armed snapshot) and clobbering
-the saved `ghostel-full-redraw' state captured on first entry."
+typed input (it restores the empty armed snapshot)."
   (let ((buf (generate-new-buffer " *ghostel-test-line-force-after-arm*"))
         (alt-on t))
     (unwind-protect
@@ -1952,9 +1921,6 @@ the saved `ghostel-full-redraw' state captured on first entry."
               (should (eq ghostel--input-mode 'line))
               ;; The fix: the real entry cleared the stale sentinel.
               (should-not ghostel--line-mode-paused)
-              ;; Capture the saved redraw state so we can detect a
-              ;; second entry re-capturing it from modified values.
-              (should-not (car ghostel--line-mode-saved-full-redraw))
               ;; User types a command in line mode.
               (goto-char (point-max))
               (insert "ls -la")
@@ -1966,8 +1932,7 @@ the saved `ghostel-full-redraw' state captured on first entry."
               ;; Still in line mode, input intact, no double-enter.
               (should (eq ghostel--input-mode 'line))
               (should (equal (ghostel--line-mode-input-text) "ls -la"))
-              (should-not ghostel--line-mode-paused)
-              (should-not (car ghostel--line-mode-saved-full-redraw)))))
+              (should-not ghostel--line-mode-paused))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-line-mode-alt-exit-clears-flag-so-primary-tui-pauses ()

--- a/test/hypothesis/ghostel-hypothesis-driver.el
+++ b/test/hypothesis/ghostel-hypothesis-driver.el
@@ -53,7 +53,6 @@ After all ops, a final incremental redraw is compared with a full redraw."
                  (ghostel--term-cols cols)
                  (ghostel-enable-url-detection nil)
                  (ghostel-enable-file-detection nil)
-                 (ghostel-full-redraw nil)
                  (inhibit-read-only t))
             (dotimes (i (length ops))
               (let* ((op (aref ops i))


### PR DESCRIPTION
## Summary
- remove the `ghostel-full-redraw` defcustom and documented option
- replace line-mode's buffer-local override with an explicit full-redraw request while line mode is active
- drop tests and benchmark/hypothesis bindings that referenced the option

## Verification
- `git diff --check`
- `make byte-compile .build/tests/elisp-ghostel-line-mode-test.ok`

Note: a direct byte-compile of `bench/ghostel-bench.el` and `test/hypothesis/ghostel-hypothesis-driver.el` still hits pre-existing warnings/errors unrelated to this change.