### PR TITLE
Bump libghostty and use upstream color parser

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .fingerprint = 0x5a44bdd1198a0f4b,
     .dependencies = .{
         .ghostty = .{
-            .url = "https://github.com/ghostty-org/ghostty/archive/07d31666e73bce337b9cece60a884c67fe8906f4.tar.gz",
-            .hash = "ghostty-1.3.2-dev-5UdBC0njFgWhKuT1D5Cas4TqQnpeBuptGZ6Lz_rigcyS",
+            .url = "https://github.com/ghostty-org/ghostty/archive/c41c6b81a4642ccba18d47b375d9495664de72a0.tar.gz",
+            .hash = "ghostty-1.3.2-dev-5UdBCyCeGgX3-erS43WT4wCWWnD-tw_VpVdir5iihnMk",
         },
     },
 }

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -11,8 +11,6 @@ const GhostelHandler = @import("handler.zig").GhostelHandler;
 const Renderer = @import("Renderer.zig");
 const input = @import("input.zig");
 const kitty_graphics = @import("kitty_graphics.zig");
-const utils = @import("utils.zig");
-const parseHexColor = utils.parseHexColor;
 const PtyProcess = @import("PtyProcess.zig");
 const NativeProcess = @import("NativeProcess.zig");
 const pty_utils = @import("pty_utils.zig");
@@ -651,7 +649,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 var idx: usize = 0;
                 while (idx < 16) : (idx += 1) {
                     const pos = idx * 7;
-                    palette[idx] = try parseHexColor(colors_str[pos .. pos + 7]);
+                    palette[idx] = try gt.color.RGB.parse(colors_str[pos .. pos + 7]);
                 }
                 term.setColorPalette(palette);
                 return env.t();
@@ -679,8 +677,8 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 const bg_str = try env.extractString(args[2], &bg_buf);
                 term.lockTerm();
                 defer term.unlockTerm();
-                term.terminal.colors.foreground.default = try parseHexColor(fg_str);
-                term.terminal.colors.background.default = try parseHexColor(bg_str);
+                term.terminal.colors.foreground.default = try gt.color.RGB.parse(fg_str);
+                term.terminal.colors.background.default = try gt.color.RGB.parse(bg_str);
                 return env.t();
             }
         },
@@ -706,7 +704,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 } else {
                     var hex_buf: [16]u8 = undefined;
                     const hex = try env.extractString(val, &hex_buf);
-                    term.renderer.bold_config = .{ .color = try parseHexColor(hex) };
+                    term.renderer.bold_config = .{ .color = try gt.color.RGB.parse(hex) };
                 }
                 return env.t();
             }

--- a/src/comint_filter.zig
+++ b/src/comint_filter.zig
@@ -17,7 +17,6 @@ const gt = @import("ghostty-vt");
 
 const emacs = @import("emacs.zig");
 const style_face = @import("style_face.zig");
-const parseHexColor = @import("utils.zig").parseHexColor;
 
 const Self = @This();
 
@@ -427,7 +426,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 var idx: usize = 0;
                 while (idx < 16) : (idx += 1) {
                     const pos = idx * 7;
-                    palette16[idx] = try parseHexColor(colors_str[pos .. pos + 7]);
+                    palette16[idx] = try gt.color.RGB.parse(colors_str[pos .. pos + 7]);
                 }
                 filter.setPalette16(palette16);
                 return env.t();

--- a/src/comint_filter.zig
+++ b/src/comint_filter.zig
@@ -187,6 +187,14 @@ const Handler = struct {
             .print => self.appendCodepoint(value.cp) catch |err| {
                 log.warn("appendCodepoint failed: {s}", .{@errorName(err)});
             },
+            .print_slice => {
+                for (value.cps) |cp| {
+                    self.appendCodepoint(@intCast(cp)) catch |err| {
+                        log.warn("appendCodepoint failed: {s}", .{@errorName(err)});
+                        return;
+                    };
+                }
+            },
 
             // C0 controls — pass through so comint's carriage-motion
             // filter can interpret them.

--- a/src/style_face.zig
+++ b/src/style_face.zig
@@ -8,7 +8,6 @@ const std = @import("std");
 const emacs = @import("emacs.zig");
 const gt = @import("ghostty-vt");
 const FixedArrayList = @import("fixed_array_list.zig").FixedArrayList;
-const utils = @import("utils.zig");
 
 /// Globally-stable identity for an OSC 8 hyperlink span.  `.explicit`
 /// holds the user-supplied `id=...`; `.implicit` is ghostty's auto-counter
@@ -70,7 +69,7 @@ pub fn getGhostelDefaultColor(env: emacs.Env, comptime prop: anytype) !gt.color.
         .{ s.@"ghostel-default", @field(s, prop) },
     );
     var buf: [8]u8 = undefined;
