### PR TITLE
Guard the native PTY kill-buffer hook against a dead or nil process

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4422,11 +4422,12 @@ writes a final exit status before closing it."
 (defun ghostel--kill-native-process-hook ()
   "Detach the native event pipe and request child termination.
 Run from `kill-buffer-hook' in native PTY buffers."
-  ;; Do not let `kill-buffer' delete the pipe early.  Keep the
-  ;; pipe alive until the native reaper reports that the child
-  ;; exited, matching Emacs process lifetime semantics.
-  (set-process-buffer ghostel--process nil)
-  (ghostel--kill-native-process ghostel--term))
+  (when (process-live-p ghostel--process)
+    ;; Do not let `kill-buffer' delete the pipe early.  Keep the
+    ;; pipe alive until the native reaper reports that the child
+    ;; exited, matching Emacs process lifetime semantics.
+    (set-process-buffer ghostel--process nil)
+    (ghostel--kill-native-process ghostel--term)))
 
 (defun ghostel--start-process ()
   "Start the configured shell with a PTY.


### PR DESCRIPTION
## Problem

`ghostel--kill-native-process-hook` is added to `kill-buffer-hook` once, when the native PTY pipe is
spawned (`lisp/ghostel.el:4390`), and is never removed. So `kill-buffer` still runs it in states where
the native child is already gone:

- the pipe sentinel has already torn things down — `[Process exited]` left the buffer alive because
  `ghostel-kill-buffer-on-exit` is nil, or
- the buffer was reinitialized.

In both states `ghostel--process` is nil or a dead pipe, so the hook's unconditional
`(set-process-buffer ghostel--process nil)` signalled `(wrong-type-argument processp nil)`. Any
`kill-buffer` on such a buffer hit it; it shows up most readily when a command kills a group of buffers
at once — e.g. a `tab-bar-tab-pre-close-functions` hook that kills the buffers of the tab being closed.

## Fix

Guard the reap on `(process-live-p ghostel--process)`:

- Only a live pipe needs detaching and child termination. When the pipe is nil or dead the child is
  already gone, so there is nothing to reap.
- The guard also keeps `kill-buffer` from signalling `(wrong-type-argument processp nil)` in that case.
