### PR TITLE
Clamp rightward cursor moves instead of undoing autocompletes in evil-ghostel

### DIFF
--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -315,56 +315,31 @@ Loops `accept-process-output' (capped by
 
 (defun evil-ghostel-goto-input-position (pos)
   "Drive the terminal cursor and Emacs point to buffer position POS.
-Returns t when the cursor reached POS.  Only meaningful in semi-char mode."
+On the cursor row a rightward target is clamped to `evil-ghostel--input-end',
+so the move never right-arrows across a trailing autosuggestion, which the
+shell would accept (zsh-autosuggestions / fish).  Only meaningful in
+semi-char mode.  Returns non-nil when it ran."
   (when (and ghostel--term ghostel--cursor-pos)
-    (let* ((start-char-pos ghostel--cursor-char-pos)
-           (start-cursor ghostel--cursor-pos)
-           (start-col (car start-cursor))
-           (start-row-vp (cdr start-cursor))
-           (target-col (save-excursion (goto-char pos) (current-column)))
+    (let* ((start-col (car ghostel--cursor-pos))
+           (start-row-vp (cdr ghostel--cursor-pos))
            (target-row-vp (or (ghostel--viewport-row-at pos) start-row-vp))
-           (dy (- target-row-vp start-row-vp))
-           (dx (- target-col start-col))
-           (right-arrow-drained nil)
-           (reached
-            (progn
-              (cond ((> dy 0) (dotimes (_ dy) (ghostel--send-encoded "down" "")))
-                    ((< dy 0) (dotimes (_ (abs dy)) (ghostel--send-encoded "up" ""))))
-              (cond ((> dx 0) (dotimes (_ dx) (ghostel--send-encoded "right" "")))
-                    ((< dx 0) (dotimes (_ (abs dx)) (ghostel--send-encoded "left" ""))))
-              ;; Verify landing only on rightward moves (the ones that can
-              ;; trip literal-echo or autosuggest).  Echo detection needs a
-              ;; rendered baseline; without one, treat the send as success.
-              (if (or (<= dx 0) (null start-char-pos))
-                  t
-                (setq right-arrow-drained t)
-                (evil-ghostel--sync-render)
-                (let ((post-cur ghostel--cursor-char-pos))
-                  (cond
-                   ((and post-cur (= post-cur pos)) t)
-                   ;; Literal-echo: cursor advanced 4×dx and buffer ends
-                   ;; with "^[[C".  Echo is 4 chars per arrow; send 3
-                   ;; backspaces per arrow to undo.
-                   ((and post-cur (zerop dy)
-                         (= post-cur (+ start-char-pos (* 4 dx)))
-                         (save-excursion
-                           (goto-char post-cur)
-                           (looking-back (regexp-quote "^[[C") (min 4 post-cur))))
-                    (dotimes (_ (* 3 dx)) (ghostel--send-encoded "backspace" ""))
-                    nil)
-                   ;; Cursor jumped past target — autosuggest accepted.
-                   ((and post-cur (> post-cur pos))
-                    (ghostel--send-encoded "_" "ctrl")
-                    nil)
-                   (t nil)))))))
-      (when reached
-        ;; Drain so `ghostel--cursor-pos' reflects the move, unless the
-        ;; rightward branch already drained or no arrows were sent.
-        (when (and (not right-arrow-drained)
-                   (or (/= dx 0) (/= dy 0)))
+           (dy (- target-row-vp start-row-vp)))
+      ;; Clamp only a rightward, same-row target: at end-of-input a right
+      ;; arrow accepts the greyed suggestion.
+      ;; `input-end' excludes it, so stopping there means we never accept.
+      (when (and (zerop dy)
+                 ghostel--cursor-char-pos
+                 (> pos ghostel--cursor-char-pos))
+        (setq pos (min pos (or (evil-ghostel--input-end) pos))))
+      (let ((dx (- (save-excursion (goto-char pos) (current-column)) start-col)))
+        (cond ((> dy 0) (dotimes (_ dy) (ghostel--send-encoded "down" "")))
+              ((< dy 0) (dotimes (_ (abs dy)) (ghostel--send-encoded "up" ""))))
+        (cond ((> dx 0) (dotimes (_ dx) (ghostel--send-encoded "right" "")))
+              ((< dx 0) (dotimes (_ (abs dx)) (ghostel--send-encoded "left" ""))))
+        (when (or (/= dx 0) (/= dy 0))
           (evil-ghostel--sync-render))
-        (goto-char pos))
-      reached)))
+        (goto-char pos)
+        t))))
 
 (defun evil-ghostel-delete-input-region (beg end)
   "Delete BEG..END from input by backspacing over the PTY; return the count.

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -962,6 +962,72 @@ without a real native module."
         (evil-ghostel-goto-input-position ghostel--cursor-char-pos))
       (should (zerop (length keys-sent))))))
 
