### PR TITLE
Install compiled module after recompile

### DIFF
--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -366,10 +366,6 @@ same as in any compilation buffer."
           (when start
             (ghostel-compile--trim-trailing-blanks start))
           (ghostel-compile--teardown-terminal)
-          ;; Run standard compilation finish hooks before switching major mode:
-          ;; callers may install buffer-local hooks or continuation state, and
-          ;; `funcall' below kills those locals as part of the mode change.
-          (run-hook-with-args 'compilation-finish-functions buffer msg)
           ;; Switch major mode now that the process is dead.  Preserve state
           ;; that `kill-all-local-variables' would otherwise wipe.  A
           ;; per-buffer override (set by the `compilation-start' advice
@@ -386,9 +382,19 @@ same as in any compilation buffer."
                  (saved-compilation-arguments
                   (and saved-compilation-arguments-local
                        compilation-arguments))
+                 ;; Some callers (Dape) install buffer-local finish hooks
+                 ;; after starting compilation, with buffer-local state those
+                 ;; hooks need.  Run those before the mode switch kills locals;
+                 ;; run the normal hook below too so the finished mode can add
+                 ;; its own local hooks, matching `compilation-start'.
+                 (saved-local-finish-functions
+                  (and (local-variable-p 'compilation-finish-functions)
+                       (remq t compilation-finish-functions)))
                  (target-mode (or ghostel-compile--view-mode-override
                                   ghostel-compile-finished-major-mode)))
             (when target-mode
+              (dolist (fn saved-local-finish-functions)
+                (funcall fn buffer msg))
               (funcall target-mode))
             (setq-local ghostel-compile--command saved-command
                         ghostel-compile--directory saved-directory
@@ -434,6 +440,8 @@ same as in any compilation buffer."
             (with-selected-window win (recenter -1))))
         (ghostel-compile--set-mode-line-exit exit)
         (setq next-error-last-buffer buffer)
+        (run-hook-with-args 'compilation-finish-functions
+                            buffer (ghostel-compile--status-message exit))
         (ghostel-compile--auto-jump buffer)
         (run-hook-with-args 'ghostel-compile-finish-functions
                             buffer (ghostel-compile--status-message exit))))))

--- a/lisp/ghostel-module-install.el
+++ b/lisp/ghostel-module-install.el
@@ -16,6 +16,7 @@
 ;;; Code:
 
 (require 'compat)
+(require 'compile)
 (require 'url-parse)
 
 (declare-function ghostel--module-version "ghostel-module")
@@ -47,6 +48,14 @@ nil        - do nothing; the user must install the module manually."
                  (const :tag "Download pre-built binary" download)
                  (const :tag "Compile from source" compile)
                  (const :tag "Do nothing" nil))
+  :group 'ghostel)
+
+(defcustom ghostel-module-compile-command
+  "zig build --prefix %s -Doptimize=ReleaseFast -Dcpu=baseline"
+  "Shell command used by `ghostel-module-compile'.
+The command is formatted with one argument: the shell-quoted temporary
+Zig install prefix."
+  :type 'string
   :group 'ghostel)
 
 (defcustom ghostel-github-release-url
@@ -373,39 +382,59 @@ Leaving the prompt empty downloads the latest release."
           (message "ghostel: module loaded successfully"))
       (user-error "Download failed.  Try M-x ghostel-module-compile to build from source"))))
 
