### PR TITLE
Fix renderer position preservation regressions

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2073,7 +2073,8 @@ point to the live cursor and stays in semi-char (skipped when
      ((and active
            (= (event-click-count event) 1)
            (not ghostel--mouse-press-was-selected))
-      (goto-char (or ghostel--cursor-char-pos (point-max)))
+      (when ghostel--cursor-char-pos
+        (goto-char ghostel--cursor-char-pos))
       (deactivate-mark))
      ;; Multi-click, or a single click in an already-selected window: set
      ;; point/selection, then freeze (a focus click never reaches here).

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -919,6 +919,7 @@ fn render(
     var current_span: ?struct {
         start_val: emacs.Value,
         node: *const gt.PageList.List.Node,
+        adjusted_line_start: usize,
     } = null;
 
     var it = start_pin.rowIterator(.right_down, null);
@@ -952,6 +953,7 @@ fn render(
                 current_span = .{
                     .start_val = line_start_val,
                     .node = row_pin.node,
+                    .adjusted_line_start = env.cast(usize, line_start_val),
                 };
                 try self.span.clear();
             }
@@ -960,7 +962,12 @@ fn render(
             const line_start = env.cast(usize, line_start_val);
             const old_line_len = env.cast(usize, old_line_end_val) - line_start;
             if (old_line_len > 0) {
-                self.saved_markers.adjustRegion(line_start, old_line_len, new_line_len);
+                self.saved_markers.adjustRegion(
+                    current_span.?.adjusted_line_start,
+                    old_line_len,
+                    new_line_len,
+                );
+                current_span.?.adjusted_line_start += new_line_len;
             }
 
             if (page) |p| {

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -524,8 +524,7 @@ pub const SpanContent = struct {
         var trim_byte_len: usize = self.text.items.len;
         var trim_char_len: usize = self.char_len;
 
-        const cursor_visible = term.modes.get(.cursor_visible);
-        const cursor_col = if (cursor_visible and isSameRow(row_pin, screen.cursor.page_pin.*))
+        const cursor_col = if (isSameRow(row_pin, screen.cursor.page_pin.*))
             screen.cursor.page_pin.x
         else
             null;
@@ -889,10 +888,7 @@ fn isSameRow(a: gt.Pin, b: gt.Pin) bool {
 fn isRowDirty(self: *Self, pin: gt.Pin) bool {
     if (pin.rowAndCell().row.dirty) return true;
 
-    const cursor = if (self.term.modes.get(.cursor_visible))
-        self.term.screens.active.cursor.page_pin.*
-    else
-        null;
+    const cursor: ?gt.Pin = self.term.screens.active.cursor.page_pin.*;
 
     // Cursor movement requires rebuilding both the previous and current cursor rows.
     if (!std.meta.eql(cursor, self.rendered_cursor)) {
@@ -986,18 +982,17 @@ fn render(
 }
 
 fn renderCursor(self: *Self, env: emacs.Env) !void {
+    const screen = self.term.screens.active;
+    _ = env.set("ghostel--cursor-pos", env.cons(screen.cursor.x, screen.cursor.y));
+    self.rendered_cursor = screen.cursor.page_pin.*;
+
     if (self.term.modes.get(.cursor_visible)) {
-        const screen = self.term.screens.active;
-        _ = env.set("ghostel--cursor-pos", env.cons(screen.cursor.x, screen.cursor.y));
         env.set(
             "ghostel--cursor-style",
             @intFromEnum(screen.cursor.cursor_style),
         );
-        self.rendered_cursor = screen.cursor.page_pin.*;
     } else {
-        _ = env.set("ghostel--cursor-pos", env.nil());
         env.set("ghostel--cursor-style", env.nil());
-        self.rendered_cursor = null;
     }
 
     _ = env.set("ghostel--cursor-blinking", if (self.term.modes.get(.cursor_blinking))

--- a/test/ghostel-mouse-paste-test.el
+++ b/test/ghostel-mouse-paste-test.el
@@ -583,6 +583,40 @@ previously-unselected window sets point normally and enters no mode."
       (should (equal fake-event set-point-event))
       (should-not copy-mode-called))))
 
+(ert-deftest ghostel-test-mouse-1-release-focus-click-hidden-cursor-does-not-anchor ()
+  "A focus click with no visible terminal cursor preserves point and scroll."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-focus-hidden-cursor*"))
+        (orig-buf (window-buffer (selected-window)))
+        (ghostel-mouse-drag-input-mode 'copy)
+        (ghostel--mouse-press-was-selected nil))
+    (unwind-protect
+        (progn
+          (set-window-buffer (selected-window) buf)
+          (with-current-buffer buf
+            (ghostel-mode)
+            (let ((inhibit-read-only t))
+              (dotimes (i 50)
+                (insert (format "row-%02d\n" i))))
+            (setq-local ghostel--term 'fake)
+            (setq-local ghostel--input-mode 'semi-char)
+            (setq-local ghostel--cursor-char-pos nil)
+            (goto-char (point-min))
+            (set-window-point (selected-window) (point-min))
+            (set-window-start (selected-window) (point-min) t)
+            (cl-letf (((symbol-function 'ghostel--mode-enabled)
+                       (lambda (_term _mode) nil))
+                      ((symbol-function 'ghostel--mouse-event)
+                       (lambda (&rest _) nil)))
+              (ghostel-mouse-release-or-set-point
+               `(mouse-1 (,(selected-window) 1 (10 . 5) 0)) 1))
+            (should (= (point) (point-min)))
+            (should (= (window-point) (point-min)))
+            (should (= (window-start) (point-min)))))
+      (when (buffer-live-p orig-buf)
+        (set-window-buffer (selected-window) orig-buf))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-mouse-1-release-single-click-already-selected-nil-target-stays ()
   "Already-selected single click with a nil target only sets point.
 With `ghostel-mouse-drag-input-mode' nil there is no copy/Emacs mode to

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -261,6 +261,24 @@ with TERM and must write MARK_TARGET, POINT_TARGET, and START_TARGET."
      (should (= old-mark (ghostel-test--token-position "MARK_TARGET")))
      (should (= old-point (ghostel-test--token-position "POINT_TARGET"))))))
 
+(ert-deftest ghostel-test-position-preservation-batched-changed-length-lines ()
+  "Adjacent changed-length dirty rows preserve later positions when batched."
+  :tags '(native)
+  (ghostel-test--with-position-preservation-case
+   (buf term 12 120 2000 (lambda (term)
+                           (ghostel--write-vt term
+                                              "aaaaaaaaaaaaaaaaaaaa mutable-one\r\n")
+                           (ghostel--write-vt term
+                                              "bbbbbbbbbbbbbbbbbbbb mutable-two\r\n")
+                           (ghostel--write-vt term "START_TARGET start-row\r\n")
+                           (ghostel--write-vt term "mark row MARK_TARGET here\r\n")
+                           (ghostel--write-vt term "point row POINT_TARGET here\r\n")
+                           (dotimes (i 3)
+                             (ghostel--write-vt term
+                                                (format "tail-%02d\r\n" i)))))
+   (ghostel--write-vt term "\e[1;1H\e[2Kx\e[2;1H\e[2Ky")
+   (ghostel--redraw term)))
+
 (ert-deftest ghostel-test-position-preservation-on-shortened-line-clamps ()
   "Positions past a shortened dirty row clamp to that row's end."
   :tags '(native)

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -1303,6 +1303,29 @@ the sentinel."
                             (point-min) (point-max))))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-hidden-cursor-keeps-logical-position ()
+  "Hiding the terminal cursor keeps its logical buffer position."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-hidden-cursor*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let ((term (ghostel--new 3 10 100))
+                (inhibit-read-only t))
+            (ghostel--write-vt term "abc")
+            (ghostel--redraw term t)
+            (should (equal '(3 . 0) ghostel--cursor-pos))
+            (should (= (+ (point-min) 3) ghostel--cursor-char-pos))
+            (ghostel--write-vt term "\e[?25l")
+            (ghostel--redraw term)
+            (should (equal '(3 . 0) ghostel--cursor-pos))
+            (should (= (+ (point-min) 3) ghostel--cursor-char-pos))
+            (should-not ghostel--cursor-style)
+            (ghostel--write-vt term "\e[1;2H")
+            (ghostel--redraw term)
+            (should (equal '(1 . 0) ghostel--cursor-pos))
+            (should (= (+ (point-min) 1) ghostel--cursor-char-pos))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-alt-screen-partial-redraw-only-dirty-row-rebuilt ()
   "Incremental alt-screen redraw rebuilds only changed rows."
   :tags '(native)


### PR DESCRIPTION
## Summary
- preserve saved markers/window positions correctly across batched changed-length renderer spans
- keep logical cursor positions updated even when the terminal cursor is hidden
- avoid snapping focus clicks to `point-max` when no cursor position is available

## Verification
- `make .build/tests/native-ghostel-render-test.ok`
- `make .build/tests/native-ghostel-mouse-paste-test.ok`