### PR TITLE
Let Lisp IMEs compose in read-only ghostel buffers

### DIFF
--- a/lisp/ghostel-ime.el
+++ b/lisp/ghostel-ime.el
@@ -94,7 +94,10 @@ to the PTY as UTF-8 only in terminal-input modes."
             ;; translator; calling it would silently skip composition.
             (eq original #'list))
         (list key)
-      (let ((events (let ((inhibit-read-only t))
+      ;; Bind `buffer-read-only' too: some Lisp IMEs (e.g. `hangul2-input-method')
+      ;; gate composition on the variable directly, not on `inhibit-read-only'.
+      (let ((events (let ((inhibit-read-only t)
+                          (buffer-read-only nil))
                       (funcall original key))))
         (let ((after-point (point)))
           (when (> after-point before-point)

--- a/test/ghostel-ime-test.el
+++ b/test/ghostel-ime-test.el
@@ -139,6 +139,40 @@ It waits for the activation hook to deliver a genuine translator."
         (should (equal sent
                        (list (encode-coding-string text 'utf-8))))))))
 
+(ert-deftest ghostel-test-ime-wrap-composes-in-read-only-buffer ()
+  "IMEs that gate composition on `buffer-read-only' still compose and forward.
+`hangul2-input-method' (and the 3-Bulsik variants) open with
+  (if (or buffer-read-only ...) (list key) ...)
+and return the key untranslated whenever the buffer is read-only.  A bare
+`inhibit-read-only' bind lifts the modification barrier but leaves that
+variable set, so the IME never composes and the raw keystroke is forwarded
+instead of the syllable.  The wrapper must present a writable buffer."
+  (ghostel-test--with-compile-buffer buf
+    ;; Precondition: ghostel buffers are protected (read-only) by default.
+    (should buffer-read-only)
+    (let ((inhibit-read-only t))
+      (erase-buffer))
+    (let (sent gate-saw-writable)
+      ;; Fake IME mirroring hangul's read-only gate exactly.
+      (setq-local ghostel-ime--original-input-method-function
+                  (lambda (key)
+                    (if buffer-read-only
+                        (list key)
+                      (setq gate-saw-writable t)
+                      (insert "가")
+                      nil)))
+      (cl-letf (((symbol-function 'ghostel--terminal-input-mode-p)
+                 (lambda () t))
+                ((symbol-function 'ghostel--send-string)
+                 (lambda (string) (push string sent))))
+        (should (null (ghostel-ime--wrap-input-method ?r))))
+      ;; The IME saw a writable buffer, so it composed instead of passing through.
+      (should gate-saw-writable)
+      ;; Transient insertion removed locally; only the PTY sees the commit.
+      (should (equal (buffer-string) ""))
+      (should (equal sent
+                     (list (encode-coding-string "가" 'utf-8)))))))
+
 (ert-deftest ghostel-test-ime-wrap-discards-cjk-commits-in-protected-non-input-modes ()
   "Buffer-inserted IME commits in protected non-input modes are removed."
   (ghostel-test--with-compile-buffer buf


### PR DESCRIPTION
### Context

Thank you for the continued work on ghostel — it has become the terminal
integration I reach for daily, running Emacs `-nw` in a terminal with the
built-in Korean input method (`hangul2-input-method`). This is a corner that is
easy to never encounter unless you type CJK through Emacs' Lisp IMEs, so I hope a
small report from that corner is useful.

This follows up on #343 (the IME-forward + redraw-guard work you kindly merged).
That infrastructure still works — this is a narrow interaction with a later
change.

### The regression

`9e8460a` ("Make ghostel buffers read-only") interacts with the IME-commit path
from #343. Several Lisp IMEs gate composition on `buffer-read-only` **directly**,
not through `inhibit-read-only`. `hangul2-input-method` (and the 3-Bulsik
variants) open with:

```elisp
(if (or buffer-read-only ...) (list key) ...)
```

so they return the raw key untranslated whenever the buffer is read-only. The
commit-forward wrapper binds `inhibit-read-only` around the input method, which
lifts the *modification* barrier but leaves `buffer-read-only` set — so the IME
never composes in a protected ghostel buffer, and the un-composed keystroke is
forwarded to the PTY instead of the committed syllable. In practice, Korean input
stopped composing entirely in ghostel after buffers became read-only.

### The fix

Bind `buffer-read-only` to nil alongside `inhibit-read-only` around the
input-method call in `ghostel-ime--wrap-input-method`, so the IME sees a writable
buffer. The transient insertion is still removed once the call returns
(`buffer-read-only` is restored), and the committed text is forwarded to the PTY
exactly as before — behavior is unchanged for every other path.

Scope is deliberately minimal: one functional line in `ghostel-ime.el`, plus a
characterization test with a fake IME that mirrors hangul's read-only gate (it
fails without the change). `ghostel.el` core is untouched.

### Verification

Rebased cleanly onto current `main` (v0.41.0 + 3 commits) — the touched files
were byte-identical from v0.38 through v0.41, so this replays without conflict.
All green locally:

- `make test` (elisp) — pass
- `make test-native` — pass
- `make byte-compile` with `byte-compile-error-on-warn` — no warnings
- `make checkdoc` on the changed file — clean

I keep this rebased against upstream continuously, so I'm happy to trim, reshape,
or fold it however fits your taste — no rush on your end. Thanks again for the
care you put into this project.
