### PR TITLE
Fix ghostel-debug-info report truncation and dead key-encoding probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `ghostel-debug-info` no longer truncates the report to the key-encoding
+  section: the probe terminal (`ghostel--new` is buffer-affine and erases the
+  current buffer since 0.40.0) is now created in a temp buffer instead of
+  `*ghostel-debug*`.
+- The key-encoding probe and `ghostel-debug-keypress` report encoder bytes
+  again: `ghostel--encode-key` now returns the encoded bytes (the native PTY
+  path no longer routes them through the elisp `ghostel--write-pty`).
+
 ## [0.40.0] — 2026-07-02
 
 ### Added

--- a/lisp/ghostel-debug.el
+++ b/lisp/ghostel-debug.el
@@ -1109,40 +1109,49 @@ omit it when the connection itself is the suspected fault."
          ((not (fboundp 'ghostel--encode-key))
           (insert "(native module not loaded — cannot probe encoder)\n"))
          (t
-          (let ((probe (ignore-errors (ghostel--new 25 80 100)))
-                (sent nil))
-            (cond
-             ((null probe)
-              (insert "(could not create probe terminal)\n"))
-             (t
-              (cl-letf (((symbol-function 'ghostel--write-pty)
-                         (lambda (_term s) (setq sent s))))
-                (dolist (chord '(("backspace" ""          "Backspace")
-                                 ("backspace" "ctrl"      "C-Backspace")
-                                 ("backspace" "meta"      "M-Backspace")
-                                 ("f"         "meta"      "M-f")
-                                 ("b"         "meta"      "M-b")
-                                 ("."         "meta"      "M-.")
-                                 ("f"         "ctrl,meta" "C-M-f")
-                                 ("v"         "ctrl,meta" "C-M-v")
-                                 ("h"         "ctrl"      "C-h")))
-                  (setq sent nil)
-                  ;; Mirror `ghostel--send-encoded': try encoder, fall back
-                  ;; to the raw-key-sequence path on nil.  Encoder skips
-                  ;; plain Meta+letter when no utf8 is supplied (live
-                  ;; keystrokes don't supply it either) — the fallback
-                  ;; produces ESC + char.
-                  (unless (ghostel--encode-key probe (nth 0 chord)
-                                               (nth 1 chord) nil)
-                    (setq sent (ghostel--raw-key-sequence (nth 0 chord)
-                                                          (nth 1 chord))))
-                  (insert (format "  %-13s → %s\n"
-                                  (nth 2 chord)
+          ;; `ghostel--new' is buffer-affine: it initializes renderer state
+          ;; in the current buffer, erasing it.  Keep the probe terminal and
+          ;; all operations on it in a temp buffer so it can't wipe the
+          ;; report; only the formatted rows travel back.
+          (let ((rows
+                 (with-temp-buffer
+                   (when-let* ((probe (ignore-errors (ghostel--new 25 80 100))))
+                     (mapcar
+                      (lambda (chord)
+                        (pcase-let* ((`(,key ,mods ,label) chord)
+                                     ;; Mirror `ghostel--send-encoded': try
+                                     ;; encoder, fall back to the
+                                     ;; raw-key-sequence path on nil.  Encoder
+                                     ;; skips plain Meta+letter when no utf8
+                                     ;; is supplied (live keystrokes don't
+                                     ;; supply it either) — the fallback
+                                     ;; produces ESC + char.
+                                     (sent (or (ghostel--encode-key probe key mods nil)
+                                               (ghostel--raw-key-sequence key mods))))
+                          (format "  %-13s → %s\n"
+                                  label
                                   (cond ((null sent) "(no output)")
+                                        ;; Pre-0.41 modules return t, not the bytes.
+                                        ((not (stringp sent))
+                                         "(sent — module too old to report bytes)")
                                         ((string-empty-p sent) "(empty)")
                                         (t (mapconcat
                                             (lambda (b) (format "0x%02x" b))
-                                            (string-to-list sent) " ")))))))
+                                            (string-to-list sent) " "))))))
+                      '(("backspace" ""          "Backspace")
+                        ("backspace" "ctrl"      "C-Backspace")
+                        ("backspace" "meta"      "M-Backspace")
+                        ("f"         "meta"      "M-f")
+                        ("b"         "meta"      "M-b")
+                        ("."         "meta"      "M-.")
+                        ("f"         "ctrl,meta" "C-M-f")
+                        ("v"         "ctrl,meta" "C-M-v")
+                        ("h"         "ctrl"      "C-h")))))))
+            (cond
+             ((null rows)
+              (insert "(could not create probe terminal)\n"))
+             (t
+              (dolist (row rows) (insert row))
               (insert "\nReadline `.inputrc' rules expecting these byte streams:\n")
               (insert "  \"\\C-?\"     → 0x7f          (Backspace)\n")
               (insert "  \"\\C-\\b\"    → 0x08          (C-Backspace, also C-h in legacy)\n")
@@ -1757,7 +1766,7 @@ Bounded by `:send-cap'; sets `:send-truncated' once exceeded."
   "In-progress `ghostel-debug-keypress' capture, or nil.
 A plist with at least :buffer (the target ghostel buffer) and :calls
 \(an alist of (KIND . BYTES) reverse-collected during the captured
-command, where KIND is `:write-pty' or `:send-string').")
+command, where KIND is `:encode-key', `:write-pty', or `:send-string').")
 
 ;;;###autoload
 (defun ghostel-debug-keypress ()
@@ -1777,6 +1786,8 @@ during the command, terminal mode flags, and process state."
               #'ghostel--debug-kp-record-write-pty)
   (advice-add 'ghostel--send-string :before
               #'ghostel--debug-kp-record-send-string)
+  (advice-add 'ghostel--encode-key :filter-return
+              #'ghostel--debug-kp-record-encode-key)
   (add-hook 'pre-command-hook #'ghostel--debug-kp-pre-command)
   (message "ghostel-debug-keypress: armed — press a key in this buffer"))
 
@@ -1799,6 +1810,16 @@ during the command, terminal mode flags, and process state."
   (when (eq (current-buffer)
             (plist-get ghostel--debug-kp-state :buffer))
     (ghostel--debug-kp-add-call :send-string string)))
+
+(defun ghostel--debug-kp-record-encode-key (bytes)
+  "Record BYTES returned by `ghostel--encode-key'.
+`:filter-return' advice — the native encoder writes the PTY directly, so
+the bytes never pass through `ghostel--write-pty'."
+  (when (and (stringp bytes)
+             (eq (current-buffer)
+                 (plist-get ghostel--debug-kp-state :buffer)))
+    (ghostel--debug-kp-add-call :encode-key bytes))
+  bytes)
 
 (defun ghostel--debug-kp-pre-command ()
   "Capture event details just before the user's command runs."
@@ -1831,6 +1852,7 @@ during the command, terminal mode flags, and process state."
   "Remove all advice and hooks installed by `ghostel-debug-keypress'."
   (advice-remove 'ghostel--write-pty #'ghostel--debug-kp-record-write-pty)
   (advice-remove 'ghostel--send-string #'ghostel--debug-kp-record-send-string)
+  (advice-remove 'ghostel--encode-key #'ghostel--debug-kp-record-encode-key)
   (remove-hook 'pre-command-hook #'ghostel--debug-kp-pre-command)
   (remove-hook 'post-command-hook #'ghostel--debug-kp-post-command)
   (setq ghostel--debug-kp-state nil))
@@ -1872,7 +1894,8 @@ during the command, terminal mode flags, and process state."
         ;; Sends
         (insert "\n--- Sends during this command ---\n")
         (if (null calls)
-            (insert "(no calls to ghostel--send-string or ghostel--write-pty)\n")
+            (insert "(no bytes sent — no calls to ghostel--encode-key,\n"
+                    " ghostel--send-string, or ghostel--write-pty)\n")
           (cl-loop for (kind . data) in calls
                    for i from 1
                    do (insert (format "%d. %s: %s\n"

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -164,10 +164,11 @@ pub fn effect(_: *Self, comptime func: []const u8, args: anytype) void {
 
 pub fn encode(
     self: *Self,
+    buf: []u8,
     key: gt.input.Key,
     mods: gt.input.KeyMods,
     utf8: ?[]const u8,
-) !bool {
+) !?[]const u8 {
     const options = gt.input.KeyEncodeOptions.fromTerminal(&self.terminal);
     var event = gt.input.KeyEvent{ .action = .press, .key = key, .mods = mods };
     if (utf8) |text| {
@@ -175,14 +176,13 @@ pub fn encode(
     }
 
     // Encode
-    var buf: [128]u8 = undefined;
-    var writer = std.io.Writer.fixed(&buf);
+    var writer = std.io.Writer.fixed(buf);
     try gt.input.encodeKey(&writer, event, options);
     const encoded = writer.buffered();
 
-    if (encoded.len == 0) return false;
+    if (encoded.len == 0) return null;
     try self.ptyWrite(encoded);
-    return true;
+    return encoded;
 }
 
 pub fn encodeMouse(
@@ -544,6 +544,9 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
         \\Encode a key event using the terminal's key encoder.
         \\
         \\(ghostel--encode-key TERM KEY MODS &optional UTF8)
+        \\
+        \\Writes the encoded bytes to the PTY and returns them as a unibyte
+        \\string, or nil when the encoder produced no output.
         ,
         .impl = struct {
             pub fn call(env: emacs.Env, nargs: isize, args: [*c]emacs.Value) !emacs.Value {
@@ -560,8 +563,12 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                     null;
                 const key = input.mapKey(key_name);
                 const mods = input.parseMods(mod_str);
-                const sent = try term.encode(key, mods, utf8);
-                return if (sent) env.t() else env.nil();
+                var encode_buf: [128]u8 = undefined;
+                const sent = try term.encode(&encode_buf, key, mods, utf8);
+                return if (sent) |bytes|
+                    env.makeUnibyteString(bytes) orelse env.t()
+                else
+                    env.nil();
             }
         },
     },

--- a/test/ghostel-debug-test.el
+++ b/test/ghostel-debug-test.el
@@ -625,5 +625,44 @@ path: `ghostel--enable-vt-log' must route libghostty logs to
       (ghostel--disable-vt-log)
       (kill-buffer ghostel-debug--log-buffer))))
 
+(ert-deftest ghostel-test-debug-info-survives-key-probe ()
+  "The key-encoding probe must not wipe the report.
+`ghostel--new' is buffer-affine and erases the current buffer on init;
+a probe created with *ghostel-debug* current silently truncated the
+report to the tail of the key-encoding table."
+  :tags '(native)
+  (let ((display-buffer-overriding-action '(display-buffer-no-window))
+        (inhibit-message t)
+        (ghostel--terminfo-warned t))
+    (unwind-protect
+        (save-window-excursion
+          (with-temp-buffer
+            (ghostel-debug-info)
+            (with-current-buffer "*ghostel-debug*"
+              (let ((content (buffer-string)))
+                ;; Sections inserted before the probe survive it.
+                (should (string-match-p "--- System ---" content))
+                (should (string-match-p "--- Environment ---" content))
+                (should (string-match-p
+                         (regexp-quote "--- Key encoding (legacy mode) ---")
+                         content))
+                ;; Encoder-handled chords report actual bytes, not
+                ;; "(no output)" (the native encoder bypasses the elisp
+                ;; `ghostel--write-pty' the old capture hooked into).
+                (should (string-match-p "Backspace +→ 0x7f" content))
+                (should (string-match-p "C-h +→ 0x08" content))))))
+      (when (get-buffer "*ghostel-debug*")
+        (kill-buffer "*ghostel-debug*")))))
+
+(ert-deftest ghostel-test-encode-key-returns-bytes ()
+  "`ghostel--encode-key' returns the encoded bytes as a unibyte string.
+nil means the encoder produced nothing (plain Meta+letter without utf8
+defers to the elisp raw fallback)."
+  :tags '(native)
+  (with-temp-buffer
+    (let ((probe (ghostel--new 25 80 100)))
+      (should (equal (ghostel--encode-key probe "backspace" "" nil) "\x7f"))
+      (should-not (ghostel--encode-key probe "f" "meta" nil)))))
+
 (provide 'ghostel-debug-test)
 ;;; ghostel-debug-test.el ends here


### PR DESCRIPTION
## Problem

`M-x ghostel-debug-info` produced a nearly empty report: only a headerless tail of the key-encoding table plus the non-default-settings section survived, and the encoder chords all showed `(no output)`.

Two regressions from the 0.40 renderer/PTY rework:

1. **Report wiped by the probe terminal.** Since the renderer became buffer-affine (679b113a), `ghostel--new` erases the current buffer on init. The key-encoding probe was created with `*ghostel-debug*` current, silently wiping every section inserted before it (System, Ghostel, Frame, Environment, Buffer, Process, …). No error was signaled.
2. **Encoder byte capture dead.** The probe captured bytes by overriding the elisp `ghostel--write-pty`, but the native PTY path (40f1269a) writes the PTY directly from Zig and never calls it — and silently drops bytes when no process is live. Only the elisp raw-fallback chords (M-f/M-b/M-.) still showed bytes. `ghostel-debug-keypress` had the same blindness via its `ghostel--write-pty` advice.

## Fix

- Create the probe terminal and run all encodes inside `with-temp-buffer`, so the buffer-affine init can't touch `*ghostel-debug*`.
- `ghostel--encode-key` now returns the encoded bytes as a unibyte string (nil when the encoder produced nothing) instead of `t`. The live send path only tests truthiness and is unchanged; no extra heap on the Zig side (the stack buffer moved to the caller). The probe reads bytes from the return value, and `ghostel-debug-keypress` records them via `:filter-return` advice.

## Verification

- `make -j8 all` passes; two new native ERT tests (report survives the probe; `ghostel--encode-key` returns `0x7f` for Backspace).
- Live-verified under elate: all 13 report sections present, every chord shows real bytes (Backspace → 0x7f, C-M-f → 0x1b 0x06, M-Backspace → 0x1b 0x7f), and `ghostel-debug-keypress` on Backspace records `encode-key: hex 7f`.