### PR TITLE
ghostel-kitty: ensure scale of kitty images to avoid cropping

### DIFF
--- a/lisp/ghostel-kitty.el
+++ b/lisp/ghostel-kitty.el
@@ -189,6 +189,7 @@ user shouldn't have to trigger one)."
                  (img (create-image data (if is-png 'png 'pbm) t
                                     :width (* g-cols cw)
                                     :height (* g-rows ch)
+                                    :scale 1
                                     :ascent 'center))
                  (skip (max 0 abs-row))
                  (start-row (max 0 (- abs-row)))
@@ -267,6 +268,7 @@ DATA is a unibyte string (PNG or PPM).  IS-PNG is non-nil for PNG."
             (setq img (create-image data (if is-png 'png 'pbm) t
                                     :width (* grid-cols cw)
                                     :height (* grid-rows ch)
+                                    :scale 1
                                     :ascent 'center))
             ;; Second pass: apply per-row slices on placeholder regions.
             ;; Walks line by line — `line-end-position' is O(1) with no


### PR DESCRIPTION
Emacs tries to match the height of kitty images to the surrounding text is scale isn't set due to `create-image`:

> create-image is an autoloaded native-comp-function in ‘image.el’.
> ...
> If the property ‘:scale’ is not given and the display has a high
> resolution (more exactly, when the average width of a character
> in the default font is more than 10 pixels), the image is
> automatically scaled up in proportion to the default font.

without the patch:
<img width="1101" height="373" alt="image" src="https://github.com/user-attachments/assets/78fb834c-8d2e-4f92-95e4-974a0d349e69" />

with the patch:
<img width="1103" height="542" alt="image" src="https://github.com/user-attachments/assets/64f095b3-5542-4a6f-acf6-ca12346acac2" />

this is using ghostel v0.43.0 on windows.