### PR TITLE
Fix normal-state point tracking during terminal output in evil-ghostel

### DIFF
--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -134,10 +134,16 @@ Comparable to `ghostel--cursor-pos''s row."
   (when ghostel--term-rows
     (- (line-number-at-pos (point) t) 1 (evil-ghostel--scrollback-lines))))
 
-;; Redraw: preserve Evil point/visual semantics.  ghostel repaints the
-;; viewport on each redraw without snapping point to the cursor; right
-;; for normal state.  Point follows the cursor only in insert/emacs state
-;; (where typed chars land there); visual markers are restored around it.
+(defun evil-ghostel--following-window-p ()
+  "Return non-nil when the buffer's window follows the live output.
+No window showing the buffer counts as following."
+  (let ((win (get-buffer-window (current-buffer) t)))
+    (or (null win) (ghostel--window-anchored-p win))))
+
+;; Redraw: preserve Evil point/visual semantics.  Point follows the
+;; cursor in insert/emacs state, and in normal/motion state while parked
+;; exactly at the cursor; once the user moves off it, point stays put.
+;; Visual markers are restored around the redraw.
 
 (defun evil-ghostel--around-redraw (orig-fn term &optional full)
   "Apply Evil point/visual handling around `ghostel--redraw'.
@@ -145,18 +151,29 @@ ORIG-FN is the advised function (TERM, FULL).  Skipped in alt-screen (1049)."
   (if (and evil-ghostel-mode
            (not (ghostel--mode-enabled term 1049)))
       (let* ((visual-p (eq evil-state 'visual))
+             ;; Sampled pre-render (window check included): only then does
+             ;; point == cursor mean the user has not navigated; the render
+             ;; advances the cursor and a burst un-anchors the window.
+             (tracked (and (memq evil-state '(normal motion))
+                           (eq ghostel--input-mode 'semi-char)
+                           ghostel--cursor-char-pos
+                           (= (point) ghostel--cursor-char-pos)
+                           (evil-ghostel--following-window-p)))
              (saved-vb (and visual-p (bound-and-true-p evil-visual-beginning)
                             (marker-position evil-visual-beginning)))
              (saved-ve (and visual-p (bound-and-true-p evil-visual-end)
                             (marker-position evil-visual-end))))
         (funcall orig-fn term full)
-        ;; Don't drag point to the cursor while the user reads scrollback;
-        ;; redisplay would yank the viewport back to the bottom each frame.
-        ;; (No window showing the buffer → treat as following.)
-        (when (and (memq evil-state '(insert emacs))
-                   (let ((win (get-buffer-window (current-buffer) t)))
-                     (or (null win) (ghostel--window-anchored-p win))))
-          (evil-ghostel--reset-cursor-point))
+        (cond
+         ;; Exact target; column geometry can diverge on wide glyphs.
+         (tracked
+          (when ghostel--cursor-char-pos
+            (goto-char ghostel--cursor-char-pos)))
+         ;; Don't drag point to the cursor while the user reads scrollback;
+         ;; redisplay would yank the viewport back to the bottom each frame.
+         ((and (memq evil-state '(insert emacs))
+               (evil-ghostel--following-window-p))
+          (evil-ghostel--reset-cursor-point)))
         (when visual-p
           (let ((pmax (point-max)))
             (when saved-vb

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -141,9 +141,10 @@ No window showing the buffer counts as following."
     (or (null win) (ghostel--window-anchored-p win))))
 
 ;; Redraw: preserve Evil point/visual semantics.  Point follows the
-;; cursor in insert/emacs state, and in normal/motion state while parked
-;; exactly at the cursor; once the user moves off it, point stays put.
-;; Visual markers are restored around the redraw.
+;; cursor in insert/emacs state; in normal/motion state it follows
+;; exactly while parked at the cursor, and row-wise (keeping the user's
+;; column) while elsewhere on the cursor's row.  Off that row point
+;; stays put.  Visual markers are restored around the redraw.
 
 (defun evil-ghostel--around-redraw (orig-fn term &optional full)
   "Apply Evil point/visual handling around `ghostel--redraw'.
@@ -152,13 +153,19 @@ ORIG-FN is the advised function (TERM, FULL).  Skipped in alt-screen (1049)."
            (not (ghostel--mode-enabled term 1049)))
       (let* ((visual-p (eq evil-state 'visual))
              ;; Sampled pre-render (window check included): only then does
-             ;; point == cursor mean the user has not navigated; the render
-             ;; advances the cursor and a burst un-anchors the window.
-             (tracked (and (memq evil-state '(normal motion))
-                           (eq ghostel--input-mode 'semi-char)
-                           ghostel--cursor-char-pos
-                           (= (point) ghostel--cursor-char-pos)
-                           (evil-ghostel--following-window-p)))
+             ;; point on the cursor's row mean the user has not left the
+             ;; prompt; the render advances the cursor and a burst
+             ;; un-anchors the window.
+             (on-row (and (memq evil-state '(normal motion))
+                          (eq ghostel--input-mode 'semi-char)
+                          ghostel--cursor-char-pos
+                          (= (line-beginning-position)
+                             (save-excursion
+                               (goto-char ghostel--cursor-char-pos)
+                               (line-beginning-position)))
+                          (evil-ghostel--following-window-p)))
+             (tracked (and on-row (= (point) ghostel--cursor-char-pos)))
+             (saved-col (and on-row (not tracked) (current-column)))
              (saved-vb (and visual-p (bound-and-true-p evil-visual-beginning)
                             (marker-position evil-visual-beginning)))
              (saved-ve (and visual-p (bound-and-true-p evil-visual-end)
@@ -169,6 +176,11 @@ ORIG-FN is the advised function (TERM, FULL).  Skipped in alt-screen (1049)."
          (tracked
           (when ghostel--cursor-char-pos
             (goto-char ghostel--cursor-char-pos)))
+         ;; Roamed within the cursor's row: follow the row, keep the column.
+         (saved-col
+          (when ghostel--cursor-char-pos
+            (goto-char ghostel--cursor-char-pos)
+            (move-to-column saved-col)))
          ;; Don't drag point to the cursor while the user reads scrollback;
          ;; redisplay would yank the viewport back to the bottom each frame.
          ((and (memq evil-state '(insert emacs))

--- a/test/elate/README.md
+++ b/test/elate/README.md
@@ -24,6 +24,8 @@ the parallel bash/zsh/fish/python3 sessions from the evil-ghostel rewrite
 - `matrix/boundary-<shell>-ghostel.json` — the input-region boundary suite (autosuggestion,
   right prompt, syntax-highlight tail, multi-line) on bash/zsh/fish/nu; see the boundary-suite
   section below.
+- `matrix/tracking-ghostel.json` — normal-state point tracking across streamed output
+  (#228 / #454); see the point-tracking section below.
 
 ## Running (elate 0.11.0+)
 
@@ -105,6 +107,29 @@ automated: narrow-width output wraps too, so the shell-as-oracle assertion can't
 across the soft-wrap newline; that stays covered by ERT
 (`...end-of-line-excludes-autosuggestion`, `...replace-count-excludes-soft-wraps`).
 
+## Point-tracking suite (normal state vs streamed output)
+
+The operator matrix edits at a quiet prompt and never exercises redraw-time point
+placement, so it stayed green through the #228 tracking regression.
+`matrix/tracking-ghostel.json` covers that surface directly (shell-agnostic point
+handling, driven on zsh):
+
+```sh
+elate run --keep-going --format json test/elate/matrix/tracking-ghostel.json
+```
+
+- **parked-stream / parked-burst** — point parked at the live cursor in normal state
+  must follow it across a line-at-a-time stream and across a single-frame burst (the
+  burst un-anchors the window until point snaps, so it catches post-render guard skew).
+- **roamed-burst** — point moved off the cursor (`k k k`) must stay put (#454).
+- **re-engage** — after roaming, `i` re-parks point; tracking must engage again.
+- **esc-clamp** (xfail) — an ESC processed before the RET echo renders sits at the typed
+  text's EOL; evil's normal-state EOL adjust parks point at cursor-1 and exact-position
+  tracking disengages.  Cursor-line-scope tracking would absorb this.
+
+The tracked groups send ESC only after a short idle inside a `sleep 2` prefix so it
+lands on the rendered empty line rather than in the esc-clamp condition.
+
 ## Known xfails (flagged, not fixed — confirmed live on elate 0.11.0)
 
 - **`u` (undo) on `nu` and `python3`** — `evil-ghostel-undo` sends `C-_` (readline/zle
@@ -114,6 +139,9 @@ across the soft-wrap newline; that stays covered by ERT
 - **`~` (toggle-case) on all shells** — evil-ghostel doesn't remap `~`, so vanilla Evil
   runs against the read-only `*ghostel*` render buffer and the keystroke itself signals
   `Buffer is read-only` (the op errors outright, not just "reverts on redraw").
+- **`esc-clamp` in the tracking suite** — evil's EOL adjust at the quiet prompt parks
+  point one char off the cursor, disengaging exact-position tracking (see the
+  point-tracking section).
 
 Each is marked `expect: "fail"` so a regression elsewhere still shows red and a future
 fix shows **XPASS**. Everything else passed on bash/zsh/fish/nu (incl. `a X s S p`,

--- a/test/elate/README.md
+++ b/test/elate/README.md
@@ -121,14 +121,16 @@ elate run --keep-going --format json test/elate/matrix/tracking-ghostel.json
 - **parked-stream / parked-burst** — point parked at the live cursor in normal state
   must follow it across a line-at-a-time stream and across a single-frame burst (the
   burst un-anchors the window until point snaps, so it catches post-render guard skew).
-- **roamed-burst** — point moved off the cursor (`k k k`) must stay put (#454).
+- **roamed-burst** — point moved off the cursor's row (`k k k`) must stay put (#454).
 - **re-engage** — after roaming, `i` re-parks point; tracking must engage again.
-- **esc-clamp** (xfail) — an ESC processed before the RET echo renders sits at the typed
-  text's EOL; evil's normal-state EOL adjust parks point at cursor-1 and exact-position
-  tracking disengages.  Cursor-line-scope tracking would absorb this.
+- **esc-clamp** — an ESC processed before the RET echo renders sits at the typed text's
+  EOL, where evil's normal-state EOL adjust parks point at cursor-1 on the cursor's row;
+  row-wise tracking must still carry point to the new prompt.
+- **row-roam** — `0` on the prompt row, then a background burst: point rides the
+  cursor's row at its own column, never snapped onto the cursor.
 
-The tracked groups send ESC only after a short idle inside a `sleep 2` prefix so it
-lands on the rendered empty line rather than in the esc-clamp condition.
+The parked groups send ESC only after a short idle inside a `sleep 2` prefix so it
+lands exactly on the cursor (the esc-clamp group covers the atomic RET+ESC timing).
 
 ## Known xfails (flagged, not fixed — confirmed live on elate 0.11.0)
 
@@ -139,9 +141,6 @@ lands on the rendered empty line rather than in the esc-clamp condition.
 - **`~` (toggle-case) on all shells** — evil-ghostel doesn't remap `~`, so vanilla Evil
   runs against the read-only `*ghostel*` render buffer and the keystroke itself signals
   `Buffer is read-only` (the op errors outright, not just "reverts on redraw").
-- **`esc-clamp` in the tracking suite** — evil's EOL adjust at the quiet prompt parks
-  point one char off the cursor, disengaging exact-position tracking (see the
-  point-tracking section).
 
 Each is marked `expect: "fail"` so a regression elsewhere still shows red and a future
 fix shows **XPASS**. Everything else passed on bash/zsh/fish/nu (incl. `a X s S p`,

--- a/test/elate/matrix/tracking-ghostel.json
+++ b/test/elate/matrix/tracking-ghostel.json
@@ -1,6 +1,6 @@
 {
   "name": "tracking-ghostel",
-  "comment": "Normal-state point tracking across streamed output (#228 / #454). The operator matrix never exercises redraw-time point placement, so tracking regressions stay invisible to it. Point parked at the live cursor must follow it across a line-at-a-time stream AND a single-frame burst (the burst un-anchors the window until point snaps, catching post-render guard skew); a roamed point must stay put; tracking must re-engage after roaming. Commands are prefixed with `sleep 2` and ESC is sent after a short idle so it lands on the rendered empty line: an ESC processed before the RET echo renders sits at the typed text's EOL, and evil's normal-state EOL adjust pulls point off the cursor (see the xfail esc-clamp group, which pins that residual gap). Shell-agnostic point handling, driven on zsh.",
+  "comment": "Normal-state point tracking across streamed output (#228 / #454). The operator matrix never exercises redraw-time point placement, so tracking regressions stay invisible to it. Point parked at the live cursor must follow it across a line-at-a-time stream AND a single-frame burst (the burst un-anchors the window until point snaps, catching post-render guard skew); point elsewhere on the cursor's row follows row-wise keeping its column (row-roam, esc-clamp); a roamed point off the row must stay put; tracking must re-engage after roaming. Tracked groups prefix commands with `sleep 2` and send ESC after a short idle so it lands on the rendered empty line; esc-clamp sends RET+ESC atomically so ESC sits at the typed text's EOL where evil's EOL adjust pulls point one char off the cursor. Shell-agnostic point handling, driven on zsh.",
   "session": {
     "ui": "tty",
     "size": "100x30",
@@ -61,13 +61,24 @@
     {"wait": "idle", "min_idle": 0.8, "timeout": 10.0},
     {"eval": "(unless (= (point) ghostel--cursor-char-pos) (error \"DETACHED point=%d/l%d cursor=%d/l%d\" (point) (line-number-at-pos) ghostel--cursor-char-pos (line-number-at-pos ghostel--cursor-char-pos)))"},
 
-    {"group": "esc-clamp", "comment": "atomic RET+ESC: ESC processes before the echo renders, at the typed text's EOL; evil's EOL adjust pulls point one char off the cursor and exact-position tracking disengages"},
+    {"group": "esc-clamp", "comment": "atomic RET+ESC: ESC processes before the echo renders and evil's EOL adjust parks point one char off the cursor, on its row; row-wise tracking carries it to the empty next line where the column caps to the cursor and exact tracking takes over"},
     {"keys": "i"},
     {"type": "sleep 2 && seq 1 500"},
     {"keys": "RET <escape>"},
     {"wait": "text", "pattern": "^500$", "timeout": 25.0},
     {"wait": "idle", "min_idle": 0.8, "timeout": 10.0},
-    {"eval": "(unless (= (point) ghostel--cursor-char-pos) (error \"DETACHED point=%d/l%d cursor=%d/l%d\" (point) (line-number-at-pos) ghostel--cursor-char-pos (line-number-at-pos ghostel--cursor-char-pos)))",
-     "expect": "fail", "reason": "normal-state EOL adjust at the quiet prompt parks point at cursor-1; cursor-line-scope tracking would absorb this"}
+    {"eval": "(unless (= (point) ghostel--cursor-char-pos) (error \"DETACHED point=%d/l%d cursor=%d/l%d\" (point) (line-number-at-pos) ghostel--cursor-char-pos (line-number-at-pos ghostel--cursor-char-pos)))"},
+
+    {"group": "row-roam", "comment": "0 at the prompt, then a background burst ending without newline: point rides the cursor's row at column 0, never snapped to the cursor"},
+    {"keys": "i"},
+    {"type": "{ sleep 2; seq 1 450; printf noeol; } &!"},
+    {"keys": "RET"},
+    {"wait": "idle", "min_idle": 0.3, "timeout": 3.0},
+    {"keys": "<escape> 0"},
+    {"wait": "text", "pattern": "noeol", "timeout": 25.0},
+    {"wait": "idle", "min_idle": 0.8, "timeout": 10.0},
+    {"eval": "(unless (= (line-beginning-position) (save-excursion (goto-char ghostel--cursor-char-pos) (line-beginning-position))) (error \"OFF-ROW point=%d/l%d cursor=%d/l%d\" (point) (line-number-at-pos) ghostel--cursor-char-pos (line-number-at-pos ghostel--cursor-char-pos)))"},
+    {"eval": "(unless (= 0 (current-column)) (error \"COLUMN %d\" (current-column)))"},
+    {"eval": "(when (= (point) ghostel--cursor-char-pos) (error \"SNAPPED to cursor %d\" (point)))"}
   ]
 }

--- a/test/elate/matrix/tracking-ghostel.json
+++ b/test/elate/matrix/tracking-ghostel.json
@@ -1,0 +1,73 @@
+{
+  "name": "tracking-ghostel",
+  "comment": "Normal-state point tracking across streamed output (#228 / #454). The operator matrix never exercises redraw-time point placement, so tracking regressions stay invisible to it. Point parked at the live cursor must follow it across a line-at-a-time stream AND a single-frame burst (the burst un-anchors the window until point snaps, catching post-render guard skew); a roamed point must stay put; tracking must re-engage after roaming. Commands are prefixed with `sleep 2` and ESC is sent after a short idle so it lands on the rendered empty line: an ESC processed before the RET echo renders sits at the typed text's EOL, and evil's normal-state EOL adjust pulls point off the cursor (see the xfail esc-clamp group, which pins that residual gap). Shell-agnostic point handling, driven on zsh.",
+  "session": {
+    "ui": "tty",
+    "size": "100x30",
+    "config": "minimal",
+    "eval": [
+      "(load \"/Users/daniel/.emacs.d/lib/ghostel/test/elate/lib/evil-ghostel-setup.el\")",
+      "(setq ghostel-shell \"/bin/zsh\")"
+    ]
+  },
+  "steps": [
+    {"eval": "(ghostel)"},
+    {"wait": "idle", "min_idle": 1.0, "timeout": 15.0},
+
+    {"group": "prompt", "comment": "short prompt"},
+    {"type": "PROMPT='> '; RPROMPT=''"},
+    {"keys": "RET"},
+    {"wait": "idle", "min_idle": 0.5, "timeout": 5.0},
+
+    {"group": "parked-stream", "comment": "ESC during the sleep, then a line-at-a-time stream: point rides the cursor to the new prompt"},
+    {"type": "sleep 2 && for i in {1..30}; do echo s-$i; sleep 0.05; done"},
+    {"keys": "RET"},
+    {"wait": "idle", "min_idle": 0.3, "timeout": 3.0},
+    {"keys": "<escape>"},
+    {"wait": "text", "pattern": "^s-30$", "timeout": 20.0},
+    {"wait": "idle", "min_idle": 0.8, "timeout": 10.0},
+    {"eval": "(unless (eq evil-state 'normal) (error \"STATE %s\" evil-state))"},
+    {"eval": "(unless (= (point) ghostel--cursor-char-pos) (error \"DETACHED point=%d/l%d cursor=%d/l%d\" (point) (line-number-at-pos) ghostel--cursor-char-pos (line-number-at-pos ghostel--cursor-char-pos)))"},
+
+    {"group": "parked-burst", "comment": "whole burst lands in one redraw: the window guard must not latch tracking off"},
+    {"keys": "i"},
+    {"type": "sleep 2 && seq 1 200"},
+    {"keys": "RET"},
+    {"wait": "idle", "min_idle": 0.3, "timeout": 3.0},
+    {"keys": "<escape>"},
+    {"wait": "text", "pattern": "^200$", "timeout": 25.0},
+    {"wait": "idle", "min_idle": 0.8, "timeout": 10.0},
+    {"eval": "(unless (= (point) ghostel--cursor-char-pos) (error \"DETACHED point=%d/l%d cursor=%d/l%d\" (point) (line-number-at-pos) ghostel--cursor-char-pos (line-number-at-pos ghostel--cursor-char-pos)))"},
+
+    {"group": "roamed-burst", "comment": "k k k during the sleep: point stays where the user moved, not dragged to the new prompt"},
+    {"keys": "i"},
+    {"type": "sleep 2 && seq 1 300"},
+    {"keys": "RET"},
+    {"wait": "idle", "min_idle": 0.3, "timeout": 3.0},
+    {"keys": "<escape> k k k"},
+    {"eval": "(setq eg-track--roam (point))"},
+    {"wait": "text", "pattern": "^300$", "timeout": 25.0},
+    {"wait": "idle", "min_idle": 0.8, "timeout": 10.0},
+    {"eval": "(unless (= eg-track--roam (point)) (error \"MOVED %d -> %d\" eg-track--roam (point)))"},
+    {"eval": "(when (= (point) ghostel--cursor-char-pos) (error \"DRAGGED to cursor %d\" (point)))"},
+
+    {"group": "re-engage", "comment": "insert re-parks point on the cursor; tracking must engage again after roaming"},
+    {"keys": "i"},
+    {"type": "sleep 2 && seq 1 400"},
+    {"keys": "RET"},
+    {"wait": "idle", "min_idle": 0.3, "timeout": 3.0},
+    {"keys": "<escape>"},
+    {"wait": "text", "pattern": "^400$", "timeout": 25.0},
+    {"wait": "idle", "min_idle": 0.8, "timeout": 10.0},
+    {"eval": "(unless (= (point) ghostel--cursor-char-pos) (error \"DETACHED point=%d/l%d cursor=%d/l%d\" (point) (line-number-at-pos) ghostel--cursor-char-pos (line-number-at-pos ghostel--cursor-char-pos)))"},
+
+    {"group": "esc-clamp", "comment": "atomic RET+ESC: ESC processes before the echo renders, at the typed text's EOL; evil's EOL adjust pulls point one char off the cursor and exact-position tracking disengages"},
+    {"keys": "i"},
+    {"type": "sleep 2 && seq 1 500"},
+    {"keys": "RET <escape>"},
+    {"wait": "text", "pattern": "^500$", "timeout": 25.0},
+    {"wait": "idle", "min_idle": 0.8, "timeout": 10.0},
+    {"eval": "(unless (= (point) ghostel--cursor-char-pos) (error \"DETACHED point=%d/l%d cursor=%d/l%d\" (point) (line-number-at-pos) ghostel--cursor-char-pos (line-number-at-pos ghostel--cursor-char-pos)))",
+     "expect": "fail", "reason": "normal-state EOL adjust at the quiet prompt parks point at cursor-1; cursor-line-scope tracking would absorb this"}
+  ]
+}

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -314,6 +314,26 @@ never moved (issue #228)."
    (evil-ghostel-test--streamed-output-redraw)
    (should (= (point-min) (point)))))
 
+(ert-deftest evil-ghostel-test-around-redraw-follows-cursor-row-keeps-column ()
+  "Normal-state point elsewhere on the cursor's row follows it row-wise.
+Point rides to the new cursor's row at its old column instead of
+snapping to the cursor or stranding in scrollback."
+  (evil-ghostel-test--with-evil-buffer
+   (insert "one\ntwo\n$ ")
+   (setq-local ghostel--term 'fake
+               ghostel--cursor-char-pos (point-max)
+               ghostel--cursor-pos '(2 . 2))
+   (evil-normal-state)
+   ;; Park at column 0 of the cursor's row (left of the cursor).
+   (goto-char ghostel--cursor-char-pos)
+   (move-to-column 0)
+   (evil-ghostel-test--streamed-output-redraw)
+   (should (= (line-beginning-position)
+              (save-excursion (goto-char ghostel--cursor-char-pos)
+                              (line-beginning-position))))
+   (should (= 0 (current-column)))
+   (should (/= (point) ghostel--cursor-char-pos))))
+
 (ert-deftest evil-ghostel-test-around-redraw-lets-point-follow-in-emacs ()
   "Point follows the TUI cursor in `emacs'/`insert' states."
   (evil-ghostel-test--with-evil-buffer
@@ -691,6 +711,22 @@ must not disengage tracking."
                                   (evil-ghostel-test--stream-overflow term)
                                   (should (> (count-lines (point-min) (point-max)) 5))
                                   (should (= ghostel--cursor-char-pos (point)))))
+
+(ert-deftest evil-ghostel-test-redraw-follows-cursor-row-in-scrollback ()
+  "Output that grows scrollback carries an on-row point to the new cursor row.
+Point parked on the cursor's row (but not at the cursor) keeps its
+column on the row where the cursor lands."
+  (evil-ghostel-test--with-buffer 5 40 "$ "
+                                  (evil-normal-state)
+                                  (goto-char ghostel--cursor-char-pos)
+                                  (move-to-column 0)
+                                  (evil-ghostel-test--stream-overflow term)
+                                  (should (= (line-beginning-position)
+                                             (save-excursion
+                                               (goto-char ghostel--cursor-char-pos)
+                                               (line-beginning-position))))
+                                  (should (= 0 (current-column)))
+                                  (should (/= (point) ghostel--cursor-char-pos))))
 
 (ert-deftest evil-ghostel-test-redraw-keeps-roamed-point-in-scrollback ()
   "Output that grows scrollback leaves a roamed normal-state point on its text

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -271,6 +271,49 @@ The mock erases and reinserts the same text so these tests exercise
       (evil-ghostel--around-redraw (symbol-function 'ghostel--redraw) nil))
      (should (= renderer-point (point))))))
 
+(defun evil-ghostel-test--streamed-output-redraw ()
+  "Run `evil-ghostel--around-redraw' with a mock render streaming output.
+The mock appends rows below, advances the cursor to the new prompt at
+`point-max', and leaves point untouched, like the renderer."
+  (cl-letf (((symbol-function 'ghostel--redraw)
+             (lambda (_term &optional _full)
+               (save-excursion
+                 (goto-char (point-max))
+                 (evil-ghostel-test--insert "\nout-1\nout-2\n$ "))
+               (setq ghostel--cursor-char-pos (point-max)
+                     ghostel--cursor-pos '(2 . 5))))
+            ((symbol-function 'ghostel--mode-enabled)
+             (lambda (_term _mode) nil)))
+    (evil-ghostel--around-redraw (symbol-function 'ghostel--redraw) 'fake)))
+
+(ert-deftest evil-ghostel-test-around-redraw-tracks-parked-normal-point ()
+  "Normal-state point parked at the cursor follows it across a redraw.
+Output that advances the cursor must not detach a point the user
+never moved (issue #228)."
+  (evil-ghostel-test--with-evil-buffer
+   (insert "one\ntwo\n$ ")
+   (setq-local ghostel--term 'fake
+               ghostel--cursor-char-pos (point-max)
+               ghostel--cursor-pos '(2 . 2))
+   (evil-normal-state)
+   (goto-char ghostel--cursor-char-pos)
+   (evil-ghostel-test--streamed-output-redraw)
+   (should (= ghostel--cursor-char-pos (point)))
+   (should (= 6 (line-number-at-pos)))))
+
+(ert-deftest evil-ghostel-test-around-redraw-keeps-roamed-normal-point ()
+  "Normal-state point off the cursor stays put across an output redraw
+\(issue #454)."
+  (evil-ghostel-test--with-evil-buffer
+   (insert "one\ntwo\n$ ")
+   (setq-local ghostel--term 'fake
+               ghostel--cursor-char-pos (point-max)
+               ghostel--cursor-pos '(2 . 2))
+   (evil-normal-state)
+   (goto-char (point-min))
+   (evil-ghostel-test--streamed-output-redraw)
+   (should (= (point-min) (point)))))
+
 (ert-deftest evil-ghostel-test-around-redraw-lets-point-follow-in-emacs ()
   "Point follows the TUI cursor in `emacs'/`insert' states."
   (evil-ghostel-test--with-evil-buffer
@@ -607,11 +650,10 @@ diffing — otherwise dy is wrong by the scrollback line count."
 ;; -----------------------------------------------------------------------
 
 (ert-deftest evil-ghostel-test-redraw-preserves-point-normal ()
-  "Redraws preserve point in evil normal state.
-Unlike vterm, the renderer does not snap point to the terminal cursor;
-in normal state point stays wherever the user navigated (the rewrite
-dropped the old prompt-following heuristic — only insert / emacs state
-sync point to the cursor)."
+  "Redraws preserve point in evil normal state once the user navigated.
+The renderer does not snap point to the terminal cursor; in normal
+state point stays wherever the user moved it.  Point follows the
+cursor only while parked exactly on it (and in insert / emacs state)."
   (evil-ghostel-test--with-buffer 5 40 "first\r\nsecond\r\nthird"
                                   (evil-normal-state)
                                   (save-window-excursion
@@ -626,6 +668,41 @@ sync point to the cursor)."
                                     (ghostel--redraw term t))
                                   (should (= 3 (current-column)))
                                     (should (= 1 (line-number-at-pos))))))
+
+(defun evil-ghostel-test--stream-overflow (term)
+  "Stream output through TERM that overflows a 5-row viewport, then redraw.
+The whole burst lands in a single redraw, like fast un-throttled output."
+  (ghostel--write-vt term "\r\n")
+  (dotimes (i 8)
+    (ghostel--write-vt term (format "out-%d\r\n" i)))
+  (ghostel--write-vt term "$ ")
+  (let ((inhibit-read-only t))
+    (ghostel--redraw term nil)))
+
+(ert-deftest evil-ghostel-test-redraw-tracks-cursor-when-parked ()
+  "Output that grows scrollback keeps a parked normal-state point on the cursor.
+Point must end up at the new cursor, not stranded above the new prompt
+in freshly materialized scrollback (issue #228).  The buffer stays
+displayed: the whole point is that a burst through a visible window
+must not disengage tracking."
+  (evil-ghostel-test--with-buffer 5 40 "$ "
+                                  (evil-normal-state)
+                                  (goto-char ghostel--cursor-char-pos)
+                                  (evil-ghostel-test--stream-overflow term)
+                                  (should (> (count-lines (point-min) (point-max)) 5))
+                                  (should (= ghostel--cursor-char-pos (point)))))
+
+(ert-deftest evil-ghostel-test-redraw-keeps-roamed-point-in-scrollback ()
+  "Output that grows scrollback leaves a roamed normal-state point on its text
+\(issue #454)."
+  (evil-ghostel-test--with-buffer 5 40 "alpha\r\nbeta\r\n$ "
+                                  (evil-normal-state)
+                                  (goto-char (point-min))
+                                  (move-to-column 3)
+                                  (let ((saved (point)))
+                                    (evil-ghostel-test--stream-overflow term)
+                                    (should (= saved (point)))
+                                    (should (looking-back "alp" (line-beginning-position))))))
 
 (ert-deftest evil-ghostel-test-redraw-moves-point-insert ()
   "Test that redraws move point to terminal cursor in insert state."


### PR DESCRIPTION
## Problem

#228 regressed (reported in the [latest comment](https://github.com/dakra/ghostel/issues/228#issuecomment-4948443235)): in evil normal state, point parked at the prompt stopped following the live cursor during output and stranded in scrollback.

Regression chain:
1. `6a96954` fixed #228 with a `last-cursor-line` heuristic in the redraw advice.
2. `a6c0500` (command-remap rewrite) dropped it; tracking fell to the core anchor, which over-tracked and caused #454.
3. `0a539fb` (#454 fix) added the anchor veto comparing `(point)` against `ghostel--cursor-char-pos` — but *after* the render, when the cursor has already advanced while point stayed at its old text position. During streaming output the comparison always differs, the anchor is permanently vetoed, and point strands.

## Fix

**Commit 1 — parked tracking.** Sample the parked check pre-render in `evil-ghostel--around-redraw`, where point and `ghostel--cursor-char-pos` are still same-frame values (no skew). While parked, snap point to the new cursor with `goto-char ghostel--cursor-char-pos` (exact by construction; column geometry can diverge on wide glyphs). The window-anchored guard is sampled pre-render too — a multi-line burst un-anchors the window until point snaps, which otherwise latches tracking off. Point moved off the cursor still stays put, and the veto keeps the viewport from being yanked back (#454 contract).

**Commit 2 — row-wise tracking.** Point elsewhere on the cursor's *row* (most commonly evil's EOL adjust parking point at cursor−1 after a keypress at a quiet prompt) follows row-wise: it rides to the new cursor's row and keeps its column. This closes the async-output gap (background jobs / agents streaming without a fresh RET) and matches the "prompt line" behavior discussed in #228.

## Tests

- ERT: mock + native regression tests for parked / row-roamed / off-row point across scrollback-growing redraws (the originals were deleted in the rewrite; the streaming case had no coverage).
- New elate scenario `test/elate/matrix/tracking-ghostel.json` (7 groups: parked stream/burst, roamed, re-engage, esc-clamp, row-roam) — the operator matrix never exercises redraw-time point placement, which is why it stayed green through the regression. Verified red on the pre-fix code (3 groups fail) and fully green with both commits.
- Live-verified under elate (zsh): slow streams, single-frame 200-line bursts, background-job bursts, insert-state control, roaming control.
- `make -j8 all` green.
