### PR TITLE
Honor C-g in ghostel-keymap-exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `ghostel-keymap-exceptions` now honors `C-g`: adding `"C-g"` to the list leaves
+  it unbound in ghostel so it falls through to your global binding (e.g.
+  `keyboard-quit`) instead of forwarding `BEL` to the terminal.
+  Fixes [#489](https://github.com/dakra/ghostel/issues/489).
+
 ## [0.39.0] — 2026-06-26
 
 ### Added

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1188,8 +1188,7 @@ When NO-EXCEPTIONS is non-nil, also bind the keys in
   ;; Control keys - bind all C-<letter> to send ASCII control codes.
   ;; C-i = TAB and C-m = RET are equivalent to <tab>/<return> (bound above).
   ;; C-y is reserved for ghostel-yank in semi-char mode.
-  ;; C-g is always handled by `ghostel-send-C-g' so the mark and
-  ;; `quit-flag' are cleared in addition to forwarding BEL.
+  ;; C-g is bound separately via `ghostel--rebuild-semi-char-keymap'.
   (let ((skip (if no-exceptions '(?i ?m ?g) '(?i ?m ?y ?g))))
     (dolist (c (number-sequence ?a ?z))
       (let ((key-str (format "C-%c" c)))
@@ -1261,7 +1260,6 @@ Input modes (`ghostel-semi-char-mode-map', `ghostel-char-mode-map',
   "C-c C-z"          #'ghostel-send-C-z
   "C-c C-\\"         #'ghostel-send-C-backslash
   "C-c C-d"          #'ghostel-send-C-d
-  "C-g"              #'ghostel-send-C-g
   "C-c C-t"          #'ghostel-copy-mode
   "C-c M-w"          #'ghostel-copy-all
   "C-c C-y"          #'ghostel-paste
@@ -1343,7 +1341,11 @@ reference to it picks up the new bindings."
       "S-<insert>"     #'ghostel-yank
       "<remap> <yank>" #'ghostel-yank
       "M-y"            #'ghostel-yank-pop)
-    (setcdr ghostel-semi-char-mode-map (cdr fresh))))
+    (setcdr ghostel-semi-char-mode-map (cdr fresh)))
+  ;; C-g honors the exception list: bound to nil (unbound) when excepted.
+  (define-key ghostel-mode-map (kbd "C-g")
+              (unless (member "C-g" ghostel-keymap-exceptions)
+                #'ghostel-send-C-g)))
 
 (ghostel--rebuild-semi-char-keymap)
 

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -669,6 +669,34 @@ regardless of exceptions."
                       #'ghostel--send-event)))
       (customize-set-variable 'ghostel-keymap-exceptions orig))))
 
+(ert-deftest ghostel-test-c-g-exception-unbinds ()
+  "Adding \\`C-g' to the exceptions leaves it unbound so it falls through.
+The base-map binding is dropped (resolves to nil), so Emacs's
+global \\`C-g' takes over.  Char mode and read-only fast-exit bind
+\\`C-g' themselves and stay put (regression for issue #489)."
+  (let ((orig (default-value 'ghostel-keymap-exceptions)))
+    (unwind-protect
+        (progn
+          ;; Baseline: C-g routes through the send handler.
+          (should (eq (lookup-key ghostel-mode-map (kbd "C-g"))
+                      #'ghostel-send-C-g))
+          (customize-set-variable 'ghostel-keymap-exceptions
+                                  (cons "C-g" orig))
+          ;; Excepted: unbound in the base map and through semi-char,
+          ;; so C-g falls through to the global binding.
+          (should-not (lookup-key ghostel-mode-map (kbd "C-g")))
+          (should-not (lookup-key ghostel-semi-char-mode-map (kbd "C-g")))
+          ;; Modes with their own C-g are unaffected.
+          (should (eq (lookup-key ghostel-char-mode-map (kbd "C-g"))
+                      #'ghostel-send-C-g))
+          (should (eq (lookup-key ghostel-readonly-fast-exit-mode-map
+                                  (kbd "C-g"))
+                      #'ghostel-readonly-exit)))
+      (customize-set-variable 'ghostel-keymap-exceptions orig))
+    ;; Restored: C-g is bound again.
+    (should (eq (lookup-key ghostel-mode-map (kbd "C-g"))
+                #'ghostel-send-C-g))))
+
 (ert-deftest ghostel-test-keymap-rebuild-preserves-object-identity ()
   "Rebuilding mutates `ghostel-semi-char-mode-map' in place.
 Buffer-local references to the keymap need `eq'-identity to


### PR DESCRIPTION
Fixes #489.

## Problem

Adding `"C-g"` to `ghostel-keymap-exceptions` had no effect — C-g was still sent to the terminal. Every other exception key is bound through `ghostel--define-terminal-keys` and simply omitted when listed, but C-g was hardcoded in the static base map `ghostel-mode-map`, which every input mode inherits and which the exception filter never touches.

## Fix

Bind C-g in `ghostel--rebuild-semi-char-keymap` instead (the function that runs at load and on every `setopt`/`customize`), driven by the exception list:

- not excepted → `ghostel-send-C-g` (sends BEL, as before)
- excepted → left **unbound**, so it falls through to the user's own global binding (normally `keyboard-quit`, but whatever they've bound — no command hardcoded)

`ghostel-send-C-g` itself is untouched. Char mode and read-only fast-exit keep their own explicit C-g bindings and are intentionally unaffected (char mode forwards everything to the TUI app; fast-exit C-g exits the mode).

## Verification

- `make all` green; new ERT test `ghostel-test-c-g-exception-unbinds`.
- Live-tested in real `*ghostel*` buffers across **semi-char, char, line, copy, Emacs (fast-exit on/off), and evil-ghostel (insert/normal/visual)**, in both directions (active by default; falls through to `keyboard-quit` when excepted or `nil`-bound).
- Confirmed the `inhibit-quit`/`quit-flag` interaction is clean: the fall-through `keyboard-quit` lands, `quit-flag` clears, no stray pending quit, no wedge.