-    return try utils.parseHexColor(try env.extractString(color_val, &buf));
+    return try gt.color.RGB.parse(try env.extractString(color_val, &buf));
 }
 
 /// Blend a foreground color toward a background color to produce a "dim"

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,30 +1,6 @@
-const std = @import("std");
-
 const gt = @import("ghostty-vt");
 
 const emacs = @import("emacs.zig");
-
-pub fn parseHexByte(hi: u8, lo: u8) !u8 {
-    const h = try hexDigit(hi);
-    const l = try hexDigit(lo);
-    return (h << 4) | l;
-}
-
-pub fn hexDigit(ch: u8) !u8 {
-    if (ch >= '0' and ch <= '9') return ch - '0';
-    if (ch >= 'a' and ch <= 'f') return ch - 'a' + 10;
-    if (ch >= 'A' and ch <= 'F') return ch - 'A' + 10;
-    return error.InvalidHexDigit;
-}
-
-/// Parse a "#RRGGBB" hex color string into a ColorRgb.
-pub fn parseHexColor(s: []const u8) !gt.color.RGB {
-    if (s.len < 7 or s[0] != '#') return error.InvalidHexColorLength;
-    const r = try parseHexByte(s[1], s[2]);
-    const g = try parseHexByte(s[3], s[4]);
-    const b = try parseHexByte(s[5], s[6]);
-    return .{ .r = r, .g = g, .b = b };
-}
 
 pub fn cellCharCount(page: *gt.Page, cell: *gt.Cell) usize {
     if (cell.wide == .spacer_head or cell.wide == .spacer_tail) {


### PR DESCRIPTION
## Summary

- Bump the pinned `ghostty-org/ghostty` dependency from `07d3166` to `c41c6b8`.
- Handle upstream's new `print_slice` stream action in the comint filter so printable text is not dropped.
- Replace ghostel's local `#RRGGBB` parser with `gt.color.RGB.parse` where possible.

## Verification

- `zig build --prefix .`
- `zig build --prefix . -Doptimize=ReleaseFast`
- `bench/run-bench.sh --no-vterm --no-eat --no-term`
- 5 interleaved longer A/B runs of `backend/plain/native` with `--min-duration 3`

## Benchmark summary

Compared against `4c6351f` (parent before this branch's two commits). Both sides were rebuilt with `zig build --prefix . -Doptimize=ReleaseFast`.

| Section | Geomean speedup | Change |
|---|---:|---:|
| e2e | 1.66x | +65.8% |
| backend | 1.04x | +4.0% |
| stream | 1.55x | +54.8% |
| tui-frame | 1.48x | +48.2% |
| tui-partial | 1.03x | +3.2% |
| engine | 2.53x | +153.2% |
| **overall** | **1.60x** | **+60.0%** |

Selected results:

| Scenario | Before ms | After ms | Speedup |
|---|---:|---:|---:|
| `e2e/plain/ghostel` | 9.70 | 4.56 | 2.13x |
| `e2e/urls/ghostel` | 18.29 | 14.13 | 1.29x |
| `stream/ghostel-incr` | 14.88 | 9.38 | 1.59x |
| `engine/plain/ghostel-incr/24x80` | 6.47 | 1.38 | 4.68x |
| `engine/unicode/ghostel-incr/24x80` | 4.81 | 1.54 | 3.12x |

The one reproducible regression is isolated to native PTY plain output:

| Metric (`backend/plain/native`) | Before | After | Change |
|---|---:|---:|---:|
| Mean over 5 longer interleaved runs | 17.25 ms | 19.24 ms | 0.90x (-10.3%) |
| Median | 17.33 ms | 19.31 ms | 0.90x (-10.2%) |
| Stddev | 0.15 ms | 0.17 ms | — |

This likely indicates the faster VT engine has moved the bottleneck to the native PTY read/event-notification path: plain parsing no longer provides as much incidental batching before `WouldBlock`, so the reader may notify/redraw more often. Parser-only and stream-only paths show large wins, so this does not look like a raw VT parsing regression.