+(defmacro evil-ghostel-test--with-cursor-fixture (prompt typed trail &rest body)
+  "Mock terminal: PROMPT (`ghostel-prompt') + TYPED (`ghostel-input') + TRAIL,
+with `ghostel--cursor-char-pos' at the TYPED/TRAIL boundary so TRAIL occupies
+cells to the right of the cursor.  Runs BODY with evil + `evil-ghostel-mode'
+on and the terminal mocked."
+  (declare (indent 3))
+  `(let ((buf (generate-new-buffer " *evil-ghostel-test-cursor*")))
+     (unwind-protect
+         (with-current-buffer buf
+           (ghostel-mode)
+           (let ((inhibit-read-only t))
+             (insert (propertize ,prompt 'ghostel-prompt t))
+             (insert (propertize ,typed 'ghostel-input t))
+             (setq ghostel--cursor-char-pos (point))
+             (setq ghostel--cursor-pos (cons (current-column) 0))
+             (insert (propertize ,trail 'ghostel-input t)))
+           (setq ghostel--term 'fake)
+           (setq ghostel--term-rows 1)
+           (evil-local-mode 1)
+           (evil-ghostel-mode 1)
+           (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                      (lambda (&rest _) nil)))
+             ,@body))
+       (kill-buffer buf))))
+
+;; The color-based suggestion detection (`suggestion-p'/`greyed-out-p') is not
+;; exercisable under `--batch' (`color-values' has no display frame), so these
+;; test the clamp contract directly by stubbing `evil-ghostel--input-end' — the
+;; boundary the clamp trims a rightward target to.
+
+(ert-deftest evil-ghostel-test-goto-clamps-rightward-into-suggestion ()
+  "A rightward target past `evil-ghostel--input-end' (a trailing autosuggestion)
+is clamped to it: no right arrows cross the boundary and no `C-_'/backspace
+correction is emitted (issue #493)."
+  (evil-ghostel-test--with-cursor-fixture "$ " "ls" " --all"
+    (let ((sent '()))
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key mods &rest _) (push (cons key mods) sent)))
+                ((symbol-function 'evil-ghostel--sync-render) #'ignore)
+                ;; Suggestion trails the cursor -> the input end is the cursor.
+                ((symbol-function 'evil-ghostel--input-end)
+                 (lambda () ghostel--cursor-char-pos)))
+        ;; Aim into the trailing "suggestion".
+        (evil-ghostel-goto-input-position (+ ghostel--cursor-char-pos 3)))
+      (should-not (cl-find "right" sent :key #'car :test #'equal))
+      (should-not (cl-find '("_" . "ctrl") sent :test #'equal))
+      (should-not (cl-find "backspace" sent :key #'car :test #'equal))
+      ;; Point clamped back to the cursor (start of the suggestion).
+      (should (= (point) ghostel--cursor-char-pos)))))
+
+(ert-deftest evil-ghostel-test-goto-rightward-within-input-sends-right ()
+  "Rightward motion within typed input still sends right arrows — the
+suggestion clamp does not over-restrict (issue #493)."
+  (evil-ghostel-test--with-cursor-fixture "$ " "hel" "lo"
+    (let ((sent '()))
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key mods &rest _) (push (cons key mods) sent)))
+                ((symbol-function 'evil-ghostel--sync-render) #'ignore)
+                ;; Real input end is two cells right of the cursor.
+                ((symbol-function 'evil-ghostel--input-end)
+                 (lambda () (+ ghostel--cursor-char-pos 2))))
+        (evil-ghostel-goto-input-position (+ ghostel--cursor-char-pos 2)))
+      (should (= 2 (cl-count "right" sent :key #'car :test #'equal)))
+      (should-not (cl-find '("_" . "ctrl") sent :test #'equal))
+      (should-not (cl-find "backspace" sent :key #'car :test #'equal)))))
+
 (ert-deftest evil-ghostel-test-sync-render-forces-deferred-redraw ()
   "`sync-render' force-runs `ghostel--redraw-now' after a bulk-output drain.
 The filter only takes the synchronous redraw path for small echoes


### PR DESCRIPTION
## What #493 reported

`evil-ghostel` sends synthetic arrow keys into inline TUIs (e.g. Claude Code) when
entering insert state. Those arrows are **by design** — `evil-ghostel-goto-input-position`
drives the terminal cursor to match Emacs point by emitting left/right/up/down, and it
works correctly in cursor-key-aware programs like Claude Code. That behavior is unchanged.

The genuinely-wrong part was a **`C-_` (readline/zle undo)** the same function emitted as
a correction.

## The bug

Evil motions run on the *rendered* ghostel buffer, which contains a trailing greyed
autosuggestion (zsh-autosuggestions / fish) as real buffer text. So a motion like `$`
puts point *past* the typed input, and the cursor move then right-arrows across the
suggestion — which the shell **accepts**.

The old code coped after the fact: it detected the overshoot and sent `C-_` to unwind the
acceptance. That undo has effects beyond the acceptance (it is a full readline/zle undo)
and fired in cases it should not.

## The fix

Clamp instead of undo. On a same-row rightward move the target is trimmed to
`evil-ghostel--input-end`, which excludes the greyed suggestion — so the move stops at the
last real character and never triggers acceptance. There is then nothing to undo, and no
`C-_` is sent. No caller reads the return value, so dropping the old `nil`/`t` "reached"
signal is inert.

This also removes the old literal-`^[[C`-echo backspace cleanup, which only applied to
inline programs that do not interpret cursor keys (e.g. `cat`) and could not position the
cursor correctly there anyway.

## Testing

- New ERT coverage for the clamp contract (`evil-ghostel--input-end` stubbed, since the
  color-based suggestion detection is not exercisable under `--batch`).
- `make -j8 all` and `make test-evil` pass.
- Verified live across bash / zsh / fish / nu and a python3 REPL; a reusable elate
  scenario matrix for that lands in a follow-up commit.

Refs #493.
