### PR TITLE
Optimize renderer incremental redraws

### DIFF
--- a/README.org
+++ b/README.org
@@ -732,7 +732,7 @@ TRAMP-aware =auth-source-pick-first-password= example.
 :custom_id: rendering
 :end:
 
-- Incremental redraw - only dirty rows are re-rendered.
+- Incremental redraw - unchanged rows are skipped.
 - Timer-based batched updates with adaptive frame rate.
 - *Immediate redraw* for interactive typing echo - PTY output arriving shortly
   after a keystroke bypasses the timer, eliminating 16-33ms of latency per
@@ -1965,9 +1965,9 @@ in =view-lossage=, the recent-keys ring, and anything else watching input.
 *Input methods.*  Ghostel and vterm forward Emacs input methods into the terminal
 (ghostel via =ghostel-ime-mode=); eat does not.
 
-*Rendering.*  All three use text properties rather than overlays.  Ghostel's
-engine provides three-level dirty tracking (none / partial / full) at per-row
-granularity and defaults to ~30 fps; vterm uses damage-rectangle callbacks and
+*Rendering.*  All three use text properties rather than overlays.  Ghostel uses
+libghostty's row dirtiness plus cursor tracking to update only the rows that need
+to change, and defaults to ~30 fps; vterm uses damage-rectangle callbacks and
 defaults to ~10 fps; eat coalesces output within an 8-33 ms latency window.
 
 *Performance.*  On the cross-emulator benchmark (1 MB streamed, ~1,000 lines of
@@ -1995,7 +1995,7 @@ Ghostel has a two-layer design: a *Zig native module* (the terminal engine) and
 ghostel.el            Elisp: keymap, process management, mode, commands
 src/module.zig        Entry point: emacs_module_init, function registration
 src/GhostelTerm.zig   Terminal state wrapping libghostty-vt (and the native reader)
-src/Renderer.zig      RenderState -> Emacs buffer with styled text
+src/Renderer.zig      Terminal pages -> Emacs buffer with styled text
 src/input.zig         Key encoding via ghostty encoders
 src/handler.zig       Intercepts OSC actions and routes them to Elisp callbacks
 src/PtyProcess.zig    Native PTY: open master/replica, spawn the child
@@ -2044,8 +2044,8 @@ the VT parser):
    =ghostel--filter=, which calls =ghostel--write-vt= and then =ghostel--invalidate=
    synchronously.)
 3. =ghostel--invalidate= runs =ghostel--redraw-now= - immediately for interactive
-   echo, otherwise on a coalescing timer - which drives =Renderer.zig= to read the
-   dirty rows and update the buffer with propertized text.
+   echo, otherwise on a coalescing timer - which drives =Renderer.zig= to scan the
+   terminal pages and update dirty rows with propertized text.
 
 ** Renderer and buffer positions
 :properties:

--- a/bench/ghostel-bench.el
+++ b/bench/ghostel-bench.el
@@ -90,6 +90,17 @@ this many seconds.  Explicit `ghostel-bench-iterations' remains a floor.")
   (when ghostel-bench-force-gui-redisplay
     (redisplay t)))
 
+(defun ghostel-bench--redraw (term full-p)
+  "Redraw ghostel TERM for renderer benchmarks.
+Use the same local bindings as production `ghostel--redraw-now' around
+raw `ghostel--redraw' calls so synthetic renderer measurements do not
+include GC or hook overhead that production redraws suppress."
+  (let ((inhibit-read-only t)
+        (inhibit-redisplay t)
+        (inhibit-modification-hooks t)
+        (gc-cons-threshold most-positive-fixnum))
+    (ghostel--redraw term full-p)))
+
 ;; ---------------------------------------------------------------------------
 ;; Data generators
 ;; ---------------------------------------------------------------------------
@@ -790,7 +801,7 @@ terminal engine with periodic redraws, all in a tight loop."
                  (setq offset end)
                  (cl-incf chunk-count)
                  (when (zerop (% chunk-count redraw-every))
-                   (ghostel--redraw term nil)))))))))
+                   (ghostel-bench--redraw term nil)))))))))
     ;; ghostel full
     (ghostel-bench--with-bench-buffer
       (let* ((data (ghostel-bench--encode-for-backend raw-data 'ghostel))
@@ -807,7 +818,7 @@ terminal engine with periodic redraws, all in a tight loop."
                  (setq offset end)
                  (cl-incf chunk-count)
                  (when (zerop (% chunk-count redraw-every))
-                   (ghostel--redraw term t)))))))))
+                   (ghostel-bench--redraw term t)))))))))
     ;; ghostel default, no detection
     (ghostel-bench--with-bench-buffer
       (let* ((data (ghostel-bench--encode-for-backend raw-data 'ghostel))
@@ -826,7 +837,7 @@ terminal engine with periodic redraws, all in a tight loop."
                  (setq offset end)
                  (cl-incf chunk-count)
                  (when (zerop (% chunk-count redraw-every))
-                   (ghostel--redraw term nil)))))))))
+                   (ghostel-bench--redraw term nil)))))))))
     ;; vterm
     (when ghostel-bench-include-vterm
       (ghostel-bench--with-bench-buffer
@@ -908,7 +919,7 @@ content — relevant for apps like htop, vim, claude-code."
                     (string-bytes frame) tui-iterations
                     (lambda ()
                       (ghostel--write-vt term frame)
-                      (ghostel--redraw term nil)))))
+                      (ghostel-bench--redraw term nil)))))
               (message "    ^ %.0f fps" (/ 1000.0 (plist-get result :per-iter-ms))))))
         ;; ghostel full
         (ghostel-bench--with-bench-buffer
@@ -921,7 +932,7 @@ content — relevant for apps like htop, vim, claude-code."
                     (string-bytes frame) tui-iterations
                     (lambda ()
                       (ghostel--write-vt term frame)
-                      (ghostel--redraw term t)))))
+                      (ghostel-bench--redraw term t)))))
               (message "    ^ %.0f fps" (/ 1000.0 (plist-get result :per-iter-ms))))))
         ;; vterm
         (when ghostel-bench-include-vterm
@@ -996,7 +1007,7 @@ status bars, prompt redraws, and most TUI updates actually produce."
                  (inhibit-read-only t)
                  (counter 0))
             (ghostel--write-vt term static)
-            (ghostel--redraw term t)
+            (ghostel-bench--redraw term t)
             (let ((result
                    (ghostel-bench--measure
                     (format "tui-partial/ghostel-incr/%s" label)
@@ -1005,7 +1016,7 @@ status bars, prompt redraws, and most TUI updates actually produce."
                       (cl-incf counter)
                      (ghostel--write-vt
                        term (format status-template (format "status #%d" counter)))
-                      (ghostel--redraw term nil)))))
+                      (ghostel-bench--redraw term nil)))))
               (message "    ^ %.0f fps" (/ 1000.0 (plist-get result :per-iter-ms))))))
         ;; ghostel full
         (ghostel-bench--with-bench-buffer
@@ -1016,7 +1027,7 @@ status bars, prompt redraws, and most TUI updates actually produce."
                  (inhibit-read-only t)
                  (counter 0))
             (ghostel--write-vt term static)
-            (ghostel--redraw term t)
+            (ghostel-bench--redraw term t)
             (let ((result
                    (ghostel-bench--measure
                     (format "tui-partial/ghostel-full/%s" label)
@@ -1025,7 +1036,7 @@ status bars, prompt redraws, and most TUI updates actually produce."
                       (cl-incf counter)
                      (ghostel--write-vt
                        term (format status-template (format "status #%d" counter)))
-                      (ghostel--redraw term t)))))
+                      (ghostel-bench--redraw term t)))))
               (message "    ^ %.0f fps" (/ 1000.0 (plist-get result :per-iter-ms))))))
         ;; vterm
         (when ghostel-bench-include-vterm
@@ -1113,7 +1124,7 @@ When RENDER-P is non-nil, also call redraw after write-input."
                (setq counter (1+ counter))
                (ghostel--write-vt term (format "\e[H%d\r\n" counter))
                (ghostel--write-vt term data)
-               (ghostel--redraw term nil))
+               (ghostel-bench--redraw term nil))
            (lambda () (ghostel--write-vt term data))))))
     ;; ghostel full
     (when render-p
@@ -1129,7 +1140,7 @@ When RENDER-P is non-nil, also call redraw after write-input."
              (setq counter (1+ counter))
              (ghostel--write-vt term (format "\e[H%d\r\n" counter))
              (ghostel--write-vt term data)
-             (ghostel--redraw term t))))))
+             (ghostel-bench--redraw term t))))))
     ;; vterm
     (when ghostel-bench-include-vterm
       (ghostel-bench--with-bench-buffer
@@ -1467,7 +1478,7 @@ backend-include flags do not apply."
                (string-bytes frame) ghostel-bench-iterations
                (lambda ()
                  (ghostel--write-vt term frame)
-                 (ghostel--redraw term nil)))))
+                 (ghostel-bench--redraw term nil)))))
          (message "    ^ %.0f fps" (/ 1000.0 (plist-get result :per-iter-ms))))))))
 
 (defun ghostel-bench--run-one-tui-partial (size)
@@ -1489,7 +1500,7 @@ backend-include flags do not apply."
            (inhibit-read-only t)
            (counter 0))
        (ghostel--write-vt term static)
-       (ghostel--redraw term nil)
+       (ghostel-bench--redraw term nil)
        (let ((result
               (ghostel-bench--measure
                (format "tui-partial/%s" size)
@@ -1498,7 +1509,7 @@ backend-include flags do not apply."
                  (cl-incf counter)
                  (ghostel--write-vt
                   term (format status-template (format "status #%d" counter)))
-                 (ghostel--redraw term nil)))))
+                 (ghostel-bench--redraw term nil)))))
          (message "    ^ %.0f fps" (/ 1000.0 (plist-get result :per-iter-ms))))))))
 
 (defun ghostel-bench--run-one-typing (backend)

--- a/bench/ghostel-bench.el
+++ b/bench/ghostel-bench.el
@@ -67,6 +67,11 @@ This is intended for GUI profiling runs where the trace should include
 window redisplay/font/rendering work, not only terminal parsing and buffer
 mutation.")
 
+(defvar ghostel-bench-reuse-backend-terminal nil
+  "When non-nil, keep one terminal alive for backend/* case iterations.
+This is intended for profiler runs where repeated native PTY reader
+thread creation would obscure the terminal output path being profiled.")
+
 (defvar ghostel-bench-min-duration 0.5
   "Minimum target duration in seconds for very fast benchmark cases.
 When the warmup trial shows a case is too fast to time reliably,
@@ -625,6 +630,7 @@ covers the full read -> libghostty -> buffer pipeline."
     (unwind-protect
         (with-current-buffer buf
           (ghostel-mode)
+          (setq-local ghostel-detect-password-prompts nil)
           (setq ghostel--term (ghostel--new rows cols
                                             (* ghostel-bench-scrollback 1024))
                 ghostel--term-rows rows
@@ -645,6 +651,76 @@ covers the full read -> libghostty -> buffer pipeline."
       (when (buffer-live-p buf)
         (when ghostel--term
           (ignore-errors (ghostel--kill-native-process ghostel--term)))
+        (kill-buffer buf)))))
+
+(defun ghostel-bench--backend-send-string (native-p string)
+  "Send STRING to the current backend PTY.
+NATIVE-P selects the native Zig PTY writer; nil uses the Emacs process."
+  (if native-p
+      (ghostel--write-pty ghostel--term string)
+    (process-send-string ghostel--process string)))
+
+(defun ghostel-bench--buffer-contains-p (string)
+  "Return non-nil when the current buffer contains STRING."
+  (save-excursion
+    (goto-char (point-min))
+    (search-forward string nil t)))
+
+(defun ghostel-bench--with-persistent-cat (data-file native-p body-fn)
+  "Run BODY-FN with a reusable `cat DATA-FILE' backend driver.
+BODY-FN is called with a thunk that streams DATA-FILE through one live
+terminal process and waits until the corresponding completion marker is
+rendered.  NATIVE-P selects the native Zig PTY or Emacs process backend."
+  (let* ((rows 24) (cols 80)
+         (buf (generate-new-buffer " *ghostel-backend-bench*"))
+         (marker-prefix (format "__ghostel_bench_done_%s_"
+                                (md5 (format "%s%s" data-file (float-time)))))
+         (driver (format (concat "stty -echo 2>/dev/null || true; "
+                                 "i=0; while IFS= read -r file; do "
+                                 "cat \"$file\"; i=$((i + 1)); "
+                                 "printf '\\r\\n%s%%06d\\r\\n' \"$i\"; done")
+                         marker-prefix))
+         (counter 0)
+         (ghostel-use-native-pty native-p)
+         (ghostel-kill-buffer-on-exit nil)
+         (ghostel-shell-integration nil)
+         (ghostel-macos-login-shell nil)
+         (ghostel-enable-url-detection nil)
+         (ghostel-enable-file-detection nil)
+         (ghostel-shell (list "/bin/sh" "-c" driver)))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (setq-local ghostel-detect-password-prompts nil)
+          (setq ghostel--term (ghostel--new rows cols
+                                            (* ghostel-bench-scrollback 1024))
+                ghostel--term-rows rows
+                ghostel--term-cols cols)
+          (when (window-live-p (selected-window))
+            (set-window-buffer (selected-window) buf))
+          (ghostel--start-process)
+          (funcall
+           body-fn
+           (lambda ()
+             (cl-incf counter)
+             (let ((marker (format "%s%06d" marker-prefix counter))
+                   (deadline (+ (float-time) 120)))
+               (ghostel-bench--backend-send-string
+                native-p (concat (expand-file-name data-file) "\n"))
+               (while (and (< (float-time) deadline)
+                           (not (ghostel-bench--buffer-contains-p marker)))
+                 (accept-process-output ghostel--process 0.01)
+                 (when (buffer-live-p buf)
+                   (ghostel--redraw-now buf)))
+               (unless (ghostel-bench--buffer-contains-p marker)
+                 (error "Timed out waiting for backend benchmark marker: %s"
+                        marker))))))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf
+          (when ghostel--term
+            (ignore-errors (ghostel--kill-native-process ghostel--term)))
+          (when (and ghostel--process (process-live-p ghostel--process))
+            (delete-process ghostel--process)))
         (kill-buffer buf)))))
 
 (defun ghostel-bench--run-backend-scenarios ()
@@ -1180,8 +1256,14 @@ real-world performance (see the end-to-end and backend benchmarks)."
                  (plist-get r :per-iter-ms)
                  (plist-get r :throughput-mbs))))
     (when backend-results
-      (message "\n  Native vs Emacs PTY backend (cat %s, real spawn):"
-               (ghostel-bench--human-size ghostel-bench-data-size))
+      (message "\n  Native vs Emacs PTY backend (cat %s, %s):"
+               (ghostel-bench--human-size ghostel-bench-data-size)
+               (if (cl-some (lambda (r)
+                              (eq (plist-get r :backend-mode)
+                                  'persistent-terminal))
+                            backend-results)
+                   "one persistent terminal"
+                 "real spawn"))
       (dolist (r (sort (copy-sequence backend-results)
                        (lambda (a b) (string< (plist-get a :name)
                                               (plist-get b :name)))))
@@ -1336,10 +1418,23 @@ backend-include flags do not apply."
                    ((string= backend "emacs") nil)
                    (t (error "Unknown backend benchmark backend: %s" backend)))))
     (unwind-protect
-        (ghostel-bench--measure
-         (format "backend/%s/%s" shape backend)
-         ghostel-bench-data-size ghostel-bench-iterations
-         (lambda () (ghostel-bench--spawn-cat data-file native-p)))
+        (if ghostel-bench-reuse-backend-terminal
+            (progn
+              (message "  [reusing one backend terminal for all iterations]")
+              (let ((result
+                     (ghostel-bench--with-persistent-cat
+                      data-file native-p
+                      (lambda (run-cat)
+                        (ghostel-bench--measure
+                         (format "backend/%s/%s" shape backend)
+                         ghostel-bench-data-size ghostel-bench-iterations
+                         run-cat)))))
+                (plist-put result :backend-mode 'persistent-terminal)
+                result))
+          (ghostel-bench--measure
+           (format "backend/%s/%s" shape backend)
+           ghostel-bench-data-size ghostel-bench-iterations
+           (lambda () (ghostel-bench--spawn-cat data-file native-p))))
       (delete-file data-file))))
 
 (defun ghostel-bench--parse-size (size)

--- a/bench/run-gui-xctrace.sh
+++ b/bench/run-gui-xctrace.sh
@@ -22,6 +22,7 @@ MIN_DURATION=""
 COUNT=""
 OUTPUT_DIR="$GHOSTEL_DIR/bench/profiles"
 OPEN_TRACE=false
+ELISP_PROFILE_MODE=""
 REDISPLAY="nil"
 INCLUDE_VTERM="t"
 INCLUDE_EAT="t"
@@ -45,6 +46,10 @@ Options:
   --template NAME   xctrace template (default: Time Profiler)
   --output-dir DIR  Directory for .trace and .log files
   --open            Open the resulting .trace in Instruments
+  --elisp-profile MODE
+                   Also run Emacs's Elisp profiler during the benchmark.
+                   MODE is cpu, mem, or cpu+mem. Use mem to find allocation
+                   sites that make GC run.
   --emacs PATH      GUI Emacs executable
   --emacsclient PATH
   --vterm-dir DIR   Path to vterm package directory
@@ -59,6 +64,7 @@ Examples:
   $(basename "$0") --case e2e/urls/ghostel --size 1048576 --iterations 5
   $(basename "$0") --case tui-partial/40x120 --min-duration 10
   $(basename "$0") --case backend/mixed/native --redisplay
+  $(basename "$0") --case backend/mixed/native --elisp-profile mem
 EOF
     exit 0
 }
