### PR TITLE
Resolve terminal from WINDOW's buffer in `ghostel--adjust-size'

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4852,32 +4852,36 @@ If WINDOW was anchored to the live viewport before the size change,
 keep it anchored.  Redraw synchronously when the terminal size
 actually changes.  When FORCE is non-nil, run the resize/redraw
 path even when the row/column count is unchanged."
-  (when (and ghostel--term ghostel--process (ghostel--terminal-live-p))
-    (when (ghostel--window-anchored-p
-           window (window-old-body-pixel-height window))
-      (ghostel--anchor-window window))
-    (when-let* ((adjust-fn (or (default-value 'window-adjust-process-window-size-function)
-                               #'window-adjust-process-window-size-smallest))
-                (windows (ghostel--windows (current-buffer) t))
-                (size (funcall adjust-fn ghostel--process windows))
-                (width (car size))
-                (height (cdr size)))
-      (let* ((same-size-p (and (eql height ghostel--term-rows)
-                               (eql width ghostel--term-cols)))
-             ;; Don't resize on minibuffer-induced rows-only change.
-             ;; E.g. fish clears and re-emits its prompt on every SIGWINCH; a
-             ;; `consult-buffer'/`M-x' cycle that grows then shrinks the body
-             ;; would otherwise produce two prompt repaints in quick succession.
-             ;; Skip the deferral on the alt screen TUIs.
-             (minibuffer-excepted-p (and (active-minibuffer-window)
-                                         (eql width ghostel--term-cols)
-                                         (not (ghostel--alt-screen-p ghostel--term)))))
-        (when (or force (and (not same-size-p) (not minibuffer-excepted-p)))
-          (ghostel--set-size-with-cell-dims ghostel--term (max 1 height) (max 1 width))
-          (setq ghostel--force-next-redraw t)
-          ;; Redraw synchronously so the buffer is updated before
-          ;; Emacs displays the stale content at the new window size.
-          (ghostel--redraw-now (current-buffer)))))))
+  ;; Buffer-local `window-size-change-functions' are run by redisplay
+  ;; with an arbitrary buffer current, so the terminal state must be
+  ;; resolved from WINDOW's buffer.
+  (with-current-buffer (window-buffer window)
+    (when (and ghostel--term ghostel--process (ghostel--terminal-live-p))
+      (when (ghostel--window-anchored-p
+             window (window-old-body-pixel-height window))
+        (ghostel--anchor-window window))
+      (when-let* ((adjust-fn (or (default-value 'window-adjust-process-window-size-function)
+                                 #'window-adjust-process-window-size-smallest))
+                  (windows (ghostel--windows (current-buffer) t))
+                  (size (funcall adjust-fn ghostel--process windows))
+                  (width (car size))
+                  (height (cdr size)))
+        (let* ((same-size-p (and (eql height ghostel--term-rows)
+                                 (eql width ghostel--term-cols)))
+               ;; Don't resize on minibuffer-induced rows-only change.
+               ;; E.g. fish clears and re-emits its prompt on every SIGWINCH; a
+               ;; `consult-buffer'/`M-x' cycle that grows then shrinks the body
+               ;; would otherwise produce two prompt repaints in quick succession.
+               ;; Skip the deferral on the alt screen TUIs.
+               (minibuffer-excepted-p (and (active-minibuffer-window)
+                                           (eql width ghostel--term-cols)
+                                           (not (ghostel--alt-screen-p ghostel--term)))))
+          (when (or force (and (not same-size-p) (not minibuffer-excepted-p)))
+            (ghostel--set-size-with-cell-dims ghostel--term (max 1 height) (max 1 width))
+            (setq ghostel--force-next-redraw t)
+            ;; Redraw synchronously so the buffer is updated before
+            ;; Emacs displays the stale content at the new window size.
+            (ghostel--redraw-now (current-buffer))))))))
 
 (defun ghostel--around-font-scale (fn args &optional buffer)
   "Resize and re-anchor Ghostel windows around font scaling by FN with ARGS.

--- a/test/ghostel-terminal-test.el
+++ b/test/ghostel-terminal-test.el
@@ -187,6 +187,8 @@ modes (47 / 1047 / 1049) are handled uniformly."
                 (lambda (&rest _) '(fake-win)))
                ((symbol-function 'process-buffer)
                 (lambda (_proc) cur-buf))
+               ((symbol-function 'window-buffer)
+                (lambda (&optional _window) cur-buf))
                ((default-value 'window-adjust-process-window-size-function)
                 (lambda (_proc _wins) ,size)))
        ,@body)))
@@ -257,6 +259,28 @@ modes (47 / 1047 / 1049) are handled uniformly."
         (should (equal '(fake 40 120) set-size-args))
         (should ghostel--force-next-redraw)
         (should redraw-called)))))
+
+(ert-deftest ghostel-test-resize-window-buffer-not-current ()
+  "Resize works when WINDOW's buffer is not the current buffer.
+Buffer-local `window-size-change-functions' are run by redisplay with
+an arbitrary buffer current, so `ghostel--adjust-size' must resolve
+the terminal from WINDOW's buffer rather than the ambient current
+buffer.  Regression test: a split from another window (or any
+programmatic resize) silently skipped the resize, leaving the grid at
+its old size."
+  (with-temp-buffer
+    (let ((set-size-args nil))
+      (setq-local ghostel--term 'fake
+                  ghostel--process 'fake-proc
+                  ghostel--force-next-redraw nil)
+      (cl-letf (((symbol-function 'ghostel--set-size-with-cell-dims)
+                 (lambda (_term h w) (setq set-size-args (list h w))))
+                ((symbol-function 'ghostel--redraw-now) #'ignore))
+        (ghostel-test--with-resize-stubs '(120 . 40)
+          (with-temp-buffer            ; unrelated buffer is current
+            (ghostel--adjust-size 'fake-window))))
+      (should (equal '(40 120) set-size-args))
+      (should ghostel--force-next-redraw))))
 
 (ert-deftest ghostel-test-windows-excludes-daemon-dummy-frame ()
   "`ghostel--windows' drops windows on the daemon's dummy initial frame.


### PR DESCRIPTION
## Problem

Buffer-local `window-size-change-functions` are run by redisplay with an
arbitrary buffer current, not necessarily WINDOW's buffer.
`ghostel--adjust-size` read `ghostel--term`/`ghostel--process` from the
ambient current buffer, so when it ran with some other buffer current —
e.g. a split from another window, or any programmatic resize — those
locals were nil, the `when` guard bailed, and the resize was silently
skipped. The grid stayed at its old size.

## Fix

Wrap the body in `with-current-buffer` on `(window-buffer window)` so the
terminal state is always resolved from WINDOW's own buffer, regardless of
what buffer happens to be current when the hook fires.

## Testing

`make test` — `ghostel-terminal-test` passes 16/16, including a new
regression test `ghostel-test-resize-window-buffer-not-current` that
drives `ghostel--adjust-size` with an unrelated buffer current and asserts
the resize still happens.