### PR TITLE
Follow live output while point rides the live edge (Emacs and line mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All notable changes to this project will be documented in this file.
   scrolling, and returning point to the cursor resumes it (`M->` in the
   read-only modes lands on the terminal cursor when the cursor sits past the
   last content, so in Emacs mode an end-of-buffer jump resumes the follow).
+- Line mode now stops following live output the moment point leaves the
+  live edge (the input region, or the end of output while a command runs)
+  instead of drifting until the reading position hits the top of the
+  window; `M->`, clicking the prompt, or typing resumes the follow.
+  This applies to the selected window; other windows showing the
+  terminal keep following as before.
+  While reading scrollback with pending typed input, async output no
+  longer teleports point back to the input line.
 
 ### Fixed
 - URLs and `file:line` references that the terminal wrapped across rows are now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.
   instead of keeping the terminal's. The variable is `permanent-local`, so the
   terminal's setting survived the mode switch and the joined rows were
   truncated at the window edge.
+- Emacs mode now follows live output while point sits on the terminal
+  cursor; moving point off the cursor (or activating the region) stops the
+  scrolling, and returning point to the cursor resumes it (`M->` in the
+  read-only modes lands on the terminal cursor when the cursor sits past the
+  last content, so in Emacs mode an end-of-buffer jump resumes the follow).
 
 ### Fixed
 - URLs and `file:line` references that the terminal wrapped across rows are now

--- a/README.md
+++ b/README.md
@@ -166,7 +166,9 @@ In **char mode** (`C-c M-d`), *all* keys go to the terminal. `M-RET` to exit.
 **line mode** (`C-c C-l`) is similar to `M-x shell` in that Ghostel is like a
 normal Emacs buffer and *no* key gets sent to the terminal.
 Only after you finish typing a line and press enter, the whole line
-is sent at once.
+is sent at once. The window follows live output while point is at the
+prompt (or riding the end of a running command's output) and stays put
+once you move point into the scrollback.
 
 **emacs** (`C-c C-e`) and **copy mode** (`C-c C-t`) give you normal Emacs
 navigation over the read-only terminal buffer so you can look around and copy text.

--- a/README.md
+++ b/README.md
@@ -169,11 +169,10 @@ Only after you finish typing a line and press enter, the whole line
 is sent at once.
 
 **emacs** (`C-c C-e`) and **copy mode** (`C-c C-t`) give you normal Emacs
-navigation over the read-only terminal buffer so you can look around and copy
-text. The difference between the two is that **copy mode** freezes the terminal,
-so if you have continuous output nothing "scrolls away" while you try to select
-something. **emacs mode** is *live* so new output keeps coming in while you
-scroll/select.
+navigation over the read-only terminal buffer so you can look around and copy text.
+The difference between the two is that **copy mode** freezes the terminal, so if
+you have continuous output nothing "scrolls away" while you try to select something.
+**emacs mode** is *live* so new output keeps coming in while you scroll/select.
 
 Those read-only modes have by default `ghostel-readonly-fast-exit`
 set to true, which automatically exits those modes on most keys

--- a/README.org
+++ b/README.org
@@ -570,6 +570,11 @@ new prompt-end afterwards, so async output or a fresh prompt arriving mid-edit
 does not clobber what you typed.  After =RET=, line mode stays active - the next
 prompt is found on the following redraw cycle and the input marker moves there.
 
+The window follows live output while point rides the live edge - the input
+region while composing, or the end of the output while a command runs.  Move
+point up into the scrollback and the view stays put; =M->=, clicking the
+prompt, or simply typing resumes the following.
+
 Line mode uses the terminal cursor as the input-area boundary, so REPLs without
 shell integration (=python3=, =irb=, =sqlite3=, ...) work too.  When OSC 133 prompt
 markers are present on the cursor's row, the prompt prefix is recognised and the

--- a/README.org
+++ b/README.org
@@ -435,9 +435,10 @@ etc. themselves.  =M-RET= (or =C-M-m=) is the sole escape hatch.
 Entered with =C-c C-e=.  *The terminal keeps running*, the buffer is read-only,
 and standard Emacs bindings fall through to the global map.  =isearch-forward=,
 =occur=, =M-x=, =C-SPC= + =M-w=, arrow keys, wheel scroll - all work unmodified.  The
-terminal keeps producing output and the buffer keeps growing, but your point
-stays where you navigated it (the delayed-redraw path preserves point in Emacs
-mode).
+terminal keeps producing output and the buffer keeps growing.  While point sits
+on the live terminal cursor the window follows the new output; the moment you
+navigate away (or start a selection) the following stops and point stays where
+you put it, resuming once point returns to the cursor (=M->= jumps back to it).
 
 *Typed keys do not reach the shell* - Emacs mode is a "look but don't touch"
 view.  Self-insert, =RET=, =TAB=, =DEL= fall through to the read-only buffer and
@@ -498,8 +499,9 @@ output cannot clobber the selection - the target is picked by
 - =copy= - enter copy mode.  Redraws pause; the selection is stable regardless of
   where it sits.
 - =emacs= - enter Emacs mode.  The terminal keeps streaming and the buffer becomes
-  read-only; selections wholly in scrollback survive, selections over rows the
-  live program rewrites can still be lost.
+  read-only; the window never follows live output while the region is active.
+  Selections wholly in scrollback survive, selections over rows the live
+  program rewrites can still be lost.
 - =nil= - stay in semi-char.  Same selection-survival guarantees as =emacs=, but
   =M-w= is forwarded to the shell so it cannot copy the region - pick this only if
   you copy via primary selection or the GUI menu.

--- a/lisp/ghostel-line-mode.el
+++ b/lisp/ghostel-line-mode.el
@@ -241,6 +241,19 @@ from a raw fullscreen TUI when deciding whether to enter on the alt screen."
                                    (line-beginning-position))))
     (and (text-property-not-all bol cursor 'ghostel-prompt nil) t)))
 
+(defun ghostel--line-mode-on-live-edge-p (window)
+  "Non-nil if WINDOW's point rides the live edge of its ghostel buffer.
+The live edge is the input region, the terminal cursor, or `point-max'.
+WINDOW's buffer must be current."
+  (let ((wp (window-point window)))
+    (or (and (markerp ghostel--line-input-start)
+             (marker-position ghostel--line-input-start)
+             (>= wp ghostel--line-input-start)
+             (<= wp ghostel--line-input-end))
+        (and ghostel--cursor-char-pos
+             (= wp ghostel--cursor-char-pos))
+        (= wp (point-max)))))
+
 (defun ghostel--line-mode-apply-readonly (marker-pos)
   "Mark `[point-min, MARKER-POS)' read-only with the rear-nonsticky trick.
 The non-sticky flag lands on the last protected character so
@@ -319,7 +332,8 @@ forwarding the pending input raw.
 
 Trims pure-whitespace tails past the input but preserves any
 non-blank content the renderer wrote past the prompt row (e.g. a
-status bar)."
+status bar).  Point is restored from the snapshot's offset when it
+was inside the input region, and left untouched otherwise."
   (when snapshot
     (let ((prompt-end (ghostel-input-start-point)))
       (when prompt-end
@@ -337,10 +351,11 @@ status bar)."
           (setq ghostel--line-input-end (copy-marker prompt-end t))
           (set-marker-insertion-type ghostel--line-input-end t)
           (when (and input (> (length input) 0))
-            (goto-char (marker-position ghostel--line-input-start))
-            ;; Insertion advances `ghostel--line-input-end' (insertion
-            ;; type t) so end-marker tracks the tail of the input.
-            (insert input))
+            (save-excursion
+              (goto-char (marker-position ghostel--line-input-start))
+              ;; Insertion advances `ghostel--line-input-end' (insertion
+              ;; type t) so end-marker tracks the tail of the input.
+              (insert input)))
           (let ((start-pos (marker-position ghostel--line-input-start))
                 (end-pos (marker-position ghostel--line-input-end)))
             (ghostel--line-mode-apply-readonly start-pos)
@@ -464,7 +479,10 @@ to the shell in one write.
 
 Completion runs against the editable input and follows OSC 7 / TRAMP
 directory tracking.  The terminal stays live while output streams
-around the prompt.  After RET, line mode stays active for the next
+around the prompt.  The window follows new output while point rides
+the live edge (the input region, or the end of output while a command
+runs); move point into the scrollback and the view stays put until
+point returns.  After RET, line mode stays active for the next
 prompt.
 
 On the alt screen, line mode enters at a shell prompt whose OSC 133

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1967,7 +1967,11 @@ Return non-nil if the event was encoded and sent."
   "Move to the bottom of the buffer (current viewport) in read-only mode."
   (interactive)
   (goto-char (point-max))
-  (skip-chars-backward " \t\n"))
+  (skip-chars-backward " \t\n")
+  (when (and ghostel--cursor-char-pos
+             (<= ghostel--cursor-char-pos (point-max))
+             (> ghostel--cursor-char-pos (point)))
+    (goto-char ghostel--cursor-char-pos)))
 
 ;; Let isearch treat this as the buffer-end motion command.
 (put 'ghostel-readonly-end-of-buffer 'isearch-motion
@@ -2556,14 +2560,13 @@ a non-read-only mode."
 
 (defun ghostel-emacs-mode ()
   "Toggle Emacs mode — read-only buffer with the terminal still running.
-The terminal keeps running and scrollback keeps growing.  The
-buffer is read-only, so standard Emacs commands like `isearch',
-`occur', `M-x', `C-SPC' / `M-w', and regular navigation all work
-unmodified over the entire materialised scrollback.  When already
-in Emacs mode this exits back to the previous mode (mirroring
-`ghostel-copy-mode'); otherwise exit with an explicit mode-switch
-command (`\\[ghostel-semi-char-mode]'), or \\`q'/\\`C-g'/any
-self-insert key when `ghostel-readonly-fast-exit' is non-nil."
+The terminal keeps running and scrollback keeps growing.
+The buffer is read-only, so standard Emacs commands like `isearch', `occur',
+`C-SPC' / `M-w', and regular navigation all work unmodified over the entire
+materialised scrollback.  While point sits on the live terminal cursor the
+window follows new output.
+Moving point off the cursor stops scrolling until point returns to the cursor.
+When already in Emacs mode this exits back to the previous mode."
   (interactive)
   (ghostel--ensure-ghostel-buffer)
   (if (eq ghostel--input-mode 'emacs)
@@ -4940,6 +4943,18 @@ Windows on the daemon's dummy initial frame are excluded."
      'no-minibuf all-frames)
     (nreverse windows)))
 
+(defun ghostel--window-on-cursor-p (window)
+  "Non-nil if WINDOW's point rides the live terminal cursor.
+WINDOW's buffer must be current.  Point exactly on the cursor or at
+`point-max' counts as riding, so an end-of-buffer jump resumes following.
+Content between the cursor and `point-max' (a prompt tail behind a moved-back
+readline cursor, TUI rows below the cursor) does not.  An active region counts
+as having navigated away, so a selection is never dragged by live output."
+  (and ghostel--cursor-char-pos
+       (not (and (eq window (selected-window)) (region-active-p)))
+       (or (= (window-point window) ghostel--cursor-char-pos)
+           (= (window-point window) (point-max)))))
+
 (defun ghostel--window-anchored-p (window &optional body-pixel-height)
   "Non-nil if WINDOW is scrolled to follow the live terminal output.
 WINDOW follows the output when the lines from its `window-start' to
@@ -4950,10 +4965,15 @@ line the graphical anchor leaves via `window-vscroll'.
 
 A cursor-clamped anchor (see `ghostel--anchor-window') can start above
 that geometric bound; WINDOW also counts as anchored while its
-`window-start' sits exactly on the live cursor's line."
+`window-start' sits exactly on the live cursor's line.
+In Emacs mode, WINDOW additionally follows only while its point rides
+the live terminal cursor (see `ghostel--window-on-cursor-p'); once the
+user navigates away the window stays where they put it."
   (with-current-buffer (window-buffer window)
     (when (and (derived-mode-p 'ghostel-mode)
-               (not (eq ghostel--input-mode 'emacs)))
+               ;; Emacs mode follows only while point rides the live cursor.
+               (or (not (eq ghostel--input-mode 'emacs))
+                   (ghostel--window-on-cursor-p window)))
       (or (and ghostel--cursor-char-pos
                (not (eq ghostel--input-mode 'line))
                (eql (window-start window)
@@ -5022,7 +5042,7 @@ the bottom of WINDOW."
               (start (nth 2 size)))
     (cons start (max 0 (- (nth 1 size) body-height)))))
 
-(defun ghostel--anchor-window (&optional window force)
+(defun ghostel--anchor-window (&optional window force following)
   "Scroll WINDOW so that the last row is aligned to the bottom of the window.
 In graphical frames, use Emacs's pixel layout for exact bottom alignment.
 In text frames, use line-count geometry with no vscroll.
@@ -5036,18 +5056,21 @@ instead.  `ghostel--window-anchored-p' recognizes such a clamped window
 as still following the output.
 
 Copy mode is never anchored (the viewport is frozen).  Emacs mode is
-anchored only when FORCE is non-nil, reserved for deliberate anchors such
-as paste/yank that should scroll to the live cursor even in Emacs mode;
-auto-follow callers leave FORCE nil so a buffer reading its scrollback in
-Emacs mode keeps its position.  Semi-char/char always anchor and snap
-point to the live cursor; line mode anchors the viewport but keeps the
-user's point, since its input region is user-owned."
+anchored while WINDOW's point rides the live cursor, when
+FOLLOWING is non-nil (a caller that established that before a render
+moved the cursor), or when FORCE is non-nil, reserved for deliberate
+anchors such as paste/yank that should scroll to the live cursor even in
+Emacs mode; a buffer reading its scrollback in Emacs mode keeps its
+position.  Semi-char/char always anchor and snap point to the live
+cursor; line mode anchors the viewport but keeps the user's point, since
+its input region is user-owned."
   (when-let* ((window (or window (selected-window)))
               (buffer (window-buffer window))
               ((with-current-buffer buffer
                  (and (derived-mode-p 'ghostel-mode)
                       (if (eq ghostel--input-mode 'emacs)
-                          force
+                          (or force following
+                              (ghostel--window-on-cursor-p window))
                         (ghostel--terminal-live-p))
                       ;; Per-window veto: a consumer (e.g. evil-ghostel) can
                       ;; keep point roaming off the live cursor while the
@@ -5143,7 +5166,10 @@ them during synchronized output or when BUFFER has no render window."
               (setq ghostel--pending-redraw nil
                     ghostel--force-next-redraw nil))
             (ghostel--apply-cursor-style)
-            (dolist (win anchored) (ghostel--anchor-window win))
+            ;; FOLLOWING=t: the render advanced the cursor while preserving
+            ;; window-point, so the pre-render snapshot carries the Emacs-mode
+            ;; follow decision.
+            (dolist (win anchored) (ghostel--anchor-window win nil t))
             (let ((line-restored
                    (and line-snapshot
                         (ghostel--line-mode-restore line-snapshot))))

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4945,15 +4945,28 @@ Windows on the daemon's dummy initial frame are excluded."
 
 (defun ghostel--window-on-cursor-p (window)
   "Non-nil if WINDOW's point rides the live terminal cursor.
-WINDOW's buffer must be current.  Point exactly on the cursor or at
-`point-max' counts as riding, so an end-of-buffer jump resumes following.
-Content between the cursor and `point-max' (a prompt tail behind a moved-back
-readline cursor, TUI rows below the cursor) does not.  An active region counts
-as having navigated away, so a selection is never dragged by live output."
+WINDOW's buffer must be current.  Riding means point exactly on the cursor or
+at `point-max'; positions between the two do not count.  An active region vetoes
+the ride, except in a non-selected window showing the selected window's buffer."
   (and ghostel--cursor-char-pos
-       (not (and (eq window (selected-window)) (region-active-p)))
+       (not (and (region-active-p)
+                 (or (eq window (selected-window))
+                     (not (eq (window-buffer (selected-window))
+                              (current-buffer))))))
        (or (= (window-point window) ghostel--cursor-char-pos)
            (= (window-point window) (point-max)))))
+
+(defun ghostel--window-follows-p (window)
+  "Non-nil if WINDOW's point lets it follow live terminal output.
+WINDOW's buffer must be current.  Emacs mode follows on the live cursor,
+a line-mode window selected in its frame on the live edge (other windows' point
+carries no user intent); all other modes always follow."
+  (pcase ghostel--input-mode
+    ('emacs (ghostel--window-on-cursor-p window))
+    ('line (or (not (eq window (frame-selected-window
+                                (window-frame window))))
+               (ghostel--line-mode-on-live-edge-p window)))
+    (_ t)))
 
 (defun ghostel--window-anchored-p (window &optional body-pixel-height)
   "Non-nil if WINDOW is scrolled to follow the live terminal output.
@@ -4966,14 +4979,11 @@ line the graphical anchor leaves via `window-vscroll'.
 A cursor-clamped anchor (see `ghostel--anchor-window') can start above
 that geometric bound; WINDOW also counts as anchored while its
 `window-start' sits exactly on the live cursor's line.
-In Emacs mode, WINDOW additionally follows only while its point rides
-the live terminal cursor (see `ghostel--window-on-cursor-p'); once the
-user navigates away the window stays where they put it."
+WINDOW additionally follows only while `ghostel--window-follows-p'
+holds."
   (with-current-buffer (window-buffer window)
     (when (and (derived-mode-p 'ghostel-mode)
-               ;; Emacs mode follows only while point rides the live cursor.
-               (or (not (eq ghostel--input-mode 'emacs))
-                   (ghostel--window-on-cursor-p window)))
+               (ghostel--window-follows-p window))
       (or (and ghostel--cursor-char-pos
                (not (eq ghostel--input-mode 'line))
                (eql (window-start window)
@@ -5055,23 +5065,19 @@ window over a mostly-empty grid), the anchor starts at the cursor's line
 instead.  `ghostel--window-anchored-p' recognizes such a clamped window
 as still following the output.
 
-Copy mode is never anchored (the viewport is frozen).  Emacs mode is
-anchored while WINDOW's point rides the live cursor, when
-FOLLOWING is non-nil (a caller that established that before a render
-moved the cursor), or when FORCE is non-nil, reserved for deliberate
-anchors such as paste/yank that should scroll to the live cursor even in
-Emacs mode; a buffer reading its scrollback in Emacs mode keeps its
-position.  Semi-char/char always anchor and snap point to the live
-cursor; line mode anchors the viewport but keeps the user's point, since
-its input region is user-owned."
+Copy mode is never anchored (the viewport is frozen).  Otherwise
+WINDOW anchors while `ghostel--window-follows-p' holds, or when
+FOLLOWING (the caller established the follow before the render moved
+the cursor) or FORCE (deliberate anchors such as paste/yank) is
+non-nil.  Semi-char/char/Emacs snap point to the live cursor; line
+mode keeps the user's point."
   (when-let* ((window (or window (selected-window)))
               (buffer (window-buffer window))
               ((with-current-buffer buffer
                  (and (derived-mode-p 'ghostel-mode)
-                      (if (eq ghostel--input-mode 'emacs)
-                          (or force following
-                              (ghostel--window-on-cursor-p window))
-                        (ghostel--terminal-live-p))
+                      (ghostel--terminal-live-p)
+                      (or force following
+                          (ghostel--window-follows-p window))
                       ;; Per-window veto: a consumer (e.g. evil-ghostel) can
                       ;; keep point roaming off the live cursor while the
                       ;; buffer stays in a follow-capable input mode.
@@ -5178,9 +5184,9 @@ them during synchronized output or when BUFFER has no render window."
               (when (and line-snapshot (not line-restored))
                 (let ((input (plist-get line-snapshot :input)))
                   (when (and input (> (length input) 0))
-                    (ghostel--write-pty ghostel--term input))
-                  (message
-                   "ghostel: line-mode prompt lost; input forwarded raw")))
+                    (ghostel--write-pty ghostel--term input)
+                    (message
+                     "ghostel: line-mode prompt lost; input forwarded raw"))))
               (ghostel--schedule-link-detection))
             ;; Resume line mode if alt-screen just turned off, and update the
             ;; alt-screen-prev cache for the next cycle.

--- a/test/ghostel-line-mode-test.el
+++ b/test/ghostel-line-mode-test.el
@@ -1521,6 +1521,39 @@ ambiguous)."
                 (should (get-text-property (point-min) 'read-only))))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-line-mode-restore-keeps-outside-point ()
+  "`ghostel--line-mode-restore' leaves an away-point alone.
+With pending input and point parked outside the input region (reading
+scrollback), the re-insert must not drag point to the input line."
+  (let ((buf (generate-new-buffer " *ghostel-test-line-restore-away*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (ghostel-test--insert-rendered (propertize "$ " 'ghostel-prompt t))
+          (let ((ghostel--term 'fake)
+                (ghostel--process 'fake-proc))
+            (cl-letf (((symbol-function 'ghostel--alt-screen-p)
+                       (lambda (&rest _) nil))
+                      ((symbol-function 'ghostel--redraw) #'ignore)
+                      ((symbol-function 'ghostel--invalidate) #'ignore))
+              (ghostel-line-mode)
+              (insert "command")
+              ;; Point in the scrollback: the snapshot records no offset.
+              (goto-char (point-min))
+              (let ((snap (ghostel--line-mode-snapshot)))
+                (should-not (plist-get snap :point-offset))
+                (ghostel-test--with-rendered-output
+                  (erase-buffer)
+                  (insert "background line\n")
+                  (ghostel-test--insert-rendered
+                   (propertize "$ " 'ghostel-prompt t)))
+                (goto-char (point-min))
+                (let ((parked (point)))
+                  (should (ghostel--line-mode-restore snap))
+                  (should (equal (ghostel--line-mode-input-text) "command"))
+                  (should (= (point) parked)))))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-line-mode-restore-no-prompt-returns-nil ()
   "`ghostel--line-mode-restore' returns nil when the prompt cannot be found."
   (with-temp-buffer

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -125,7 +125,7 @@ nothing."
 
 (ert-deftest ghostel-test-emacs-mode-preserves-point ()
   "In Emacs mode, point stays put while the terminal keeps running.
-The delayed redraw path always preserves point in Emacs mode,
+The delayed redraw path preserves point once it has moved off the live cursor,
 unlike semi-char mode where it tracks the terminal cursor."
   :tags '(native)
   (ghostel-test--with-terminal-buffer (buf term 5 80 1000)
@@ -506,6 +506,40 @@ unlike semi-char mode where it tracks the terminal cursor."
             (goto-char (point-min))
             (ghostel-readonly-end-of-buffer)
             (should (looking-back "20" (line-beginning-position)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-readonly-end-of-buffer-lands-on-cursor ()
+  "`ghostel-readonly-end-of-buffer' lands on a cursor past the last content.
+The whitespace skip alone would stop short of a cursor sitting after
+trailing whitespace (a prompt's trailing space, the empty row below
+streaming output) — in Emacs mode that would leave the follow suspended.
+A cursor above the last content (frozen TUI) or outside a narrowed
+buffer does not pull point off the content end."
+  (let ((buf (generate-new-buffer " *ghostel-test-readonly-nav*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (ghostel-test--with-rendered-output
+            (insert "output\n$ \n"))
+          ;; Cursor after the prompt's trailing space.
+          (setq ghostel--cursor-char-pos (1- (point-max)))
+          (goto-char (point-min))
+          (ghostel-readonly-end-of-buffer)
+          (should (= (point) ghostel--cursor-char-pos))
+          ;; Cursor above the last content: land on the content end.
+          (setq ghostel--cursor-char-pos (point-min))
+          (ghostel-readonly-end-of-buffer)
+          (should (looking-back "\\$" (line-beginning-position)))
+          ;; Cursor beyond a narrowed buffer: land on the narrowed content
+          ;; end instead of clamping onto trailing whitespace.
+          (setq ghostel--cursor-char-pos (1- (point-max)))
+          (save-restriction
+            (narrow-to-region (point-min)
+                              (save-excursion
+                                (goto-char (point-min))
+                                (line-beginning-position 2)))
+            (ghostel-readonly-end-of-buffer)
+            (should (looking-back "output" (line-beginning-position)))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-input-mode-default-is-semi-char ()
@@ -1161,11 +1195,11 @@ the buffer, which is in the default semi-char mode."
        (set-window-buffer (selected-window) previous-buffer)
        (kill-buffer buf))))
 
-(ert-deftest ghostel-test-anchor-window-emacs-mode-force ()
-  "`ghostel--anchor-window' anchors an Emacs-mode window only when FORCE is set.
-Auto-follow callers leave FORCE nil, so a buffer reading its scrollback in
-Emacs mode keeps its position.  Deliberate callers (paste/yank) pass FORCE to
-snap to the live cursor."
+(ert-deftest ghostel-test-anchor-window-emacs-mode-follow-and-force ()
+  "`ghostel--anchor-window' in Emacs mode needs FORCE, or point on the cursor.
+A buffer reading its scrollback in Emacs mode keeps its position.
+Deliberate callers (paste/yank) pass FORCE to snap to the live cursor,
+and a window whose point sits on the live cursor follows without FORCE."
   (ghostel-test--with-anchor-window-buffer
     (setq ghostel--input-mode 'emacs)
     (setq ghostel--cursor-char-pos (point-max))
@@ -1176,6 +1210,11 @@ snap to the live cursor."
     (should (= (window-start (selected-window)) (point-min)))
     ;; With FORCE: a deliberate anchor scrolls to the live cursor.
     (ghostel--anchor-window (selected-window) t)
+    (should (> (window-start (selected-window)) (point-min)))
+    ;; Point on the live cursor: follows without FORCE.
+    (goto-char ghostel--cursor-char-pos)
+    (set-window-start (selected-window) (point-min) t)
+    (ghostel--anchor-window (selected-window))
     (should (> (window-start (selected-window)) (point-min)))))
 
 (defun ghostel-test--line-3-pos ()

--- a/test/ghostel-scroll-test.el
+++ b/test/ghostel-scroll-test.el
@@ -662,5 +662,151 @@ cursor and scroll to the bottom.  FORCE bypasses the veto."
       (set-window-buffer (selected-window) previous-buffer)
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-emacs-mode-follows-output-on-cursor ()
+  "Emacs mode keeps following live output while point rides the cursor.
+Two write/redraw rounds prove the follow loop self-sustains through the
+post-render anchor's point snap."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (ghostel-test-scroll--write-lines term "scroll" 80)
+    (ghostel--redraw term t)
+    (let ((win (selected-window)))
+      ;; Anchor in semi-char so window-point snaps to the live cursor,
+      ;; then enter Emacs mode with point still riding it.
+      (ghostel-test-scroll--anchor-window win)
+      (setq ghostel--input-mode 'emacs)
+      (dotimes (round 2)
+        (ghostel-test-scroll--write-lines
+         term (format "extra%d" round) 5)
+        (ghostel--redraw-now buf)
+        (should (ghostel-test-scroll--bottom-visible-p win))
+        (should (= (window-point win) ghostel--cursor-char-pos))))))
+
+(ert-deftest ghostel-test-emacs-mode-stops-following-off-cursor ()
+  "Emacs mode stops following once point leaves the live cursor."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (ghostel-test-scroll--write-lines term "scroll" 80)
+    (ghostel--redraw term t)
+    (let ((win (selected-window)))
+      (ghostel-test-scroll--anchor-window win)
+      (setq ghostel--input-mode 'emacs)
+      (let ((parked (save-excursion
+                      (goto-char ghostel--cursor-char-pos)
+                      (forward-line -3)
+                      (line-beginning-position))))
+        (set-window-point win parked)
+        (let ((start-before (window-start win)))
+          (ghostel-test-scroll--write-lines term "extra" 5)
+          (ghostel--redraw-now buf)
+          (should (= start-before (window-start win)))
+          (should (= parked (window-point win)))
+          (should-not (ghostel-test-scroll--bottom-visible-p win)))))))
+
+(ert-deftest ghostel-test-emacs-mode-resumes-following-at-end ()
+  "Emacs mode resumes following when point lands at or past the cursor.
+Jumping to `point-max' (or anywhere past the cursor) counts as riding
+the cursor, so an end-of-buffer jump resumes the follow."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (ghostel-test-scroll--write-lines term "scroll" 80)
+    (ghostel--redraw term t)
+    (let ((win (selected-window)))
+      (ghostel-test-scroll--anchor-window win)
+      (setq ghostel--input-mode 'emacs)
+      ;; Stop the follow by navigating off the cursor.
+      (ghostel-test-scroll--scroll-window-to-history win)
+      (ghostel-test-scroll--write-lines term "extra" 5)
+      (ghostel--redraw-now buf)
+      (should-not (ghostel-test-scroll--bottom-visible-p win))
+      ;; Jump to the end: the next redraw follows and snaps to the cursor.
+      (set-window-point win (point-max))
+      (ghostel--anchor-window win)
+      (ghostel-test-scroll--write-lines term "more" 5)
+      (ghostel--redraw-now buf)
+      (should (ghostel-test-scroll--bottom-visible-p win))
+      (should (= (window-point win) ghostel--cursor-char-pos)))))
+
+(ert-deftest ghostel-test-emacs-mode-follow-is-per-window ()
+  "In Emacs mode one window can follow while a peer reads scrollback."
+  :tags '(native)
+  (ghostel-test-scroll--with-anchored-and-history-windows
+   (buf term anchored history)
+   (setq ghostel--input-mode 'emacs)
+   (let ((history-start-before (window-start history))
+         (history-point-before (window-point history)))
+     (ghostel--write-vt term "extra\r\n")
+     (ghostel--redraw-now buf)
+     (should (ghostel-test-scroll--bottom-visible-p anchored))
+     (should (= (window-point anchored) ghostel--cursor-char-pos))
+     (should (= history-start-before (window-start history)))
+     (should (= history-point-before (window-point history)))
+     (should-not (ghostel-test-scroll--bottom-visible-p history)))))
+
+(ert-deftest ghostel-test-anchor-window-emacs-mode-following-arg ()
+  "FOLLOWING anchors an Emacs-mode window whose point sits at the old cursor.
+The redraw path decides \"was following\" before the native render
+advances `ghostel--cursor-char-pos' away from the preserved window-point;
+FOLLOWING carries that decision past the render.  Without FOLLOWING the
+self-check sees the stale point and declines."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (ghostel-test-scroll--write-lines term "scroll" 80)
+    (ghostel--redraw term t)
+    (let ((win (selected-window)))
+      (ghostel-test-scroll--anchor-window win)
+      (setq ghostel--input-mode 'emacs)
+      ;; Raw native render: cursor advances, window-point is preserved.
+      (ghostel-test-scroll--write-lines term "extra" 5)
+      (ghostel--redraw term t)
+      (should-not (= (window-point win) ghostel--cursor-char-pos))
+      (let ((start-before (window-start win)))
+        (ghostel--anchor-window win)
+        (should (= start-before (window-start win)))
+        (ghostel--anchor-window win nil t)
+        (should (ghostel-test-scroll--bottom-visible-p win))
+        (should (= (window-point win) ghostel--cursor-char-pos))))))
+
+(ert-deftest ghostel-test-window-on-cursor-p-riding-positions ()
+  "Point on the cursor or at `point-max' rides; between them does not.
+A region vetoes only the selected window's ride."
+  (let ((buf (generate-new-buffer " *ghostel-test-on-cursor*"))
+        (previous-buffer (window-buffer (selected-window)))
+        (orig-config (current-window-configuration)))
+    (unwind-protect
+        (progn
+          (delete-other-windows)
+          (set-window-buffer (selected-window) buf)
+          (with-current-buffer buf
+            (ghostel-mode)
+            (ghostel-test--with-rendered-output
+              (insert "out\n$ ls\n"))
+            ;; Readline cursor moved back over the typed tail "ls".
+            (setq ghostel--cursor-char-pos (- (point-max) 3))
+            (let ((win (selected-window)))
+              (set-window-point win ghostel--cursor-char-pos)
+              (should (ghostel--window-on-cursor-p win))
+              (set-window-point win (point-max))
+              (should (ghostel--window-on-cursor-p win))
+              ;; Between cursor and point-max: parked on content, no ride.
+              (set-window-point win (1- (point-max)))
+              (should-not (ghostel--window-on-cursor-p win))
+              ;; A region vetoes the selected window, not a peer window.
+              ;; Batch runs without `transient-mark-mode'; enable it so
+              ;; `region-active-p' can report the activated mark.
+              (let ((transient-mark-mode t)
+                    (w2 (split-window)))
+                (set-window-buffer w2 buf)
+                (set-window-point win ghostel--cursor-char-pos)
+                (set-window-point w2 ghostel--cursor-char-pos)
+                (push-mark (point-min) t t)
+                (should-not (ghostel--window-on-cursor-p win))
+                (should (ghostel--window-on-cursor-p w2))
+                (deactivate-mark)))))
+      (set-window-configuration orig-config)
+      (when (buffer-live-p previous-buffer)
+        (set-window-buffer (selected-window) previous-buffer))
+      (kill-buffer buf))))
+
 (provide 'ghostel-scroll-test)
 ;;; ghostel-scroll-test.el ends here

--- a/test/ghostel-scroll-test.el
+++ b/test/ghostel-scroll-test.el
@@ -769,7 +769,7 @@ self-check sees the stale point and declines."
 
 (ert-deftest ghostel-test-window-on-cursor-p-riding-positions ()
   "Point on the cursor or at `point-max' rides; between them does not.
-A region vetoes only the selected window's ride."
+A region vetoes the ride except in a peer window of the selected one."
   (let ((buf (generate-new-buffer " *ghostel-test-on-cursor*"))
         (previous-buffer (window-buffer (selected-window)))
         (orig-config (current-window-configuration)))
@@ -802,10 +802,103 @@ A region vetoes only the selected window's ride."
                 (push-mark (point-min) t t)
                 (should-not (ghostel--window-on-cursor-p win))
                 (should (ghostel--window-on-cursor-p w2))
+                ;; Selection left behind for another buffer: vetoed.
+                (set-window-buffer win previous-buffer)
+                (should-not (ghostel--window-on-cursor-p w2))
+                (set-window-buffer win buf)
                 (deactivate-mark)))))
       (set-window-configuration orig-config)
       (when (buffer-live-p previous-buffer)
         (set-window-buffer (selected-window) previous-buffer))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-line-mode-stops-following-in-scrollback ()
+  "Line mode follows while point rides the end, stops in scrollback, resumes."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (ghostel-test-scroll--write-lines term "scroll" 80)
+    (ghostel--redraw term t)
+    (let ((win (selected-window)))
+      (ghostel-test-scroll--anchor-window win)
+      (setq ghostel--input-mode 'line)
+      ;; Riding the streaming end (no input region): follows.
+      (set-window-point win (point-max))
+      (ghostel-test-scroll--write-lines term "extra" 5)
+      (ghostel--redraw-now buf)
+      (should (ghostel-test-scroll--bottom-visible-p win))
+      ;; Parked in the scrollback: redraws leave the window alone.
+      (ghostel-test-scroll--scroll-window-to-history win)
+      (let ((start-before (window-start win))
+            (point-before (window-point win)))
+        (ghostel-test-scroll--write-lines term "more" 5)
+        (ghostel--redraw-now buf)
+        (should (= start-before (window-start win)))
+        (should (= point-before (window-point win)))
+        (should-not (ghostel-test-scroll--bottom-visible-p win)))
+      ;; Back at the end: following resumes.
+      (set-window-point win (point-max))
+      (ghostel--anchor-window win)
+      (ghostel-test-scroll--write-lines term "tail" 5)
+      (ghostel--redraw-now buf)
+      (should (ghostel-test-scroll--bottom-visible-p win)))))
+
+(ert-deftest ghostel-test-line-mode-nonselected-window-follows ()
+  "A non-selected line-mode window keeps following across redraws.
+Its point carries no user intent, so the live-edge rule must not
+apply to it."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (ghostel-test-scroll--write-lines term "scroll" 80)
+    (ghostel--redraw term t)
+    (let ((win (selected-window))
+          (other (split-window)))
+      (unwind-protect
+          (progn
+            (ghostel-test-scroll--anchor-window win)
+            (setq ghostel--input-mode 'line)
+            ;; Point off the live edge, as a collapsed input region
+            ;; leaves it while a command streams.
+            (set-window-point win (window-start win))
+            (select-window other)
+            (dotimes (_ 3)
+              (ghostel-test-scroll--write-lines term "more" 5)
+              (ghostel--redraw-now buf)
+              (should (ghostel-test-scroll--bottom-visible-p win))))
+        (select-window win)
+        (delete-window other)))))
+
+(ert-deftest ghostel-test-line-mode-on-live-edge-positions ()
+  "The line-mode live edge is the input region, the cursor, or `point-max'."
+  (let ((buf (generate-new-buffer " *ghostel-test-live-edge*"))
+        (previous-buffer (window-buffer (selected-window))))
+    (unwind-protect
+        (progn
+          (set-window-buffer (selected-window) buf)
+          (with-current-buffer buf
+            (ghostel-mode)
+            (ghostel-test--with-rendered-output
+              (insert "out\n$ echo hi\n"))
+            (let* ((win (selected-window))
+                   (prompt-end (+ (point-min) 6))   ; after "out\n$ "
+                   (input-end (+ prompt-end 7)))    ; after "echo hi"
+              ;; Input region live: any position inside rides.
+              (setq ghostel--line-input-start (copy-marker prompt-end))
+              (setq ghostel--line-input-end (copy-marker input-end t))
+              (dolist (pos (list prompt-end (+ prompt-end 3) input-end))
+                (set-window-point win pos)
+                (should (ghostel--line-mode-on-live-edge-p win)))
+              (set-window-point win (point-min))
+              (should-not (ghostel--line-mode-on-live-edge-p win))
+              ;; No input region (command running): cursor or point-max.
+              (set-marker ghostel--line-input-start nil)
+              (setq ghostel--cursor-char-pos (1- (point-max)))
+              (set-window-point win ghostel--cursor-char-pos)
+              (should (ghostel--line-mode-on-live-edge-p win))
+              (set-window-point win (point-max))
+              (should (ghostel--line-mode-on-live-edge-p win))
+              (set-window-point win (point-min))
+              (should-not (ghostel--line-mode-on-live-edge-p win)))))
+      (set-window-buffer (selected-window) previous-buffer)
       (kill-buffer buf))))
 
 (provide 'ghostel-scroll-test)


### PR DESCRIPTION
Two commits: the same two-state follow rule ("follow while point rides the live edge, stop the moment it leaves") for Emacs mode and for line mode.

## Emacs mode

Emacs mode (`C-c C-e`) is read-only but live, yet the window never followed new output — entering it mid-stream froze the viewport while output piled up below the fold.

Now an Emacs-mode window scrolls with the live output for as long as its point rides the terminal cursor, matching what semi-char users see at the prompt:

- **Follows** while `window-point` sits exactly on the live cursor (or at `point-max`), indefinitely.
- **Stops** the moment point moves off the cursor — one `C-p`, an isearch, or activating the region freezes the view exactly where you are while the buffer keeps growing.
- **Resumes** when point returns to the cursor: `M->` (`ghostel-readonly-end-of-buffer`) now lands on the cursor whenever the cursor sits past the last non-whitespace character (in copy mode too), so an end-of-buffer jump picks the follow back up.

## Line mode

Line mode had the same problem in a different shape: its follow rule was purely geometric, so moving point up during streaming produced drift-then-jolt — the view kept scrolling while your line drifted toward the top, `window-start` overshot past point, redisplay snapped your line to the top row, and the follow died. Separately, with pending typed input, every redraw's restore teleported point back to the prompt while you were reading scrollback.

Now the selected line-mode window follows only while point rides the live edge:

- **Follows** while point sits in the prompt's input region (composing), or on the terminal cursor / `point-max` while a command runs; after `RET` the collapsed input region keeps the follow alive through the whole stream.
- **Stops** instantly when point leaves the live edge — no drift, no overshoot, no snap.
- **Resumes** via `M->`, clicking the prompt, or simply typing (`self-insert` snaps point into the input region).
- Windows not selected in their frame keep the old geometric rule — their `window-point` carries no user intent, so a background `make` split keeps scrolling to the bottom.
- The redraw restore no longer moves a point parked outside the input region, so async output can't yank point back to the prompt.

## Implementation notes

- The per-mode follow decision is centralized in `ghostel--window-follows-p` (Emacs → point on cursor, selected line-mode window → point on live edge, everything else → follows), used by both the pre-render window snapshot and the anchor gate.
- The follow decision is made by the pre-render snapshot in `ghostel--redraw-now` and carried past the native render via a `FOLLOWING` argument to `ghostel--anchor-window` — post-render, the cursor has already advanced away from the preserved `window-point`, so a late check would always fail. All other anchor call sites self-check at anchor time, which keeps minibuffer-driven jumps (e.g. `consult-line`) from being yanked back.
- Point parked *between* the cursor and `point-max` (prompt tail behind a moved-back readline cursor, TUI rows below the cursor) does not count as riding, so it is never stomped. An active region vetoes the follow except in a non-selected window sharing the selected window's buffer (where the anchor cannot drag the region), so a selection is never silently extended by live output — including in a window you switched away from.
- Composes with the cursor-clamp anchoring from 7aa53db.

## Verification

New ERT tests for both modes (follow self-sustains across redraws, stop/resume, riding-position semantics, per-window independence, non-selected line-mode window keeps following, restore keeps an away-point, `M->` landing incl. narrowing) plus live end-to-end sessions for each mode. The line-mode live matrix: composing at the prompt during background redraws (point and input untouched), instant stop on `C-p` mid-stream with `window-start`/`window-point` frozen while `point-max` grows, `M->` resume, post-`RET` follow through a full stream, and geometric follow of the non-selected split window — all sampled structurally, no drift/jolt/teleport observed.