@@ -83,6 +89,8 @@ while [[ $# -gt 0 ]]; do
         --template)    need_arg "$1" "${2-}"; TEMPLATE="$2"; shift 2 ;;
         --output-dir)  need_arg "$1" "${2-}"; OUTPUT_DIR="$2"; shift 2 ;;
         --open)        OPEN_TRACE=true; shift ;;
+        --elisp-profile)
+                       need_arg "$1" "${2-}"; ELISP_PROFILE_MODE="$2"; shift 2 ;;
         --emacs)       need_arg "$1" "${2-}"; EMACS_BIN="$2"; shift 2 ;;
         --emacsclient) need_arg "$1" "${2-}"; EMACSCLIENT="$2"; shift 2 ;;
         --vterm-dir)   need_arg "$1" "${2-}"; VTERM_DIR="$2"; shift 2 ;;
@@ -102,6 +110,15 @@ fi
 if [[ ! "$CASE" =~ ^[A-Za-z0-9_./-]+$ ]]; then
     echo "ERROR: invalid benchmark case syntax: $CASE" >&2
     exit 1
+fi
+if [ -n "$ELISP_PROFILE_MODE" ]; then
+    case "$ELISP_PROFILE_MODE" in
+        cpu|mem|cpu+mem) ;;
+        *)
+            echo "ERROR: --elisp-profile MODE must be cpu, mem, or cpu+mem" >&2
+            exit 1
+            ;;
+    esac
 fi
 
 if ! command -v xcrun >/dev/null 2>&1; then
@@ -187,6 +204,7 @@ TRACE_PATH="$BASE.trace"
 BENCH_LOG="$BASE.log"
 EMACS_LOG="$BASE.emacs.log"
 XCTRACE_LOG="$BASE.xctrace.log"
+ELISP_PROFILE_BASE="$BASE.elisp"
 SERVER_SOCKET="$TMPDIR/server"
 NOTIFY="com.ghostel.xctrace.started.$STAMP.$$"
 
@@ -198,6 +216,8 @@ GHOSTEL_LISP_EL="$(elisp_string "$GHOSTEL_DIR/lisp")"
 BENCH_FILE_EL="$(elisp_string "$SCRIPT_DIR/ghostel-bench.el")"
 CASE_EL="$(elisp_string "$CASE")"
 BENCH_LOG_EL="$(elisp_string "$BENCH_LOG")"
+ELISP_PROFILE_MODE_EL="$(elisp_string "$ELISP_PROFILE_MODE")"
+ELISP_PROFILE_BASE_EL="$(elisp_string "$ELISP_PROFILE_BASE")"
 VTERM_DIR_EL="$(elisp_string "$VTERM_DIR")"
 EAT_DIR_EL="$(elisp_string "$EAT_DIR")"
 SERVER_SOCKET_EL="$(elisp_string "$SERVER_SOCKET")"
@@ -272,13 +292,66 @@ RUN_EVAL="
       (setq ghostel-bench-include-vterm $INCLUDE_VTERM
             ghostel-bench-include-eat $INCLUDE_EAT
             ghostel-bench-include-term $INCLUDE_TERM
-            ghostel-bench-force-gui-redisplay $REDISPLAY)
+            ghostel-bench-force-gui-redisplay $REDISPLAY
+            ghostel-bench-reuse-backend-terminal t)
       $(if $QUICK; then echo "(setq ghostel-bench-data-size (* 100 1024) ghostel-bench-iterations 2 ghostel-bench-typing-count 50)"; fi)
       $(if [ -n "$SIZE" ]; then echo "(setq ghostel-bench-data-size $SIZE)"; fi)
       $(if [ -n "$ITERS" ]; then echo "(setq ghostel-bench-iterations $ITERS)"; fi)
       $(if [ -n "$MIN_DURATION" ]; then echo "(setq ghostel-bench-min-duration $MIN_DURATION)"; fi)
       $(if [ -n "$COUNT" ]; then echo "(setq ghostel-bench-typing-count $COUNT)"; fi)
