### PR TITLE
Bump ghostty for native OSC color-query replies

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .fingerprint = 0x5a44bdd1198a0f4b,
     .dependencies = .{
         .ghostty = .{
-            .url = "https://github.com/ghostty-org/ghostty/archive/c41c6b81a4642ccba18d47b375d9495664de72a0.tar.gz",
-            .hash = "ghostty-1.3.2-dev-5UdBCyCeGgX3-erS43WT4wCWWnD-tw_VpVdir5iihnMk",
+            .url = "https://github.com/ghostty-org/ghostty/archive/11b9a6ef17e21b89e2ef14dd786992cc5577b69b.tar.gz",
+            .hash = "ghostty-1.3.2-dev-5UdBC_uYGwWN5ZXbjh8tmyawbr5rgTfy9lP8WJKoJLvr",
         },
     },
 }

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -2,8 +2,6 @@
 //! standard terminal handler but intercepts OSC-related actions so we can route
 //! them to Elisp callbacks instead of re-parsing the same bytes ourselves.
 
-const std = @import("std");
-
 const emacs = @import("emacs.zig");
 const gt = @import("ghostty-vt");
 const GhostelTerm = @import("GhostelTerm.zig");
@@ -39,17 +37,12 @@ pub fn GhostelHandler(Context: type) type {
             value: gt.StreamAction.Value(action),
         ) void {
             switch (action) {
-                // For `semantic_prompt` and `color_operation` we forward FIRST
-                // so the standard handler updates terminal state (per-row
-                // semantic flag, palette/dynamic color sets), then fire the
-                // Elisp callback / emit the query reply.
+                // For `semantic_prompt` we forward FIRST so the standard
+                // handler updates terminal state (per-row semantic flag),
+                // then fire the Elisp callback.
                 .semantic_prompt => {
                     self.inner.vt(action, value);
                     self.handleSemanticPrompt(value);
-                },
-                .color_operation => {
-                    self.inner.vt(action, value);
-                    self.handleColorOperation(value);
                 },
 
                 // For these, the standard handler is a no-op (see
@@ -215,96 +208,6 @@ pub fn GhostelHandler(Context: type) type {
             };
             const progress_val = if (v.progress) |p| p else null;
             self.context.effect("ghostel--osc-progress", .{ state_str, progress_val });
-        }
-
-        // ---------------------------------------------------------------------------
-        // OSC 4 / 10 / 11 — color query reply
-        // ---------------------------------------------------------------------------
-
-        /// Walk the request list looking for `.query` entries and emit a reply for each.
-        /// The standard handler has already applied any `.set` / `.reset` entries in
-        /// the same list, so the colors we read are the post-update values - which
-        /// matches what shells expect when a single OSC carries both a set and a query.
-        ///
-        /// We reply for OSC 4 (palette), OSC 10 (foreground), and OSC 11 (background).
-        /// Other dynamic colors (cursor, pointer, highlight, tektronix) are queryable through
-        /// this same action but ghostel doesn't track them, so their queries silently drop.
-        fn handleColorOperation(self: *Self, v: gt.StreamAction.ColorOperation) void {
-            var it = v.requests.constIterator(0);
-            while (it.next()) |req| {
-                const target = switch (req.*) {
-                    .query => |t| t,
-                    else => continue,
-                };
-                switch (target) {
-                    .palette => |idx| {
-                        const color = self.inner.terminal.colors.palette.current[idx];
-                        self.sendPaletteColorReply(idx, color, v.terminator);
-                    },
-                    .dynamic => |d| switch (d) {
-                        .foreground => {
-                            if (self.inner.terminal.colors.foreground.get()) |color|
-                                self.sendDynamicColorReply(10, color, v.terminator);
-                        },
-                        .background => {
-                            if (self.inner.terminal.colors.background.get()) |color|
-                                self.sendDynamicColorReply(11, color, v.terminator);
-                        },
-                        else => {}, // cursor / highlight / pointer / tektronix — drop
-                    },
-                    .special => {}, // OSC 5 — drop
-                }
-            }
-        }
-
-        /// Send `OSC N;rgb:RRRR/GGGG/BBBB <term>` for a dynamic color (OSC 10/11).
-        fn sendDynamicColorReply(
-            self: *Self,
-            osc_num: u8,
-            color: gt.color.RGB,
-            terminator: gt.osc.Terminator,
-        ) void {
-            var buf: [64]u8 = undefined;
-            const written = std.fmt.bufPrint(
-                &buf,
-                "\x1b]{d};rgb:{x:0>2}{x:0>2}/{x:0>2}{x:0>2}/{x:0>2}{x:0>2}{s}",
-                .{
-                    osc_num,
-                    color.r,
-                    color.r,
-                    color.g,
-                    color.g,
-                    color.b,
-                    color.b,
-                    terminator.string(),
-                },
-            ) catch return;
-            self.context.ptyWrite(written) catch {};
-        }
-
-        /// Send `OSC 4;INDEX;rgb:RRRR/GGGG/BBBB <term>` for a palette entry.
-        fn sendPaletteColorReply(
-            self: *Self,
-            index: u8,
-            color: gt.color.RGB,
-            terminator: gt.osc.Terminator,
-        ) void {
-            var buf: [64]u8 = undefined;
-            const written = std.fmt.bufPrint(
-                &buf,
-                "\x1b]4;{d};rgb:{x:0>2}{x:0>2}/{x:0>2}{x:0>2}/{x:0>2}{x:0>2}{s}",
-                .{
-                    index,
-                    color.r,
-                    color.r,
-                    color.g,
-                    color.g,
-                    color.b,
-                    color.b,
-                    terminator.string(),
-                },
-            ) catch return;
-            self.context.ptyWrite(written) catch {};
         }
     };
 }

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -610,7 +610,7 @@ fresh."
         (should (equal "PARTIAL" ghostel--last-directory))))))
 
 (ert-deftest ghostel-test-osc-color-query ()
-  "Test that OSC 4/10/11 color queries get responses."
+  "Test that OSC 4/10/11/12 and Kitty OSC 21 color queries get responses."
   :tags '(native)
   (let ((python (executable-find "python3")))
     (skip-unless python)
@@ -648,7 +648,30 @@ fresh."
             ;; Multi-pair OSC 4 query: the index=1 value seeded above is still
             ;; there, and both indices get replied to in order.
             '("\e]4;1;?;3;?\e\\" :match
-              "\\`1b5d343b313b7267623a313131312f323232322f333333331b5c1b5d343b333b7267623a.*1b5c\\'"))))
+              "\\`1b5d343b313b7267623a313131312f323232322f333333331b5c1b5d343b333b7267623a.*1b5c\\'")
+            ;; OSC 12 cursor query with no cursor color set falls back to the
+            ;; foreground color (xterm-style reporting) — rgb:aa/bb/cc was
+            ;; seeded by the OSC 10 set above.
+            '("\e]12;?\e\\" :equal
+              "1b5d31323b7267623a616161612f626262622f636363631b5c")
+            ;; OSC 12 set (no reply), then a query that must see it.
+            '("\e]12;rgb:11/22/33\e\\" :none)
+            '("\e]12;?\e\\" :equal
+              "1b5d31323b7267623a313131312f323232322f333333331b5c")
+            ;; Kitty OSC 21 cursor query while the cursor color is set uses
+            ;; the 8-bit rgb form: \e]21;cursor=rgb:11/22/33 ST.
+            '("\e]21;cursor=?\e\\" :equal
+              "1b5d32313b637572736f723d7267623a31312f32322f33331b5c")
+            ;; OSC 112 resets the cursor color (no reply)...
+            '("\e]112\e\\" :none)
+            ;; ...after which OSC 12 falls back to the foreground again and
+            ;; the Kitty query reports an empty value: \e]21;cursor= ST.
+            '("\e]12;?\e\\" :equal
+              "1b5d31323b7267623a616161612f626262622f636363631b5c")
+            '("\e]21;cursor=?\e\\" :equal "1b5d32313b637572736f723d1b5c")
+            ;; Kitty OSC 21 foreground query: \e]21;foreground=rgb:aa/bb/cc ST.
+            '("\e]21;foreground=?\e\\" :equal
+              "1b5d32313b666f726567726f756e643d7267623a61612f62622f63631b5c"))))
       (cl-labels ((run-probe (payloads)
                     (ghostel-test--with-exec-buffer
                         (buf proc python


### PR DESCRIPTION
Bumps the ghostty pin from `c41c6b81a` to `11b9a6ef1`, picking up native OSC/Kitty color-query replies in libghostty-vt ([ghostty#13239](https://github.com/ghostty-org/ghostty/pull/13239)) and deleting ghostel's hand-rolled replies in `src/handler.zig` — the standard stream handler now answers queries itself through the same `write_pty` effect, so keeping both would double-reply.

## What this gains

- **OSC 12** cursor-color queries (xterm-style fallback to foreground when unset) — previously dropped
- **Kitty OSC 21** color-protocol queries — previously unanswered
- Reply batching: a multi-query OSC now produces one PTY write
- Upstream fix for an OSC-parser leak of color request lists
- Terminal hardening/perf in the bump range (all in `src/terminal/`): scroll-region fast paths, explicit page-ownership tracking on PageList nodes, bitmap-allocator chunk sizing and zero-capacity growth fixes, free-listed page memory returned to the OS

## Changes

- `build.zig.zon`: pin bump
- `src/handler.zig`: remove the `.color_operation` arm and the OSC 4/10/11 reply helpers (−103 lines); the action now falls through to the standard handler
- `test/ghostel-osc-test.el`: extend `ghostel-test-osc-color-query` with OSC 12 (fallback, set/query, OSC 112 reset) and Kitty OSC 21 cases (set value, empty-value reply for unset keys, foreground query); existing OSC 4/10/11 expectations pass unchanged — the wire format is identical, and the `:equal` cases guard against double replies

## Verification

- `make -j8 all`, `make test-zig`, `make test-native` all green
- Live session smoke test: OSC 11 answered exactly once; OSC 12 and Kitty 21 answered with theme colors; `seq 1 50000` flood renders with zero scrollback breaks (structural check over the whole buffer) — exercising the upstream PageList/scroll-region rewrites