+(defvar-local ghostel--module-compile-build-dir nil
+  "Temporary Zig install prefix for an interactive module compile buffer.")
+
+(defvar-local ghostel--module-compile-dest-dir nil
+  "Final module directory for an interactive module compile buffer.")
+
+(put 'ghostel--module-compile-build-dir 'permanent-local t)
+(put 'ghostel--module-compile-dest-dir 'permanent-local t)
+
+(defun ghostel--install-built-module-after-compilation (buf status)
+  "Move the module built by an interactive compile in BUF on successful STATUS."
+  (when (buffer-live-p buf)
+    (with-current-buffer buf
+      (let ((build-dir ghostel--module-compile-build-dir)
+            (dest-dir ghostel--module-compile-dest-dir))
+        (when (and build-dir dest-dir)
+          (let ((file-name (concat "ghostel-module" module-file-suffix))
+                (sidecar "ghostel-module.version"))
+            (unwind-protect
+                (when (string-match-p "finished" status)
+                  (let ((built (expand-file-name file-name build-dir))
+                        (final (expand-file-name file-name dest-dir))
+                        (built-sidecar (expand-file-name sidecar build-dir))
+                        (final-sidecar (expand-file-name sidecar dest-dir)))
+                    (when (file-exists-p built)
+                      (condition-case err
+                          (progn
+                            (ghostel--install-module-pair
+                             built final built-sidecar final-sidecar)
+                            (message "ghostel: module installed at %s" final))
+                        (error
+                         (display-warning
+                          'ghostel
+                          (format "Build succeeded but installing into %s failed: %s"
+                                  dest-dir (error-message-string err))))))))
+              (when (file-directory-p build-dir)
+                (ignore-errors (delete-directory build-dir t))))))))))
+
+(define-derived-mode ghostel-module-compilation-mode compilation-mode "Compilation"
+  "Compilation mode for `ghostel-module-compile'."
+  (add-hook 'compilation-finish-functions
+            #'ghostel--install-built-module-after-compilation
+            nil t))
+
+(defun ghostel--module-compilation-buffer-name (_mode-name)
+  "Return the buffer name used by `ghostel-module-compile'."
+  "*compilation*")
+
 (defun ghostel--install-built-module-on-finish (compile-buf build-dir dest-dir)
-  "Move the built module from BUILD-DIR into DEST-DIR when COMPILE-BUF finishes.
-Registers a one-shot `compilation-finish-functions' handler that
-filters on COMPILE-BUF and removes itself on first match.  Used so the
-interactive `ghostel-module-compile' honours `ghostel-module-directory'.
-The sidecar version file written by `build.zig' is moved alongside the module."
-  (let* ((file-name (concat "ghostel-module" module-file-suffix))
-         (sidecar "ghostel-module.version")
-         handler)
-    (setq handler
-          (lambda (buf status)
-            (when (eq buf compile-buf)
-              (remove-hook 'compilation-finish-functions handler)
-              (unwind-protect
-                  (when (string-match-p "finished" status)
-                    (let ((built (expand-file-name file-name build-dir))
-                          (final (expand-file-name file-name dest-dir))
-                          (built-sidecar (expand-file-name sidecar build-dir))
-                          (final-sidecar (expand-file-name sidecar dest-dir)))
-                      (when (file-exists-p built)
-                        (condition-case err
-                            (progn
-                              (ghostel--install-module-pair
-                               built final built-sidecar final-sidecar)
-                              (message "ghostel: module installed at %s" final))
-                          (error
-                           (display-warning
-                            'ghostel
-                            (format "Build succeeded but installing into %s failed: %s"
-                                    dest-dir (error-message-string err))))))))
-                (when (file-directory-p build-dir)
-                  (ignore-errors (delete-directory build-dir t)))))))
-    (add-hook 'compilation-finish-functions handler)))
+  "Record BUILD-DIR and DEST-DIR for module installation from COMPILE-BUF."
+  (with-current-buffer compile-buf
+    (setq-local ghostel--module-compile-build-dir build-dir
+                ghostel--module-compile-dest-dir dest-dir)))
 
 (defun ghostel-module-compile ()
   "Compile the ghostel native module by running zig build.
@@ -413,13 +442,17 @@ The output is shown in a `*compilation*' buffer.
 The produced module is moved into `ghostel-module-directory' once
 the build finishes."
   (interactive)
+  (save-some-buffers (not compilation-ask-about-save)
+                     compilation-save-buffers-predicate)
   (let* ((source-dir (ghostel--resource-root))
          (dest-dir (ghostel--module-directory))
          (build-dir (ghostel--make-module-build-dir dest-dir))
          (default-directory source-dir)
-         (compile-buf (compile (format "zig build --prefix %s -Doptimize=ReleaseFast -Dcpu=baseline"
-                                       (shell-quote-argument (expand-file-name build-dir)))
-                               t)))
+         (compile-buf (compilation-start
+                       (format ghostel-module-compile-command
+                               (shell-quote-argument (expand-file-name build-dir)))
+                       #'ghostel-module-compilation-mode
+                       #'ghostel--module-compilation-buffer-name)))
     (ghostel--install-built-module-on-finish compile-buf build-dir dest-dir)))
 
 (defun ghostel--check-module-version (dir &optional prompt-user)

--- a/test/ghostel-compile-test.el
+++ b/test/ghostel-compile-test.el
@@ -9,7 +9,21 @@
 
 (require 'ghostel-test-helpers)
 
+(defvar ghostel-test-compile--mode-finish-called nil)
+
 (defvar-local ghostel-test-compile--finish-continuation nil)
+
+(define-derived-mode ghostel-test-compile-finish-mode compilation-mode "Test-Compilation"
+  "Compilation mode that installs a mode-local finish hook for tests."
+  (setq-local ghostel-test-compile--finish-continuation
+              (lambda (buffer message)
+                (setq ghostel-test-compile--mode-finish-called
+                      (cons buffer message))))
+  (add-hook 'compilation-finish-functions
+            (lambda (buffer message)
+              (funcall ghostel-test-compile--finish-continuation
+                       buffer message))
+            nil t))
 
 (ert-deftest ghostel-test-compile-finalize-scans-errors ()
   "`ghostel-compile--finalize' parses errors in the scan region."
@@ -396,8 +410,8 @@ scrolled below the window."
       (should (equal 1 (length c-calls)))                     ; compile hook
       (should (equal "finished\n" (cdar c-calls))))))
 
