### PR TITLE
Preserve Ghostel anchoring across font scaling

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4503,7 +4503,7 @@ run the shell on the remote host."
 Used as the reference window for determining graphics properties when
 rendering, such as fonts and glyph sizes.  Prefer graphical windows over
 terminal windows."
-  (let ((wins (get-buffer-window-list buffer nil t)))
+  (let ((wins (ghostel--windows buffer t)))
     (or (cl-find-if (lambda (w) (display-graphic-p (window-frame w)))
                     wins)
         (car wins))))
@@ -4560,6 +4560,20 @@ remain handled inside the renderer."
      (or begin (ghostel--viewport-start) (point-min))
      (or end (point-max)))))
 
+(defun ghostel--windows (&optional buffer all-frames)
+  "Return Ghostel windows, optionally limited to BUFFER.
+ALL-FRAMES has the same meaning as in `walk-windows'."
+  (let (windows)
+    (walk-windows
+     (lambda (window)
+       (let ((window-buffer (window-buffer window)))
+         (when (and (or (null buffer) (eq window-buffer buffer))
+                    (with-current-buffer window-buffer
+                      (derived-mode-p 'ghostel-mode)))
+           (push window windows))))
+     'no-minibuf all-frames)
+    (nreverse windows)))
+
 (defun ghostel--window-anchored-p (window &optional body-pixel-height)
   "Non-nil if WINDOW is scrolled to follow the live terminal output.
 WINDOW follows the output when the lines from its `window-start' to
@@ -4577,6 +4591,23 @@ line the graphical anchor leaves via `window-vscroll'."
                 (ws (window-start window))
                 (ws-lines-to-end (count-lines ws (point-max))))
       (<= ws-lines-to-end (1+ (floor screen-lines))))))
+
+(defun ghostel--anchored-windows (&optional buffer all-frames)
+  "Return anchored Ghostel windows.
+BUFFER and ALL-FRAMES have the same meaning as in `ghostel--windows'."
+  (cl-remove-if-not #'ghostel--window-anchored-p
+                    (ghostel--windows buffer all-frames)))
+
+(defun ghostel--window-buffer-pairs (windows)
+  "Return (WINDOW . BUFFER) pairs for WINDOWS."
+  (mapcar (lambda (window) (cons window (window-buffer window))) windows))
+
+(defun ghostel--window-buffer-pair-live-p (entry)
+  "Return non-nil if ENTRY's window still shows ENTRY's buffer."
+  (let ((window (car entry))
+        (buffer (cdr entry)))
+    (and (window-live-p window)
+         (eq (window-buffer window) buffer))))
 
 (defconst ghostel--set-window-vscroll-preserve-supported-p
   (let ((max-args (cdr (subr-arity (symbol-function 'set-window-vscroll)))))
@@ -4699,9 +4730,7 @@ opportunistic output redraws that may safely wait for the frame to end."
           (ghostel--line-mode-pre-redraw)
           (setq ghostel--force-next-redraw nil)
           (when-let* ((render-win (ghostel--get-render-window buffer)))
-            (let* ((all-windows (get-buffer-window-list buffer nil t))
-                   (anchored (cl-remove-if-not #'ghostel--window-anchored-p
-                                               all-windows))
+            (let* ((anchored (ghostel--anchored-windows buffer t))
                    ;; In line mode the user's in-progress input lives
                    ;; in the buffer past the prompt and is not in
                    ;; libghostty's grid; the renderer would otherwise
@@ -4811,7 +4840,7 @@ path even when the row/column count is unchanged."
     (ghostel--anchor-window window))
   (when-let* ((adjust-fn (or (default-value 'window-adjust-process-window-size-function)
                              #'window-adjust-process-window-size-smallest))
-              (windows (get-buffer-window-list nil nil t))
+              (windows (ghostel--windows (current-buffer) t))
               (size (funcall adjust-fn ghostel--process windows))
               (width (car size))
               (height (cdr size)))
@@ -4867,17 +4896,13 @@ and the TTY display that needs it off keeps working in parallel)."
   "Schedule anchoring of all the currently anchored Ghostel windows.
 The minibuffer when used with packages such as Vertico can cause a resize of
 a Ghostel window making it lose its anchoring."
-  (when-let* ((anchored (cl-loop for win in (window-list)
-                                 when (ghostel--window-anchored-p win)
-                                 collect (cons win (window-buffer win)))))
+  (when-let* ((anchored (ghostel--window-buffer-pairs
+                         (ghostel--anchored-windows))))
     (run-at-time 0 nil
                  (lambda ()
                    (dolist (entry anchored)
-                     (let ((win (car entry))
-                           (buffer (cdr entry)))
-                       (when (and (window-live-p win)
-                                  (eq (window-buffer win) buffer))
-                         (ghostel--anchor-window win))))))))
+                     (when (ghostel--window-buffer-pair-live-p entry)
+                       (ghostel--anchor-window (car entry))))))))
 
 (defun ghostel--minibuffer-exit-maybe-leave ()
   "Run `ghostel-maybe-leave-input' after a minibuffer command, deferred.

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4585,7 +4585,7 @@ line the graphical anchor leaves via `window-vscroll'."
   (with-current-buffer (window-buffer window)
     (when-let* (((derived-mode-p 'ghostel-mode))
                 ((not (eq ghostel--input-mode 'emacs)))
-                (dlh (default-line-height))
+                (dlh (with-selected-window window (default-line-height)))
                 (body-pixel-height (or body-pixel-height
                                        (window-body-height window t)))
                 (screen-lines (/ (float body-pixel-height) (float dlh)))
@@ -4863,11 +4863,34 @@ path even when the row/column count is unchanged."
           ;; Emacs displays the stale content at the new window size.
           (ghostel--redraw-now (current-buffer)))))))
 
-(defun ghostel--text-scale-changed ()
-  "Update terminal size and redraw after `text-scale-mode' changes the cell font."
-  (when (and ghostel--term (ghostel--terminal-live-p))
-    (when-let* ((window (get-buffer-window (current-buffer) t)))
-      (ghostel--adjust-size window t))))
+(defun ghostel--around-font-scale (fn args &optional buffer)
+  "Resize and re-anchor Ghostel windows around font scaling by FN with ARGS.
+When BUFFER is non-nil, only refit windows showing BUFFER."
+  (let ((anchored (ghostel--window-buffer-pairs
+                   (ghostel--anchored-windows buffer 'visible))))
+    (prog1 (apply fn args)
+      (dolist (window (ghostel--windows buffer 'visible))
+        (when (window-live-p window)
+          (with-current-buffer (window-buffer window)
+            (ghostel--adjust-size window t))))
+      (dolist (entry anchored)
+        (when (ghostel--window-buffer-pair-live-p entry)
+          (ghostel--anchor-window (car entry)))))))
+
+(defun ghostel--around-local-font-scale (fn &rest args)
+  "Resize and re-anchor around local text scaling by FN with ARGS."
+  (ghostel--around-font-scale fn args (current-buffer)))
+
+(defun ghostel--around-global-font-scale (fn &rest args)
+  "Resize and re-anchor around global text scaling by FN with ARGS."
+  (ghostel--around-font-scale fn args))
+
+(unless (advice-member-p #'ghostel--around-local-font-scale 'text-scale-mode)
+  (advice-add 'text-scale-mode :around #'ghostel--around-local-font-scale))
+(when (and (fboundp 'global-text-scale-adjust)
+           (not (advice-member-p #'ghostel--around-global-font-scale
+                                 'global-text-scale-adjust)))
+  (advice-add 'global-text-scale-adjust :around #'ghostel--around-global-font-scale))
 
 (defun ghostel--sync-tty-composition (window)
   "Sync `auto-composition-mode' with WINDOW's frame for ghostel buffers.
@@ -4977,7 +5000,6 @@ for both native and Emacs PTY paths."
   (add-hook 'window-buffer-change-functions #'ghostel--window-buffer-change nil t)
   (add-hook 'window-buffer-change-functions #'ghostel--sync-tty-composition nil t)
   (add-hook 'window-size-change-functions #'ghostel--adjust-size nil t)
-  (add-hook 'text-scale-mode-hook #'ghostel--text-scale-changed nil t)
   (add-hook 'minibuffer-exit-hook #'ghostel--minibuffer-exit)
   (add-hook 'minibuffer-exit-hook #'ghostel--minibuffer-exit-maybe-leave)
   (add-hook 'activate-mark-hook #'ghostel--mark-activated nil t)

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2522,6 +2522,7 @@ Add it to other jump commands as a hook or `:after' advice (see the README)."
         ('char  (ghostel-char-mode))
         ('emacs (ghostel-emacs-mode))
         (_      (ghostel-semi-char-mode)))
+      (ghostel--adjust-size (selected-window) t)
       (ghostel--anchor-window nil t)
       (ghostel-force-redraw))
     (message "Read-only mode exited")))
@@ -4835,31 +4836,32 @@ If WINDOW was anchored to the live viewport before the size change,
 keep it anchored.  Redraw synchronously when the terminal size
 actually changes.  When FORCE is non-nil, run the resize/redraw
 path even when the row/column count is unchanged."
-  (when (ghostel--window-anchored-p
-         window (window-old-body-pixel-height window))
-    (ghostel--anchor-window window))
-  (when-let* ((adjust-fn (or (default-value 'window-adjust-process-window-size-function)
-                             #'window-adjust-process-window-size-smallest))
-              (windows (ghostel--windows (current-buffer) t))
-              (size (funcall adjust-fn ghostel--process windows))
-              (width (car size))
-              (height (cdr size)))
-    (let* ((same-size-p (and (eql height ghostel--term-rows)
-                             (eql width ghostel--term-cols)))
-           ;; Don't resize on minibuffer-induced rows-only change.
-           ;; E.g. fish clears and re-emits its prompt on every SIGWINCH; a
-           ;; `consult-buffer'/`M-x' cycle that grows then shrinks the body
-           ;; would otherwise produce two prompt repaints in quick succession.
-           ;; Skip the deferral on the alt screen TUIs.
-           (minibuffer-excepted-p (and (active-minibuffer-window)
-                                       (eql width ghostel--term-cols)
-                                       (not (ghostel--alt-screen-p ghostel--term)))))
-      (when (or force (and (not same-size-p) (not minibuffer-excepted-p)))
-        (ghostel--set-size-with-cell-dims ghostel--term (max 1 height) (max 1 width))
-        (setq ghostel--force-next-redraw t)
-        ;; Redraw synchronously so the buffer is updated before
-        ;; Emacs displays the stale content at the new window size.
-        (ghostel--redraw-now (current-buffer))))))
+  (when (and ghostel--term ghostel--process (ghostel--terminal-live-p))
+    (when (ghostel--window-anchored-p
+           window (window-old-body-pixel-height window))
+      (ghostel--anchor-window window))
+    (when-let* ((adjust-fn (or (default-value 'window-adjust-process-window-size-function)
+                               #'window-adjust-process-window-size-smallest))
+                (windows (ghostel--windows (current-buffer) t))
+                (size (funcall adjust-fn ghostel--process windows))
+                (width (car size))
+                (height (cdr size)))
+      (let* ((same-size-p (and (eql height ghostel--term-rows)
+                               (eql width ghostel--term-cols)))
+             ;; Don't resize on minibuffer-induced rows-only change.
+             ;; E.g. fish clears and re-emits its prompt on every SIGWINCH; a
+             ;; `consult-buffer'/`M-x' cycle that grows then shrinks the body
+             ;; would otherwise produce two prompt repaints in quick succession.
+             ;; Skip the deferral on the alt screen TUIs.
+             (minibuffer-excepted-p (and (active-minibuffer-window)
+                                         (eql width ghostel--term-cols)
+                                         (not (ghostel--alt-screen-p ghostel--term)))))
+        (when (or force (and (not same-size-p) (not minibuffer-excepted-p)))
+          (ghostel--set-size-with-cell-dims ghostel--term (max 1 height) (max 1 width))
+          (setq ghostel--force-next-redraw t)
+          ;; Redraw synchronously so the buffer is updated before
+          ;; Emacs displays the stale content at the new window size.
+          (ghostel--redraw-now (current-buffer)))))))
 
 (defun ghostel--text-scale-changed ()
   "Update terminal size and redraw after `text-scale-mode' changes the cell font."

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -75,6 +75,23 @@ unlike semi-char mode where it tracks the terminal cursor."
 						      (point-min) (point-max))))
 					(should (string-match-p "frozen-2" content)))))
 
+(ert-deftest ghostel-test-copy-mode-exit-forces-size-adjustment ()
+  "Exiting copy mode forces a size adjustment."
+  (with-temp-buffer
+    (ghostel-mode)
+    (let ((ghostel--term 'fake)
+          (ghostel--process 'fake-proc)
+          (ghostel--input-mode 'copy)
+          (ghostel--pre-readonly-mode 'semi-char)
+          (adjust-args nil))
+      (cl-letf (((symbol-function 'ghostel--adjust-size)
+                 (lambda (&rest args) (setq adjust-args args)))
+                ((symbol-function 'ghostel--anchor-window) #'ignore)
+                ((symbol-function 'ghostel-force-redraw) #'ignore)
+                ((symbol-function 'message) #'ignore))
+        (ghostel-readonly-exit)
+        (should (equal (list (selected-window) t) adjust-args))))))
+
 (ert-deftest ghostel-test-copy-mode-cursor ()
   "Test that copy-mode restores cursor visibility when terminal hid it."
   (let ((buf (generate-new-buffer " *ghostel-test-copy-cursor*")))

--- a/test/ghostel-terminal-test.el
+++ b/test/ghostel-terminal-test.el
@@ -183,7 +183,7 @@ modes (47 / 1047 / 1049) are handled uniformly."
                 (lambda (&rest _) nil))
                ((symbol-function 'window-old-body-pixel-height)
                 (lambda (_window) nil))
-               ((symbol-function 'get-buffer-window-list)
+               ((symbol-function 'ghostel--windows)
                 (lambda (&rest _) '(fake-win)))
                ((symbol-function 'process-buffer)
                 (lambda (_proc) cur-buf))

--- a/test/ghostel-terminal-test.el
+++ b/test/ghostel-terminal-test.el
@@ -258,18 +258,40 @@ modes (47 / 1047 / 1049) are handled uniformly."
         (should ghostel--force-next-redraw)
         (should redraw-called)))))
 
-(ert-deftest ghostel-test-text-scale-change-forces-size-adjustment ()
-  "Text-scale changes use a forced size adjustment."
-  (with-temp-buffer
-    (let ((ghostel--term 'fake)
-          (ghostel--input-mode 'semi-char)
-          (adjust-args nil))
-      (cl-letf (((symbol-function 'get-buffer-window)
-                 (lambda (&rest _) 'fake-window))
-                ((symbol-function 'ghostel--adjust-size)
-                 (lambda (&rest args) (setq adjust-args args))))
-        (ghostel--text-scale-changed)
-        (should (equal '(fake-window t) adjust-args))))))
+(ert-deftest ghostel-test-local-font-scale-refits-anchored-window ()
+  "Local font scaling resizes and re-anchors previously anchored windows."
+  (let ((buf (generate-new-buffer " *ghostel-test-local-font-scale*"))
+        (orig-buf (window-buffer (selected-window))))
+    (unwind-protect
+        (progn
+          (set-window-buffer (selected-window) buf)
+          (with-current-buffer buf
+            (ghostel-mode)
+            (let ((ghostel--term 'fake)
+                  (ghostel--input-mode 'semi-char)
+                  (phase 'before)
+                  (adjust-args nil)
+                  (anchor-args nil))
+              (cl-letf (((symbol-function 'ghostel--window-anchored-p)
+                         (lambda (window &optional _body-pixel-height)
+                           (and (eq window (selected-window))
+                                (eq phase 'before))))
+                        ((symbol-function 'ghostel--terminal-live-p)
+                         (lambda () t))
+                        ((symbol-function 'ghostel--adjust-size)
+                         (lambda (&rest args) (setq adjust-args args)))
+                        ((symbol-function 'ghostel--anchor-window)
+                         (lambda (&rest args) (setq anchor-args args))))
+                (should (eq 'scaled
+                            (ghostel--around-local-font-scale
+                             (lambda ()
+                               (setq phase 'after)
+                               'scaled))))
+                (should (equal (list (selected-window) t) adjust-args))
+                (should (equal (list (selected-window)) anchor-args))))))
+      (when (buffer-live-p orig-buf)
+        (set-window-buffer (selected-window) orig-buf))
+      (kill-buffer buf))))
 
 (ert-deftest ghostel-test-resize-rows-only-during-minibuffer-suppressed ()
   "Rows-only resize while a minibuffer is active is deferred (#268).

--- a/tools/agent-output.sh
+++ b/tools/agent-output.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Emit synthetic coding-agent output for testing Ghostel bottom anchoring.
+# Stop with Ctrl-C.
+
+set -euo pipefail
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  cat <<'EOF'
+Usage: tools/agent-output.sh
+
+Environment:
+  LINES=N       Stop after roughly N output lines (default: 0, run forever)
+  DELAY=S       Sleep between chunks, in seconds (default: 0.04)
+  SYNC=0        Disable DEC 2026 synchronized spinner/status updates
+  NO_COLOR=1    Disable ANSI colours
+EOF
+  exit 0
+fi
+
+limit="${LINES:-0}"
+delay="${DELAY:-0.04}"
+sync="${SYNC:-1}"
+
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+  dim=$'\033[2m'
+  bold=$'\033[1m'
+  reset=$'\033[0m'
+  blue=$'\033[34m'
+  green=$'\033[32m'
+  yellow=$'\033[33m'
+  cyan=$'\033[36m'
+  red=$'\033[31m'
+else
+  dim=''
+  bold=''
+  reset=''
+  blue=''
+  green=''
+  yellow=''
+  cyan=''
+  red=''
+fi
+
+line_count=0
+turn=1
+
+trap 'printf "\n%sinterrupted%s\n" "$dim" "$reset"; exit 130' INT
+
+emit() {
+  printf '%b\n' "$*"
+  ((++line_count))
+  sleep "$delay"
+}
+
+spinner() {
+  local frame="$1" status="$2"
+  if [[ "$sync" == 1 ]]; then
+    printf '\033[?2026h\r\033[K%b %s\n\033[K  ⎿  %s\033[A\r\033[?2026l' \
+      "${cyan}${frame}${reset}" "Working…" "$status"
+  else
+    printf '\r\033[K%b %s' "${cyan}${frame}${reset}" "$status"
+  fi
+  sleep "$delay"
+}
+
+keep_going() {
+  [[ "$limit" == 0 || "$line_count" -lt "$limit" ]]
+}
+
+prompts=(
+  'fix bottom anchoring after text-scale-adjust'
+  'inspect why the terminal jumps after C-x C-+'
+  'add a small regression test for resize follow mode'
+  'simplify window anchoring helpers'
+)
+
+files=(
+  'lisp/ghostel.el'
+  'test/ghostel-scroll-test.el'
+  'test/ghostel-terminal-test.el'
+  'test/ghostel-modes-test.el'
+)
+
+frames=(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏)
+
+emit "${bold}agent anchor output demo${reset} ${dim}(Ctrl-C to stop)${reset}"
+emit "${dim}LINES=${limit} DELAY=${delay} SYNC=${sync}${reset}"
+emit ''
+
+while keep_going; do
+  prompt="${prompts[$((RANDOM % ${#prompts[@]}))]}"
+  emit "${blue}╭─ user${reset}"
+  emit "${blue}│${reset} ${prompt}"
+  emit "${blue}╰────${reset}"
+
+  for i in 0 1 2 3 4; do
+    spinner "${frames[$(((turn + i) % ${#frames[@]}))]}" "reading context ${i}/4"
+  done
+  printf '\r\033[K'
+
+  emit "${yellow}●${reset} I'll keep this narrow and verify the anchoring path."
+
+  for step in 1 2 3 4 5 6; do
+    file="${files[$((RANDOM % ${#files[@]}))]}"
+    case $(((turn + step) % 4)) in
+      0)
+        emit "${cyan}◇ read${reset} ${file} ${dim}:$((RANDOM % 5000 + 1))${reset}"
+        ;;
+      1)
+        emit "${yellow}\$${reset} rg -n \"anchor|resize|text-scale\" ${file}"
+        emit "${dim}  → matched $((RANDOM % 9 + 1)) lines in $((RANDOM % 80 + 10))ms${reset}"
+        ;;
+      2)
+        emit "${dim}diff --git a/${file} b/${file}${reset}"
+        emit "${green}+  (ghostel--anchor-window window)${reset}"
+        emit "${red}-  (set-window-start window (point-min))${reset}"
+        ;;
+      *)
+        emit "${green}✓${reset} checked ${file}"
+        ;;
+    esac
+    keep_going || break
+  done
+
+  emit "${green}✔${reset} turn ${turn} complete ${dim}($((RANDOM % 1800 + 400)) tokens)${reset}"
+  emit ''
+  ((turn++))
+done


### PR DESCRIPTION
## Summary
- add shared helpers for finding visible Ghostel windows and anchored windows
- force size adjustment after leaving copy/read-only mode
- preserve bottom anchoring when text/global font scaling changes terminal geometry
- add a small agent-output script for manual anchoring tests

## Verification
- `emacs --batch -Q -L lisp --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile lisp/ghostel.el`
- `emacs --batch -Q -L lisp -L test -l ert -l test/ghostel-test-helpers.el -l test/ghostel-modes-test.el --eval "(ert-run-tests-batch-and-exit '(not (tag native)))"`
- `emacs --batch -Q -L lisp -L test -l ert -l test/ghostel-test-helpers.el -l test/ghostel-terminal-test.el --eval "(ert-run-tests-batch-and-exit '(not (tag native)))"`
- `emacs --batch -Q -L lisp -L test -l ert -l test/ghostel-test-helpers.el -l test/ghostel-scroll-test.el --eval "(ert-run-tests-batch-and-exit '(not (tag native)))"`
- `checkdoc` on `lisp/ghostel.el`
- `bash -n tools/agent-output.sh`
- smoke run of `tools/agent-output.sh`
- `git diff --check`