### PR TITLE
Shield ghostel buffers from global default-text-properties

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -5018,6 +5018,10 @@ for both native and Emacs PTY paths."
   (setq-local truncate-lines t)
   (setq-local scroll-conservatively 101)
   (setq-local line-spacing 0)
+  ;; Shield row geometry from a global `default-text-properties':
+  ;; `line-spacing'/`line-height' properties supplied through its fallback
+  ;; inflate rendered rows invisibly to the `window-screen-lines' sizing math.
+  (setq-local default-text-properties nil)
   (setq-local filter-buffer-substring-function #'ghostel--filter-buffer-substring)
   ;; expose cwd to buffer-menu/ibuffer
   (setq-local list-buffers-directory (expand-file-name default-directory))

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -16,6 +16,25 @@
     (should (member 'ghostel-default
                     (cdr (assq 'default face-remapping-alist))))))
 
+(ert-deftest ghostel-test-mode-shields-default-text-properties ()
+  "A global `default-text-properties' does not reach ghostel buffers.
+Its `line-spacing'/`line-height' fallback would inflate rendered rows
+invisibly to the grid sizing math (discussion #534)."
+  (let ((old (default-value 'default-text-properties)))
+    (unwind-protect
+        (progn
+          (setq-default default-text-properties
+                        '(line-spacing 0.1 line-height 1.05))
+          (with-temp-buffer
+            (ghostel-mode)
+            (should (local-variable-p 'default-text-properties))
+            (should (null default-text-properties))
+            (let ((inhibit-read-only t))
+              (insert "x\n"))
+            (should (null (get-char-property (point-min) 'line-spacing)))
+            (should (null (get-char-property (point-min) 'line-height)))))
+      (setq-default default-text-properties old))))
+
 (ert-deftest ghostel-test-emacs-mode-preserves-point ()
   "In Emacs mode, point stays put while the terminal keeps running.
 The delayed redraw path always preserves point in Emacs mode,


### PR DESCRIPTION
Setting line geometry through `default-text-properties`, e.g.

```elisp
(setq default-text-properties '(line-spacing 0.1 line-height 1.05))
```

inflates every rendered row via the text-property fallback, but those properties are invisible to `window-screen-lines`/`default-line-height` (Emacs' `default_line_pixel_height` deliberately ignores line-height properties). The grid is therefore sized for more rows than fit the window body, and the bottom anchor vscrolls the top rows out of view — reported in discussion #534 ("vscrolls up, hiding the first two lines").

Unlike the `line-spacing` *variable* (already pinned to 0 in `ghostel-mode`), this mechanism can't be tolerated by better sizing math: no supported metric exposes property-driven row heights, and measuring rendered pixels would diverge from the unit the standard `window-adjust-process-window-size` path uses, reintroducing the #192 dual-authority resize problem.

Fix: set `default-text-properties` buffer-locally to `nil` in the `ghostel-mode` body, next to the existing `line-spacing` override. The user's global value stays untouched for all other buffers.

Verified live (GUI Emacs, reporter's exact config): unpatched, rows render 15 px while all metrics report 14 px → 3 px vscroll and two hidden rows; patched, a fresh terminal renders 14 px rows, zero vscroll, all rows visible with the prompt bottom-aligned, and re-setting the global while the terminal runs cannot re-poison it. Includes a regression test asserting the buffer-local shield.