-(ert-deftest ghostel-test-compile-buffer-local-finish-hook-state-is-available ()
-  "Buffer-local compile finish hook state is available at finalization."
+(ert-deftest ghostel-test-compile-existing-local-finish-hook-state-is-available ()
+  "Existing buffer-local compile finish hook state is available at finalization."
   (ghostel-test--with-compile-buffer buf
     (let ((finish-called nil)
           (continuation-called nil))
@@ -414,6 +428,20 @@ scrolled below the window."
       (ghostel-compile--finalize buf 0 (current-time))
       (should finish-called)
       (should continuation-called))))
+
+(ert-deftest ghostel-test-compile-mode-local-finish-hook-runs ()
+  "A custom compilation mode's buffer-local finish hook runs at finalization."
+  (ghostel-test--with-compile-buffer buf
+    (let ((ghostel-compile-finished-major-mode
+           #'ghostel-test-compile-finish-mode)
+          (ghostel-test-compile--mode-finish-called nil))
+      (setq ghostel-compile--command "true"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--scan-marker (copy-marker (point-max)))
+      (ghostel-compile--finalize buf 0 (current-time))
+      (should (eq major-mode 'ghostel-test-compile-finish-mode))
+      (should (equal (cons buf "finished\n")
+                     ghostel-test-compile--mode-finish-called)))))
 
 (ert-deftest ghostel-test-compile-auto-jump-to-first-error ()
   "With `compilation-auto-jump-to-first-error' set, jump after parsing."

--- a/test/ghostel-module-test.el
+++ b/test/ghostel-module-test.el
@@ -401,16 +401,19 @@ module beside a stale sidecar (issue #256 follow-up B1)."
                 ((symbol-function 'ghostel--install-built-module-on-finish)
                  (lambda (buf build-dir dest-dir)
                    (setq finish-args (list buf build-dir dest-dir))))
-                ((symbol-function 'compile)
-                 (lambda (command &optional comint)
-                   (setq compile-invocation (list command comint default-directory))
+                ((symbol-function 'compilation-start)
+                 (lambda (command &optional mode name-function &rest _)
+                   (setq compile-invocation
+                         (list command mode name-function default-directory))
                    (current-buffer))))
         (ghostel-module-compile)
         (should (equal (concat "zig build --prefix /src/ghostel/.ghostel-build/ "
                                "-Doptimize=ReleaseFast -Dcpu=baseline")
                        (nth 0 compile-invocation)))
-        (should (eq t (nth 1 compile-invocation)))
-        (should (equal "/src/ghostel/" (nth 2 compile-invocation)))
+        (should (eq #'ghostel-module-compilation-mode (nth 1 compile-invocation)))
+        (should (eq #'ghostel--module-compilation-buffer-name
+                    (nth 2 compile-invocation)))
+        (should (equal "/src/ghostel/" (nth 3 compile-invocation)))
         (should (equal (list (current-buffer)
                              "/src/ghostel/.ghostel-build/"
                              "/src/ghostel/")
@@ -433,20 +436,71 @@ sidecar and then renames the module and sidecar into place."
                 ((symbol-function 'ghostel--install-built-module-on-finish)
                  (lambda (buf build-dir dest-dir)
                    (setq finish-args (list buf build-dir dest-dir))))
-                ((symbol-function 'compile)
-                 (lambda (command &optional comint)
-                   (setq compile-invocation (list command comint default-directory))
+                ((symbol-function 'compilation-start)
+                 (lambda (command &optional mode name-function &rest _)
+                   (setq compile-invocation
+                         (list command mode name-function default-directory))
                    (current-buffer))))
         (ghostel-module-compile)
         (should (equal (concat "zig build --prefix /custom/dir/.ghostel-build/ "
                                "-Doptimize=ReleaseFast -Dcpu=baseline")
                        (nth 0 compile-invocation)))
-        (should (eq t (nth 1 compile-invocation)))
-        (should (equal "/src/ghostel/" (nth 2 compile-invocation)))
+        (should (eq #'ghostel-module-compilation-mode (nth 1 compile-invocation)))
+        (should (eq #'ghostel--module-compilation-buffer-name
+                    (nth 2 compile-invocation)))
+        (should (equal "/src/ghostel/" (nth 3 compile-invocation)))
         (should (equal (list (current-buffer)
                              "/custom/dir/.ghostel-build/"
                              "/custom/dir/")
                        finish-args))))))
+
+(ert-deftest ghostel-test-module-compile-recompile-installs-built-module ()
+  "`ghostel-module-compile' installs artifacts again after `recompile'."
+  (let* ((root (make-temp-file "ghostel-module-recompile" t))
+         (dest-dir (file-name-as-directory (expand-file-name "module" root)))
+         (counter (expand-file-name "counter" root))
+         (module-name (concat "ghostel-module" module-file-suffix))
+         (final (expand-file-name module-name dest-dir))
+         (final-sidecar (expand-file-name "ghostel-module.version" dest-dir))
+         (compile-buffer-name " *ghostel-module-recompile*")
+         (compilation-ask-about-save nil)
+         (ghostel-module-directory dest-dir)
+         (ghostel-module-compile-command
+          (format "sh -c %s sh %%s"
+                  (shell-quote-argument
+                   (format (concat "n=$(($(cat %s 2>/dev/null || echo 0)+1)); "
+                                   "printf \"$n\" > %s; "
+                                   "mkdir -p \"$1\"; "
+                                   "printf \"module-$n\" > \"$1/%s\"; "
+                                   "printf \"$n\" > \"$1/ghostel-module.version\"")
+                           (shell-quote-argument counter)
+                           (shell-quote-argument counter)
+                           module-name)))))
+    (cl-labels ((read-file (file)
+                  (and (file-exists-p file)
+                       (with-temp-buffer
+                         (insert-file-contents file)
+                         (buffer-string))))
+                (wait-for-module (contents)
+                  (ghostel-test--wait-until
+                   (lambda () (equal contents (read-file final)))
+                   nil 5)))
+      (cl-letf (((symbol-function 'ghostel--resource-root)
+                 (lambda () root))
+                ((symbol-function 'ghostel--module-compilation-buffer-name)
+                 (lambda (_mode-name) compile-buffer-name)))
+        (unwind-protect
+            (let ((inhibit-message t))
+              (ghostel-module-compile)
+              (wait-for-module "module-1")
+              (should (equal "1" (read-file final-sidecar)))
+              (with-current-buffer compile-buffer-name
+                (recompile))
+              (wait-for-module "module-2")
+              (should (equal "2" (read-file final-sidecar))))
+          (when-let* ((buf (get-buffer compile-buffer-name)))
+            (kill-buffer buf))
+          (delete-directory root t))))))
 
 (ert-deftest ghostel-test-module-version-match ()
   "Test that version check does nothing when module meets minimum."


### PR DESCRIPTION
## Summary
- make ghostel-compile run existing live buffer-local finish hooks before mode reset, then run standard finish hooks after the final compilation mode is installed
- run ghostel-module-compile through a dedicated compilation mode with buffer-local install metadata
- add a configurable module compile command and regression coverage for compile + recompile installing final artifacts

## Verification
- `emacs --batch -Q -L lisp --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile lisp/ghostel-compile.el lisp/ghostel-module-install.el`
- `emacs --batch -Q -L lisp -L test --eval '(setq load-prefer-newer t)' -l ert -l test/ghostel-test-helpers.el -l test/ghostel-compile-test.el --eval "(ert-run-tests-batch-and-exit '(not (tag native)))"`
- `emacs --batch -Q -L lisp -L test --eval '(setq load-prefer-newer t)' -l ert -l test/ghostel-test-helpers.el -l test/ghostel-module-test.el --eval "(ert-run-tests-batch-and-exit '(not (tag native)))"`
- `git diff --check`