### PR TITLE
Host-qualify ghostel-project buffer identity for remote roots

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -361,9 +361,9 @@ project:
   A terminal that walked out of the project is excluded; a plain
   `ghostel' buffer that cd'd into the project is included.
 - `identity': match each buffer's `ghostel--buffer-identity'
-  against the value `project-prefixed-buffer-name' would produce
-  for the current project.  Stable across `cd', but only finds
-  buffers originally created via `ghostel-project'.
+  against the name `ghostel-project' would use for the current project.
+  Stable across `cd', but only finds buffers originally
+  created via `ghostel-project'.
 - `both' (default): union of the two - `default-directory' first,
   then identity-matched buffers not already covered."
   :type '(choice (const :tag "Match by buffer default-directory" default-directory)
@@ -5178,10 +5178,23 @@ already has a live ghostel process."
       (let ((remote-p (file-remote-p default-directory)))
         (ghostel--spawn-pty program args nil remote-p)))))
 
+(defun ghostel--project-buffer-name (root)
+  "Return the project-prefixed ghostel buffer name for project ROOT.
+For remote ROOTs the TRAMP prefix is folded into the name so a local
+and a remote project with the same name get distinct buffers."
+  (let ((name (project-prefixed-buffer-name
+               (string-trim ghostel-buffer-name "*" "*")))
+        (remote (file-remote-p root)))
+    (if remote
+        (format "%s@%s*" (substring name 0 -1)
+                (string-trim remote "/" ":"))
+      name)))
+
 ;;;###autoload
 (defun ghostel-project (&optional arg)
   "Start a new Ghostel terminal in the current project's root.
-The buffer name is prefixed with the project name.
+The buffer name is prefixed with the project name; remote (TRAMP) projects also
+carry the remote host, to distinguish equally named local and remote projects.
 If a buffer already exists for this project, switch to it.
 Otherwise create a new Ghostel buffer.  ARG is passed through to
 `ghostel' and accepts the same universal argument conventions.
@@ -5189,9 +5202,8 @@ To add this to `project-switch-commands':
   (add-to-list \\='project-switch-commands \\='(ghostel-project \"Ghostel\") t)
 Returns the buffer."
   (interactive "P")
-  (let ((default-directory (project-root (project-current t)))
-        (ghostel-buffer-name (project-prefixed-buffer-name
-                              (string-trim ghostel-buffer-name "*" "*"))))
+  (let* ((default-directory (project-root (project-current t)))
+         (ghostel-buffer-name (ghostel--project-buffer-name default-directory)))
     (ghostel arg)))
 
 (defun ghostel-other ()
@@ -5229,11 +5241,7 @@ against a TRAMP path would walk the remote filesystem
 synchronously on every cycle."
   (let* ((proj (project-current t))
          (root (project-root proj))
-         (identity-prefix
-          (let ((ghostel-buffer-name
-                 (project-prefixed-buffer-name
-                  (string-trim ghostel-buffer-name "*" "*"))))
-            ghostel-buffer-name))
+         (identity-prefix (ghostel--project-buffer-name root))
          (scope ghostel-project-buffer-scope)
          (all (ghostel--all-buffers))
          (by-dir

--- a/test/ghostel-project-test.el
+++ b/test/ghostel-project-test.el
@@ -61,6 +61,113 @@
       (should (equal (car captured) '(4)))
       (should (equal (cdr captured) "*myproj-ghostel*")))))
 
+(ert-deftest ghostel-test-project-buffer-name-remote ()
+  "`ghostel--project-buffer-name' host-qualifies remote roots (bug #344)."
+  (require 'project)
+  (let ((ghostel-buffer-name "*ghostel*"))
+    (cl-letf (((symbol-function 'project-prefixed-buffer-name)
+               (lambda (name) (format "*myproj-%s*" name))))
+      (should (equal (ghostel--project-buffer-name "/tmp/myproj/")
+                     "*myproj-ghostel*"))
+      (should (equal (ghostel--project-buffer-name
+                      "/ssh:user@host:/tmp/myproj/")
+                     "*myproj-ghostel@ssh:user@host*")))))
+
+(ert-deftest ghostel-test-project-remote-not-confused-with-local ()
+  "`ghostel-project' on a remote root ignores an equally named local buffer.
+Regression test for bug #344: a local and a remote project with the
+same name must get separate buffers."
+  (require 'project)
+  (let* ((ghostel-buffer-name "*ghostel*")
+         (local (generate-new-buffer "*myproj-ghostel*"))
+         (created (generate-new-buffer " *ghostel-test-remote-proj*"))
+         result)
+    (unwind-protect
+        (progn
+          (with-current-buffer local
+            (ghostel-mode)
+            (setq-local ghostel--buffer-identity "*myproj-ghostel*")
+            (setq-local ghostel--term 'fake-term))
+          (cl-letf (((symbol-function 'project-current)
+                     (lambda (&rest _)
+                       '(transient . "/ssh:user@host:/tmp/myproj/")))
+                    ((symbol-function 'project-root)
+                     (lambda (proj) (cdr proj)))
+                    ((symbol-function 'project-prefixed-buffer-name)
+                     (lambda (name) (format "*myproj-%s*" name)))
+                    ((symbol-function 'ghostel--load-module)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'ghostel--create)
+                     (lambda (&rest _) created))
+                    ((symbol-function 'ghostel--start-process) #'ignore))
+            (setq result (ghostel-project)))
+          (should (eq result created))
+          (with-current-buffer created
+            (should (equal ghostel--buffer-identity
+                           "*myproj-ghostel@ssh:user@host*"))))
+      (dolist (b (list local created))
+        (when (buffer-live-p b) (kill-buffer b))))))
+
+(ert-deftest ghostel-test-project-remote-reuses-remote ()
+  "`ghostel-project' reuses the buffer of the same remote project."
+  (require 'project)
+  (let* ((ghostel-buffer-name "*ghostel*")
+         (existing (generate-new-buffer "*myproj-ghostel@ssh:user@host*"))
+         (pre-count (length (buffer-list)))
+         popped)
+    (unwind-protect
+        (progn
+          (with-current-buffer existing
+            (ghostel-mode)
+            (setq-local ghostel--buffer-identity
+                        "*myproj-ghostel@ssh:user@host*")
+            (setq-local ghostel--term 'fake-term))
+          (cl-letf (((symbol-function 'project-current)
+                     (lambda (&rest _)
+                       '(transient . "/ssh:user@host:/tmp/myproj/")))
+                    ((symbol-function 'project-root)
+                     (lambda (proj) (cdr proj)))
+                    ((symbol-function 'project-prefixed-buffer-name)
+                     (lambda (name) (format "*myproj-%s*" name)))
+                    ((symbol-function 'ghostel--load-module)
+                     (lambda (&rest _) nil))
+                    ((symbol-function 'pop-to-buffer)
+                     (lambda (b &rest _) (setq popped b))))
+            (ghostel-project))
+          (should (eq popped existing))
+          (should (= pre-count (length (buffer-list)))))
+      (when (buffer-live-p existing) (kill-buffer existing)))))
+
+(ert-deftest ghostel-test-project-buffers-identity-scope-remote ()
+  "Identity scope separates local and remote projects of the same name."
+  (require 'project)
+  (let ((ghostel-buffer-name "*ghostel*")
+        (ghostel-project-buffer-scope 'identity)
+        (local (generate-new-buffer "*ghostel: local myproj*"))
+        (remote (generate-new-buffer "*ghostel: remote myproj*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer local
+            (ghostel-mode)
+            (setq-local ghostel--buffer-identity "*myproj-ghostel*"))
+          (with-current-buffer remote
+            (ghostel-mode)
+            (setq-local ghostel--buffer-identity
+                        "*myproj-ghostel@ssh:user@host*"))
+          (cl-letf (((symbol-function 'project-prefixed-buffer-name)
+                     (lambda (name) (format "*myproj-%s*" name)))
+                    ((symbol-function 'project-root)
+                     (lambda (proj) (cdr proj))))
+            (cl-letf (((symbol-function 'project-current)
+                       (lambda (&rest _) '(transient . "/tmp/myproj/"))))
+              (should (equal (ghostel--project-buffers) (list local))))
+            (cl-letf (((symbol-function 'project-current)
+                       (lambda (&rest _)
+                         '(transient . "/ssh:user@host:/tmp/myproj/"))))
+              (should (equal (ghostel--project-buffers) (list remote))))))
+      (dolist (b (list local remote))
+        (when (buffer-live-p b) (kill-buffer b))))))
+
 (ert-deftest ghostel-test-reuses-identity-match-after-rename ()
   "`ghostel' reuses an identity-matched buffer after a title-tracking rename."
   (let* ((ghostel-buffer-name "*ghostel*")


### PR DESCRIPTION
Fixes #344.

## Problem

`ghostel-project` derives its buffer identity via `project-prefixed-buffer-name`, which only uses the project root's basename. A local project `~/foo` and a remote `/ssh:user@host:~/foo` therefore collide on `*foo-ghostel*`, and invoking `ghostel-project` from the remote project reused (and displayed) the local project's terminal instead of creating one on the remote host. The same host-blind prefix was used by `ghostel--project-buffers`, so identity-scoped `ghostel-project-next/previous/list-buffers` could cycle into the other host's buffers.

## Fix

New helper `ghostel--project-buffer-name`: for local roots it returns the same `*NAME-ghostel*` as before (no behavior change); for remote roots it folds the TRAMP prefix into the name, e.g. `*foo-ghostel@ssh:user@host*`. The full `method:user@host` prefix is used rather than just the host, since different users or methods on one host are different environments. `file-remote-p` is purely syntactic, so no connection is opened. Both `ghostel-project` and `ghostel--project-buffers` use the helper, so creation, reuse, and cycling agree on the identity.

Plain `M-x ghostel` singleton behavior is unchanged (confirmed as intended in the issue discussion).

## Tests

Four new elisp tests in `test/ghostel-project-test.el`: helper naming for local vs remote roots, the regression scenario itself (remote project must not reuse the local buffer), idempotent reuse of the remote buffer, and identity-scope separation in `ghostel--project-buffers`. `make -j8 all` passes.

Also verified live in a sandboxed Emacs session: a real local `ghostel-project` terminal plus a stubbed-spawn remote invocation yield two distinct buffers with distinct identities; re-running the remote call reuses the remote buffer and the local call still reuses the local one.