### PR TITLE
Require exactly Zig 0.15.2 to build the native module

### DIFF
--- a/README.org
+++ b/README.org
@@ -155,7 +155,8 @@ binaries are available for:
 - =aarch64-windows=
 
 If you prefer to build from source or need a different platform, you will also
-need [[https://ziglang.org/][Zig]] 0.15.2 - see [[#building-from-source][Building from source]].
+need *exactly* [[https://ziglang.org/][Zig]] 0.15.2 - older or newer Zig versions will not build.  See
+[[#building-from-source][Building from source]].
 
 * Installation
 :properties:
@@ -263,6 +264,9 @@ window resizing for Windows-to-TRAMP terminals is not currently supported.
 Building is only needed if you do not want the pre-built binaries.  Ghostel
 vendors a generated =vendor/emacs-module.h=, so normal builds do not require
 local Emacs headers.
+
+Building requires *exactly* [[https://ziglang.org/][Zig]] 0.15.2 - older or newer Zig versions will not build.
+Check your installed version with =zig version=.
 
 #+begin_src sh
 git clone https://github.com/dakra/ghostel.git

--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,13 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const module_version = @import("src/version.zig").version;
+
+// Keep in sync with build.zig.zon (minimum_zig_version) and the CI workflows.
+const required_zig = std.SemanticVersion{ .major = 0, .minor = 15, .patch = 2 };
+comptime {
+    if (builtin.zig_version.order(required_zig) != .eq)
+        @compileError("ghostel requires exactly Zig 0.15.2, found " ++ builtin.zig_version_string);
+}
 
 const vendored_emacs_module_dir = "vendor";
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
     .name = .ghostel,
     .version = "0.44.0",
+    .minimum_zig_version = "0.15.2",
     .paths = .{""},
     .fingerprint = 0x5a44bdd1198a0f4b,
     .dependencies = .{

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -73,10 +73,10 @@
 ;;
 ;; Native module:
 ;;
-;;   A pre-built binary is downloaded automatically on first use.  To
-;;   build from source instead (requires Zig 0.15.2+), run zig build --prefix .
-;;   from the project root, or M-x ghostel-module-compile.  M-x
-;;   ghostel-download-module re-fetches the pre-built binary.
+;;   A pre-built binary is downloaded automatically on first use.
+;;   To build from source instead (requires exactly Zig 0.15.2), run
+;;   zig build --prefix . from the project root, or M-x ghostel-module-compile.
+;;   M-x ghostel-download-module re-fetches the pre-built binary.
 ;;
 ;; See also: evil-ghostel.el (evil-mode integration), ghostel-compile.el
 ;; (TTY-backed M-x compile replacement), ghostel-eshell.el (eshell


### PR DESCRIPTION
Several users hit opaque Zig compiler errors when building the native module with a Zig version other than 0.15.2. Nothing enforced or clearly stated the exact-version requirement.

- `build.zig.zon`: add `minimum_zig_version = "0.15.2"` so older Zig gets a clean official error before the build script even compiles.
- `build.zig`: add a file-scope comptime guard that fails any other version (including newer Zig) with `ghostel requires exactly Zig 0.15.2, found <version>`. The message also surfaces in `M-x ghostel-module-compile`'s `*compilation*` buffer and the auto-install `*ghostel-build*` log, since both just run `zig build`.
- README.org: state the exact version requirement in the requirements section and at the top of Building from source.
- `ghostel.el`: fix the commentary that said "Zig 0.15.2+".

Verified: `make -j8 all` passes with Zig 0.15.2; pinning the guard to 0.15.3 reproduces the mismatch and shows the error in both the `*compilation*` buffer and the auto-install warning path in a live Emacs session.