### PR TITLE
Filter Ghostel copy text through buffer substring

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2582,6 +2582,12 @@ These are newlines with the `ghostel-wrap' text property."
          (trimmed (mapcar (lambda (line) (string-trim-right line)) lines)))
     (mapconcat #'identity trimmed "\n")))
 
+(defun ghostel--filter-buffer-substring (beg end delete)
+  "Filter Ghostel buffer text between BEG and END for copying.
+DELETE has the same meaning as in `filter-buffer-substring'."
+  (ghostel--clean-copy-text
+   (funcall (default-value 'filter-buffer-substring-function) beg end delete)))
+
 (defun ghostel-readonly-copy ()
   "Copy the selected region.
 Soft-wrapped newlines are removed and trailing whitespace is
@@ -2589,11 +2595,7 @@ stripped so the copied text matches the original terminal content.
 When `ghostel-readonly-fast-exit' is non-nil, also exits read-only mode."
   (interactive)
   (when (use-region-p)
-    (let ((text (ghostel--clean-copy-text
-                 (buffer-substring (region-beginning) (region-end)))))
-      (kill-new text)
-      (setq deactivate-mark t)  ; matching `kill-ring-save'
-      (message "Copied to kill ring")))
+    (kill-ring-save (region-beginning) (region-end)))
   (when ghostel-readonly-fast-exit
     (ghostel-readonly-exit)))
 
@@ -4990,6 +4992,7 @@ for both native and Emacs PTY paths."
   (setq-local truncate-lines t)
   (setq-local scroll-conservatively 101)
   (setq-local line-spacing 0)
+  (setq-local filter-buffer-substring-function #'ghostel--filter-buffer-substring)
   ;; expose cwd to buffer-menu/ibuffer
   (setq-local list-buffers-directory (expand-file-name default-directory))
   ;; bookmark this buffer's cwd (loads ghostel-bookmark.el lazily on use)

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -618,7 +618,19 @@ are retained — only unwritten padding cells are trimmed."
   (let ((s (concat "aaa" (propertize "\n" 'ghostel-wrap t) "bbb\nccc")))
     (should (equal "aaabbb\nccc" (ghostel--filter-soft-wraps s)))))
 
-
+(ert-deftest ghostel-test-kill-ring-save-filters-soft-wraps ()
+  "Generic copy commands filter renderer-inserted soft-wrap newlines."
+  (let ((kill-ring nil)
+        (kill-ring-yank-pointer nil)
+        (interprogram-cut-function nil))
+    (with-temp-buffer
+      (ghostel-mode)
+      (let ((inhibit-read-only t))
+        (insert "hello")
+        (insert (propertize "\n" 'ghostel-wrap t))
+        (insert "world   "))
+      (kill-ring-save (point-min) (point-max))
+      (should (equal (car kill-ring) "helloworld")))))
 
 ;;; Palette, faces, and theme sync
 


### PR DESCRIPTION
## Summary
- install a Ghostel buffer-local `filter-buffer-substring-function` so generic copy paths remove renderer soft-wrap newlines
- make `ghostel-readonly-copy` delegate to `kill-ring-save`
- add a regression test for `kill-ring-save` copying soft-wrapped text

## Verification
- `emacs --batch -Q -L lisp -L test -l test/ghostel-test-helpers.el --eval "(byte-compile-file \"lisp/ghostel.el\")"`
- `emacs --batch -Q -L lisp -L test -l ert -l test/ghostel-test-helpers.el -l test/ghostel-render-test.el --eval "(ert-run-tests-batch-and-exit '(or ghostel-test-filter-soft-wraps ghostel-test-kill-ring-save-filters-soft-wraps))"`
- `emacs --batch -Q -L lisp -L test -l ert -l test/ghostel-test-helpers.el -l test/ghostel-mouse-paste-test.el --eval "(ert-run-tests-batch-and-exit '(or ghostel-test-readonly-copy-exits-when-fast-exit-enabled ghostel-test-readonly-copy-no-exit-when-fast-exit-disabled ghostel-test-readonly-copy-deactivates-mark))"`