### PR TITLE
Ignore the daemon's dummy initial frame when sizing the PTY

### DIFF
--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -536,7 +536,8 @@ local machine happens to have)."
     (set-process-window-size proc height width)
     (when compilation-always-kill
       (set-process-query-on-exit-flag proc nil))
-    (process-put proc 'adjust-window-size-function nil)
+    ;; See `ghostel--spawn-pty'.
+    (process-put proc 'adjust-window-size-function #'ignore)
     proc))
 
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4349,7 +4349,10 @@ returned process owns the PTY and receives `ghostel--filter' and
     ;; Set the PTY's actual window size (ioctl TIOCSWINSZ) so that
     ;; the program's line editor (readline/ZLE) can render properly.
     (set-process-window-size proc ghostel--term-rows ghostel--term-cols)
-    (process-put proc 'adjust-window-size-function nil)
+    ;; `ghostel--adjust-size' owns sizing; `ignore' (nil would fall
+    ;; back to the default) opts out of core's all-frames
+    ;; `window--adjust-process-windows'.
+    (process-put proc 'adjust-window-size-function #'ignore)
     proc))
 
 (defun ghostel--spawn-via-native (command)
@@ -4561,14 +4564,24 @@ remain handled inside the renderer."
      (or begin (ghostel--viewport-start) (point-min))
      (or end (point-max)))))
 
+(defun ghostel--daemon-dummy-frame-p (frame)
+  "Non-nil if FRAME is the daemon's invisible initial frame.
+Killing a buffer can substitute a ghostel buffer into that frame's sole window.
+Its 80x24 dummy size must never count as a display of the buffer.
+`frame-visible-p' and `terminal-live-p' are both t on it,
+so compare against `terminal-frame' instead."
+  (and (daemonp) (eq frame terminal-frame)))
+
 (defun ghostel--windows (&optional buffer all-frames)
   "Return Ghostel windows, optionally limited to BUFFER.
-ALL-FRAMES has the same meaning as in `walk-windows'."
+ALL-FRAMES has the same meaning as in `walk-windows'.
+Windows on the daemon's dummy initial frame are excluded."
   (let (windows)
     (walk-windows
      (lambda (window)
        (let ((window-buffer (window-buffer window)))
          (when (and (or (null buffer) (eq window-buffer buffer))
+                    (not (ghostel--daemon-dummy-frame-p (window-frame window)))
                     (with-current-buffer window-buffer
                       (derived-mode-p 'ghostel-mode)))
            (push window windows))))

--- a/test/ghostel-terminal-test.el
+++ b/test/ghostel-terminal-test.el
@@ -258,6 +258,29 @@ modes (47 / 1047 / 1049) are handled uniformly."
         (should ghostel--force-next-redraw)
         (should redraw-called)))))
 
+(ert-deftest ghostel-test-windows-excludes-daemon-dummy-frame ()
+  "`ghostel--windows' drops windows on the daemon's dummy initial frame.
+Killing a buffer can substitute a ghostel buffer into that invisible
+80x24 frame, which then clamps the PTY size (#504)."
+  (let ((buf (generate-new-buffer " *ghostel-test-dummy-frame*"))
+        (orig-buf (window-buffer (selected-window))))
+    (unwind-protect
+        (progn
+          (with-current-buffer buf
+            (setq major-mode 'ghostel-mode))
+          (set-window-buffer (selected-window) buf)
+          (should (memq (selected-window) (ghostel--windows buf t)))
+          (cl-letf (((symbol-function 'daemonp) (lambda () t)))
+            ;; Selected frame plays the daemon's initial frame.
+            (let ((terminal-frame (selected-frame)))
+              (should-not (ghostel--windows buf t)))
+            ;; Some other frame is the dummy one: window stays.
+            (let ((terminal-frame 'other-frame))
+              (should (memq (selected-window) (ghostel--windows buf t))))))
+      (when (buffer-live-p orig-buf)
+        (set-window-buffer (selected-window) orig-buf))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-local-font-scale-refits-anchored-window ()
   "Local font scaling resizes and re-anchors previously anchored windows."
   (let ((buf (generate-new-buffer " *ghostel-test-local-font-scale*"))


### PR DESCRIPTION
## Problem

With an Emacs daemon + client frame, killing the buffer that was selected when `M-x ghostel` was started (e.g. `*scratch*`) resets the PTY to 79x22 (issue #504).

The daemon keeps an invisible ~80x24 initial frame whose sole window shows `*scratch*`. Killing that buffer substitutes the ghostel buffer into that window. Both ghostel's own resize path (`ghostel--windows` with all-frames) and core's `window--adjust-process-windows` collect windows across **all** frames, so `window-adjust-process-window-size-smallest` clamps the PTY to the dummy window's 79x22 body.

Note that `frame-visible-p` and `terminal-live-p` are both `t` on the dummy frame, so visibility can't be used as a filter; the reliable test is `(and (daemonp) (eq frame terminal-frame))` — `Vterminal_frame` is assigned exactly once at startup, so client tty frames are never affected.

## Fix

- `ghostel--daemon-dummy-frame-p`: identifies the dummy frame.
- `ghostel--windows` now skips windows on it — fixes the clamp in `ghostel--adjust-size` and keeps `ghostel--get-render-window`/anchoring off the dummy frame.
- `ghostel--adjust-process-window-size` drops dummy-frame windows and delegates to the standard sizing function; installed as the process's `adjust-window-size-function` on both PTY spawn sites (`ghostel--spawn-pty`, `ghostel-compile`). The previous `(process-put proc 'adjust-window-size-function nil)` was a no-op — core falls back to the global `window-adjust-process-window-size-function` on a nil property, so core was resizing the elisp PTY with an unfiltered all-frames window list.

If the buffer is shown *only* in the dummy frame, the window list is empty and the sizing function returns nil, leaving the PTY size alone.

## Verification

- 3 new ERT tests (elisp group).
- Live daemon repro (daemon + 200x50 tty client): PTY stays 47x199 after killing `*scratch*` (was 22x79), `stty size` confirms; normal window resizes still track on both the native-PTY and elisp-PTY (`ghostel-use-native-pty` nil) paths.

For the record: eat exhibits the identical bug (verified live), and core's `window--process-window-list` walks all frames, so this is arguably also an upstream Emacs issue.

Fixes #504