### PR TITLE
Never scroll the live cursor out of view when anchoring

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2378,9 +2378,9 @@ Most keys are sent to the terminal; keys in
       ;; Snap the window to the live viewport so the user lands back at the
       ;; prompt after exiting copy/emacs/line.  FORCE so a deliberate switch
       ;; wins over any `ghostel-inhibit-anchor-functions' roaming veto.
+      (goto-char (point-max))
       (ghostel--anchor-window nil t)
       (setq ghostel--force-next-redraw t)
-      (goto-char (point-max))
       (ghostel--invalidate))))
 
 (defun ghostel-char-mode ()
@@ -2409,9 +2409,9 @@ Even keys listed in `ghostel-keymap-exceptions' (\\`C-c', \\`C-x',
     (ghostel--mode-line-refresh)
     (when ghostel--term
       ;; FORCE: a deliberate switch wins over any roaming veto.
+      (goto-char (point-max))
       (ghostel--anchor-window nil t)
       (setq ghostel--force-next-redraw t)
-      (goto-char (point-max))
       (ghostel--invalidate))
     (message "Char mode (%s to exit)"
              (substitute-command-keys
@@ -4637,17 +4637,29 @@ WINDOW follows the output when the lines from its `window-start' to
 `point-max' fit within its body, measured from BODY-PIXEL-HEIGHT (default
 `window-body-height' in pixels, excluding the mode-line and header-line to
 match the terminal grid), plus one line of tolerance for the partial top
