### PR TITLE
Add nushell shell integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Shell integration now supports **nushell** alongside bash, zsh, and fish.
+  Directory tracking (OSC 7), prompt navigation (OSC 133), and title tracking
+  (OSC 2) come from nushell's built-in `$env.config.shell_integration`; ghostel
+  adds `ghostel_cmd` and the outbound `ssh` terminfo-install wrapper. Works with
+  auto-injection (`ghostel-shell-integration`), manual `source`, and remote
+  TRAMP sessions (`ghostel-tramp-shell-integration`).
+
 ### Fixed
 - `ghostel-keymap-exceptions` now honors `C-g`: adding `"C-g"` to the list leaves
   it unbound in ghostel so it falls through to your global binding (e.g.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ghostel's features include synchronized output, true color, the Kitty keyboard
 and graphics protocols, hyperlinks, desktop notifications, progress reports and a lot more.
 
 Shell integration (directory tracking, prompt navigation) all works out of the
-box for bash, zsh and fish.
+box for bash, zsh, fish and nushell.
 
 Check the [documentation](https://dakra.github.io/ghostel/#features) for a full list of features or how it [compares](https://dakra.github.io/ghostel/#ghostel-vs-vterm) to [vterm](https://github.com/akermu/emacs-libvterm) or [eat](https://codeberg.org/akib/emacs-eat).
 
@@ -120,7 +120,7 @@ If you're an evil user you can install the [evil-ghostel](https://melpa.org/#/ev
 
 ## Shell integration
 
-Directory tracking and prompt navigation are on by default for local bash, zsh or fish sessions.
+Directory tracking and prompt navigation are on by default for local bash, zsh, fish or nushell sessions.
 See [shell integration](https://dakra.github.io/ghostel/#shell-integration) for tramp support and more.
 
 To call Emacs functions from your shell you have to add them to the

--- a/README.org
+++ b/README.org
@@ -272,8 +272,13 @@ regenerate it via =make regen-terminfo= after bumping libghostty.
 
 Shell integration (directory tracking via OSC 7, prompt navigation via OSC 133,
 title tracking via OSC 2, and =ghostel_cmd= for [[#calling-elisp-from-the-shell][calling Elisp from the shell]]) is
-*automatic* for bash, zsh, and fish.  No changes to your shell configuration
-files are needed.
+*automatic* for bash, zsh, fish, and nushell.  No changes to your shell
+configuration files are needed.
+
+For nushell, OSC 7/133/2 come from nushell's own =$env.config.shell_integration=
+(on by default), so ghostel's =ghostel.nu= only adds =ghostel_cmd= and the
+outbound =ssh= terminfo wrapper.  Leave =shell_integration.osc7= and =.osc133=
+enabled or directory tracking and prompt navigation will stop working.
 
 This is controlled by =ghostel-shell-integration= (default =t=).  Set it to =nil=
 to disable auto-injection and source the scripts manually instead:
@@ -291,6 +296,14 @@ to disable auto-injection and source the scripts manually instead:
 #+begin_src fish
 # fish - add to ~/.config/fish/config.fish:
 string match -qr '^ghostel(,|$)' -- "$INSIDE_EMACS"; and source "$EMACS_GHOSTEL_PATH/etc/shell/ghostel.fish"
+#+end_src
+
+#+begin_src text
+# nushell - add to your config.nu (use the absolute path to your ghostel
+# checkout).  nushell's `source' needs a parse-time-constant path, so it
+# cannot be gated on $INSIDE_EMACS; the script is inert until used, so an
+# unconditional source is safe:
+source /path/to/ghostel/etc/shell/ghostel.nu
 #+end_src
 
 Remote (TRAMP / outbound =ssh=) shell integration has its own setup; see [[#tramp-remote-terminals][TRAMP
@@ -989,7 +1002,7 @@ or =~/.terminfo= (see [[#manual-terminfo-install][Manual install]] for that alte
 
 #+begin_src bash
 ssh REMOTE 'mkdir -p ~/.local/share/ghostel/terminfo'
-scp "$EMACS_GHOSTEL_PATH"/etc/shell/ghostel.{bash,zsh,fish} REMOTE:.local/share/ghostel/
+scp "$EMACS_GHOSTEL_PATH"/etc/shell/ghostel.{bash,zsh,fish,nu} REMOTE:.local/share/ghostel/
 scp -r "$EMACS_GHOSTEL_PATH"/etc/terminfo/{x,78} REMOTE:.local/share/ghostel/terminfo/
 #+end_src
 
@@ -1019,6 +1032,13 @@ fi
 if string match -qr '^ghostel(,|$)' -- "$INSIDE_EMACS"; or test "$TERM" = 'xterm-ghostty'
     source ~/.local/share/ghostel/ghostel.fish
 end
+#+end_src
+
+#+begin_src text
+# nushell - config.nu on the remote host.  nushell's `source' cannot be
+# gated at runtime, but ghostel.nu is inert until used, so source it
+# unconditionally (tilde expands at parse time):
+source ~/.local/share/ghostel/ghostel.nu
 #+end_src
 
 The two-clause gate covers both ways a remote ghostel shell can be reached:

--- a/etc/shell/bootstrap/nushell/vendor/autoload/integration.nu
+++ b/etc/shell/bootstrap/nushell/vendor/autoload/integration.nu
@@ -1,0 +1,33 @@
+# Ghostel shell integration auto-injection for nushell.
+# Auto-loaded via XDG_DATA_DIRS — nushell scans
+# <entry>/nushell/vendor/autoload/*.nu for each XDG_DATA_DIRS entry, the
+# same mechanism (and the same injected entry) we use for fish.  This
+# shim restores XDG_DATA_DIRS and then chains to the real integration in
+# etc/shell/ghostel.nu (single source of truth; also used by manual
+# source and TRAMP).
+
+# Restore XDG_DATA_DIRS by removing our injected path so subprocesses
+# don't inherit it (mirrors ghostty's nushell cleanup and our fish shim).
+if "GHOSTEL_SHELL_INTEGRATION_XDG_DIR" in $env {
+    if "XDG_DATA_DIRS" in $env {
+        let cleaned = ($env.XDG_DATA_DIRS
+            | split row ":"
+            | where {|d| $d != $env.GHOSTEL_SHELL_INTEGRATION_XDG_DIR }
+            | str join ":")
+        if ($cleaned | is-empty) {
+            hide-env XDG_DATA_DIRS
+        } else {
+            $env.XDG_DATA_DIRS = $cleaned
+        }
+    }
+    hide-env GHOSTEL_SHELL_INTEGRATION_XDG_DIR
+}
+
+# Load the real integration.  `path self' locates ghostel.nu relative to
+# this file: nushell `source' needs a parse-time-constant path, so we
+# cannot use $EMACS_GHOSTEL_PATH here the way the bash/zsh/fish shims do.
+# This file lives at
+#   <root>/etc/shell/bootstrap/nushell/vendor/autoload/integration.nu
+# so ghostel.nu is five directories up at <root>/etc/shell/ghostel.nu.
+const ghostel_root = (path self | path dirname --num-levels 5)
+source ($ghostel_root | path join "ghostel.nu")

--- a/etc/shell/ghostel.nu
+++ b/etc/shell/ghostel.nu
@@ -1,0 +1,158 @@
+# Ghostel shell integration for nushell
+# Source this from your `config.nu'.
+#
+# Local `config.nu' (nushell `source' needs a parse-time-constant path,
+# so use an absolute path — the file is inert until `ghostel_cmd' is
+# called or `ssh' is wrapped, so an unconditional source is fine):
+#   source /path/to/ghostel/etc/shell/ghostel.nu
+#
+# Remote `config.nu' (over ssh), pointing at the installed copy:
+#   source ~/.local/share/ghostel/ghostel.nu
+# See the README "Manual setup" section for the full rationale.
+#
+# Unlike the bash/zsh/fish integrations, this file does NOT emit OSC 7
+# (cwd) or OSC 133 (semantic prompt marks) itself.  Nushell reports
+# those natively via `$env.config.shell_integration' (osc2/osc7/osc133,
+# all on by default) and derives OSC 7's host from gethostname(2) — so
+# it already matches Emacs `(system-name)' the way our bash/zsh
+# capture-once logic does, without the $HOSTNAME pollution worry.  We
+# only add the ghostel-specific pieces: the `ghostel_cmd' elisp bridge
+# and the outbound `ssh' terminfo-install wrapper.
+#
+# No idempotency guard is needed: this file only (re)defines commands
+# and never appends to hooks or the prompt, so sourcing it more than
+# once is harmless.  (Do not disable `$env.config.shell_integration.osc7'
+# or `.osc133' in your config or directory tracking and prompt
+# navigation will stop working inside ghostel.)
+
+# Call an Emacs Elisp function from the shell.
+# Usage: ghostel_cmd FUNCTION [ARGS...]
+# The function must be in `ghostel-eval-cmds'.
+def ghostel_cmd [...args] {
+    mut payload = ""
+    for arg in $args {
+        let a = ($arg
+                 | str replace --all "\\" "\\\\"
+                 | str replace --all "\"" "\\\"")
+        $payload = $payload + "\"" + $a + "\" "
+    }
+    print -n $"\u{1b}]52;e;($payload)\u{1b}\\"
+}
+
+# Outbound `ssh' wrapper.  Activated when the elisp side sets
+# `ghostel-ssh-install-terminfo' (which exports
+# GHOSTEL_SSH_INSTALL_TERMINFO).  See etc/shell/ghostel.bash for the
+# full design notes — this is the nushell port of the same
+# install-and-cache logic: on first connection to a host it installs
+# xterm-ghostty terminfo via `tic', caches the outcome under
+# $XDG_CACHE_HOME/ghostel/ssh-terminfo-cache (key includes a hash of the
+# local terminfo), and connects with TERM=xterm-ghostty.  Failures cache
+# a skip marker and downgrade to xterm-256color.
+#
+# Always defined and gated at runtime (like ghostty's nushell wrapper):
+# nushell `def' cannot be conditionally defined by a runtime env var.
+# Per-call escape hatch: prefix with GHOSTEL_SSH_KEEP_TERM=1 to bypass.
+def --wrapped ssh [...args] {
+    # Feature off, escape hatch, or no local infocmp: pass through.
+    if (($env.GHOSTEL_SSH_INSTALL_TERMINFO? | is-empty)
+        or (not ($env.GHOSTEL_SSH_KEEP_TERM? | is-empty))
+        or (which infocmp | is-empty)) {
+        ^ssh ...$args
+        return
+    }
+
+    # Resolve the canonical target (normalises ssh_config aliases).
+    mut user = ""
+    mut host = ""
+    mut port = ""
+    let cfg = (do { ^ssh -G ...$args } | complete)
+    for line in ($cfg.stdout | lines) {
+        let parts = ($line | split row " ")
+        if ($parts | length) < 2 { continue }
+        let k = ($parts | first)
+        let v = ($parts | get 1)
+        if $k == "user" { $user = $v }
+        if $k == "hostname" { $host = $v }
+        if $k == "port" { $port = $v }
+        if ($user != "" and $host != "" and $port != "") { break }
+    }
+
+    # No host (e.g. `ssh -V`, `ssh -h`): pass through.
+    if ($host == "") {
+        ^ssh ...$args
+        return
+    }
+
+    let target = $"($user)@($host):($port)"
+    let hash = ((do { ^infocmp -0 -x xterm-ghostty | ^cksum } | complete).stdout
+                | split row " " | first | str trim)
+    let cache_dir = (if ($env.XDG_CACHE_HOME? | is-empty) {
+        $"($env.HOME)/.cache/ghostel"
+    } else {
+        $"($env.XDG_CACHE_HOME)/ghostel"
+    })
+    let cache = ($cache_dir | path join "ssh-terminfo-cache")
+    let key = $"($target):($hash)"
+
+    # Cache hit?
+    if ($cache | path exists) {
+        let entries = (open $cache | lines)
+        if ($"($key) ok" in $entries) {
+            with-env {TERM: "xterm-ghostty"} { ^ssh ...$args }
+            return
+        }
+        if ($"($key) skip" in $entries) {
+            with-env {TERM: "xterm-256color"} { ^ssh ...$args }
+            return
+        }
+    }
+
+    # Skip install when the user passed a remote command — combining our
+    # install script with their command via the same ssh invocation is
+    # fragile.  The next interactive `ssh HOST' will trigger install.
+    mut positional = 0
+    mut skip = false
+    for arg in $args {
+        if $skip {
+            $skip = false
+            continue
+        }
+        if ($arg in ["-b" "-c" "-D" "-E" "-e" "-F" "-I" "-i" "-J" "-L" "-l" "-m" "-O" "-o" "-P" "-p" "-Q" "-R" "-S" "-W" "-w"]) {
+            $skip = true
+        } else if ($arg | str starts-with "-") {
+            # flag without an argument
+        } else {
+            $positional = $positional + 1
+        }
+    }
+    if ($positional > 1) {
+        with-env {TERM: "xterm-256color"} { ^ssh ...$args }
+        return
+    }
+
+    # Combined probe + install in a single setup ssh invocation.
+    # Mkdir-as-lock (external `mkdir' fails if the dir exists) so
+    # concurrent first-time `ssh HOST' from two ghostel buffers don't
+    # both spawn a setup connection.  Lock keyed on (target, hash) so
+    # different targets run in parallel.
+    mkdir $cache_dir
+    let lock = ($cache_dir | path join $".lock.($target).($hash)")
+    if ((do { ^mkdir $lock } | complete).exit_code != 0) {
+        with-env {TERM: "xterm-256color"} { ^ssh ...$args }
+        return
+    }
+    let install = "infocmp xterm-ghostty >/dev/null 2>&1 && exit 0
+command -v tic >/dev/null 2>&1 || exit 1
+mkdir -p \"$HOME/.terminfo\" && tic -x - >/dev/null 2>&1"
+    let res = (do { ^infocmp -0 -x xterm-ghostty | ^ssh ...$args $install } | complete)
+    if ($res.exit_code == 0) {
+        $"($key) ok\n" | save --append $cache
+        ^rmdir $lock
+        with-env {TERM: "xterm-ghostty"} { ^ssh ...$args }
+    } else {
+        print -e $"ghostel: failed to install xterm-ghostty terminfo on ($host) \(no tic on remote?\), using xterm-256color."
+        $"($key) skip\n" | save --append $cache
+        ^rmdir $lock
+        with-env {TERM: "xterm-256color"} { ^ssh ...$args }
+    }
+}

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -240,9 +240,9 @@ FALLBACK, when present, is used when login-shell detection fails.
 
 Any elements after FALLBACK are extra arguments passed to the shell.
 When none are given, ghostel supplies a type-aware default: recognized shells
-\(bash, zsh, fish) are started as login+interactive shells (`-l -i') so they
-source the user's rc/profile files, mirroring an interactive `ssh host' login.
-Unrecognized shells (e.g. /bin/sh) get no args.
+\(bash, zsh, fish, nushell) are started as login+interactive shells (`-l -i')
+so they source the user's rc/profile files, mirroring an interactive `ssh host'
+login.  Unrecognized shells (e.g. /bin/sh) get no args.
 To override, list the arguments explicitly after FALLBACK,
 e.g. (\"ssh\" login-shell nil \"-i\").
 
@@ -639,7 +639,7 @@ reference opened at its start.")
   "Automatically inject shell integration on startup.
 When non-nil, ghostel modifies the shell invocation to automatically
 load shell integration scripts without requiring changes to the user's
-shell configuration files.  Supports bash, zsh, and fish."
+shell configuration files.  Supports bash, zsh, fish, and nushell."
   :type 'boolean)
 
 (defcustom ghostel-macos-login-shell (eq system-type 'darwin)
@@ -676,7 +676,10 @@ Set to t for all supported shells, or a list of symbols
   :type '(choice (const :tag "Disabled" nil)
                  (const :tag "All shells" t)
                  (repeat :tag "Specific shells"
-                         (choice (const bash) (const zsh) (const fish)))))
+                         (choice (const bash)
+                                 (const zsh)
+                                 (const fish)
+                                 (const nu)))))
 
 (defcustom ghostel-tramp-default-method nil
   "TRAMP method for constructing remote paths from OSC 7 directory reports.
@@ -3802,12 +3805,13 @@ EVENT is the state-change description passed by Emacs."
             (insert "\n[Process exited]\n")))))))
 
 (defun ghostel--detect-shell (shell)
-  "Return shell type symbol (bash, zsh, fish) from SHELL path, or nil."
+  "Return shell type symbol (bash, zsh, fish, nu) from SHELL path, or nil."
   (let ((base (file-name-nondirectory shell)))
     (cond
      ((string-match-p "bash" base) 'bash)
      ((string-match-p "zsh" base) 'zsh)
-     ((string-match-p "fish" base) 'fish))))
+     ((string-match-p "fish" base) 'fish)
+     ((member base '("nu" "nushell")) 'nu))))
 
 (defun ghostel--local-host-p (host)
   "Return non-nil if HOST refers to the local machine."
@@ -3860,13 +3864,13 @@ element is the program path and the remaining elements are arguments."
 
 (defun ghostel--default-remote-shell-args (program &optional integration)
   "Return default extra args for a remote shell PROGRAM.
-Recognized shells (bash, zsh, fish) start login+interactive (`-l -i') so
-remote sessions source the user's rc/profile files; unrecognized shells
-\(e.g. /bin/sh) get no args.  With INTEGRATION active, bash uses `-i'
-only (a login bash ignores the integration's `--rcfile')."
+Recognized shells (bash, zsh, fish, nushell) start login+interactive
+\(`-l -i') so remote sessions source the user's rc/profile files;
+unrecognized shells \(e.g. /bin/sh) get no args.  With INTEGRATION active,
+bash uses `-i' only (a login bash ignores the integration's `--rcfile')."
   (pcase (ghostel--detect-shell program)
     ('bash (if integration '("-i") '("-l" "-i")))
-    ((or 'zsh 'fish) '("-l" "-i"))
+    ((or 'zsh 'fish 'nu) '("-l" "-i"))
     (_ nil)))
 
 (defun ghostel--resolve-shell-spec ()
@@ -4102,6 +4106,18 @@ Returns nil on failure."
              (list :env nil
                    :args (list "-C" (format "source %s"
                                             (shell-quote-argument path)))
+                   :temp-files (list temp))))
+          ;; Nushell: --execute runs after config (like fish's -C).
+          ;; nushell `source' needs a parse-time-constant path, so the
+          ;; literal remote temp path is embedded in the --execute arg.
+          ('nu
+           (let* ((temp (make-temp-file
+                         (concat remote-prefix "ghostel-") nil ".nu"))
+                  (path (file-remote-p temp 'localname)))
+             (ghostel--write-remote-file temp integration)
+             (list :env nil
+                   :args (list "--execute" (format "source %s"
+                                                   (shell-quote-argument path)))
                    :temp-files (list temp)))))))
         (if tinfo
             (ghostel--merge-integration-plists base tinfo)
@@ -4429,7 +4445,8 @@ run the shell on the remote host."
                             (push (format "GHOSTEL_ZSH_ZDOTDIR=%s" old-zdotdir) env))
                           (push (format "ZDOTDIR=%s" zsh-dir) env)
                           env))))
-                   ('fish
+                   ;; Fish and nushell both auto-load from XDG_DATA_DIRS
+                   ((or 'fish 'nu)
                     (let ((integ-dir (expand-file-name
                                       "etc/shell/bootstrap" ghostel-dir)))
                       (when (file-directory-p integ-dir)

--- a/test/ghostel-shell-test.el
+++ b/test/ghostel-shell-test.el
@@ -207,6 +207,80 @@ newest-first list aligns with the buffer-order regions."
                                       (match-string 1 output))))
       (delete-directory fish-home t))))
 
+(ert-deftest ghostel-test-nu-auto-inject-loads-integration ()
+  "Nushell auto-inject shim chains to ghostel.nu and cleans XDG_DATA_DIRS.
+The shim is vendor-autoloaded via XDG_DATA_DIRS; it locates ghostel.nu
+with `path self' and sources it.  Driven with `nu --execute' because
+nushell only runs vendor autoload for interactive sessions (plain `-c'
+skips it), and `--execute' enters an interactive shell."
+  :tags '(:nu)
+  (skip-unless (executable-find "nu"))
+  (let* ((ghostel-dir (or (ghostel--resource-root)
+                          (file-name-directory
+                           (or (locate-library "ghostel")
+                               load-file-name
+                               buffer-file-name))))
+         (integ-dir (directory-file-name
+                     (expand-file-name "etc/shell/bootstrap" ghostel-dir)))
+         ;; Isolate from the dev's nushell config: point HOME and
+         ;; XDG_CONFIG_HOME at an empty temp dir so a user `config.nu'
+         ;; (which could pre-define ghostel_cmd/ssh) can't satisfy the
+         ;; assertions.  XDG_DATA_DIRS still carries our bootstrap dir so
+         ;; vendor autoload runs.
+         (nu-home (make-temp-file "ghostel-test-nu-home-" t)))
+    (unwind-protect
+        (let* ((probe (concat
+                       "let c = (scope commands | where name == \"ghostel_cmd\" | length)\n"
+                       "print (\"cmd=\" + (if $c > 0 { \"yes\" } else { \"no\" }))\n"
+                       "let s = (scope commands | where name == \"ssh\" | length)\n"
+                       "print (\"sshw=\" + (if $s > 0 { \"yes\" } else { \"no\" }))\n"
+                       "print (\"xdg=\" + ($env.XDG_DATA_DIRS? | default \"NONE\"))\n"
+                       "exit\n"))
+               (process-environment
+                (append (list (format "HOME=%s" nu-home)
+                              (format "XDG_CONFIG_HOME=%s" nu-home)
+                              (format "EMACS_GHOSTEL_PATH=%s" ghostel-dir)
+                              "GHOSTEL_SSH_INSTALL_TERMINFO=1"
+                              (format "XDG_DATA_DIRS=%s:/usr/local/share:/usr/share"
+                                      integ-dir)
+                              (format "GHOSTEL_SHELL_INTEGRATION_XDG_DIR=%s"
+                                      integ-dir))
+                        process-environment))
+               (default-directory nu-home)
+               (output (with-temp-buffer
+                         (call-process "nu" nil (current-buffer) nil
+                                       "--execute" probe)
+                         (buffer-string))))
+          ;; Shim must chain (via `path self') to etc/shell/ghostel.nu so
+          ;; ghostel_cmd is defined.
+          (should (string-match-p "^cmd=yes$" output))
+          ;; ghostel.nu also defines the outbound `ssh' wrapper.
+          (should (string-match-p "^sshw=yes$" output))
+          ;; XDG cleanup must strip the injected bootstrap dir so
+          ;; subprocesses don't re-autoload the shim.
+          (should (string-match "^xdg=\\(.*\\)$" output))
+          (should-not (string-match-p (regexp-quote integ-dir)
+                                      (match-string 1 output))))
+      (delete-directory nu-home t))))
+
+(ert-deftest ghostel-test-nu-ghostel-cmd-emits-osc52 ()
+  "Nushell `ghostel_cmd' emits an OSC 52 ;e payload with quoted args."
+  :tags '(:nu)
+  (skip-unless (executable-find "nu"))
+  (let* ((ghostel-dir (or (ghostel--resource-root)
+                          (file-name-directory
+                           (or (locate-library "ghostel")
+                               load-file-name
+                               buffer-file-name))))
+         (script (expand-file-name "etc/shell/ghostel.nu" ghostel-dir))
+         (output (with-temp-buffer
+                   (call-process "nu" nil (current-buffer) nil "-n" "-c"
+                                 (format "source %s; ghostel_cmd \"a b\""
+                                         (shell-quote-argument script)))
+                   (buffer-string))))
+    ;; ESC ] 52 ; e ; "a b" <space> ... ESC \
+    (should (string-match-p "\e]52;e;\"a b\" " output))))
+
 (ert-deftest ghostel-test-update-directory ()
   "Test OSC 7 directory tracking helper."
   (let* ((ghostel--last-directory nil)

--- a/test/ghostel-spawn-test.el
+++ b/test/ghostel-spawn-test.el
@@ -123,11 +123,24 @@ written by `ghostel-test--pty-winsize-script'."
 
 ;;; Remote shell spec resolution (issue #444)
 
+(ert-deftest ghostel-test-detect-shell ()
+  "`ghostel--detect-shell' maps binaries to shell-type symbols."
+  (should (eq 'bash (ghostel--detect-shell "/bin/bash")))
+  (should (eq 'zsh (ghostel--detect-shell "/usr/bin/zsh")))
+  (should (eq 'fish (ghostel--detect-shell "/usr/bin/fish")))
+  ;; Nushell's binary is `nu' (exact match, also accept `nushell').
+  (should (eq 'nu (ghostel--detect-shell "/opt/homebrew/bin/nu")))
+  (should (eq 'nu (ghostel--detect-shell "nushell")))
+  ;; "nu" must be exact: a path merely containing "nu" is not nushell.
+  (should-not (ghostel--detect-shell "/usr/bin/gnushell-wrapper"))
+  (should-not (ghostel--detect-shell "/bin/sh")))
+
 (ert-deftest ghostel-test-default-remote-shell-args-recognized ()
   "Recognized remote shells default to login+interactive args."
   (should (equal '("-l" "-i") (ghostel--default-remote-shell-args "/bin/zsh")))
   (should (equal '("-l" "-i") (ghostel--default-remote-shell-args "/bin/bash")))
   (should (equal '("-l" "-i") (ghostel--default-remote-shell-args "/usr/bin/fish")))
+  (should (equal '("-l" "-i") (ghostel--default-remote-shell-args "/opt/homebrew/bin/nu")))
   ;; NixOS-style path: detection keys off the basename.
   (should (equal '("-l" "-i")
                  (ghostel--default-remote-shell-args
@@ -142,9 +155,10 @@ written by `ghostel-test--pty-winsize-script'."
   "With integration active, bash drops `-l'; zsh/fish keep login+interactive."
   ;; Bash: `-l' would make login bash ignore integration's `--rcfile'.
   (should (equal '("-i") (ghostel--default-remote-shell-args "/bin/bash" t)))
-  ;; Zsh and fish compose cleanly with `-l -i'.
+  ;; Zsh, fish, and nushell compose cleanly with `-l -i'.
   (should (equal '("-l" "-i") (ghostel--default-remote-shell-args "/usr/bin/zsh" t)))
   (should (equal '("-l" "-i") (ghostel--default-remote-shell-args "/usr/bin/fish" t)))
+  (should (equal '("-l" "-i") (ghostel--default-remote-shell-args "/opt/homebrew/bin/nu" t)))
   ;; Unrecognized shells still get nothing.
   (should-not (ghostel--default-remote-shell-args "/bin/sh" t)))
 


### PR DESCRIPTION
## Summary

Adds nushell (`nu`) as a first-class supported shell alongside bash, zsh, and
fish — for auto-injection, manual `source`, and remote TRAMP sessions.

## Design

Unlike the other shells, **nushell emits OSC 7 (cwd), OSC 133 (prompt marks),
and OSC 2 (title) natively** via its built-in `$env.config.shell_integration`
(on by default), and derives OSC 7's host from `gethostname(2)` — so it already
matches Emacs `(system-name)` the way the bash/zsh capture-once logic does,
without the `$HOSTNAME`-pollution workarounds. So `etc/shell/ghostel.nu` only
adds the ghostel-specific pieces:

- `ghostel_cmd` — the OSC 52 `;e` bridge for calling Elisp from the shell.
- The outbound `ssh` terminfo-install wrapper (nushell port of the bash/fish
  install-and-cache logic, runtime-gated on `GHOSTEL_SSH_INSTALL_TERMINFO`).

**Injection mirrors fish:** nushell vendor-autoloads from `XDG_DATA_DIRS`
(`<dir>/nushell/vendor/autoload/`), so `'nu` reuses fish's bootstrap dir and
`GHOSTEL_SHELL_INTEGRATION_XDG_DIR` cleanup. The autoload shim locates
`ghostel.nu` via `path self` because nushell's `source` needs a
parse-time-constant path. Remote/TRAMP uses `--execute "source …"` (the
analogue of fish's `-C`), and nushell starts login+interactive (`-l -i`).

## Changes

- New: `etc/shell/ghostel.nu` and
  `etc/shell/bootstrap/nushell/vendor/autoload/integration.nu`.
- `lisp/ghostel.el`: shell detection (`nu`/`nushell` → `'nu`), local injection
  (folded into the fish XDG branch), remote TRAMP branch, default remote args,
  and the `ghostel-shell-integration` / `ghostel-tramp-shell-integration`
  customizations.
- Tests: shell detection, default remote args, the auto-inject chain (drives
  `nu --execute`, asserting the autoload → `path self` → source chain and XDG
  cleanup), and `ghostel_cmd`'s OSC 52 output.
- Docs: README (manual setup, local + remote) and CHANGELOG.

## Caveat

Directory tracking and prompt navigation rely on nushell's native
`shell_integration.osc7`/`.osc133` (enabled by default); disabling them in your
nushell config disables those features inside ghostel. Documented in the README.

## Testing

- `make -j8 all` green (build + lint + all tests, 0 unexpected).
- Live-verified in a sandboxed Emacs: a real ghostel buffer running nushell —
  integration loaded (`ghostel_cmd`/`ssh` defined), `cd /tmp` updates
  `default-directory`, and `XDG_DATA_DIRS` is cleaned with no env leak.
