### PR TITLE
Respect Zig install prefix for native module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,9 @@ jobs:
       - name: Build native module
         run: |
           if [ -n "${{ matrix.target }}" ]; then
-            zig build -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast -Dcpu=baseline
+            zig build --prefix . -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast -Dcpu=baseline
           else
-            zig build -Doptimize=ReleaseFast -Dcpu=baseline
+            zig build --prefix . -Doptimize=ReleaseFast -Dcpu=baseline
           fi
 
       - name: Upload module artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Build native module
         run: |
           if [ -n "${{ matrix.target }}" ]; then
-            zig build -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast -Dcpu=baseline
+            zig build --prefix . -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast -Dcpu=baseline
           else
-            zig build -Doptimize=ReleaseFast -Dcpu=baseline
+            zig build --prefix . -Doptimize=ReleaseFast -Dcpu=baseline
           fi
 
       - name: Strip non-exported symbols (macOS)

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ zig-out/
 .zig-cache/
 zig-pkg/
 .build/
+.ghostel-build/
 .hypothesis/
 *.dylib
 *.so

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ ifeq ($(UNAME),Darwin)
 else
   MODULE := ghostel-module.so
 endif
+ZIG_BUILD_FLAGS := --prefix . -Doptimize=ReleaseFast -Dcpu=baseline
 ZIG_SOURCES := $(wildcard src/*.zig src/*.c build.zig build.zig.zon symbols.map) \
                $(wildcard vendor/*.h)
 
@@ -47,7 +48,7 @@ all: build test-all test-evil lint
 build: $(MODULE)
 
 $(MODULE): $(ZIG_SOURCES)
-	zig build -Doptimize=ReleaseFast -Dcpu=baseline
+	zig build $(ZIG_BUILD_FLAGS)
 
 test-zig:
 	zig build test
@@ -243,7 +244,7 @@ public/index.html: README.org $(DOC_DEPS_STAMP)
 		          (org-export-to-file 'html \"public/index.html\"))"
 
 clean:
-	rm -f ghostel-module.dylib ghostel-module.so
+	rm -f ghostel-module.dylib ghostel-module.so ghostel-module.version
 	rm -f $(ELC)
 	rm -rf zig-out .zig-cache .build public
 

--- a/README.org
+++ b/README.org
@@ -236,8 +236,8 @@ local Emacs headers.
 git clone https://github.com/dakra/ghostel.git
 cd ghostel
 
-# Build everything (fetches ghostty automatically via the Zig package manager)
-zig build -Doptimize=ReleaseFast
+# Build everything into the checkout (fetches ghostty automatically)
+zig build --prefix . -Doptimize=ReleaseFast
 #+end_src
 
 To override the vendored Emacs header, set =EMACS_INCLUDE_DIR= to a directory
@@ -249,12 +249,16 @@ your local path:
 
 #+begin_src sh
 zig fetch --save=ghostty /path/to/ghostty
-zig build -Doptimize=ReleaseFast
+zig build --prefix . -Doptimize=ReleaseFast
 #+end_src
 
+The module and =ghostel-module.version= sidecar are installed under Zig's
+install prefix.  Use =--prefix .= when building into a checkout that Ghostel
+should load directly, or pass another prefix matching =ghostel-module-directory=.
+
 When installed from MELPA, =M-x ghostel-module-compile= builds the native module
-from source using =zig build=; the Zig package manager fetches the ghostty
-dependency automatically.
+from source using =zig build --prefix <ghostel-module-directory>=; the Zig package
+manager fetches the ghostty dependency automatically.
 
 ** Bundled terminfo
 

--- a/bench/run-bench.sh
+++ b/bench/run-bench.sh
@@ -119,7 +119,7 @@ for ext in dylib so; do
     fi
 done
 if [ -z "$MODULE" ]; then
-    echo "ERROR: ghostel native module not found. Run zig build -Doptimize=ReleaseFast first."
+    echo "ERROR: ghostel native module not found. Run zig build --prefix . -Doptimize=ReleaseFast first."
     exit 1
 fi
 echo "ghostel module: $MODULE"

--- a/bench/run-gui-xctrace.sh
+++ b/bench/run-gui-xctrace.sh
@@ -149,7 +149,7 @@ for ext in dylib so; do
     fi
 done
 if [ -z "$MODULE" ]; then
-    echo "ERROR: ghostel native module not found. Run zig build -Doptimize=ReleaseFast first." >&2
+    echo "ERROR: ghostel native module not found. Run zig build --prefix . -Doptimize=ReleaseFast first." >&2
     exit 1
 fi
 

--- a/build.zig
+++ b/build.zig
@@ -54,8 +54,6 @@ pub fn build(b: *std.Build) void {
         }
     }
 
-    b.installArtifact(lib);
-
     const copy_step = b.addInstallFile(
         lib.getEmittedBin(),
         moduleOutputName(target_os),
@@ -64,11 +62,10 @@ pub fn build(b: *std.Build) void {
 
     // Sidecar version file sitting next to the binary.  The elisp loader
     // reads this before `module-load` to detect a stale module without
-    // mapping it into the process.  Mirrors the path of the .so/.dylib
-    // produced above.
+    // mapping it into the process.
     const version_wf = b.addWriteFiles();
     const version_file = version_wf.add("ghostel-module.version", module_version ++ "\n");
-    const copy_version_step = b.addInstallFile(version_file, "../ghostel-module.version");
+    const copy_version_step = b.addInstallFile(version_file, "ghostel-module.version");
     b.getInstallStep().dependOn(&copy_version_step.step);
 
     // ----------------------------------------------------------------
@@ -157,7 +154,7 @@ fn dirHasEmacsModuleHeader(allocator: std.mem.Allocator, dir: []const u8) bool {
 
 fn moduleOutputName(target_os: std.Target.Os.Tag) []const u8 {
     return switch (target_os) {
-        .macos => "../ghostel-module.dylib",
-        else => "../ghostel-module.so",
+        .macos => "ghostel-module.dylib",
+        else => "ghostel-module.so",
     };
 }

--- a/lisp/ghostel-module-install.el
+++ b/lisp/ghostel-module-install.el
@@ -7,7 +7,7 @@
 
 ;; Provisioning for Ghostel's native module (`ghostel-module', the compiled
 ;; libghostty .so/.dylib): downloading a pre-built binary from GitHub releases
-;; compiling from source via `zig build', maintainingthe on-disk version sidecar,
+;; compiling from source via `zig build', maintaining the on-disk version sidecar,
 ;; and loading the module — including the version checks that decide whether
 ;; an on-disk module is fresh enough to map.
 ;;
@@ -149,30 +149,33 @@ Returns non-nil on success."
 The build runs in `ghostel--resource-root' (which holds build.zig);
 on success the produced module and its sidecar are moved into DEST-DIR."
   (let* ((source-dir (ghostel--resource-root))
+         (build-dir nil)
          (default-directory source-dir))
     (message "ghostel: compiling native module with zig build (this may take a moment)...")
     (condition-case err
-        (let ((ret (process-file "zig" nil "*ghostel-build*" nil
-                                 "build" "-Doptimize=ReleaseFast" "-Dcpu=baseline")))
-          (if (not (eq ret 0))
-              (display-warning 'ghostel
-                               "Module compilation failed.  See *ghostel-build* buffer for details.")
-            (let* ((file-name (concat "ghostel-module" module-file-suffix))
-                   (built (expand-file-name file-name source-dir))
-                   (final (expand-file-name file-name dest-dir)))
-              (cond
-               ((not (file-exists-p built))
-                (display-warning 'ghostel
-                                 (format "Build succeeded but module not produced at %s"
-                                         built)))
-               ((equal built final)
-                (message "ghostel: native module compiled successfully"))
-               (t
-                (ghostel--install-module-pair
-                 built final
-                 (expand-file-name "ghostel-module.version" source-dir)
-                 (expand-file-name "ghostel-module.version" dest-dir))
-                (message "ghostel: native module compiled successfully"))))))
+        (unwind-protect
+            (progn
+              (setq build-dir (ghostel--make-module-build-dir dest-dir))
+              (let ((ret (process-file "zig" nil "*ghostel-build*" nil
+                                       "build" "--prefix" build-dir
+                                       "-Doptimize=ReleaseFast" "-Dcpu=baseline")))
+                (if (not (eq ret 0))
+                    (display-warning 'ghostel
+                                     "Module compilation failed.  See *ghostel-build* buffer for details.")
+                  (let* ((file-name (concat "ghostel-module" module-file-suffix))
+                         (built (expand-file-name file-name build-dir))
+                         (final (expand-file-name file-name dest-dir)))
+                    (if (not (file-exists-p built))
+                        (display-warning 'ghostel
+                                         (format "Build succeeded but module not produced at %s"
+                                                 built))
+                      (ghostel--install-module-pair
+                       built final
+                       (expand-file-name "ghostel-module.version" build-dir)
+                       (expand-file-name "ghostel-module.version" dest-dir))
+                      (message "ghostel: native module compiled successfully"))))))
+          (when (and build-dir (file-directory-p build-dir))
+            (ignore-errors (delete-directory build-dir t))))
       (file-missing
        (display-warning 'ghostel
                         (format "zig executable not found while compiling in %s" source-dir)))
@@ -211,7 +214,7 @@ Returns \\='download, \\='compile, or nil."
 
   [d] Download pre-built binary from:
       %s
-  [c] Compile from source via build.sh
+  [c] Compile from source via zig build
   [s] Skip — install manually later
 
 Choice: " url)
@@ -328,14 +331,20 @@ A missing or empty file returns nil; the result is otherwise trimmed."
       (when (and tmp (file-exists-p tmp))
         (ignore-errors (delete-file tmp))))))
 
+(defun ghostel--make-module-build-dir (dest-dir)
+  "Return the temporary Zig install prefix inside DEST-DIR."
+  (make-directory dest-dir t)
+  (let ((dir (expand-file-name ".ghostel-build/" dest-dir)))
+    (when (file-directory-p dir)
+      (delete-directory dir t))
+    (make-directory dir t)
+    (file-name-as-directory dir)))
+
 (defun ghostel--install-module-pair (built-mod final-mod
                                                built-sidecar final-sidecar)
   "Move BUILT-MOD and BUILT-SIDECAR into FINAL-MOD and FINAL-SIDECAR.
 The destination sidecar is removed before the module is moved, so every
-failure path ends in `sidecar absent' rather than `sidecar stale'.
-The loader treats the former as backward-compat (load and run a live
-version check); the latter as `refuse to map', which would leave the
-user stuck with a fresh module they cannot load."
+failure path ends in `sidecar absent' rather than `sidecar stale'."
   (make-directory (file-name-directory final-mod) t)
   (when (file-exists-p final-sidecar)
     (delete-file final-sidecar))
@@ -364,8 +373,8 @@ Leaving the prompt empty downloads the latest release."
           (message "ghostel: module loaded successfully"))
       (user-error "Download failed.  Try M-x ghostel-module-compile to build from source"))))
 
-(defun ghostel--install-built-module-on-finish (compile-buf source-dir dest-dir)
-  "Move the built module from SOURCE-DIR into DEST-DIR when COMPILE-BUF finishes.
+(defun ghostel--install-built-module-on-finish (compile-buf build-dir dest-dir)
+  "Move the built module from BUILD-DIR into DEST-DIR when COMPILE-BUF finishes.
 Registers a one-shot `compilation-finish-functions' handler that
 filters on COMPILE-BUF and removes itself on first match.  Used so the
 interactive `ghostel-module-compile' honours `ghostel-module-directory'.
@@ -377,38 +386,41 @@ The sidecar version file written by `build.zig' is moved alongside the module."
           (lambda (buf status)
             (when (eq buf compile-buf)
               (remove-hook 'compilation-finish-functions handler)
-              (when (string-match-p "finished" status)
-                (let ((built (expand-file-name file-name source-dir))
-                      (final (expand-file-name file-name dest-dir))
-                      (built-sidecar (expand-file-name sidecar source-dir))
-                      (final-sidecar (expand-file-name sidecar dest-dir)))
-                  (when (file-exists-p built)
-                    (condition-case err
-                        (progn
-                          (ghostel--install-module-pair
-                           built final built-sidecar final-sidecar)
-                          (message "ghostel: module installed at %s" final))
-                      (error
-                       (display-warning
-                        'ghostel
-                        (format "Build succeeded but installing into %s failed: %s"
-                                dest-dir (error-message-string err)))))))))))
+              (unwind-protect
+                  (when (string-match-p "finished" status)
+                    (let ((built (expand-file-name file-name build-dir))
+                          (final (expand-file-name file-name dest-dir))
+                          (built-sidecar (expand-file-name sidecar build-dir))
+                          (final-sidecar (expand-file-name sidecar dest-dir)))
+                      (when (file-exists-p built)
+                        (condition-case err
+                            (progn
+                              (ghostel--install-module-pair
+                               built final built-sidecar final-sidecar)
+                              (message "ghostel: module installed at %s" final))
+                          (error
+                           (display-warning
+                            'ghostel
+                            (format "Build succeeded but installing into %s failed: %s"
+                                    dest-dir (error-message-string err))))))))
+                (when (file-directory-p build-dir)
+                  (ignore-errors (delete-directory build-dir t)))))))
     (add-hook 'compilation-finish-functions handler)))
 
 (defun ghostel-module-compile ()
   "Compile the ghostel native module by running zig build.
 The output is shown in a `*compilation*' buffer.
-When `ghostel-module-directory' points outside the package tree, the
-produced module is moved into that directory once the build finishes."
+The produced module is moved into `ghostel-module-directory' once
+the build finishes."
   (interactive)
   (let* ((source-dir (ghostel--resource-root))
          (dest-dir (ghostel--module-directory))
+         (build-dir (ghostel--make-module-build-dir dest-dir))
          (default-directory source-dir)
-         (compile-buf (compile "zig build -Doptimize=ReleaseFast -Dcpu=baseline" t)))
-    (unless (equal (file-name-as-directory (expand-file-name source-dir))
-                   (file-name-as-directory (expand-file-name dest-dir)))
-      (ghostel--install-built-module-on-finish compile-buf source-dir dest-dir))))
-
+         (compile-buf (compile (format "zig build --prefix %s -Doptimize=ReleaseFast -Dcpu=baseline"
+                                       (shell-quote-argument (expand-file-name build-dir)))
+                               t)))
+    (ghostel--install-built-module-on-finish compile-buf build-dir dest-dir)))
 
 (defun ghostel--check-module-version (dir &optional prompt-user)
   "Check if the loaded module is older than required.

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -74,7 +74,7 @@
 ;; Native module:
 ;;
 ;;   A pre-built binary is downloaded automatically on first use.  To
-;;   build from source instead (requires Zig 0.15.2+), run zig build
+;;   build from source instead (requires Zig 0.15.2+), run zig build --prefix .
 ;;   from the project root, or M-x ghostel-module-compile.  M-x
 ;;   ghostel-download-module re-fetches the pre-built binary.
 ;;

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -54,5 +54,5 @@ For Emacs functions registered through `FunctionEntry`, prefer the error-union `
 ## Build and format workflow
 
 After editing any `.zig` file:
-1. `zig build` — must pass before moving on
+1. `zig build --prefix .` — must pass before moving on
 2. `zig fmt <file>` — format before committing

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -54,5 +54,5 @@ For Emacs functions registered through `FunctionEntry`, prefer the error-union `
 ## Build and format workflow
 
 After editing any `.zig` file:
-1. `zig build` — must pass before moving on
+1. `zig build --prefix .` — must pass before moving on
 2. `zig fmt <file>` — format before committing

--- a/src/NativeProcess.zig
+++ b/src/NativeProcess.zig
@@ -188,11 +188,12 @@ fn loopOnce(self: *Self) !bool {
         self.stream.nextSlice(buf[0..len]);
     }
 
+    try self.notifyVtUpdate();
+
     if (pollfds[0].revents & posix.POLL.HUP != 0) {
         return false;
     }
 
-    try self.notifyVtUpdate();
     return true;
 }
 

--- a/test/ghostel-module-test.el
+++ b/test/ghostel-module-test.el
@@ -196,6 +196,21 @@ file mmap'd keeps a valid mapping (issue #247)."
                                 (expand-file-name "~/custom/ghostel/")))
                      (downcase (ghostel--module-directory)))))))
 
+(ert-deftest ghostel-test-module-build-dir-is-reset ()
+  "The temporary build directory is reset before use."
+  (let* ((dir (make-temp-file "ghostel-test-build-dir" t))
+         (build-dir (expand-file-name ".ghostel-build/" dir))
+         (stale (expand-file-name "stale" build-dir)))
+    (unwind-protect
+        (progn
+          (make-directory build-dir t)
+          (with-temp-file stale (insert "stale"))
+          (should (equal (file-name-as-directory build-dir)
+                         (ghostel--make-module-build-dir dir)))
+          (should (file-directory-p build-dir))
+          (should-not (file-exists-p stale)))
+      (delete-directory dir t))))
+
 (ert-deftest ghostel-test-download-module-targets-custom-directory ()
   "Interactive download writes into `ghostel-module-directory' when set."
   (let ((ghostel-module-directory "/custom/dir/")
@@ -252,7 +267,7 @@ file mmap'd keeps a valid mapping (issue #247)."
     (should (string-prefix-p (expand-file-name "/custom/dir/")
                              loaded-path))))
 
-(ert-deftest ghostel-test-compile-module-invokes-zig-build ()
+(ert-deftest ghostel-test-compile-module-invokes-zig-build-with-prefix ()
   "Source compilation runs zig build in the resource root."
   (let ((default-directory nil)
         (messages nil)
@@ -261,8 +276,18 @@ file mmap'd keeps a valid mapping (issue #247)."
     (let ((native-comp-enable-subr-trampolines nil))
       (cl-letf (((symbol-function 'ghostel--resource-root)
                  (lambda () "C:/ghostel/"))
+                ((symbol-function 'ghostel--make-module-build-dir)
+                 (lambda (_dest-dir) "C:/ghostel/.ghostel-build/"))
                 ((symbol-function 'file-exists-p)
                  (lambda (_) t))
+                ((symbol-function 'file-directory-p)
+                 (lambda (_) nil))
+                ((symbol-function 'rename-file)
+                 (lambda (&rest _)))
+                ((symbol-function 'delete-file)
+                 (lambda (&rest _)))
+                ((symbol-function 'make-directory)
+                 (lambda (&rest _)))
                 ((symbol-function 'message)
                  (lambda (fmt &rest args)
                    (push (apply #'format fmt args) messages)))
@@ -276,7 +301,10 @@ file mmap'd keeps a valid mapping (issue #247)."
                    0)))
         (ghostel--compile-module "C:/ghostel/")
         (should (equal
-                 '("zig" nil "*ghostel-build*" nil ("build" "-Doptimize=ReleaseFast" "-Dcpu=baseline") "C:/ghostel/")
+                 '("zig" nil "*ghostel-build*" nil
+                   ("build" "--prefix" "C:/ghostel/.ghostel-build/"
+                    "-Doptimize=ReleaseFast" "-Dcpu=baseline")
+                   "C:/ghostel/")
                  process-invocation))
         (should-not warnings)))))
 
@@ -293,8 +321,12 @@ module beside a stale sidecar (issue #256 follow-up B1)."
     (let ((native-comp-enable-subr-trampolines nil))
       (cl-letf (((symbol-function 'ghostel--resource-root)
                  (lambda () "/src/ghostel/"))
+                ((symbol-function 'ghostel--make-module-build-dir)
+                 (lambda (_dest-dir) "/custom/dir/.ghostel-build/"))
                 ((symbol-function 'file-exists-p)
                  (lambda (_) t))
+                ((symbol-function 'file-directory-p)
+                 (lambda (_) nil))
                 ((symbol-function 'make-directory)
                  (lambda (dir &rest _) (push dir made-dirs)))
                 ((symbol-function 'delete-file)
@@ -319,7 +351,7 @@ module beside a stale sidecar (issue #256 follow-up B1)."
               (sidecar-args (car rename-args)))
           (should (equal (downcase (expand-file-name
                                     (concat "ghostel-module" module-file-suffix)
-                                    "/src/ghostel/"))
+                                    "/custom/dir/.ghostel-build/"))
                          (downcase (nth 0 module-args))))
           (should (equal (downcase (expand-file-name
                                     (concat "ghostel-module" module-file-suffix)
@@ -327,7 +359,7 @@ module beside a stale sidecar (issue #256 follow-up B1)."
                          (downcase (nth 1 module-args))))
           (should (equal (downcase (expand-file-name
                                     "ghostel-module.version"
-                                    "/src/ghostel/"))
+                                    "/custom/dir/.ghostel-build/"))
                          (downcase (nth 0 sidecar-args))))
           (should (equal (downcase (expand-file-name
                                     "ghostel-module.version"
@@ -341,7 +373,11 @@ module beside a stale sidecar (issue #256 follow-up B1)."
     (let ((native-comp-enable-subr-trampolines nil))
       (cl-letf (((symbol-function 'ghostel--resource-root)
                  (lambda () "/src/ghostel/"))
+                ((symbol-function 'ghostel--make-module-build-dir)
+                 (lambda (_dest-dir) "/src/ghostel/.ghostel-build/"))
                 ((symbol-function 'file-exists-p)
+                 (lambda (_) nil))
+                ((symbol-function 'file-directory-p)
                  (lambda (_) nil))
                 ((symbol-function 'message) (lambda (&rest _)))
                 ((symbol-function 'display-warning)
@@ -351,99 +387,66 @@ module beside a stale sidecar (issue #256 follow-up B1)."
         (ghostel--compile-module "/src/ghostel/")
         (should warnings)))))
 
-(ert-deftest ghostel-test-module-compile-command-uses-zig-build ()
+(ert-deftest ghostel-test-module-compile-command-uses-zig-build-prefix ()
   "Interactive compilation uses zig build directly."
   (let ((compile-invocation nil)
+        (finish-args nil)
         (default-directory nil)
         (ghostel-module-directory nil))
     (let ((native-comp-enable-subr-trampolines nil))
       (cl-letf (((symbol-function 'ghostel--resource-root)
-                 (lambda () "C:/ghostel/"))
+                 (lambda () "/src/ghostel/"))
+                ((symbol-function 'ghostel--make-module-build-dir)
+                 (lambda (_dest-dir) "/src/ghostel/.ghostel-build/"))
+                ((symbol-function 'ghostel--install-built-module-on-finish)
+                 (lambda (buf build-dir dest-dir)
+                   (setq finish-args (list buf build-dir dest-dir))))
                 ((symbol-function 'compile)
                  (lambda (command &optional comint)
                    (setq compile-invocation (list command comint default-directory))
                    (current-buffer))))
         (ghostel-module-compile)
-        (should (equal "zig build -Doptimize=ReleaseFast -Dcpu=baseline"
+        (should (equal (concat "zig build --prefix /src/ghostel/.ghostel-build/ "
+                               "-Doptimize=ReleaseFast -Dcpu=baseline")
                        (nth 0 compile-invocation)))
         (should (eq t (nth 1 compile-invocation)))
-        (should (equal (downcase "C:/ghostel/")
-                       (downcase (nth 2 compile-invocation))))))))
+        (should (equal "/src/ghostel/" (nth 2 compile-invocation)))
+        (should (equal (list (current-buffer)
+                             "/src/ghostel/.ghostel-build/"
+                             "/src/ghostel/")
+                       finish-args))))))
 
 (ert-deftest ghostel-test-module-compile-installs-when-dest-differs ()
   "Interactive compile installs the built module into `ghostel-module-directory'.
 A `compilation-finish-functions' handler runs
 `ghostel--install-module-pair', which pre-deletes any existing dest
 sidecar and then renames the module and sidecar into place."
-  (let* ((compile-buf (generate-new-buffer " *ghostel-test-compile*"))
-         (compilation-finish-functions nil)
-         (rename-args nil)
-         (deleted nil)
-         (made-dirs nil)
-         (default-directory nil)
-         (ghostel-module-directory "/custom/dir/"))
-    (unwind-protect
-        (let ((native-comp-enable-subr-trampolines nil))
-          (cl-letf (((symbol-function 'ghostel--resource-root)
-                     (lambda () "/src/ghostel/"))
-                    ((symbol-function 'compile)
-                     (lambda (&rest _) compile-buf))
-                    ((symbol-function 'file-exists-p)
-                     (lambda (_) t))
-                    ((symbol-function 'make-directory)
-                     (lambda (dir &rest _) (push dir made-dirs)))
-                    ((symbol-function 'delete-file)
-                     (lambda (path) (push path deleted)))
-                    ((symbol-function 'rename-file)
-                     (lambda (from to &optional _ok)
-                       (push (list from to) rename-args)))
-                    ((symbol-function 'message) (lambda (&rest _))))
-            (ghostel-module-compile)
-            (should (equal 1 (length compilation-finish-functions)))
-            ;; Simulate compilation completion.
-            (funcall (car compilation-finish-functions) compile-buf "finished\n")
-            (should (null compilation-finish-functions))
-            ;; Pre-existing dest sidecar must be removed before any rename.
-            (should (equal 1 (length deleted)))
-            (should (equal (downcase (expand-file-name
-                                      "ghostel-module.version"
-                                      "/custom/dir/"))
-                           (downcase (car deleted))))
-            (should (equal 2 (length rename-args)))
-            ;; rename-args is push-order (newest first): sidecar, then module.
-            (let ((module-args (cadr rename-args))
-                  (sidecar-args (car rename-args)))
-              (should (equal (downcase (expand-file-name
-                                        (concat "ghostel-module" module-file-suffix)
-                                        "/src/ghostel/"))
-                             (downcase (nth 0 module-args))))
-              (should (equal (downcase (expand-file-name
-                                        (concat "ghostel-module" module-file-suffix)
-                                        "/custom/dir/"))
-                             (downcase (nth 1 module-args))))
-              (should (equal (downcase (expand-file-name
-                                        "ghostel-module.version"
-                                        "/src/ghostel/"))
-                             (downcase (nth 0 sidecar-args))))
-              (should (equal (downcase (expand-file-name
-                                        "ghostel-module.version"
-                                        "/custom/dir/"))
-                             (downcase (nth 1 sidecar-args)))))))
-      (when (buffer-live-p compile-buf)
-        (kill-buffer compile-buf)))))
-
-(ert-deftest ghostel-test-module-compile-no-install-when-dest-same ()
-  "When dest matches source, no finish handler is registered."
-  (let ((compilation-finish-functions nil)
+  (let ((compile-invocation nil)
+        (finish-args nil)
         (default-directory nil)
-        (ghostel-module-directory nil))
+        (ghostel-module-directory "/custom/dir/"))
     (let ((native-comp-enable-subr-trampolines nil))
       (cl-letf (((symbol-function 'ghostel--resource-root)
                  (lambda () "/src/ghostel/"))
+                ((symbol-function 'ghostel--make-module-build-dir)
+                 (lambda (_dest-dir) "/custom/dir/.ghostel-build/"))
+                ((symbol-function 'ghostel--install-built-module-on-finish)
+                 (lambda (buf build-dir dest-dir)
+                   (setq finish-args (list buf build-dir dest-dir))))
                 ((symbol-function 'compile)
-                 (lambda (&rest _) (current-buffer))))
+                 (lambda (command &optional comint)
+                   (setq compile-invocation (list command comint default-directory))
+                   (current-buffer))))
         (ghostel-module-compile)
-        (should (null compilation-finish-functions))))))
+        (should (equal (concat "zig build --prefix /custom/dir/.ghostel-build/ "
+                               "-Doptimize=ReleaseFast -Dcpu=baseline")
+                       (nth 0 compile-invocation)))
+        (should (eq t (nth 1 compile-invocation)))
+        (should (equal "/src/ghostel/" (nth 2 compile-invocation)))
+        (should (equal (list (current-buffer)
+                             "/custom/dir/.ghostel-build/"
+                             "/custom/dir/")
+                       finish-args))))))
 
 (ert-deftest ghostel-test-module-version-match ()
   "Test that version check does nothing when module meets minimum."
@@ -737,13 +740,19 @@ module is never paired with a stale sidecar."
         (progn
           (with-temp-file built-mod (insert "new-so"))
           (with-temp-file built-sidecar (insert "0.99.0\n"))
+          (with-temp-file final-mod (insert "old-so"))
           (with-temp-file final-sidecar (insert "0.10.0\n"))
-          (ghostel--install-module-pair built-mod final-mod
-                                        built-sidecar final-sidecar)
-          (should (file-exists-p final-mod))
-          (should (equal "new-so" (with-temp-buffer
-                                    (insert-file-contents final-mod)
-                                    (buffer-string))))
+          (let ((old-inode (file-attribute-inode-number
+                            (file-attributes final-mod))))
+            (ghostel--install-module-pair built-mod final-mod
+                                          built-sidecar final-sidecar)
+            (should (file-exists-p final-mod))
+            (should (equal "new-so" (with-temp-buffer
+                                      (insert-file-contents final-mod)
+                                      (buffer-string))))
+            (should-not (equal old-inode
+                               (file-attribute-inode-number
+                                (file-attributes final-mod)))))
           (should (equal "0.99.0" (ghostel--read-module-sidecar-version dst)))
           (should-not (file-exists-p built-mod))
           (should-not (file-exists-p built-sidecar)))

--- a/tools/ghostel-dape.el
+++ b/tools/ghostel-dape.el
@@ -32,7 +32,7 @@
   :group 'ghostel)
 
 (defcustom ghostel-dape-build-command
-  "zig build -Doptimize=Debug -Dcpu=baseline"
+  "zig build --prefix . -Doptimize=Debug -Dcpu=baseline"
   "Build command run before launching Dape.
 Set to nil to skip automatic compilation."
   :type '(choice (const :tag "Do not build" nil) string)


### PR DESCRIPTION
## Summary
- install the native module and version sidecar under Zig's install prefix instead of escaping it
- update Makefile, CI/release builds, docs, and helper scripts to pass `--prefix .` when checkout-root artifacts are expected
- keep Emacs auto-builds safe by building into a temporary prefix and renaming the module/sidecar into place

## Verification
- `emacs --batch -Q -L lisp --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile lisp/ghostel-module-install.el`
- `emacs --batch -Q -L lisp -L test --eval '(setq load-prefer-newer t)' -l ert -l test/ghostel-test-helpers.el -l test/ghostel-module-test.el --eval "(ert-run-tests-batch-and-exit '(not (tag native)))"`
- `zig build --prefix /private/tmp/ghostel-pr-prefix-test -Doptimize=Debug -Dcpu=baseline`
- `git diff --check`