### PR TITLE
Fix module build on musl when Emacs installs /usr/include/emacs-module.h

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -36,7 +36,7 @@ pub fn build(b: *std.Build) void {
         .strip = if (is_release) true else null,
         .omit_frame_pointer = if (is_release) true else null,
     });
-    mod.addSystemIncludePath(emacs_module_dir);
+    mod.addIncludePath(emacs_module_dir);
     mod.addImport(
         "ghostty-vt",
         ghostty_dep.module("ghostty-vt"),
@@ -124,7 +124,7 @@ fn resolveEmacsModuleDir(b: *std.Build) std.Build.LazyPath {
         return .{ .cwd_relative = include_dir };
     }
 
-    return .{ .cwd_relative = vendored_emacs_module_dir };
+    return b.path(vendored_emacs_module_dir);
 }
 
 fn resolveEmacsIncludeDirFromBin(


### PR DESCRIPTION
## Problem

On musl distros with Emacs installed, `zig build` fails with the translate-c error `opaque return type 'cimport.struct_timespec' not allowed` even though the vendored `vendor/emacs-module.h` carries the musl `struct timespec` workaround (#551, reported on Gentoo musl).

## Root cause

The vendored header dir was added via `addSystemIncludePath` (`-isystem`). Zig's libc include dirs precede `-isystem` dirs on native builds, so the `emacs-module.h` that a distro Emacs installs in `/usr/include` shadowed the vendored copy — the musl workaround never ran. On glibc the shadowing is harmless, which is why only musl users hit it.

Additionally, the vendored include dir was resolved relative to the invocation CWD (`.cwd_relative`), so `zig build` from a subdirectory dropped it entirely and fell back to the system header the same way.

## Fix

- `addIncludePath` instead of `addSystemIncludePath`, so the vendored (or `EMACS_INCLUDE_DIR`-overridden) header always precedes `/usr/include`.
- Resolve the vendored dir via `b.path` (build root) instead of `.cwd_relative`.

## Verification

- Reproduced the exact error in a Gentoo stage3 musl container (upstream Zig 0.15.2) with an unpatched `emacs-module.h` in `/usr/include`; with this fix the build succeeds from both the repo root and a subdirectory and produces `ghostel-module.so`.
- `make -j8 all` passes on macOS.
- Cross-compile `-Dtarget=x86_64-linux-musl` still builds.

Fixes #551