### PR TITLE
Keep read-only keymaps scoped to Ghostel buffers

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -730,7 +730,8 @@ and affected buffers will pick up the new value on the next mode transition."
          (set-default sym newval)
          (dolist (buf (buffer-list))
            (with-current-buffer buf
-             (when (memq ghostel--input-mode '(copy emacs))
+             (when (and (derived-mode-p 'ghostel-mode)
+                        (memq ghostel--input-mode '(copy emacs)))
                (use-local-map (ghostel--readonly-keymap)))))))
 
 (defcustom ghostel-readonly-fake-cursor t
@@ -2451,6 +2452,8 @@ in Emacs mode this exits back to the previous mode (mirroring
 command (`\\[ghostel-semi-char-mode]'), or \\`q'/\\`C-g'/any
 self-insert key when `ghostel-readonly-fast-exit' is non-nil."
   (interactive)
+  (unless (derived-mode-p 'ghostel-mode)
+    (user-error "Must be called from a ghostel buffer"))
   (if (eq ghostel--input-mode 'emacs)
       (ghostel-readonly-exit)
     (ghostel--enter-readonly
@@ -2466,6 +2469,8 @@ across the full scrollback.  When `ghostel-readonly-fast-exit' is
 non-nil press \\`q' or \\[ghostel-readonly-exit] to exit; exiting
 returns to whichever input mode was active before."
   (interactive)
+  (unless (derived-mode-p 'ghostel-mode)
+    (user-error "Must be called from a ghostel buffer"))
   (if (eq ghostel--input-mode 'copy)
       (ghostel-readonly-exit)
     (ghostel--enter-readonly 'copy t ":Copy"

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -738,6 +738,28 @@ repurposed as exit shortcuts, while the quit keys stay bound to the fast exit."
   (should (eq (lookup-key ghostel-readonly-fast-exit-mode-map (kbd "C-g"))
               #'ghostel-readonly-exit)))
 
+(ert-deftest ghostel-test-readonly-mode-commands-reject-non-ghostel-buffers ()
+  "Copy and Emacs modes must not install Ghostel maps outside `ghostel-mode'."
+  (dolist (command (list #'ghostel-copy-mode #'ghostel-emacs-mode))
+    (with-temp-buffer
+      (let ((map (current-local-map)))
+        (should-error (funcall command) :type 'user-error)
+        (should-not (local-variable-p 'ghostel--input-mode))
+        (should (eq (current-local-map) map))))))
+
+(ert-deftest ghostel-test-readonly-fast-exit-setter-skips-non-ghostel-buffers ()
+  "Changing `ghostel-readonly-fast-exit' only rebinds Ghostel buffers."
+  (let ((old ghostel-readonly-fast-exit))
+    (unwind-protect
+        (with-temp-buffer
+          (text-mode)
+          (let ((map (current-local-map)))
+            (setq-local ghostel--input-mode 'copy)
+            (customize-set-variable 'ghostel-readonly-fast-exit
+                                    (not old))
+            (should (eq (current-local-map) map))))
+      (customize-set-variable 'ghostel-readonly-fast-exit old))))
+
 (ert-deftest ghostel-test-emacs-mode-toggles-off ()
   "`ghostel-emacs-mode' is a toggle: calling it while in Emacs mode exits.
 Exiting returns to whatever mode the user was in beforehand, mirroring


### PR DESCRIPTION
## Summary
- reject copy/Emacs mode entry from non-Ghostel buffers
- only refresh read-only keymaps in live Ghostel buffers when `ghostel-readonly-fast-exit` changes
- add regressions for non-Ghostel buffers retaining their local maps

Closes #518.

## Verification
- `make .build/tests/elisp-ghostel-modes-test.ok`
- `git diff --check`