### PR TITLE
Redraw rows from dirty terminal pages

### DIFF
--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -185,10 +185,16 @@ pub fn redraw(self: *Self, env: emacs.Env, force_full: bool) !void {
     try self.renderCursor(env);
 
     self.active_pin.* = screen.pages.getTopLeft(.active);
+    clearPageDirtyFlags(self.active_pin.node);
     self.rows_in_buffer = if (screen.no_scrollback)
         screen.pages.rows
     else
         screen.pages.total_rows;
+}
+
+fn clearPageDirtyFlags(from_node: *gt.PageList.List.Node) void {
+    var node: ?*gt.PageList.List.Node = from_node;
+    while (node) |n| : (node = n.next) n.data.dirty = false;
 }
 
 fn invalidate(self: *Self, env: emacs.Env) !void {
@@ -906,13 +912,12 @@ fn render(
 ) !void {
     const term = self.term;
 
-    var page = if (term.screens.active.no_scrollback)
+    var materialized_page = if (term.screens.active.no_scrollback)
         null
     else
         try self.getOrAddPage(start_pin.node.serial);
 
     var eob = false;
-    var dirty_page: ?*gt.Page = null;
     var current_span: ?struct {
         start_val: emacs.Value,
         node: *const gt.PageList.List.Node,
@@ -924,19 +929,14 @@ fn render(
         const row = row_pin.rowAndCell().row;
         eob = eob or env.isNotNil(env.f("eobp", .{}));
 
-        if (page) |p| {
+        if (materialized_page) |p| {
             if (p.serial != row_pin.node.serial) {
-                page = p.next() orelse try self.addPage(row_pin.node.serial);
-                std.debug.assert(page != null);
-                std.debug.assert(page.?.serial == row_pin.node.serial);
+                materialized_page = p.next() orelse try self.addPage(row_pin.node.serial);
+                std.debug.assert(materialized_page != null);
+                std.debug.assert(materialized_page.?.serial == row_pin.node.serial);
             }
         }
 
-        const terminal_page = &row_pin.node.data;
-        const page_completed = if (dirty_page) |dirty|
-            dirty != terminal_page
-        else
-            false;
         const clean = !eob and !self.isRowDirty(row_pin);
         if (current_span) |*span| {
             if (clean or span.node != row_pin.node) {
@@ -945,11 +945,6 @@ fn render(
                 current_span = null;
             }
         }
-        if (page_completed) {
-            dirty_page.?.dirty = false;
-            dirty_page = null;
-        }
-        if (terminal_page.dirty) dirty_page = terminal_page;
 
         const line_start_val = env.f("point", .{});
         if (!eob) _ = env.f("forward-line", .{1});
@@ -977,7 +972,7 @@ fn render(
                 current_span.?.adjusted_line_start += new_line_len;
             }
 
-            if (page) |p| {
+            if (materialized_page) |p| {
                 p.len -|= old_line_len;
                 p.len += new_line_len;
             }
@@ -990,7 +985,6 @@ fn render(
         _ = env.f("delete-region", .{ span.start_val, env.f("point", .{}) });
         try self.flushSpan(env);
     }
-    if (dirty_page) |dirty| dirty.dirty = false;
 }
 
 fn renderCursor(self: *Self, env: emacs.Env) !void {

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -905,6 +905,9 @@ fn isRowDirty(self: *Self, pin: gt.Pin) bool {
     return false;
 }
 
+/// Renders rows from `start_pin` to end into the buffer at current point.
+/// Consumes row dirty flags but not page dirty flags. The latter is the
+/// responsibility of the caller.
 fn render(
     self: *Self,
     env: emacs.Env,

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -886,7 +886,7 @@ fn isSameRow(a: gt.Pin, b: gt.Pin) bool {
 }
 
 fn isRowDirty(self: *Self, pin: gt.Pin) bool {
-    if (pin.rowAndCell().row.dirty) return true;
+    if (pin.isDirty()) return true;
 
     const cursor: ?gt.Pin = self.term.screens.active.cursor.page_pin.*;
 
@@ -912,6 +912,7 @@ fn render(
         try self.getOrAddPage(start_pin.node.serial);
 
     var eob = false;
+    var dirty_page: ?*gt.Page = null;
     var current_span: ?struct {
         start_val: emacs.Value,
         node: *const gt.PageList.List.Node,
@@ -931,6 +932,11 @@ fn render(
             }
         }
 
+        const terminal_page = &row_pin.node.data;
+        const page_completed = if (dirty_page) |dirty|
+            dirty != terminal_page
+        else
+            false;
         const clean = !eob and !self.isRowDirty(row_pin);
         if (current_span) |*span| {
             if (clean or span.node != row_pin.node) {
@@ -939,6 +945,11 @@ fn render(
                 current_span = null;
             }
         }
+        if (page_completed) {
+            dirty_page.?.dirty = false;
+            dirty_page = null;
+        }
+        if (terminal_page.dirty) dirty_page = terminal_page;
 
         const line_start_val = env.f("point", .{});
         if (!eob) _ = env.f("forward-line", .{1});
@@ -979,6 +990,7 @@ fn render(
         _ = env.f("delete-region", .{ span.start_val, env.f("point", .{}) });
         try self.flushSpan(env);
     }
+    if (dirty_page) |dirty| dirty.dirty = false;
 }
 
 fn renderCursor(self: *Self, env: emacs.Env) !void {

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -1348,6 +1348,35 @@ the sentinel."
               (should (ghostel-test--line-clean-p row)))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-full-viewport-scroll-rebuilds-page-dirty-rows ()
+  "Incremental redraw rebuilds rows moved by a full-viewport scroll."
+  :tags '(native)
+  (dolist (case '((alt-screen 1000 "\e[?1049h\e[H\e[2J")
+                 (primary 0 "")))
+    (pcase-let ((`(,screen ,scrollback ,setup) case))
+      (ert-info ((format "screen: %S" screen))
+        (let ((buf (generate-new-buffer " *ghostel-test-page-dirty-scroll*")))
+          (unwind-protect
+              (with-current-buffer buf
+                (let ((term (ghostel--new 5 40 scrollback))
+                      (inhibit-read-only t))
+                  (ghostel--write-vt term setup)
+                  (ghostel--write-vt
+                   term
+                   "row-0\r\nrow-1\r\nrow-2\r\nrow-3\r\nrow-4")
+                  (ghostel--redraw term t)
+                  (ghostel--write-vt term "\e[5;1H\r\nnew")
+                  (ghostel--redraw term)
+                  (should
+                   (equal "row-1\nrow-2\nrow-3\nrow-4\nnew\n"
+                          (buffer-substring-no-properties
+                           (point-min) (point-max))))
+                  (ghostel-test--mark-all-lines-clean)
+                  (ghostel--redraw term)
+                  (dotimes (row 5)
+                    (should (ghostel-test--line-clean-p row)))))
+            (kill-buffer buf)))))))
+
 (ert-deftest ghostel-test-incremental-redraw ()
   "Test that incremental redraw correctly updates dirty rows."
   :tags '(native)

--- a/test/hypothesis/test_render.py
+++ b/test/hypothesis/test_render.py
@@ -29,7 +29,7 @@ except ImportError as exc:  # pragma: no cover - exercised by the test runner en
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EMACS = os.environ.get("EMACS", "emacs")
 EMACSFLAGS = shlex.split(os.environ.get("EMACSFLAGS", ""))
-MAX_EXAMPLES = int(os.environ.get("GHOSTEL_HYPOTHESIS_EXAMPLES", "100"))
+MAX_EXAMPLES = int(os.environ.get("GHOSTEL_HYPOTHESIS_EXAMPLES", "1000"))
 CASE_TIMEOUT = float(os.environ.get("GHOSTEL_HYPOTHESIS_TIMEOUT", "30"))
 CASES_DIR = Path(
     os.environ.get("GHOSTEL_HYPOTHESIS_CASES_DIR", REPO_ROOT / "test/hypothesis/cases")


### PR DESCRIPTION
Honor libghostty page-level dirtiness after full-viewport row rotation, and clear it only after rendering the page. Add coverage for alternate and no-scrollback primary screens.

Currently the Copilot CLI is affected. When row rotation happens, only the last row is updated.