-      (ghostel-bench-run-one $CASE_EL)
+      (let* ((profile-mode-name $ELISP_PROFILE_MODE_EL)
+             (profile-enabled (> (length profile-mode-name) 0))
+             (profile-mode (and profile-enabled (intern profile-mode-name)))
+             (profile-base $ELISP_PROFILE_BASE_EL)
+             profile-start-gcs profile-start-gc-elapsed profile-start-memory
+             profile-end-gcs profile-end-gc-elapsed profile-end-memory
+             profile-write-error)
+        (when profile-enabled
+          (require 'profiler)
+          (profiler-reset)
+          (profiler-start profile-mode)
+          (setq profile-start-gcs gcs-done
+                profile-start-gc-elapsed gc-elapsed
+                profile-start-memory (memory-use-counts)))
+        (unwind-protect
+            (ghostel-bench-run-one $CASE_EL)
+          (when profile-enabled
+            (condition-case profile-err
+                (progn
+                  (setq profile-end-gcs gcs-done
+                        profile-end-gc-elapsed gc-elapsed
+                        profile-end-memory (memory-use-counts))
+                  (profiler-stop)
+                  (let ((gc-file (concat profile-base \"-gc.txt\")))
+                    (with-temp-buffer
+                      (insert (format \"mode: %s\\n\" profile-mode-name))
+                      (insert (format \"gcs-done: %d -> %d (delta %d)\\n\"
+                                      profile-start-gcs profile-end-gcs
+                                      (- profile-end-gcs profile-start-gcs)))
+                      (insert (format \"gc-elapsed: %.6f -> %.6f (delta %.6f seconds)\\n\"
+                                      profile-start-gc-elapsed profile-end-gc-elapsed
+                                      (- profile-end-gc-elapsed profile-start-gc-elapsed)))
+                      (insert (format \"gc-cons-threshold: %S\\n\" gc-cons-threshold))
+                      (insert (format \"memory-use-counts start: %S\\n\" profile-start-memory))
+                      (insert (format \"memory-use-counts end:   %S\\n\" profile-end-memory))
+                      (insert (format \"memory-use-counts delta: %S\\n\"
+                                      (cl-mapcar #'- profile-end-memory profile-start-memory)))
+                      (write-region (point-min) (point-max) gc-file nil 'silent))
+                    (message \"Elisp GC stats: %s\" gc-file))
+                  (when (and (boundp 'profiler-cpu-log) profiler-cpu-log)
+                    (let ((data-file (concat profile-base \"-cpu.profile\")))
+                      (profiler-write-profile (profiler-cpu-profile) data-file)
+                      (message \"Elisp CPU profile: %s\" data-file)))
+                  (when (and (boundp 'profiler-memory-log) profiler-memory-log)
+                    (let ((data-file (concat profile-base \"-memory.profile\")))
+                      (profiler-write-profile (profiler-memory-profile) data-file)
+                      (message \"Elisp memory profile: %s\" data-file))))
+              (error
+               (setq profile-write-error (error-message-string profile-err))
+               (message \"ERROR writing Elisp profile: %s\"
+                        profile-write-error)))))
+        (when profile-write-error
+          (error \"ERROR writing Elisp profile: %s\" profile-write-error)))
       (with-current-buffer \"*Messages*\"
         (write-region (point-min) (point-max) $BENCH_LOG_EL nil 'silent))
       'ok)
@@ -315,6 +388,21 @@ echo "trace: $TRACE_PATH"
 echo "bench log: $BENCH_LOG"
 echo "emacs log: $EMACS_LOG"
 echo "xctrace log: $XCTRACE_LOG"
+if [ -n "$ELISP_PROFILE_MODE" ]; then
+    echo "elisp GC stats: $ELISP_PROFILE_BASE-gc.txt"
+    case "$ELISP_PROFILE_MODE" in
+        cpu)
+            echo "elisp CPU profile: $ELISP_PROFILE_BASE-cpu.profile"
+            ;;
+        mem)
+            echo "elisp memory profile: $ELISP_PROFILE_BASE-memory.profile"
+            ;;
+        cpu+mem)
+            echo "elisp CPU profile: $ELISP_PROFILE_BASE-cpu.profile"
+            echo "elisp memory profile: $ELISP_PROFILE_BASE-memory.profile"
+            ;;
+    esac
+fi
 
 if $OPEN_TRACE; then
     open -a Instruments "$TRACE_PATH"

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4753,9 +4753,8 @@ opportunistic output redraws that may safely wait for the frame to end."
                    (inhibit-read-only t)
                    (inhibit-redisplay t)
                    (inhibit-modification-hooks t)
-                   ;; Raise GC threshold to defer GC during redraw.
-                   (gc-cons-threshold (min most-positive-fixnum
-                                           (* gc-cons-threshold 3))))
+                   ;; Disable GC during redraw.
+                   (gc-cons-threshold most-positive-fixnum))
               (with-selected-window render-win
                 ;; Line mode snapshots editable input out of the buffer;
                 ;; redraw fully so the prompt row is always rebuilt

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -2,8 +2,9 @@
 
 ## Architectural guidelines
 
-- Calling `render_state.update(...)`, directly or indirectly, **consumes** dirty state from the terminal. For this reason, **only** the Renderer (in `Renderer.zig`) may do so. Any other usage of `render_state.update` **will** break the Renderer.
-- If you need information from the rendering process, add a way for the Renderer to communicate it as render output: text properties, buffer-local variables, or, as a last resort, callbacks.
+- `Renderer.zig` owns the terminal-grid → Emacs-buffer projection. It reads libghostty pages directly, combines row dirtiness with cursor movement to decide what to rewrite, clears dirty rows once rendered, and publishes render-derived state through buffer text/properties or buffer-local variables.
+- Do not read-and-clear or otherwise modify libghostty dirty flags outside the renderer. `RenderState.update` also mutates dirty state, so using it alongside the current renderer will make incremental redraws miss changes.
+- If non-renderer code needs information from the rendering process, add a way for the Renderer to communicate it as render output: text properties, buffer-local variables, or, as a last resort, callbacks.
 
 ## Emacs module function entries
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -2,8 +2,9 @@
 
 ## Architectural guidelines
 
-- Calling `render_state.update(...)`, directly or indirectly, **consumes** dirty state from the terminal. For this reason, **only** the Renderer (in `Renderer.zig`) may do so. Any other usage of `render_state.update` **will** break the Renderer.
-- If you need information from the rendering process, add a way for the Renderer to communicate it as render output: text properties, buffer-local variables, or, as a last resort, callbacks.
+- `Renderer.zig` owns the terminal-grid → Emacs-buffer projection. It reads libghostty pages directly, combines row dirtiness with cursor movement to decide what to rewrite, clears dirty rows once rendered, and publishes render-derived state through buffer text/properties or buffer-local variables.
+- Do not read-and-clear or otherwise modify libghostty dirty flags outside the renderer. `RenderState.update` also mutates dirty state, so using it alongside the current renderer will make incremental redraws miss changes.
+- If non-renderer code needs information from the rendering process, add a way for the Renderer to communicate it as render output: text properties, buffer-local variables, or, as a last resort, callbacks.
 
 ## Emacs module function entries
 

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -29,10 +29,10 @@ alloc: Allocator,
 term: *gt.Terminal,
 
 /// Tracked pin of which row to render down from.
-render_pin: ?*gt.Pin,
+active_pin: *gt.Pin,
 
-/// The screen that is currently rendered into the buffer.
-rendered_screen: *gt.Screen,
+/// Identity of the screen currently rendered into the buffer.
+rendered_screen: ScreenId,
 
 /// Pin of the last rendered cursor position
 rendered_cursor: ?gt.Pin,
@@ -46,8 +46,8 @@ pages_in_buffer: std.DoublyLinkedList = .{},
 /// Any pending resize as `.{cols, rows}`. Resizes are committed on next redraw.
 pending_resize: ?ViewportSize = null,
 
-/// Reusable instance of RowContent to reduce allocations
-row: RowContent,
+/// Currently accumulated content ready to be inserted.
+span: SpanContent,
 
 /// Cached font metrics and rendering parameters that affect glyph layout.
 /// When any field changes between redraws the viewport is fully invalidated.
@@ -62,11 +62,15 @@ saved_markers: SavedBufferMarkers = .{},
 
 const PageSerial = @FieldType(gt.PageList.List.Node, "serial");
 
+const ScreenId = struct {
+    key: gt.ScreenSet.Key,
+    generation: usize,
+};
+
 const MaterializedPage = struct {
     node: std.DoublyLinkedList.Node = .{},
     serial: PageSerial,
-    char_len: usize = 0,
-    rows: usize = 0,
+    len: usize = 0,
 
     pub fn next(self: *@This()) ?*@This() {
         return if (self.node.next) |n|
@@ -101,13 +105,13 @@ pub fn init(alloc: Allocator, env: emacs.Env, term: *gt.Terminal) !Self {
     var renderer = Self{
         .alloc = alloc,
         .term = term,
-        .render_pin = try term.screens.active.pages.trackPin(
+        .active_pin = try term.screens.active.pages.trackPin(
             term.screens.active.pages.getTopLeft(.screen),
         ),
-        .rendered_screen = term.screens.active,
+        .rendered_screen = currentScreenId(term),
         .rendered_cursor = null,
         .pending_resize = .{ .cols = term.cols, .rows = term.rows, .cell_w = 1, .cell_h = 1 },
-        .row = .{ .alloc = alloc },
+        .span = .{ .alloc = alloc },
     };
     try renderer.commitResize(env);
     return renderer;
@@ -115,10 +119,26 @@ pub fn init(alloc: Allocator, env: emacs.Env, term: *gt.Terminal) !Self {
 
 pub fn deinit(self: *Self) void {
     self.saved_markers.deinit(self.alloc);
-    self.row.deinit();
+    self.span.deinit();
     self.clearPages();
-    if (self.render_pin) |p| self.rendered_screen.pages.untrackPin(p);
+    self.untrackActivePinIfLive();
     if (self.font_info) |*fi| fi.deinit(self.alloc);
+}
+
+fn currentScreenId(term: *gt.Terminal) ScreenId {
+    return .{
+        .key = term.screens.active_key,
+        .generation = term.screens.generation(term.screens.active_key),
+    };
+}
+
+fn untrackActivePinIfLive(self: *Self) void {
+    if (self.term.screens.generation(self.rendered_screen.key) != self.rendered_screen.generation) {
+        return;
+    }
+
+    const screen = self.term.screens.get(self.rendered_screen.key) orelse return;
+    screen.pages.untrackPin(self.active_pin);
 }
 
 pub fn resize(self: *Self, cols: u16, rows: u16, cell_w: u32, cell_h: u32) !void {
@@ -139,15 +159,16 @@ pub fn redraw(self: *Self, env: emacs.Env, force_full: bool) !void {
     self.is_rendering = true;
     defer self.is_rendering = false;
 
+    const screen = self.term.screens.active;
     try self.saved_markers.save(self.alloc, env);
-    defer self.saved_markers.restoreAndClear(self.term.screens.active, env);
+    defer self.saved_markers.restoreAndClear(screen, env);
 
     self.gotoActiveStart(env);
 
     if (force_full) try self.clear(env);
     try self.updateFontInfo(env);
     try self.commitResize(env);
-    if (self.rendered_screen != self.term.screens.active) {
+    if (!std.meta.eql(self.rendered_screen, currentScreenId(self.term))) {
         try self.clear(env);
     }
     try self.invalidate(env);
@@ -155,27 +176,24 @@ pub fn redraw(self: *Self, env: emacs.Env, force_full: bool) !void {
 
     try self.render(
         env,
-        if (self.render_pin) |p|
-            p.*
+        if (screen.no_scrollback)
+            screen.pages.getTopLeft(.active)
         else
-            self.rendered_screen.pages.getTopLeft(.active),
+            self.active_pin.*,
     );
 
     try self.renderCursor(env);
 
-    if (self.render_pin) |p| p.* = self.rendered_screen.pages.getTopLeft(.active);
-
-    // Verify integrity in debug mode
-    std.debug.assert(self.rows_in_buffer == if (self.rendered_screen.no_scrollback)
-        self.term.rows
+    self.active_pin.* = screen.pages.getTopLeft(.active);
+    self.rows_in_buffer = if (screen.no_scrollback)
+        screen.pages.rows
     else
-        self.rendered_screen.pages.total_rows);
+        screen.pages.total_rows;
 }
 
 fn invalidate(self: *Self, env: emacs.Env) !void {
     const scrollback_cleared = self.rows_in_buffer > self.term.rows and
-        self.render_pin != null and
-        self.render_pin.?.eql(self.rendered_screen.pages.getTopLeft(.screen));
+        self.active_pin.eql(self.term.screens.active.pages.getTopLeft(.screen));
 
     if (scrollback_cleared) {
         try self.clear(env);
@@ -284,16 +302,16 @@ fn resolveHyperlink(page: *const gt.page.Page, local_id: gt.size.HyperlinkCountI
 fn applyProps(
     self: *Self,
     env: emacs.Env,
-    start: i64,
-    end: i64,
+    start: usize,
+    end: usize,
     node: *const gt.PageList.List.Node,
     prop_key: *const CellPropKey,
 ) !void {
     if (start >= end) return;
     const s = emacs.sym;
 
-    const start_val = env.makeInteger(start);
-    const end_val = env.makeInteger(end);
+    const start_val = env.makeValue(start);
+    const end_val = env.makeValue(end);
 
     if (try self.getFace(env, node, prop_key)) |face| {
         _ = env.f("put-text-property", .{
@@ -429,7 +447,7 @@ const CellPropKey = struct {
     }
 };
 
-pub const RowContent = struct {
+pub const SpanContent = struct {
     const Run = struct {
         start_char: usize,
         end_char: usize,
@@ -437,9 +455,9 @@ pub const RowContent = struct {
     };
 
     const CellInfo = struct {
-        col: i64,
-        char_start: i64,
-        char_end: i64,
+        col: usize,
+        char_start: usize,
+        char_end: usize,
         text_start: usize,
         text_end: usize,
         wide: bool,
@@ -469,6 +487,9 @@ pub const RowContent = struct {
     /// The UTF-8 text content of the row
     text: std.ArrayList(u8) = .empty,
 
+    /// The positions of any line wraps
+    line_wraps: std.ArrayList(usize) = .empty,
+
     /// Cells that need their glyphs metrics adjusted after insetions
     adjust_cells: std.ArrayList(CellInfo) = .empty,
 
@@ -483,22 +504,27 @@ pub const RowContent = struct {
     /// The character position of the cursor
     cursor_char_pos: ?usize = null,
 
-    pub fn build(
-        self: *RowContent,
+    /// The node this span comes from
+    node: ?*const gt.PageList.List.Node = null,
+
+    pub fn addRow(
+        self: *SpanContent,
         renderer: *Self,
         row_pin: gt.Pin,
         adjustment_threshold: u32,
-    ) !void {
-        try self.clear();
+    ) !usize {
+        if (self.node) |n| std.debug.assert(n == row_pin.node);
+        self.node = row_pin.node;
 
         const term = renderer.term;
         const screen = term.screens.active;
 
+        const row_start = self.char_len;
         // Position at the end of the last non-blank cell; final row length
         // is trimmed back to this. Any run of blank cells past the end is
         // discarded along with their default-style trailing padding.
-        var trim_byte_len: usize = 0;
-        var trim_char_len: usize = 0;
+        var trim_byte_len: usize = self.text.items.len;
+        var trim_char_len: usize = self.char_len;
 
         const cursor_visible = term.modes.get(.cursor_visible);
         const cursor_col = if (cursor_visible and isSameRow(row_pin, screen.cursor.page_pin.*))
@@ -509,6 +535,7 @@ pub const RowContent = struct {
         const page = &row_pin.node.data;
         const row = row_pin.rowAndCell().row;
         var current_prop_key: ?CellPropKey = null;
+        var first_cell = true;
         for (page.getCells(row), 0..) |*cell, col| {
             const has_cursor = @as(u16, @intCast(col)) == cursor_col;
             if (has_cursor) self.cursor_char_pos = self.char_len;
@@ -518,13 +545,14 @@ pub const RowContent = struct {
             // We use a "key" that holds a minimum set of values that are cheap to
             // compare to detect style run breaks.
             const prop_key = CellPropKey.create(&row_pin.node.data, cell);
-            if (!std.meta.eql(prop_key, current_prop_key) or self.runs.items.len == 0) {
+            if (first_cell or !std.meta.eql(prop_key, current_prop_key)) {
                 try self.runs.append(self.alloc, .{
                     .start_char = self.char_len,
                     .end_char = self.char_len,
                     .key = prop_key,
                 });
                 current_prop_key = prop_key;
+                first_cell = false;
             }
 
             const byte_start = self.text.items.len;
@@ -571,28 +599,15 @@ pub const RowContent = struct {
         // are clipped when properties are applied.
         self.text.shrinkRetainingCapacity(trim_byte_len);
         self.char_len = trim_char_len;
-        if (self.runs.items.len > 0) {
-            self.runs.items[self.runs.items.len - 1].end_char = trim_char_len;
-        }
+        self.runs.items[self.runs.items.len - 1].end_char = trim_char_len;
 
-        try self.text.append(self.alloc, '\n');
+        if (row.wrap) try self.line_wraps.append(self.alloc, self.char_len);
+        try self.appendCodepoints(&[1]u21{'\n'});
+
+        return self.char_len - row_start;
     }
 
-    pub fn deinit(self: *RowContent) void {
-        self.text.deinit(self.alloc);
-        self.adjust_cells.deinit(self.alloc);
-        self.runs.deinit(self.alloc);
-    }
-
-    fn clear(self: *RowContent) !void {
-        self.text.clearRetainingCapacity();
-        self.adjust_cells.clearRetainingCapacity();
-        self.runs.clearRetainingCapacity();
-        self.char_len = 0;
-        self.cursor_char_pos = null;
-    }
-
-    fn appendCodepoints(self: *RowContent, cluster: []const u21) !void {
+    fn appendCodepoints(self: *SpanContent, cluster: []const u21) !void {
         for (cluster) |cp| {
             const slice = try self.text.addManyAsSlice(
                 self.alloc,
@@ -602,20 +617,37 @@ pub const RowContent = struct {
             self.char_len += 1;
         }
     }
+
+    pub fn clear(self: *SpanContent) !void {
+        self.text.clearRetainingCapacity();
+        self.line_wraps.clearRetainingCapacity();
+        self.adjust_cells.clearRetainingCapacity();
+        self.runs.clearRetainingCapacity();
+        self.char_len = 0;
+        self.cursor_char_pos = null;
+        self.node = null;
+    }
+
+    pub fn deinit(self: *SpanContent) void {
+        self.text.deinit(self.alloc);
+        self.line_wraps.deinit(self.alloc);
+        self.adjust_cells.deinit(self.alloc);
+        self.runs.deinit(self.alloc);
+    }
 };
 
 fn adjustGlyphs(
     self: *Self,
     env: emacs.Env,
-    row_start: i64,
+    span_start: usize,
 ) !void {
-    if (self.row.adjust_cells.items.len == 0) return;
+    if (self.span.adjust_cells.items.len == 0) return;
     if (self.font_info == null) return;
     const window = env.f("selected-window", .{});
     if (env.isNil(window)) return;
 
-    for (self.row.adjust_cells.items) |*cell| {
-        try self.adjustGlyph(env, window, row_start, cell);
+    for (self.span.adjust_cells.items) |*cell| {
+        try self.adjustGlyph(env, window, span_start, cell);
     }
 }
 
@@ -623,15 +655,15 @@ fn adjustGlyph(
     self: *Self,
     env: emacs.Env,
     window: emacs.Value,
-    row_start: i64,
-    cell: *const RowContent.CellInfo,
+    span_start: usize,
+    cell: *const SpanContent.CellInfo,
 ) !void {
     const s = emacs.sym;
     const default_font_info = self.font_info.?;
 
-    const start_val = env.makeInteger(row_start + @as(i64, @intCast(cell.char_start)));
-    const end_val = env.makeInteger(row_start + @as(i64, @intCast(cell.char_end)));
-    const metrics = try self.getGlyphMetrics(env, window, row_start, cell) orelse return;
+    const start_val = env.makeValue(span_start + cell.char_start);
+    const end_val = env.makeValue(span_start + cell.char_end);
+    const metrics = try self.getGlyphMetrics(env, window, span_start, cell) orelse return;
 
     // Skip adjustments if size already matches perfectly
     const native_char_width: i64 = if (cell.wide) 2 else 1;
@@ -640,7 +672,7 @@ fn adjustGlyph(
         metrics.ascent == default_font_info.ascent and
         metrics.descent == default_font_info.descent) return;
 
-    const char_width = self.adjustWidth(env, row_start, cell, metrics);
+    const char_width = self.adjustWidth(env, span_start, cell, metrics);
     const slot_width = default_font_info.width * char_width;
 
     // Height is clamped per side, not on the sum: the row realizes
@@ -679,8 +711,8 @@ fn adjustGlyph(
 fn adjustWidth(
     self: *Self,
     env: emacs.Env,
-    row_start: i64,
-    cell: *const RowContent.CellInfo,
+    span_start: usize,
+    cell: *const SpanContent.CellInfo,
     metrics: GlyphMetricsCache.Metrics,
 ) i64 {
     const s = emacs.sym;
@@ -710,16 +742,17 @@ fn adjustWidth(
 
     // We don't let glyphs claim space unless it truly stands alone with space
     // on both sides since otherwise it leads to visually inconsistent sizing.
-    const preceding = cell.precedingByte(self.row.text.items);
-    const following = cell.followingByte(self.row.text.items);
-    const empty_before = preceding == null or preceding.? == ' ';
-    const empty_after = following == null or following.? == ' ';
+    // A newline is a span-local row boundary, equivalent to no neighboring cell.
+    const preceding = cell.precedingByte(self.span.text.items);
+    const following = cell.followingByte(self.span.text.items);
+    const empty_before = preceding == null or preceding.? == ' ' or preceding.? == '\n';
+    const empty_after = following == null or following.? == ' ' or following.? == '\n';
     if (!empty_before or !empty_after) return 1;
 
     // We can claim the space after, but if it's a space, we must first hide it.
     if (following) |c| {
         if (c == ' ') {
-            const claim_pos = row_start + cell.char_end;
+            const claim_pos = span_start + cell.char_end;
             _ = env.f("put-text-property", .{
                 claim_pos,
                 claim_pos + 1,
@@ -736,15 +769,15 @@ fn getGlyphMetrics(
     self: *Self,
     env: emacs.Env,
     window: emacs.Value,
-    row_start: i64,
-    cell: *const RowContent.CellInfo,
+    span_start: usize,
+    cell: *const SpanContent.CellInfo,
 ) !?GlyphMetricsCache.Metrics {
-    const key = cell.metricsKey(self.row.text.items);
+    const key = cell.metricsKey(self.span.text.items);
     if (self.font_info) |*fi| {
         if (fi.metrics_cache.get(key)) |metrics| return metrics;
     }
 
-    const gstring = findGlyphString(env, window, row_start, cell) orelse {
+    const gstring = findGlyphString(env, window, span_start, cell) orelse {
         return null;
     };
     // gstring is:
@@ -787,11 +820,11 @@ fn getGlyphMetrics(
 fn findGlyphString(
     env: emacs.Env,
     window: emacs.Value,
-    row_start: i64,
-    cell: *const RowContent.CellInfo,
+    span_start: usize,
+    cell: *const SpanContent.CellInfo,
 ) ?emacs.Value {
-    const start_val = env.makeInteger(row_start + cell.char_start);
-    const end_val = env.makeInteger(row_start + cell.char_end);
+    const start_val = env.makeValue(span_start + cell.char_start);
+    const end_val = env.makeValue(span_start + cell.char_end);
     const composition = env.f("find-composition", .{ start_val, end_val, env.nil(), env.t() });
     if (env.isNotNil(composition)) {
         const gstring = env.f("nth", .{ 2, composition });
@@ -809,53 +842,46 @@ fn findGlyphString(
     return if (env.isNil(gstring)) null else gstring;
 }
 
-/// Insert row text and apply property runs.
-fn insertRow(
-    self: *Self,
-    env: emacs.Env,
-    row_pin: gt.Pin,
-) !usize {
-    try self.row.build(
+fn addRowToSpan(self: *Self, row_pin: gt.Pin) !usize {
+    return try self.span.addRow(
         self,
         row_pin,
         if (self.font_info) |f| f.coverage else std.math.maxInt(u32),
     );
+}
 
-    const row_start = env.cast(i64, env.f("point", .{}));
-    _ = env.f("insert", .{self.row.text.items});
-    const row_end = env.cast(i64, env.f("point", .{}));
+fn flushSpan(self: *Self, env: emacs.Env) !void {
+    if (self.span.text.items.len == 0) return;
 
-    for (self.row.runs.items) |*run| {
-        if (run.end_char <= run.start_char) continue;
+    const span_start = env.cast(usize, env.f("point", .{}));
+    _ = env.f("insert", .{self.span.text.items});
 
-        const prop_start = row_start + @as(i64, @intCast(run.start_char));
-        const prop_end = row_start + @as(i64, @intCast(run.end_char));
+    for (self.span.runs.items) |*run| {
         if (run.key) |*key| {
-            try self.applyProps(env, prop_start, prop_end, row_pin.node, key);
+            const prop_start = span_start + @as(usize, @intCast(run.start_char));
+            const prop_end = span_start + @as(usize, @intCast(run.end_char));
+            try self.applyProps(env, prop_start, prop_end, self.span.node.?, key);
         }
     }
 
-    try self.adjustGlyphs(env, row_start);
+    try self.adjustGlyphs(env, span_start);
 
-    if (row_pin.rowAndCell().row.wrap) {
+    for (self.span.line_wraps.items) |offset| {
         // Mark newlines from soft-wrapped rows so copy mode can filter them
-        const point = env.f("point", .{});
         _ = env.f("put-text-property", .{
-            env.cast(i64, point) - 1,
-            point,
+            span_start + offset,
+            span_start + offset + 1,
             emacs.sym.@"ghostel-wrap",
             env.t(),
         });
     }
 
-    if (self.row.cursor_char_pos) |pos| {
+    if (self.span.cursor_char_pos) |pos| {
         env.set(
             "ghostel--cursor-char-pos",
-            @as(usize, @intCast(row_start)) + pos,
+            @as(usize, @intCast(span_start)) + pos,
         );
     }
-
-    return @intCast(row_end - row_start);
 }
 
 fn isSameRow(a: gt.Pin, b: gt.Pin) bool {
@@ -891,10 +917,16 @@ fn render(
     else
         try self.getOrAddPage(start_pin.node.serial);
 
+    var eob = false;
+    var current_span: ?struct {
+        start_val: emacs.Value,
+        node: *const gt.PageList.List.Node,
+    } = null;
+
     var it = start_pin.rowIterator(.right_down, null);
     while (it.next()) |row_pin| {
         const row = row_pin.rowAndCell().row;
-        defer row.dirty = false;
+        eob = eob or env.isNotNil(env.f("eobp", .{}));
 
         if (page) |p| {
             if (p.serial != row_pin.node.serial) {
@@ -904,36 +936,47 @@ fn render(
             }
         }
 
-        // Only process dirty rows, or if there's no existing row
-        const eob = env.isNotNil(env.f("eobp", .{}));
-        if (self.isRowDirty(row_pin) or eob) {
-            if (eob) {
-                // We're adding one line since we're at the end of the buffer
-                const line_char_len = try self.insertRow(env, row_pin);
-                self.rows_in_buffer += 1;
-                if (page) |p| {
-                    p.rows += 1;
-                    p.char_len += line_char_len;
-                }
-            } else {
-                // Line is dirty and we're not at the end of the buffer,
-                // so we're replacing the line.
-                const line_start_val = env.f("point", .{});
-                const line_start = env.cast(usize, line_start_val);
-                const old_line_end_val = env.f("pos-bol", .{2});
-                const old_line_len = env.cast(usize, old_line_end_val) - line_start;
-                _ = env.f("delete-region", .{ line_start_val, old_line_end_val });
-                const new_line_len = try self.insertRow(env, row_pin);
+        const clean = !eob and !self.isRowDirty(row_pin);
+        if (current_span) |*span| {
+            if (clean or span.node != row_pin.node) {
+                _ = env.f("delete-region", .{ span.start_val, env.f("point", .{}) });
+                try self.flushSpan(env);
+                current_span = null;
+            }
+        }
 
-                if (page) |p| {
-                    p.char_len -|= old_line_len;
-                    p.char_len += new_line_len;
-                }
+        const line_start_val = env.f("point", .{});
+        if (!eob) _ = env.f("forward-line", .{1});
+        const old_line_end_val = env.f("point", .{});
+
+        if (!clean) {
+            if (current_span == null) {
+                current_span = .{
+                    .start_val = line_start_val,
+                    .node = row_pin.node,
+                };
+                try self.span.clear();
+            }
+
+            const new_line_len = try self.addRowToSpan(row_pin);
+            const line_start = env.cast(usize, line_start_val);
+            const old_line_len = env.cast(usize, old_line_end_val) - line_start;
+            if (old_line_len > 0) {
                 self.saved_markers.adjustRegion(line_start, old_line_len, new_line_len);
             }
-        } else {
-            _ = env.f("forward-line", .{1});
+
+            if (page) |p| {
+                p.len -|= old_line_len;
+                p.len += new_line_len;
+            }
         }
+
+        row.dirty = false;
+    }
+
+    if (current_span) |*span| {
+        _ = env.f("delete-region", .{ span.start_val, env.f("point", .{}) });
+        try self.flushSpan(env);
     }
 }
 
@@ -945,7 +988,7 @@ fn renderCursor(self: *Self, env: emacs.Env) !void {
             "ghostel--cursor-style",
             @intFromEnum(screen.cursor.cursor_style),
         );
-        self.rendered_cursor = self.rendered_screen.cursor.page_pin.*;
+        self.rendered_cursor = screen.cursor.page_pin.*;
     } else {
         _ = env.set("ghostel--cursor-pos", env.nil());
         env.set("ghostel--cursor-style", env.nil());
@@ -1012,15 +1055,13 @@ fn clear(self: *Self, env: emacs.Env) !void {
     _ = env.f("erase-buffer", .{});
     self.rows_in_buffer = 0;
     self.clearPages();
-    if (self.render_pin) |p| self.rendered_screen.pages.untrackPin(p);
-    self.render_pin = null;
 
-    self.rendered_screen = self.term.screens.active;
-    if (!self.rendered_screen.no_scrollback) {
-        self.render_pin = try self.rendered_screen.pages.trackPin(
-            self.rendered_screen.pages.getTopLeft(.screen),
-        );
-    }
+    const screen = self.term.screens.active;
+    const active_pin = try screen.pages.trackPin(screen.pages.getTopLeft(.screen));
+
+    self.untrackActivePinIfLive();
+    self.active_pin = active_pin;
+    self.rendered_screen = currentScreenId(self.term);
 }
 
 fn clearPages(self: *Self) void {
@@ -1031,24 +1072,21 @@ fn clearPages(self: *Self) void {
 
 fn evictScrollback(self: *Self, env: emacs.Env) void {
     var evicted_chars: usize = 0;
-    var evicted_rows: usize = 0;
 
     // Only evict whole pages. libghostty can erase partial pages when clearing
     // the scrollback, but we handle that by detecting clearing specifically and
     // clearing the whole screen instead.
-    const term_first_page = self.rendered_screen.pages.pages.first.?;
+    const term_first_page = self.term.screens.active.pages.pages.first.?;
     while (self.pages_in_buffer.first) |n| {
         const first_page: *MaterializedPage = @fieldParentPtr("node", n);
         if (first_page.serial == term_first_page.serial) break;
 
-        evicted_chars += first_page.char_len;
-        evicted_rows += first_page.rows;
+        evicted_chars += first_page.len;
 
         _ = self.pages_in_buffer.popFirst();
         self.alloc.destroy(first_page);
     }
 
-    self.rows_in_buffer -|= evicted_rows;
     if (evicted_chars > 0) {
         _ = env.f("delete-region", .{ 1, 1 + evicted_chars });
         self.saved_markers.adjustRegion(1, evicted_chars, 0);

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -46,7 +46,7 @@ pages_in_buffer: std.DoublyLinkedList = .{},
 /// Any pending resize as `.{cols, rows}`. Resizes are committed on next redraw.
 pending_resize: ?ViewportSize = null,
 
-/// Currently accumulated content ready to be inserted.
+/// Accumulates adjacent dirty rows before inserting them into Emacs.
 span: SpanContent,
 
 /// Cached font metrics and rendering parameters that affect glyph layout.
@@ -409,9 +409,7 @@ fn getFace(
 //       We should file an issue.
 const StyleId = @FieldType(gt.page.Cell, "style_id");
 
-/// Unique identifier that is cheaper to read and compare relative to `CellProps`.
-/// We read this first and if it differs from the previous cell, we read the full
-/// `CellProps`.
+/// Compact key for deciding where Emacs text-property runs begin and end.
 const CellPropKey = struct {
     style_id: StyleId,
     hyperlink_id: gt.size.HyperlinkCountInt,
@@ -484,13 +482,13 @@ pub const SpanContent = struct {
 
     alloc: Allocator,
 
-    /// The UTF-8 text content of the row
+    /// UTF-8 text for the accumulated rows.
     text: std.ArrayList(u8) = .empty,
 
     /// The positions of any line wraps
     line_wraps: std.ArrayList(usize) = .empty,
 
-    /// Cells that need their glyphs metrics adjusted after insetions
+    /// Cells whose glyph metrics need display-property adjustment.
     adjust_cells: std.ArrayList(CellInfo) = .empty,
 
     /// The number of codepoints (as opposed to bytes) in the text. Emacs
@@ -896,7 +894,7 @@ fn isRowDirty(self: *Self, pin: gt.Pin) bool {
     else
         null;
 
-    // If the cursor moved, both the old row and the new row are dirty.
+    // Cursor movement requires rebuilding both the previous and current cursor rows.
     if (!std.meta.eql(cursor, self.rendered_cursor)) {
         if (cursor) |c| if (isSameRow(c, pin)) return true;
         if (self.rendered_cursor) |c| if (isSameRow(c, pin)) return true;

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -1,8 +1,3 @@
-/// RenderState-based terminal rendering to Emacs buffers.
-///
-/// Reads rows/cells from the ghostty render state, extracts text and
-/// style attributes, and inserts propertized text into the current
-/// Emacs buffer.  See `redraw' below for the per-redraw algorithm.
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
@@ -97,14 +92,11 @@ const FontInfo = struct {
 pub fn init(alloc: Allocator, env: emacs.Env, term: *gt.Terminal) !Self {
     const s = emacs.sym;
 
-    _ = env.f("make-local-variable", .{s.@"ghostel--query-font-cache"});
-    _ = env.set("ghostel--query-font-cache", env.f("make-hash-table", .{
+    env.defvarLocal("ghostel--query-font-cache", env.f("make-hash-table", .{
         s.@":test",
         s.eq,
     }));
-
-    _ = env.f("make-local-variable", .{s.@"ghostel--rendered-font"});
-    _ = env.set("ghostel--rendered-font", env.nil());
+    env.defvarLocal("ghostel--rendered-font", env.nil());
 
     var renderer = Self{
         .alloc = alloc,
@@ -117,7 +109,7 @@ pub fn init(alloc: Allocator, env: emacs.Env, term: *gt.Terminal) !Self {
         .pending_resize = .{ .cols = term.cols, .rows = term.rows, .cell_w = 1, .cell_h = 1 },
         .row = .{ .alloc = alloc },
     };
-    _ = try renderer.commitResize(env);
+    try renderer.commitResize(env);
     return renderer;
 }
 
@@ -288,46 +280,14 @@ fn resolveHyperlink(page: *const gt.page.Page, local_id: gt.size.HyperlinkCountI
     };
 }
 
-/// Read the style for the current cell from the render state.
-fn createCellProps(
-    self: *Self,
-    page: *const gt.Page,
-    key: CellPropKey,
-    cell: *const gt.Cell,
-) ?CellProps {
-    var props: CellProps = .{};
-
-    const style: gt.Style = if (cell.hasStyling())
-        page.styles.get(page.memory, cell.style_id).*
-    else
-        .{};
-
-    props.fg = style_face.resolveForeground(
-        &style,
-        &self.term.colors.palette.current,
-        self.bold_config,
-    );
-    props.bg = style.bg(cell, &self.term.colors.palette.current);
-    props.bold = style.flags.bold;
-    props.italic = style.flags.italic;
-    props.faint = style.flags.faint;
-    props.underline = style.flags.underline;
-    props.strikethrough = style.flags.strikethrough;
-    props.overline = style.flags.overline;
-    props.inverse = style.flags.inverse;
-    props.underline_color = style.underlineColor(&self.term.colors.palette.current);
-    props.hyperlink = resolveHyperlink(page, key.hyperlink_id);
-    props.semantic_content = cell.semantic_content;
-
-    return if (props.isPlain()) null else props;
-}
-
 /// Apply text properties to a region of the buffer.
 fn applyProps(
+    self: *Self,
     env: emacs.Env,
     start: i64,
     end: i64,
-    props: CellProps,
+    node: *const gt.PageList.List.Node,
+    prop_key: *const CellPropKey,
 ) !void {
     if (start >= end) return;
     const s = emacs.sym;
@@ -335,7 +295,7 @@ fn applyProps(
     const start_val = env.makeInteger(start);
     const end_val = env.makeInteger(end);
 
-    if (try style_face.buildFacePlist(env, props)) |face| {
+    if (try self.getFace(env, node, prop_key)) |face| {
         _ = env.f("put-text-property", .{
             start_val,
             end_val,
@@ -344,7 +304,8 @@ fn applyProps(
         });
     }
 
-    if (props.hyperlink) |link| {
+    const hyperlink = resolveHyperlink(&node.data, prop_key.hyperlink_id);
+    if (hyperlink) |link| {
         _ = env.f("put-text-property", .{
             start_val,
             end_val,
@@ -385,7 +346,7 @@ fn applyProps(
         });
     }
 
-    switch (props.semantic_content) {
+    switch (prop_key.semantic_content) {
         .prompt => _ = env.f("put-text-property", .{
             start_val,
             end_val,
@@ -402,6 +363,30 @@ fn applyProps(
     }
 }
 
+fn getFace(
+    self: *Self,
+    env: emacs.Env,
+    node: *const gt.PageList.List.Node,
+    key: *const CellPropKey,
+) !?emacs.Value {
+    return if (key.style_id != 0)
+        try style_face.buildFacePlist(
+            env,
+            node.data.styles.get(node.data.memory, key.style_id),
+            &self.term.colors.palette.current,
+            self.bold_config,
+        )
+    else if (key.bg_color != .none)
+        try style_face.buildFacePlist(
+            env,
+            &gt.Style{ .bg_color = key.bg_color },
+            &self.term.colors.palette.current,
+            self.bold_config,
+        )
+    else
+        null;
+}
+
 // TODO: Style ID type is not exported from ghostty-vt for some reason.
 //       We should file an issue.
 const StyleId = @FieldType(gt.page.Cell, "style_id");
@@ -409,19 +394,37 @@ const StyleId = @FieldType(gt.page.Cell, "style_id");
 /// Unique identifier that is cheaper to read and compare relative to `CellProps`.
 /// We read this first and if it differs from the previous cell, we read the full
 /// `CellProps`.
-const CellPropKey = packed struct {
+const CellPropKey = struct {
     style_id: StyleId,
     hyperlink_id: gt.size.HyperlinkCountInt,
     semantic_content: gt.page.Cell.SemanticContent,
+    bg_color: gt.Style.Color,
 
-    fn create(page: *const gt.Page, cell: *const gt.page.Cell) CellPropKey {
+    fn create(page: *const gt.Page, cell: *const gt.page.Cell) ?CellPropKey {
+        const hyperlink_id = if (cell.hyperlink) page.lookupHyperlink(cell) else null;
+        const bg_color: gt.Style.Color = switch (cell.content_tag) {
+            .bg_color_palette => .{ .palette = cell.content.color_palette },
+            .bg_color_rgb => .{ .rgb = .{
+                .r = cell.content.color_rgb.r,
+                .g = cell.content.color_rgb.g,
+                .b = cell.content.color_rgb.b,
+            } },
+            else => .none,
+        };
+
+        if (cell.style_id == 0 and
+            hyperlink_id == null and
+            cell.semantic_content == .output and
+            bg_color == .none)
+        {
+            return null;
+        }
+
         return .{
             .style_id = cell.style_id,
-            .hyperlink_id = if (cell.hyperlink)
-                page.lookupHyperlink(cell) orelse 0
-            else
-                0,
+            .hyperlink_id = hyperlink_id orelse 0,
             .semantic_content = cell.semantic_content,
+            .bg_color = bg_color,
         };
     }
 };
@@ -430,7 +433,7 @@ pub const RowContent = struct {
     const Run = struct {
         start_char: usize,
         end_char: usize,
-        props: ?CellProps,
+        key: ?CellPropKey,
     };
 
     const CellInfo = struct {
@@ -515,11 +518,11 @@ pub const RowContent = struct {
             // We use a "key" that holds a minimum set of values that are cheap to
             // compare to detect style run breaks.
             const prop_key = CellPropKey.create(&row_pin.node.data, cell);
-            if (prop_key != current_prop_key) {
+            if (!std.meta.eql(prop_key, current_prop_key) or self.runs.items.len == 0) {
                 try self.runs.append(self.alloc, .{
                     .start_char = self.char_len,
                     .end_char = self.char_len,
-                    .props = createCellProps(renderer, page, prop_key, cell),
+                    .key = prop_key,
                 });
                 current_prop_key = prop_key;
             }
@@ -555,7 +558,7 @@ pub const RowContent = struct {
             // We trim cells that neither have content nor styling. A blank
             // cursor cell only requires enough whitespace to place point at
             // the cursor column, not an extra rendered space under it.
-            if (cell.hasText() or last_run.props != null) {
+            if (cell.hasText() or last_run.key != null) {
                 trim_byte_len = self.text.items.len;
                 trim_char_len = self.char_len;
             } else if (has_cursor) {
@@ -827,8 +830,8 @@ fn insertRow(
 
         const prop_start = row_start + @as(i64, @intCast(run.start_char));
         const prop_end = row_start + @as(i64, @intCast(run.end_char));
-        if (run.props) |props| {
-            try applyProps(env, prop_start, prop_end, props);
+        if (run.key) |*key| {
+            try self.applyProps(env, prop_start, prop_end, row_pin.node, key);
         }
     }
 

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -33,14 +33,14 @@ alloc: Allocator,
 /// Terminal being rendered.
 term: *gt.Terminal,
 
-/// Render state for incremental screen updates.
-render_state: gt.RenderState,
-
 /// Tracked pin of which row to render down from.
 render_pin: ?*gt.Pin,
 
 /// The screen that is currently rendered into the buffer.
 rendered_screen: *gt.Screen,
+
+/// Pin of the last rendered cursor position
+rendered_cursor: ?gt.Pin,
 
 /// Number of libghostty rows already materialized into the Emacs buffer.
 rows_in_buffer: usize = 0,
@@ -109,11 +109,11 @@ pub fn init(alloc: Allocator, env: emacs.Env, term: *gt.Terminal) !Self {
     var renderer = Self{
         .alloc = alloc,
         .term = term,
-        .render_state = gt.RenderState.empty,
         .render_pin = try term.screens.active.pages.trackPin(
             term.screens.active.pages.getTopLeft(.screen),
         ),
         .rendered_screen = term.screens.active,
+        .rendered_cursor = null,
         .pending_resize = .{ .cols = term.cols, .rows = term.rows, .cell_w = 1, .cell_h = 1 },
         .row = .{ .alloc = alloc },
     };
@@ -123,7 +123,6 @@ pub fn init(alloc: Allocator, env: emacs.Env, term: *gt.Terminal) !Self {
 
 pub fn deinit(self: *Self) void {
     self.saved_markers.deinit(self.alloc);
-    self.render_state.deinit(self.alloc);
     self.row.deinit();
     self.clearPages();
     if (self.render_pin) |p| self.rendered_screen.pages.untrackPin(p);
@@ -159,10 +158,10 @@ pub fn redraw(self: *Self, env: emacs.Env, force_full: bool) !void {
     if (self.rendered_screen != self.term.screens.active) {
         try self.clear(env);
     }
-    try self.validateScrollback(env);
+    try self.invalidate(env);
     self.evictScrollback(env);
 
-    try self.renderToEnd(
+    try self.render(
         env,
         if (self.render_pin) |p|
             p.*
@@ -181,7 +180,7 @@ pub fn redraw(self: *Self, env: emacs.Env, force_full: bool) !void {
         self.rendered_screen.pages.total_rows);
 }
 
-fn validateScrollback(self: *Self, env: emacs.Env) !void {
+fn invalidate(self: *Self, env: emacs.Env) !void {
     const scrollback_cleared = self.rows_in_buffer > self.term.rows and
         self.render_pin != null and
         self.render_pin.?.eql(self.rendered_screen.pages.getTopLeft(.screen));
@@ -294,18 +293,21 @@ fn createCellProps(
     self: *Self,
     page: *const gt.Page,
     key: CellPropKey,
-    cell: *const gt.RenderState.Cell,
+    cell: *const gt.Cell,
 ) ?CellProps {
     var props: CellProps = .{};
 
-    const style: gt.Style = if (cell.raw.hasStyling()) cell.style else .{};
+    const style: gt.Style = if (cell.hasStyling())
+        page.styles.get(page.memory, cell.style_id).*
+    else
+        .{};
 
     props.fg = style_face.resolveForeground(
         &style,
         &self.term.colors.palette.current,
         self.bold_config,
     );
-    props.bg = style.bg(&cell.raw, &self.render_state.colors.palette);
+    props.bg = style.bg(cell, &self.term.colors.palette.current);
     props.bold = style.flags.bold;
     props.italic = style.flags.italic;
     props.faint = style.flags.faint;
@@ -313,9 +315,9 @@ fn createCellProps(
     props.strikethrough = style.flags.strikethrough;
     props.overline = style.flags.overline;
     props.inverse = style.flags.inverse;
-    props.underline_color = style.underlineColor(&self.render_state.colors.palette);
+    props.underline_color = style.underlineColor(&self.term.colors.palette.current);
     props.hyperlink = resolveHyperlink(page, key.hyperlink_id);
-    props.semantic_content = cell.raw.semantic_content;
+    props.semantic_content = cell.semantic_content;
 
     return if (props.isPlain()) null else props;
 }
@@ -481,11 +483,13 @@ pub const RowContent = struct {
     pub fn build(
         self: *RowContent,
         renderer: *Self,
-        row: *const gt.RenderState.Row,
-        cursor_col: ?u16,
+        row_pin: gt.Pin,
         adjustment_threshold: u32,
     ) !void {
         try self.clear();
+
+        const term = renderer.term;
+        const screen = term.screens.active;
 
         // Position at the end of the last non-blank cell; final row length
         // is trimmed back to this. Any run of blank cells past the end is
@@ -493,26 +497,29 @@ pub const RowContent = struct {
         var trim_byte_len: usize = 0;
         var trim_char_len: usize = 0;
 
-        const page = &row.pin.node.data;
-        var current_prop_key: ?CellPropKey = null;
-        var col: u16 = 0;
-        while (col < row.cells.len) : (col += 1) {
-            const cell = row.cells.get(col);
-            const raw_cell = page.getRowAndCell(col, row.pin.y).cell;
+        const cursor_visible = term.modes.get(.cursor_visible);
+        const cursor_col = if (cursor_visible and isSameRow(row_pin, screen.cursor.page_pin.*))
+            screen.cursor.page_pin.x
+        else
+            null;
 
-            const has_cursor = col == cursor_col;
+        const page = &row_pin.node.data;
+        const row = row_pin.rowAndCell().row;
+        var current_prop_key: ?CellPropKey = null;
+        for (page.getCells(row), 0..) |*cell, col| {
+            const has_cursor = @as(u16, @intCast(col)) == cursor_col;
             if (has_cursor) self.cursor_char_pos = self.char_len;
 
-            if (cell.raw.wide == .spacer_tail or cell.raw.wide == .spacer_head) continue;
+            if (cell.wide == .spacer_tail or cell.wide == .spacer_head) continue;
 
             // We use a "key" that holds a minimum set of values that are cheap to
             // compare to detect style run breaks.
-            const prop_key = CellPropKey.create(&row.pin.node.data, raw_cell);
+            const prop_key = CellPropKey.create(&row_pin.node.data, cell);
             if (prop_key != current_prop_key) {
                 try self.runs.append(self.alloc, .{
                     .start_char = self.char_len,
                     .end_char = self.char_len,
-                    .props = createCellProps(renderer, page, prop_key, &cell),
+                    .props = createCellProps(renderer, page, prop_key, cell),
                 });
                 current_prop_key = prop_key;
             }
@@ -520,24 +527,24 @@ pub const RowContent = struct {
             const byte_start = self.text.items.len;
             const char_start = self.char_len;
 
-            const codepoint: u21 = if (raw_cell.hasText()) raw_cell.codepoint() else ' ';
+            const codepoint: u21 = if (cell.hasText()) cell.codepoint() else ' ';
             try self.appendCodepoints(&[1]u21{codepoint});
-            if (raw_cell.hasGrapheme()) {
-                try self.appendCodepoints(cell.grapheme);
+            if (cell.hasGrapheme()) {
+                try self.appendCodepoints(page.lookupGrapheme(cell).?);
             }
 
             // If this is a grapheme cluster, or if the char is not covered by
             // the default font, we register it as needing font glyph adjustment
             // to fit into the monospace grid.
-            if (raw_cell.hasGrapheme() or codepoint >= adjustment_threshold) {
+            if (cell.hasGrapheme() or codepoint >= adjustment_threshold) {
                 try self.adjust_cells.append(self.alloc, .{
                     .col = @intCast(col),
                     .char_start = @intCast(char_start),
                     .char_end = @intCast(self.char_len),
                     .text_start = byte_start,
                     .text_end = self.text.items.len,
-                    .wide = raw_cell.wide == .wide,
-                    .page_serial = row.pin.node.serial,
+                    .wide = cell.wide == .wide,
+                    .page_serial = row_pin.node.serial,
                     .style_id = if (current_prop_key) |key| key.style_id else 0,
                 });
             }
@@ -548,7 +555,7 @@ pub const RowContent = struct {
             // We trim cells that neither have content nor styling. A blank
             // cursor cell only requires enough whitespace to place point at
             // the cursor column, not an extra rendered space under it.
-            if (raw_cell.hasText() or last_run.props != null) {
+            if (cell.hasText() or last_run.props != null) {
                 trim_byte_len = self.text.items.len;
                 trim_char_len = self.char_len;
             } else if (has_cursor) {
@@ -803,13 +810,11 @@ fn findGlyphString(
 fn insertRow(
     self: *Self,
     env: emacs.Env,
-    row: *const gt.RenderState.Row,
-    cursor_col: ?u16,
+    row_pin: gt.Pin,
 ) !usize {
     try self.row.build(
         self,
-        row,
-        cursor_col,
+        row_pin,
         if (self.font_info) |f| f.coverage else std.math.maxInt(u32),
     );
 
@@ -829,7 +834,7 @@ fn insertRow(
 
     try self.adjustGlyphs(env, row_start);
 
-    if (row.raw.wrap) {
+    if (row_pin.rowAndCell().row.wrap) {
         // Mark newlines from soft-wrapped rows so copy mode can filter them
         const point = env.f("point", .{});
         _ = env.f("put-text-property", .{
@@ -850,136 +855,104 @@ fn insertRow(
     return @intCast(row_end - row_start);
 }
 
+fn isSameRow(a: gt.Pin, b: gt.Pin) bool {
+    return a.node == b.node and a.y == b.y;
+}
+
+fn isRowDirty(self: *Self, pin: gt.Pin) bool {
+    if (pin.rowAndCell().row.dirty) return true;
+
+    const cursor = if (self.term.modes.get(.cursor_visible))
+        self.term.screens.active.cursor.page_pin.*
+    else
+        null;
+
+    // If the cursor moved, both the old row and the new row are dirty.
+    if (!std.meta.eql(cursor, self.rendered_cursor)) {
+        if (cursor) |c| if (isSameRow(c, pin)) return true;
+        if (self.rendered_cursor) |c| if (isSameRow(c, pin)) return true;
+    }
+
+    return false;
+}
+
 fn render(
     self: *Self,
     env: emacs.Env,
-    pin: gt.Pin,
+    start_pin: gt.Pin,
 ) !void {
-    self.term.screens.active.pages.scroll(.{ .pin = pin });
-    try self.updateRenderState();
+    const term = self.term;
 
-    if (self.render_state.dirty != .false) {
-        const skip = switch (pin.downOverflow(self.term.rows)) {
-            .overflow => |of| of.remaining - 1,
-            else => 0,
-        };
+    var page = if (term.screens.active.no_scrollback)
+        null
+    else
+        try self.getOrAddPage(start_pin.node.serial);
 
-        var page = if (self.term.screens.active.no_scrollback)
-            null
-        else
-            try self.getOrAddPage(pin.node.serial);
+    var it = start_pin.rowIterator(.right_down, null);
+    while (it.next()) |row_pin| {
+        const row = row_pin.rowAndCell().row;
+        defer row.dirty = false;
 
-        var i: usize = 0;
-        const row_dirty = self.render_state.row_data.items(.dirty);
-        while (i < self.render_state.rows) : ({
-            // Clear per-row dirty flag
-            row_dirty[i] = false;
-            i += 1;
-        }) {
-            if (i < skip) continue;
-
-            const row = self.render_state.row_data.get(i);
-            if (page) |p| {
-                if (p.serial != row.pin.node.serial) {
-                    page = p.next() orelse try self.addPage(row.pin.node.serial);
-                    std.debug.assert(page != null);
-                    std.debug.assert(page.?.serial == row.pin.node.serial);
-                }
+        if (page) |p| {
+            if (p.serial != row_pin.node.serial) {
+                page = p.next() orelse try self.addPage(row_pin.node.serial);
+                std.debug.assert(page != null);
+                std.debug.assert(page.?.serial == row_pin.node.serial);
             }
+        }
 
-            const dirty_row = self.render_state.dirty == .full or row_dirty[i];
-            // Only process dirty rows, or there's no existing row
-            const eob = env.isNotNil(env.f("eobp", .{}));
-            if (dirty_row or eob) {
-                const cursor_col = blk: {
-                    if (self.render_state.cursor.viewport) |vp| {
-                        if (vp.y == i) break :blk vp.x;
-                    }
-
-                    break :blk null;
-                };
-
-                if (eob) {
-                    // We're adding one line since we're at the end of the buffer
-                    const line_char_len = try self.insertRow(env, &row, cursor_col);
-                    self.rows_in_buffer += 1;
-                    if (page) |p| {
-                        p.rows += 1;
-                        p.char_len += line_char_len;
-                    }
-                } else {
-                    // Line is dirty and we're not at the end of the buffer,
-                    // so we're replacing the line.
-                    const line_start_val = env.f("point", .{});
-                    const line_start = env.cast(usize, line_start_val);
-                    const old_line_end_val = env.f("pos-bol", .{2});
-                    const old_line_len = env.cast(usize, old_line_end_val) - line_start;
-                    _ = env.f("delete-region", .{ line_start_val, old_line_end_val });
-                    const new_line_len = try self.insertRow(env, &row, cursor_col);
-
-                    if (page) |p| {
-                        p.char_len -|= old_line_len;
-                        p.char_len += new_line_len;
-                    }
-                    self.saved_markers.adjustRegion(line_start, old_line_len, new_line_len);
+        // Only process dirty rows, or if there's no existing row
+        const eob = env.isNotNil(env.f("eobp", .{}));
+        if (self.isRowDirty(row_pin) or eob) {
+            if (eob) {
+                // We're adding one line since we're at the end of the buffer
+                const line_char_len = try self.insertRow(env, row_pin);
+                self.rows_in_buffer += 1;
+                if (page) |p| {
+                    p.rows += 1;
+                    p.char_len += line_char_len;
                 }
             } else {
-                _ = env.f("forward-line", .{1});
+                // Line is dirty and we're not at the end of the buffer,
+                // so we're replacing the line.
+                const line_start_val = env.f("point", .{});
+                const line_start = env.cast(usize, line_start_val);
+                const old_line_end_val = env.f("pos-bol", .{2});
+                const old_line_len = env.cast(usize, old_line_end_val) - line_start;
+                _ = env.f("delete-region", .{ line_start_val, old_line_end_val });
+                const new_line_len = try self.insertRow(env, row_pin);
+
+                if (page) |p| {
+                    p.char_len -|= old_line_len;
+                    p.char_len += new_line_len;
+                }
+                self.saved_markers.adjustRegion(line_start, old_line_len, new_line_len);
             }
+        } else {
+            _ = env.f("forward-line", .{1});
         }
-
-        // Reset dirty state
-        self.render_state.dirty = .false;
-    }
-}
-
-fn updateRenderState(self: *Self) !void {
-    const pre_cursor: ?gt.RenderState.Cursor.Viewport =
-        self.render_state.cursor.viewport;
-
-    try self.render_state.update(self.alloc, self.term);
-    if (self.render_state.dirty == .full) return;
-
-    const post_cursor: ?gt.RenderState.Cursor.Viewport =
-        self.render_state.cursor.viewport;
-
-    if (!std.meta.eql(pre_cursor, post_cursor)) {
-        // The cursor moved. Both the old row and the new row are dirty.
-        if (self.render_state.dirty == .false) {
-            self.render_state.dirty = .partial;
-        }
-        const row_dirty = self.render_state.row_data.items(.dirty);
-        if (pre_cursor) |vp| row_dirty[vp.y] = true;
-        if (post_cursor) |vp| row_dirty[vp.y] = true;
     }
 }
 
 fn renderCursor(self: *Self, env: emacs.Env) !void {
-    if (self.render_state.cursor.viewport) |vp| {
-        _ = env.set("ghostel--cursor-pos", env.cons(vp.x, vp.y));
-    } else {
-        _ = env.set("ghostel--cursor-pos", env.nil());
-    }
-
-    _ = env.set("ghostel--cursor-blinking", if (self.render_state.cursor.blinking) env.t() else env.nil());
-
-    if (self.render_state.cursor.visible) {
+    if (self.term.modes.get(.cursor_visible)) {
+        const screen = self.term.screens.active;
+        _ = env.set("ghostel--cursor-pos", env.cons(screen.cursor.x, screen.cursor.y));
         env.set(
             "ghostel--cursor-style",
-            @intFromEnum(self.render_state.cursor.visual_style),
+            @intFromEnum(screen.cursor.cursor_style),
         );
+        self.rendered_cursor = self.rendered_screen.cursor.page_pin.*;
     } else {
+        _ = env.set("ghostel--cursor-pos", env.nil());
         env.set("ghostel--cursor-style", env.nil());
+        self.rendered_cursor = null;
     }
-}
 
-// Render all pages from start_pin through the end of the active area,
-// one viewport-sized chunk per page.
-fn renderToEnd(self: *Self, env: emacs.Env, start_pin: gt.Pin) !void {
-    var p: ?gt.Pin = start_pin;
-    while (p) |pin| : (p = pin.down(self.term.rows)) {
-        try self.render(env, pin);
-    }
+    _ = env.set("ghostel--cursor-blinking", if (self.term.modes.get(.cursor_blinking))
+        env.t()
+    else
+        env.nil());
 }
 
 fn commitResize(self: *Self, env: emacs.Env) !void {
@@ -1035,7 +1008,6 @@ fn addPage(self: *Self, serial: PageSerial) !*MaterializedPage {
 fn clear(self: *Self, env: emacs.Env) !void {
     _ = env.f("erase-buffer", .{});
     self.rows_in_buffer = 0;
-    self.render_state.dirty = .full;
     self.clearPages();
     if (self.render_pin) |p| self.rendered_screen.pages.untrackPin(p);
     self.render_pin = null;

--- a/src/comint_filter.zig
+++ b/src/comint_filter.zig
@@ -33,7 +33,8 @@ const log = std.log.scoped(.comint_filter);
 const Run = struct {
     start: usize, // character offset in the output string
     end: usize,
-    props: style_face.CellProps,
+    style: gt.Style,
+    hyperlink: ?[]u8 = null,
 };
 
 const Handler = struct {
@@ -49,7 +50,7 @@ const Handler = struct {
     style: gt.Style = .{},
 
     /// Current OSC 8 hyperlink URI (owned).  Null when no link is active.
-    link_uri: ?[]u8 = null,
+    hyperlink: ?[]u8 = null,
 
     /// Output bytes accumulated during the current `feed` call.
     text: std.ArrayList(u8) = .empty,
@@ -64,10 +65,6 @@ const Handler = struct {
     /// Character offset where the pending run started.
     pending_start: usize = 0,
 
-    /// Props active for the pending run.  Hyperlink URI slices here borrow
-    /// from `link_uri`; only closed runs own their copied URI strings.
-    pending_props: style_face.CellProps = .{},
-
     /// Cached Emacs env, valid only during `feed`.  Used by `.report_pwd`.
     env: ?emacs.Env = null,
 
@@ -75,50 +72,14 @@ const Handler = struct {
         self.clearRuns();
         self.text.deinit(self.alloc);
         self.runs.deinit(self.alloc);
-        if (self.link_uri) |uri| self.alloc.free(uri);
-        self.link_uri = null;
+        if (self.hyperlink) |uri| self.alloc.free(uri);
+        self.hyperlink = null;
     }
 
     /// Free per-run URIs and reset the runs list.
     fn clearRuns(self: *Handler) void {
-        for (self.runs.items) |run| if (run.props.hyperlink) |link| self.alloc.free(link.uri);
+        for (self.runs.items) |run| if (run.hyperlink) |link| self.alloc.free(link);
         self.runs.clearRetainingCapacity();
-    }
-
-    /// Compute the CellProps for the current style + hyperlink.
-    fn currentProps(self: *const Handler) style_face.CellProps {
-        return .{
-            .fg = style_face.resolveForeground(
-                &self.style,
-                &self.palette,
-                self.bold_config,
-            ),
-            .bg = switch (self.style.bg_color) {
-                .none => null,
-                .palette => |idx| self.palette[idx],
-                .rgb => |rgb| rgb,
-            },
-            .bold = self.style.flags.bold,
-            .italic = self.style.flags.italic,
-            .faint = self.style.flags.faint,
-            .underline = self.style.flags.underline,
-            .strikethrough = self.style.flags.strikethrough,
-            .overline = self.style.flags.overline,
-            .inverse = self.style.flags.inverse,
-            .underline_color = self.style.underlineColor(&self.palette),
-            .hyperlink = if (self.link_uri) |uri| .{
-                .id = .{ .implicit = 0 },
-                .uri = uri,
-            } else null,
-            // semantic_content stays default — comint has no notion of prompts here
-        };
-    }
-
-    /// Close the pending run if non-empty, then start a new pending run
-    /// with `props` at the current end of the output.
-    fn switchProps(self: *Handler, props: style_face.CellProps) !void {
-        try self.closePending();
-        self.pending_props = props;
     }
 
     /// Push the pending run onto `runs` if it has content.
@@ -129,16 +90,14 @@ const Handler = struct {
     fn closePending(self: *Handler) !void {
         const here = self.text_chars;
         if (here > self.pending_start) {
-            var run_props = self.pending_props;
-            if (run_props.hyperlink) |*link| {
-                link.uri = try self.alloc.dupe(u8, link.uri);
-            }
-            errdefer if (run_props.hyperlink) |link| self.alloc.free(link.uri);
-
             try self.runs.append(self.alloc, .{
                 .start = self.pending_start,
                 .end = here,
-                .props = run_props,
+                .style = self.style,
+                .hyperlink = if (self.hyperlink) |link|
+                    try self.alloc.dupe(u8, link)
+                else
+                    null,
             });
         }
         self.pending_start = here;
@@ -226,17 +185,8 @@ const Handler = struct {
         value: gt.StreamAction.Value(action),
     ) void {
         switch (action) {
-            .print => {
-                const new_props = self.currentProps();
-                if (!std.meta.eql(new_props, self.pending_props)) {
-                    self.switchProps(new_props) catch |err| {
-                        log.warn("switchProps failed: {s}", .{@errorName(err)});
-                        return;
-                    };
-                }
-                self.appendCodepoint(value.cp) catch |err| {
-                    log.warn("appendCodepoint failed: {s}", .{@errorName(err)});
-                };
+            .print => self.appendCodepoint(value.cp) catch |err| {
+                log.warn("appendCodepoint failed: {s}", .{@errorName(err)});
             },
 
             // C0 controls — pass through so comint's carriage-motion
@@ -257,28 +207,32 @@ const Handler = struct {
                 log.warn("BEL passthrough failed: {s}", .{@errorName(err)});
             },
 
-            .set_attribute => self.applyAttr(value),
+            .set_attribute => {
+                self.closePending() catch |err| {
+                    log.warn("closePending before start_hyperlink failed: {s}", .{@errorName(err)});
+                    return;
+                };
+                self.applyAttr(value);
+            },
 
             .start_hyperlink => {
                 self.closePending() catch |err| {
                     log.warn("closePending before start_hyperlink failed: {s}", .{@errorName(err)});
                     return;
                 };
-                if (self.link_uri) |old| self.alloc.free(old);
-                self.link_uri = self.alloc.dupe(u8, value.uri) catch |err| blk: {
+                if (self.hyperlink) |old| self.alloc.free(old);
+                self.hyperlink = self.alloc.dupe(u8, value.uri) catch |err| blk: {
                     log.warn("start_hyperlink dupe failed: {s}", .{@errorName(err)});
                     break :blk null;
                 };
-                self.pending_props = self.currentProps();
             },
             .end_hyperlink => {
                 self.closePending() catch |err| {
                     log.warn("closePending before end_hyperlink failed: {s}", .{@errorName(err)});
                     return;
                 };
-                if (self.link_uri) |old| self.alloc.free(old);
-                self.link_uri = null;
-                self.pending_props = self.currentProps();
+                if (self.hyperlink) |old| self.alloc.free(old);
+                self.hyperlink = null;
             },
 
             .report_pwd => {
@@ -330,7 +284,6 @@ pub fn feed(self: *Self, env: emacs.Env, data: []const u8) !emacs.Value {
     h.text_chars = 0;
     h.clearRuns();
     h.pending_start = 0;
-    h.pending_props = h.currentProps();
 
     h.env = env;
     defer h.env = null;
@@ -341,21 +294,23 @@ pub fn feed(self: *Self, env: emacs.Env, data: []const u8) !emacs.Value {
     const text_val = env.makeString(h.text.items);
     const s = &emacs.sym;
 
-    for (h.runs.items) |run| {
+    for (h.runs.items) |*run| {
         const start_val = env.makeInteger(@intCast(run.start));
         const end_val = env.makeInteger(@intCast(run.end));
 
-        if (try style_face.buildFacePlist(env, run.props)) |face| {
+        const face = try style_face.buildFacePlist(env, &run.style, &h.palette, h.bold_config);
+        if (face) |f| {
             _ = env.f("put-text-property", .{
                 start_val,
                 end_val,
                 s.face,
-                face,
+                f,
                 text_val,
             });
         }
-        if (run.props.hyperlink) |link| {
-            const uri_val = env.makeString(link.uri);
+
+        if (run.hyperlink) |link| {
+            const uri_val = env.makeString(link);
             _ = env.f("put-text-property", .{
                 start_val,
                 end_val,

--- a/src/comint_filter.zig
+++ b/src/comint_filter.zig
@@ -23,8 +23,8 @@ const Self = @This();
 
 const log = std.log.scoped(.comint_filter);
 
-/// One styled run within the output buffer.  If it has a hyperlink,
-/// `props.hyperlink.uri` is owned and freed on run-list reset.
+/// One styled run within the output buffer.  Hyperlink URIs are owned
+/// by the run and freed on run-list reset.
 ///
 /// Positions are *character* offsets (codepoints), not byte offsets:
 /// Emacs string positions are character-indexed for multibyte strings,
@@ -84,9 +84,8 @@ const Handler = struct {
 
     /// Push the pending run onto `runs` if it has content.
     ///
-    /// `pending_props.hyperlink.uri` borrows from the current OSC 8 state;
-    /// duplicate it for the stored run because the active hyperlink can end
-    /// before Emacs properties are applied.
+    /// Duplicate the active OSC 8 URI for stored runs because the active
+    /// hyperlink can end before Emacs properties are applied.
     fn closePending(self: *Handler) !void {
         const here = self.text_chars;
         if (here > self.pending_start) {

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -86,6 +86,11 @@ pub const Env = struct {
         _ = self.f("set", .{ @field(sym, symbol), value });
     }
 
+    pub fn defvarLocal(self: Env, comptime symbol: []const u8, default_value: anytype) void {
+        _ = self.f("make-local-variable", .{@field(sym, symbol)});
+        _ = self.set(symbol, default_value);
+    }
+
     pub fn symbolValue(self: Env, comptime symbol: []const u8) Value {
         return self.f("symbol-value", .{@field(sym, symbol)});
     }
@@ -416,6 +421,7 @@ const interned_symbols = [_][:0]const u8{
     "car",
     "cdr",
     "char-after",
+    "clrhash",
     "composition-get-gstring",
     "cons",
     "dash",
@@ -445,8 +451,9 @@ const interned_symbols = [_][:0]const u8{
     "format",
     "forward-line",
     "fset",
-    "gethash",
     "get-buffer-window-list",
+    "getenv",
+    "gethash",
     "ghostel",
     "ghostel--cursor-blinking",
     "ghostel--cursor-char-pos",
@@ -479,7 +486,6 @@ const interned_symbols = [_][:0]const u8{
     "ghostel-module",
     "ghostel-prompt",
     "ghostel-wrap",
-    "getenv",
     "goto-char",
     "height",
     "help-echo",
@@ -507,11 +513,11 @@ const interned_symbols = [_][:0]const u8{
     "process-live-p",
     "process-send-string",
     "process-tty-name",
-    "puthash",
-    "query-font",
     "propertize",
     "provide",
     "put-text-property",
+    "puthash",
+    "query-font",
     "reverse",
     "run-at-time",
     "selected-window",

--- a/src/kitty_graphics.zig
+++ b/src/kitty_graphics.zig
@@ -11,8 +11,7 @@ const gt = @import("ghostty-vt");
 const ppm = @import("ppm.zig");
 
 /// Query all visible kitty graphics placements from libghostty and
-/// emit them to Elisp for display.  Called after render_state_update()
-/// during each redraw.
+/// emit them to Elisp during redraw.
 pub fn emitPlacements(env: emacs.Env, term: *GhostelTerm) !void {
     const storage = &term.terminal.screens.active.kitty_images;
     var iterator = storage.placements.iterator();

--- a/src/style_face.zig
+++ b/src/style_face.zig
@@ -2,9 +2,8 @@
 ///
 /// Both the renderer (which materialises a 2D grid into an Emacs buffer)
 /// and the comint stream filter (which transforms a byte stream into
-/// propertized text for `comint-preoutput-filter-functions') need the
-/// same SGR-to-face plist mapping.  This module owns the data type
-/// (`CellProps`) and the plist builder so the two paths stay in sync.
+/// propertized text for `comint-preoutput-filter-functions') use the same
+/// SGR-to-face plist mapping.
 const std = @import("std");
 const emacs = @import("emacs.zig");
 const gt = @import("ghostty-vt");
@@ -132,7 +131,7 @@ fn resolveColor(
 }
 
 /// Build a face plist (`(:foreground "#xxx" :background "#yyy" ...)`)
-/// from CellProps.  Returns null if the resulting plist is empty.
+/// from a libghostty style.
 ///
 /// The caller is responsible for actually applying the plist via
 /// `put-text-property` against either the current buffer or a string.

--- a/src/style_face.zig
+++ b/src/style_face.zig
@@ -25,8 +25,13 @@ pub const Hyperlink = struct {
     uri: []const u8,
 };
 
+// TODO: Style ID type is not exported from ghostty-vt for some reason.
+//       We should file an issue.
+const StyleId = @FieldType(gt.page.Cell, "style_id");
+
 /// Resolved style attributes for a run of cells.
 pub const CellProps = struct {
+    style_id: StyleId = 0,
     fg: ?gt.color.RGB = null,
     bg: ?gt.color.RGB = null,
     bold: bool = false,
@@ -84,12 +89,12 @@ pub fn dimColor(env: emacs.Env, fg: ?gt.color.RGB, bg: ?gt.color.RGB) !gt.color.
 pub fn resolveForeground(
     style: *const gt.Style,
     palette: *const gt.color.Palette,
-    bold_opt: ?gt.Style.BoldColor,
+    bold_config: ?gt.Style.BoldColor,
 ) ?gt.color.RGB {
     switch (style.fg_color) {
         .none => {
             if (style.flags.bold) {
-                if (bold_opt) |bold| switch (bold) {
+                if (bold_config) |bold| switch (bold) {
                     .bright => {},
                     .color => |v| return v,
                 };
@@ -98,7 +103,7 @@ pub fn resolveForeground(
 
         .palette => |idx| {
             if (style.flags.bold) {
-                if (bold_opt) |_| {
+                if (bold_config) |_| {
                     const bright_offset = @intFromEnum(gt.color.Name.bright_black);
                     if (idx < bright_offset) {
                         return palette[idx + bright_offset];
@@ -115,6 +120,17 @@ pub fn resolveForeground(
     return null;
 }
 
+fn resolveColor(
+    palette: *const gt.color.Palette,
+    color: gt.Style.Color,
+) ?gt.color.RGB {
+    return switch (color) {
+        .rgb => |rgb| rgb,
+        .palette => |idx| palette[idx],
+        .none => null,
+    };
+}
+
 /// Build a face plist (`(:foreground "#xxx" :background "#yyy" ...)`)
 /// from CellProps.  Returns null if the resulting plist is empty.
 ///
@@ -122,55 +138,61 @@ pub fn resolveForeground(
 /// `put-text-property` against either the current buffer or a string.
 pub fn buildFacePlist(
     env: emacs.Env,
-    props: CellProps,
-) !?emacs.Value {
+    style: *const gt.Style,
+    palette: *const gt.color.Palette,
+    bold_config: ?gt.Style.BoldColor,
+) !emacs.Value {
     var face_props: FixedArrayList(emacs.Value, 32) = .{};
 
     const s = &emacs.sym;
 
-    if (props.faint) {
+    const fg = resolveForeground(style, palette, bold_config);
+    const bg = resolveColor(palette, style.bg_color);
+    if (style.flags.faint) {
         var buf: [7]u8 = undefined;
-        const dimmed = try dimColor(env, props.fg, props.bg);
+        const dimmed = try dimColor(env, fg, bg);
         const dim_str = formatColor(dimmed, &buf);
         try face_props.append(s.@":foreground");
         try face_props.append(env.makeString(dim_str));
-    } else if (props.fg) |fg| {
+    } else if (fg) |rgb| {
         var buf: [7]u8 = undefined;
-        const fg_str = formatColor(fg, &buf);
+        const fg_str = formatColor(rgb, &buf);
         try face_props.append(s.@":foreground");
         try face_props.append(env.makeString(fg_str));
     }
 
-    if (props.bg) |bg| {
+    if (bg) |rgb| {
         var buf: [7]u8 = undefined;
-        const bg_str = formatColor(bg, &buf);
+        const bg_str = formatColor(rgb, &buf);
         try face_props.append(s.@":background");
         try face_props.append(env.makeString(bg_str));
     }
 
-    if (props.inverse) {
+    if (style.flags.inverse) {
         try face_props.append(s.@":inverse-video");
         try face_props.append(env.t());
     }
 
-    if (props.bold) {
+    if (style.flags.bold) {
         try face_props.append(s.@":weight");
         try face_props.append(s.bold);
     }
 
-    if (props.italic) {
+    if (style.flags.italic) {
         try face_props.append(s.@":slant");
         try face_props.append(s.italic);
     }
 
-    if (props.underline != .none) {
+    if (style.flags.underline != .none) {
+        const underline_color = resolveColor(palette, style.underline_color);
+
         try face_props.append(s.@":underline");
-        if (props.underline == .single and props.underline_color == null) {
+        if (style.flags.underline == .single and underline_color == null) {
             try face_props.append(env.t());
         } else {
             var ul_props: FixedArrayList(emacs.Value, 4) = .{};
             try ul_props.append(s.@":style");
-            try ul_props.append(switch (props.underline) {
+            try ul_props.append(switch (style.flags.underline) {
                 .curly => s.wave,
                 .double => s.@"double-line",
                 .dotted => s.dot,
@@ -178,7 +200,7 @@ pub fn buildFacePlist(
                 else => s.line,
             });
 
-            if (props.underline_color) |uc| {
+            if (underline_color) |uc| {
                 var uc_buf: [7]u8 = undefined;
                 try ul_props.append(s.@":color");
                 try ul_props.append(env.makeString(formatColor(uc, &uc_buf)));
@@ -188,16 +210,15 @@ pub fn buildFacePlist(
         }
     }
 
-    if (props.strikethrough) {
+    if (style.flags.strikethrough) {
         try face_props.append(s.@":strike-through");
         try face_props.append(env.t());
     }
 
-    if (props.overline) {
+    if (style.flags.overline) {
         try face_props.append(s.@":overline");
         try face_props.append(env.t());
     }
 
-    if (face_props.len == 0) return null;
     return env.funcall(s.list, face_props.items());
 }

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -36,15 +36,16 @@ Requires the native module; without it the test is skipped
             (buf (ghostel--create " *evil-ghostel-test*" nil ,rows ,cols))
             (term (buffer-local-value 'ghostel--term buf)))
        (unwind-protect
-           (with-current-buffer buf
-             (ghostel--write-vt term ,text)
-             (evil-local-mode 1)
-             (evil-ghostel-mode 1)
-             (let ((inhibit-read-only t))
-               (ghostel--redraw term t))
-             (cl-macrolet ((insert (&rest args)
-                             `(evil-ghostel-test--insert ,@args)))
-               ,@body))
+		   (with-selected-window (display-buffer buf)
+			 (with-current-buffer buf
+               (ghostel--write-vt term ,text)
+               (evil-local-mode 1)
+               (evil-ghostel-mode 1)
+               (let ((inhibit-read-only t))
+				 (ghostel--redraw term t))
+               (cl-macrolet ((insert (&rest args)
+                               `(evil-ghostel-test--insert ,@args)))
+				 ,@body)))
          (when (buffer-live-p buf)
            (kill-buffer buf))))))
 

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -967,6 +967,51 @@ scrolling libghostty's viewport."
               (should (string-prefix-p "$ " content)))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-full-reset-clears-everything ()
+  "RIS (ESC c) resets the terminal entirely: screen, scrollback, cursor,\nSGR styles, and alt-screen state all return to initial.\nThe renderer rebuilds the buffer from libghostty's reset state, so no\npre-reset content (scrollback, styled cells, or alt-screen rows) may\nsurvive in the Emacs buffer."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-full-reset*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 40 1000))
+                 (inhibit-read-only t))
+            ;; Seed every kind of state a partial clear might leave behind:
+            ;; scrollback, SGR-styled cells, a moved cursor, and alt screen.
+            (dotimes (i 12)
+              (ghostel--write-vt term (format "row-%02d\r\n" i)))
+            (ghostel--write-vt term "\e[1;31mRED\e[0m")
+            (ghostel--redraw term t)
+            ;; Sanity-check the pre-reset state has all the things we reset.
+            (let ((before (buffer-substring-no-properties (point-min) (point-max))))
+              (should (string-match-p "row-00" before))   ; scrollback present
+              (should (string-match-p "RED" before)))     ; styled text present
+            ;; Enter alt screen and fill it so the reset must exit it.
+            (ghostel--write-vt term "\e[?1049h\e[H\e[2J")
+            (dotimes (i 5)
+              (ghostel--write-vt term (format "\e[%d;1HALT-%d" (1+ i) i)))
+            (ghostel--redraw term t)
+            (should (string-match-p
+                    "ALT-"
+                    (buffer-substring-no-properties (point-min) (point-max))))
+            ;; Full reset (RIS) — everything returns to initial state.
+            (ghostel--write-vt term "\ec")
+            (ghostel--redraw term t)
+            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+              ;; Scrollback rows are gone.
+              (should-not (string-match-p "row-" content))
+              ;; Alt-screen rows are gone.
+              (should-not (string-match-p "ALT-" content))
+              ;; Styled text is gone — every rendered cell is blank.
+              (should (string-blank-p content))
+              ;; No SGR face survives on the first cell.
+              (goto-char (point-min))
+              (should-not (get-text-property (point) 'face))
+              ;; Cursor returned home (col 0, row 0).
+              (should (equal '(0 . 0) ghostel--cursor-pos))
+              ;; Buffer collapsed to the viewport with no scrollback.
+              (should (= 5 (count-lines (point-min) (point-max)))))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-scrollback-csi3j-then-refill ()
   "CSI 3 J must not leave stale pre-clear rows in the buffer.
 

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -1245,6 +1245,29 @@ and `forward-line' for clean ones.  Only the dirty row loses the sentinel."
             (should (ghostel-test--line-clean-p 4))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-cursor-only-redraw-updates-char-pos ()
+  "Cursor movement without cell changes updates the buffer cursor position."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-cursor-only-redraw*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 3 10 100))
+                 (inhibit-read-only t))
+            (ghostel--write-vt term "abc")
+            (ghostel--redraw term t)
+            (should (equal '(3 . 0) ghostel--cursor-pos))
+            (should (= (+ (point-min) 3) ghostel--cursor-char-pos))
+            ;; Move the cursor within the same row.  No cell content changes, but
+            ;; `ghostel--cursor-char-pos' must still follow the terminal cursor.
+            (ghostel--write-vt term "\e[1;2H")
+            (ghostel--redraw term)
+            (should (equal '(1 . 0) ghostel--cursor-pos))
+            (should (= (+ (point-min) 1) ghostel--cursor-char-pos))
+            (should (equal "abc\n\n\n"
+                           (buffer-substring-no-properties
+                            (point-min) (point-max))))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-alt-screen-partial-redraw-only-dirty-row-rebuilt ()
   "Incremental alt-screen redraw rebuilds only changed rows."
   :tags '(native)

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -392,6 +392,23 @@ with TERM and must write MARK_TARGET, POINT_TARGET, and START_TARGET."
     (ghostel--write-vt term "\e[1;31mHELLO\e[0m normal")
     (should (equal "HELLO normal" (ghostel-test--row0 term)))))
 
+(ert-deftest ghostel-test-property-runs-stop-at-row-boundaries ()
+  "Background-only property runs must not leak onto following rows."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-prop-row-boundary*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 3 20 100))
+                 (inhibit-read-only t))
+            (ghostel--write-vt term "\e[H\e[2J\e[44mselected\e[K\e[0m\r\nplain")
+            (ghostel--redraw term t)
+            (goto-char (point-min))
+            (should (plist-get (get-text-property (point) 'face) :background))
+            (forward-line 1)
+            (should (looking-at-p "plain"))
+            (should-not (get-text-property (point) 'face))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-dim-text ()
   "Test that SGR 2 (faint) produces a dimmed foreground color, not :weight light."
   :tags '(native)

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -2025,6 +2025,31 @@ through; fully default text carries no face at all."
               (should (equal "#123456" (plist-get face :background))))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-render-bg-only-empty-cells-split-runs ()
+  "Adjacent bg-only empty cells with different colors render separately."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-bg-only-runs*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 1 6 100))
+                 (inhibit-read-only t))
+            (ghostel--write-vt
+             term
+             (concat "\e[48;2;17;34;51m\e[2K"
+                     "\e[4G\e[48;2;68;85;102m\e[K"))
+            (ghostel--redraw term)
+            (goto-char (point-min))
+            (should (equal "      " (buffer-substring-no-properties
+                                     (line-beginning-position)
+                                     (line-end-position))))
+            (let ((first-face (get-text-property (point-min) 'face))
+                  (second-face (get-text-property (+ (point-min) 3) 'face)))
+              (should (equal "#112233" (plist-get first-face :background)))
+              (should (equal "#445566" (plist-get second-face :background)))
+              (should (= (+ (point-min) 3)
+                         (next-single-property-change (point-min) 'face))))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-render-inverse-omits-fg-bg ()
   "Inverse video (7) on a default cell emits :inverse-video with no fg/bg.
 Emacs swaps the default face at display time, so theme colors and frame

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -1245,6 +1245,28 @@ and `forward-line' for clean ones.  Only the dirty row loses the sentinel."
             (should (ghostel-test--line-clean-p 4))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-alt-screen-partial-redraw-only-dirty-row-rebuilt ()
+  "Incremental alt-screen redraw rebuilds only changed rows."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-alt-partial-dirty*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let* ((term (ghostel--new 5 40 1000))
+                 (inhibit-read-only t))
+            (ghostel--write-vt term "\e[?1049h\e[H\e[2J")
+            (dotimes (i 5)
+              (ghostel--write-vt term (format "\e[%d;1Hrow-%d" (1+ i) i)))
+            (ghostel--write-vt term "\e[3;1H")
+            (ghostel--redraw term t)
+            (should (= 5 (count-lines (point-min) (point-max))))
+            (ghostel-test--mark-all-lines-clean)
+            (ghostel--write-vt term "modified")
+            (ghostel--redraw term)
+            (should-not (ghostel-test--line-clean-p 2))
+            (dolist (row '(0 1 3 4))
+              (should (ghostel-test--line-clean-p row)))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-incremental-redraw ()
   "Test that incremental redraw correctly updates dirty rows."
   :tags '(native)

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -1218,8 +1218,8 @@ already in scrollback must remain untouched."
 
 (ert-deftest ghostel-test-partial-redraw-only-dirty-row-rebuilt ()
   "Modifying one active row rebuilds only that row; unchanged rows are preserved.
-The incremental dirty-row path calls `delete-region' + re-insert for dirty rows
-and `forward-line' for clean ones.  Only the dirty row loses the sentinel."
+Dirty rows are replaced and clean rows are skipped.  Only the dirty row loses
+the sentinel."
   :tags '(native)
   (let ((buf (generate-new-buffer " *ghostel-test-partial-dirty*")))
     (unwind-protect

--- a/test/ghostel-test-helpers.el
+++ b/test/ghostel-test-helpers.el
@@ -341,6 +341,26 @@ bindings from the caller are honored."
       (ghostel-test--wait-for-text text proc timeout)
       (ghostel-test--terminal-text))))
 
+(defun ghostel-test--enable-start-logging ()
+  "Log each ERT test name as it starts, gated on `GHOSTEL_DEBUG_TESTS'.
+
+When the `GHOSTEL_DEBUG_TESTS' environment variable is set, add
+`:before' advice to `ert-run-test' so the name of the test about to
+run is printed synchronously before its body executes.  The last
+printed line is then the test that hung or crashed — useful for
+isolating failures in the native module or in PTY-driven tests that
+never return.  No-op when the env var is unset, so production batch
+runs are unaffected."
+  (when (getenv "GHOSTEL_DEBUG_TESTS")
+    (unless (advice-member-p #'ghostel-test--log-start 'ert-run-test)
+      (advice-add 'ert-run-test :before #'ghostel-test--log-start))))
+
+(defun ghostel-test--log-start (test)
+  "Message the ERT TEST about to run."
+  (message "ERT starting: %s" (ert-test-name test)))
+
+(ghostel-test--enable-start-logging)
+
 (defun ghostel-test-run-elisp ()
   "Run only pure Elisp tests (no native module required)."
   (ert-run-tests-batch-and-exit '(not (tag native))))

--- a/tools/ghostel-dape.el
+++ b/tools/ghostel-dape.el
@@ -99,6 +99,35 @@ Set to nil to skip automatic compilation."
          (fboundp 'dired-get-file-for-visit))
     (dired-get-file-for-visit))))
 
+(defun ghostel-dape--evil-checkout-dir ()
+  "Return the vendored evil checkout directory, mirroring `make test-evil'.
+`EVIL_DIR ?= $(XDG_CACHE_HOME)/evil' in the Makefile, defaulting to
+~/.cache/evil when `XDG_CACHE_HOME' is unset."
+  (expand-file-name "evil"
+                    (or (getenv "XDG_CACHE_HOME")
+                        (expand-file-name "~/.cache"))))
+
+(defun ghostel-dape--evil-p (file)
+  "Return non-nil if FILE is an evil-ghostel test needing evil on load-path."
+  (and file
+       (string-match-p "evil-ghostel" (file-name-nondirectory file))))
+
+(defun ghostel-dape--ert-load-path-args (file)
+  "Return extra `-L' args needed to load test FILE under Dape.
+Evil-ghostel tests need the vendored evil checkout and the in-repo
+`extensions/evil-ghostel' directory on `load-path', matching the
+`test-evil' Makefile target.  Non-evil files need no extra args."
+  (if (not (ghostel-dape--evil-p file))
+      nil
+    (let ((evil-dir (ghostel-dape--evil-checkout-dir)))
+      (unless (file-directory-p evil-dir)
+        (user-error
+         "Evil checkout not found at %s; run `make test-evil' to clone it"
+         evil-dir))
+      (list "-L" evil-dir
+            "-L" (expand-file-name "extensions/evil-ghostel"
+                                   (ghostel-dape--root))))))
+
 (defun ghostel-dape--read-hypothesis-case-file ()
   "Read a Hypothesis JSON case file name from the minibuffer."
   (let* ((root (ghostel-dape--root))
@@ -140,14 +169,15 @@ name.  The current buffer's test file is loaded into a fresh batch Emacs."
                    (ghostel-dape--current-ert-test)
                    (read-string "ERT test name: ")))
          (regexp (concat "^" (regexp-quote test) "$")))
-    (ghostel-dape--launch-emacs
-     "--batch" "-Q"
-     "-L" "lisp"
-     "-L" "test"
-     "-l" "ert"
-     "-l" "test/ghostel-test-helpers.el"
-     "-l" (ghostel-dape--relative-file file)
-     "--eval" (ghostel-dape--ert-eval regexp))))
+    (apply #'ghostel-dape--launch-emacs
+           "--batch" "-Q"
+           "-L" "lisp"
+           "-L" "test"
+           (append (ghostel-dape--ert-load-path-args file)
+                   (list "-l" "ert"
+                         "-l" "test/ghostel-test-helpers.el"
+                         "-l" (ghostel-dape--relative-file file)
+                         "--eval" (ghostel-dape--ert-eval regexp))))))
 
 ;;;###autoload
 (defun ghostel-dape-ert-file ()
@@ -156,14 +186,15 @@ name.  The current buffer's test file is loaded into a fresh batch Emacs."
   (let ((file (buffer-file-name)))
     (unless file
       (user-error "Current buffer is not visiting a file"))
-    (ghostel-dape--launch-emacs
-     "--batch" "-Q"
-     "-L" "lisp"
-     "-L" "test"
-     "-l" "ert"
-     "-l" "test/ghostel-test-helpers.el"
-     "-l" (ghostel-dape--relative-file file)
-     "--eval" "(ert-run-tests-batch-and-exit t)")))
+    (apply #'ghostel-dape--launch-emacs
+           "--batch" "-Q"
+           "-L" "lisp"
+           "-L" "test"
+           (append (ghostel-dape--ert-load-path-args file)
+                   (list "-l" "ert"
+                         "-l" "test/ghostel-test-helpers.el"
+                         "-l" (ghostel-dape--relative-file file)
+                         "--eval" "(ert-run-tests-batch-and-exit t)")))))
 
 ;;;###autoload
 (defun ghostel-dape-hypothesis-case-file (case-file)


### PR DESCRIPTION
## Summary
- render directly from libghostty terminal pages instead of maintaining a separate RenderState
- batch adjacent dirty-row insertions and preserve renderer-owned buffer positions/scrollback accounting
- resolve styles lazily and keep cursor-only movement updating `ghostel--cursor-char-pos`
- update render architecture docs, comments, tests, and benchmark/debug tooling

## Verification
- `make build`
- `make test-zig`
- targeted native ERT tests:
  - `ghostel-test-cursor-only-redraw-updates-char-pos`
  - `ghostel-test-partial-redraw-only-dirty-row-rebuilt`