-line the graphical anchor leaves via `window-vscroll'."
+line the graphical anchor leaves via `window-vscroll'.
+
+A cursor-clamped anchor (see `ghostel--anchor-window') can start above
+that geometric bound; WINDOW also counts as anchored while its
+`window-start' sits exactly on the live cursor's line."
   (with-current-buffer (window-buffer window)
-    (when-let* (((derived-mode-p 'ghostel-mode))
-                ((not (eq ghostel--input-mode 'emacs)))
-                (dlh (with-selected-window window (default-line-height)))
-                (body-pixel-height (or body-pixel-height
-                                       (window-body-height window t)))
-                (screen-lines (/ (float body-pixel-height) (float dlh)))
-                (ws (window-start window))
-                (ws-lines-to-end (count-lines ws (point-max))))
-      (<= ws-lines-to-end (1+ (floor screen-lines))))))
+    (when (and (derived-mode-p 'ghostel-mode)
+               (not (eq ghostel--input-mode 'emacs)))
+      (or (and ghostel--cursor-char-pos
+               (not (eq ghostel--input-mode 'line))
+               (eql (window-start window)
+                    (save-excursion
+                      (goto-char ghostel--cursor-char-pos)
+                      (line-beginning-position))))
+          (when-let* ((dlh (with-selected-window window
+                             (default-line-height)))
+                      (body-pixel-height (or body-pixel-height
+                                             (window-body-height window t)))
+                      (screen-lines (/ (float body-pixel-height)
+                                       (float dlh)))
+                      (ws (window-start window))
+                      (ws-lines-to-end (count-lines ws (point-max))))
+            (<= ws-lines-to-end (1+ (floor screen-lines))))))))
 
 (defun ghostel--anchored-windows (&optional buffer all-frames)
   "Return anchored Ghostel windows.
@@ -4708,6 +4720,12 @@ In text frames, use line-count geometry with no vscroll.
 Do nothing unless WINDOW displays a live Ghostel terminal.
 A `ghostel-inhibit-anchor-functions' hook can veto anchoring a window.
 
+The live cursor is never scrolled out of view: when bottom-aligning
+`point-max' would push the cursor's line above `window-start' (a shrunken
+window over a mostly-empty grid), the anchor starts at the cursor's line
+instead.  `ghostel--window-anchored-p' recognizes such a clamped window
+as still following the output.
+
 Copy mode is never anchored (the viewport is frozen).  Emacs mode is
 anchored only when FORCE is non-nil, reserved for deliberate anchors such
 as paste/yank that should scroll to the live cursor even in Emacs mode;
@@ -4729,24 +4747,38 @@ user's point, since its input region is user-owned."
                             'ghostel-inhibit-anchor-functions window force))))))
     (with-selected-window window
       (with-current-buffer buffer
-        (let ((target (point-max))
-              ;; Line mode's input region is user-owned; keep point instead of
-              ;; snapping it to the terminal cursor.
-              (orig (point)))
-          (if-let* ((anchor (and (display-graphic-p (window-frame window))
-                                 ghostel--pixel-anchor-supported-p
-                                 (ghostel--pixel-anchor window target))))
-              (progn
-                (set-window-start window (car anchor))
-                (ghostel--set-window-vscroll window (cdr anchor) t t))
-            (let ((lines (window-screen-lines)))
-              (goto-char target)
-              (forward-line (- (floor lines)))
-              (set-window-start window (point))
-              (ghostel--set-window-vscroll window 0 t t)))
+        (let* ((target (point-max))
+               ;; Line mode's input region is user-owned; keep point instead
+               ;; of snapping it to the terminal cursor.
+               (orig (point))
+               (cursor (and (not (eq ghostel--input-mode 'line))
+                            ghostel--cursor-char-pos))
+               (cursor-bol (and cursor
+                                (save-excursion
+                                  (goto-char cursor)
+                                  (line-beginning-position))))
+               (anchor (or (and (display-graphic-p (window-frame window))
+                                ghostel--pixel-anchor-supported-p
+                                (ghostel--pixel-anchor window target))
+                           (save-excursion
+                             (goto-char target)
+                             (forward-line
+                              (- (floor (window-screen-lines))))
+                             (cons (point) 0))))
+               (start (if (and cursor-bol (< cursor-bol (car anchor)))
+                          cursor-bol
+                        (car anchor)))
+               ;; A vscroll would partially clip the cursor's row whenever
+               ;; it is the top line; a clamped start sits on a line
+               ;; boundary anyway.
+               (vscroll (if (and cursor-bol (= cursor-bol start))
+                            0
+                          (cdr anchor))))
+          (set-window-start window start)
+          (ghostel--set-window-vscroll window vscroll t t)
           (set-window-point window (if (eq ghostel--input-mode 'line)
                                        orig
-                                     (or ghostel--cursor-char-pos target))))))))
+                                     (or cursor target))))))))
 
 (defun ghostel--maybe-defer-redraw (buffer)
   "Defer BUFFER's redraw if a `ghostel-inhibit-redraw-functions' hook asks.

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -1140,34 +1140,119 @@ so copy/Emacs mode entry runs without a live terminal or window."
                         (buffer-local-value 'isearch-mode-end-hook buf))))
       (kill-buffer buf))))
 
+(defmacro ghostel-test--with-anchor-window-buffer (&rest body)
+  "Run BODY in the selected window showing a fresh ghostel buffer.
+The buffer holds more rows than fit in the window, so a bottom-aligned
+anchor starts well below the first lines.  BODY runs with `buf' bound to
+the buffer, which is in the default semi-char mode."
+  (declare (indent 0) (debug t))
+  `(let ((buf (generate-new-buffer " *ghostel-test-anchor-window*"))
+         (previous-buffer (window-buffer (selected-window))))
+     (unwind-protect
+         (progn
+           (set-window-buffer (selected-window) buf)
+           (with-current-buffer buf
+             (ghostel-mode)
+             (let ((rows (max 1 (window-body-height))))
+               (ghostel-test--with-rendered-output
+                 (dotimes (i (+ rows 20))
+                   (insert (format "row-%02d\n" i)))))
+             ,@body))
+       (set-window-buffer (selected-window) previous-buffer)
+       (kill-buffer buf))))
+
 (ert-deftest ghostel-test-anchor-window-emacs-mode-force ()
   "`ghostel--anchor-window' anchors an Emacs-mode window only when FORCE is set.
 Auto-follow callers leave FORCE nil, so a buffer reading its scrollback in
 Emacs mode keeps its position.  Deliberate callers (paste/yank) pass FORCE to
 snap to the live cursor."
-  (let ((buf (generate-new-buffer " *ghostel-test-anchor-force*"))
-        (previous-buffer (window-buffer (selected-window))))
-    (unwind-protect
-        (progn
-          (set-window-buffer (selected-window) buf)
-          (with-current-buffer buf
-            (ghostel-mode)
-            (let ((rows (max 1 (window-body-height))))
-              (ghostel-test--with-rendered-output
-                (dotimes (i (+ rows 20))
-                  (insert (format "row-%02d\n" i)))))
-            (setq ghostel--input-mode 'emacs)
-            (setq ghostel--cursor-char-pos (point-max))
-            (goto-char (point-min))
-            (set-window-start (selected-window) (point-min) t)
-            ;; Without FORCE: Emacs mode keeps its reading position.
-            (ghostel--anchor-window (selected-window))
-            (should (= (window-start (selected-window)) (point-min)))
-            ;; With FORCE: a deliberate anchor scrolls to the live cursor.
-            (ghostel--anchor-window (selected-window) t)
-            (should (> (window-start (selected-window)) (point-min)))))
-      (set-window-buffer (selected-window) previous-buffer)
-      (kill-buffer buf))))
+  (ghostel-test--with-anchor-window-buffer
+    (setq ghostel--input-mode 'emacs)
+    (setq ghostel--cursor-char-pos (point-max))
+    (goto-char (point-min))
+    (set-window-start (selected-window) (point-min) t)
+    ;; Without FORCE: Emacs mode keeps its reading position.
+    (ghostel--anchor-window (selected-window))
+    (should (= (window-start (selected-window)) (point-min)))
+    ;; With FORCE: a deliberate anchor scrolls to the live cursor.
+    (ghostel--anchor-window (selected-window) t)
+    (should (> (window-start (selected-window)) (point-min)))))
+
+(defun ghostel-test--line-3-pos ()
+  "Return a position a few characters into the buffer's third line."
+  (save-excursion
+    (goto-char (point-min))
+    (forward-line 2)
+    (forward-char 3)
+    (point)))
+
+(ert-deftest ghostel-test-anchor-window-clamps-to-cursor ()
+  "An anchor never scrolls the live cursor above `window-start'.
+When bottom-aligning `point-max' would push the cursor's line out of
+view, the anchor starts at the cursor's line."
+  (ghostel-test--with-anchor-window-buffer
+    (let ((window (selected-window)))
+      (setq ghostel--cursor-char-pos (ghostel-test--line-3-pos))
+      (ghostel--anchor-window window)
+      (let ((bol (save-excursion
+                   (goto-char ghostel--cursor-char-pos)
+                   (line-beginning-position))))
+        (should (= (window-start window) bol))
+        (should (= (window-point window) ghostel--cursor-char-pos))))))
+
+(ert-deftest ghostel-test-anchor-window-clamp-noop-at-bottom ()
+  "With the cursor at `point-max' the clamp does not fire.
+The anchor bottom-aligns as for any full grid."
+  (ghostel-test--with-anchor-window-buffer
+    (let ((window (selected-window)))
+      (setq ghostel--cursor-char-pos (point-max))
+      (ghostel--anchor-window window)
+      ;; The exact start position is line-count geometry, which only the
+      ;; text-frame branch uses; graphical frames bottom-align by pixel.
+      (unless (display-graphic-p)
+        (let ((expected (save-excursion
+                          (goto-char (point-max))
+                          (forward-line (- (floor (window-screen-lines))))
+                          (point))))
+          (should (= (window-start window) expected))))
+      (should (= (window-point window) (point-max))))))
+
+(ert-deftest ghostel-test-anchor-window-nil-cursor ()
+  "A nil `ghostel--cursor-char-pos' falls back to `point-max'."
+  (ghostel-test--with-anchor-window-buffer
+    (let ((window (selected-window)))
+      (setq ghostel--cursor-char-pos nil)
+      (ghostel--anchor-window window)
+      (should (= (window-point window) (point-max))))))
+
+(ert-deftest ghostel-test-anchored-p-recognizes-clamped-anchor ()
+  "A clamped anchor still counts as anchored until the user scrolls away.
+A `window-start' on the live cursor's line satisfies
+`ghostel--window-anchored-p' even with a BODY-PIXEL-HEIGHT the geometric
+test would reject, and stops matching once `window-start' moves."
+  (ghostel-test--with-anchor-window-buffer
+    (let ((window (selected-window)))
+      (setq ghostel--cursor-char-pos (ghostel-test--line-3-pos))
+      (ghostel--anchor-window window)
+      (should (ghostel--window-anchored-p window))
+      (should (ghostel--window-anchored-p
+               window (with-selected-window window (default-line-height))))
+      (set-window-start window (point-min))
+      (should-not (ghostel--window-anchored-p window)))))
+
+(ert-deftest ghostel-test-auto-leave-noop-after-clamped-anchor ()
+  "A clamped anchor keeps point on the cursor, so auto-leave stays put.
+With the window too short for the grid, point still equals
+`ghostel--cursor-char-pos' after the anchor, and the minibuffer-exit
+check keeps semi-char mode."
+  (ghostel-test--with-anchor-window-buffer
+    (let ((window (selected-window))
+          (ghostel-point-leave-input-mode 'copy))
+      (setq ghostel--term 'fake)
+      (setq ghostel--cursor-char-pos (ghostel-test--line-3-pos))
+      (ghostel--anchor-window window)
+      (ghostel-maybe-leave-input)
+      (should (eq ghostel--input-mode 'semi-char)))))
 
 (ert-deftest ghostel-test-mode-commands-reject-non-ghostel-buffer ()
   "Input-mode commands signal `user-error' outside ghostel buffers.


### PR DESCRIPTION
## Problem

On a fresh terminal (cursor near the top, trailing blank grid rows), any window-shrinking minibuffer (vertico/fido `M-x`, `find-file`, `read-string`, …) misbehaved twice:

- While the minibuffer was open, the window scrolled to the blank tail of the grid, hiding the prompt and recent output.
- On exit, the buffer spuriously flipped into copy mode; the "Copy mode" message stomped the echo area (masking e.g. the major-mode guard error from f00d735) and the next keystroke was swallowed by the exit binding.

Root cause: `ghostel--adjust-size` defers the terminal resize during a minibuffer but still re-anchors. Bottom-aligning `point-max` in the shrunken window pushed the cursor row above `window-start`; redisplay then clamped window-point off the cursor — a pure point move no marker can track — and the deferred minibuffer-exit check misread it as user navigation.

## Fix

Fix the anchor rather than the check (redisplay's clamp is indistinguishable from a user jump):

- **`ghostel--anchor-window`** computes one `(START . VSCROLL)` from the pixel (GUI) or line-count (TTY) path, clamps `START` to the live cursor's line, and zeroes the vscroll whenever the cursor sits on the top line. One-directional: a byte-for-byte no-op whenever the cursor is at or below the bottom-aligned start (normal streaming, TUIs, filled scrollback).
- **`ghostel--window-anchored-p`** also counts a window as anchored when `window-start` sits exactly on the (capped) cursor's line, so a clamped window keeps auto-following. Stateless — recomputed from live data on every call, nothing to record or go stale.
- **`ghostel-semi-char-mode` / `ghostel-char-mode`** run `goto-char` before the forced anchor, so the anchor's point placement (the live cursor) wins and exiting copy mode cannot leave point off the cursor.
- **`ghostel-maybe-leave-input`** compares point against the capped cursor position, so a stale cursor beyond `point-max` cannot fake a jump.

Deliberate navigation (e.g. `goto-char` after `read-string`, leaving isearch away from the prompt) still enters copy mode; line mode and the `ghostel-inhibit-anchor-functions` veto (evil-ghostel) are untouched.

## Tests

Five new tests in `test/ghostel-modes-test.el` (clamp, no-op at bottom, nil/stale cursor, anchored-p recognition, end-to-end no-flip regression), sharing a fixture macro the existing force-anchor test was ported onto.

## Verification

- `make -j8 all` green; evil-ghostel 124/124.
- Live matrix (GUI + terminal Emacs, fido-vertical): `M-x text-mode` shows the guard error with no copy flip; `M-x ignore` stays semi-char with the prompt visible and `window-vscroll` 0 while the minibuffer is open; copy-mode exit lands point on the cursor; filled-scrollback, isearch, and auto-follow paths unchanged.
- Negative control: the same live harness against pre-fix HEAD reproduces the flip in both the pixel and line-count anchor paths.