### PR TITLE
Sanitize raw-byte kills before pasting into the terminal

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1763,10 +1763,23 @@ overlay clears the way \\`keyboard-quit' would in other buffers."
 (defvar-local ghostel--yank-index 0
   "Current kill ring index for `ghostel-yank-pop'.")
 
+(defun ghostel--decode-paste-bytes (text)
+  "Return TEXT as valid Unicode for `ghostel--encode-paste'.
+Re-decode raw byte runs as UTF-8 and replace anything still outside
+the Unicode range with U+FFFD."
+  (if (string-match-p "[^\x0-\x10ffff]" text)
+      (let ((repaired (decode-coding-string
+                       (if (multibyte-string-p text)
+                           (encode-coding-string text 'utf-8)
+                         text)
+                       'utf-8)))
+        (replace-regexp-in-string "[^\x0-\x10ffff]" (string #xFFFD) repaired))
+    text))
+
 (defun ghostel--paste-text (text)
   "Send TEXT to the terminal using the terminal paste encoder."
   (when text
-    (ghostel--encode-paste ghostel--term text)))
+    (ghostel--encode-paste ghostel--term (ghostel--decode-paste-bytes text))))
 
 (defun ghostel-paste ()
   "Paste text from the Emacs kill ring into the terminal.

--- a/test/ghostel-mouse-paste-test.el
+++ b/test/ghostel-mouse-paste-test.el
@@ -1946,5 +1946,42 @@ the command, with point staying at the region end."
         (should deactivate-mark)
         (should (= (point) end))))))
 
+(defun ghostel-test--has-raw-bytes (s)
+  "Return non-nil if S contains a char that isn't valid Unicode."
+  (cl-some (lambda (c) (> c #x10ffff)) (append s nil)))
+
+(ert-deftest ghostel-test-decode-paste-bytes-passthrough ()
+  "Clean text is returned unchanged, keeping proper multibyte chars."
+  (should (equal "plain ascii" (ghostel--decode-paste-bytes "plain ascii")))
+  (should (equal "em — dash → arrow 日本 🎉"
+                 (ghostel--decode-paste-bytes "em — dash → arrow 日本 🎉"))))
+
+(ert-deftest ghostel-test-decode-paste-bytes-repairs-eight-bit ()
+  "Undecoded UTF-8 bytes are re-decoded to proper characters.
+Covers both multibyte and unibyte carriers of the raw bytes."
+  (let ((mb (string-to-multibyte (concat "run" (unibyte-string #xe2 #x80 #x94) "x")))
+        (ub (concat "run" (unibyte-string #xe2 #x80 #x94) "x")))
+    (should (equal "run—x" (ghostel--decode-paste-bytes mb)))
+    (should (equal "run—x" (ghostel--decode-paste-bytes ub)))
+    (should-not (ghostel-test--has-raw-bytes (ghostel--decode-paste-bytes mb)))))
+
+(ert-deftest ghostel-test-decode-paste-bytes-replaces-invalid ()
+  "Bytes that aren't valid UTF-8 become U+FFFD so paste never errors."
+  (let* ((raw (string-to-multibyte (concat "a" (unibyte-string #xff) "b")))
+         (out (ghostel--decode-paste-bytes raw)))
+    (should (equal (concat "a" (string #xfffd) "b") out))
+    (should-not (ghostel-test--has-raw-bytes out))))
+
+(ert-deftest ghostel-test-paste-text-sanitizes ()
+  "`ghostel--paste-text' hands the encoder only valid Unicode."
+  (let (captured
+        (ghostel--term (vector 'fake-term)))
+    (cl-letf (((symbol-function 'ghostel--encode-paste)
+               (lambda (_term data) (setq captured data) t)))
+      (ghostel--paste-text
+       (string-to-multibyte (concat "x" (unibyte-string #xe2 #x80 #x94) "y"))))
+    (should (equal "x—y" captured))
+    (should-not (ghostel-test--has-raw-bytes captured))))
+
 (provide 'ghostel-mouse-paste-test)
 ;;; ghostel-mouse-paste-test.el ends here


### PR DESCRIPTION
## Problem

Pasting into a ghostel terminal fails with `ghostel--encode-paste: ghostel: error in ghostel--encode-paste: ExtractStringFailed` when the kill-ring text contains a raw, undecoded byte.

The native paste encoder extracts the string via the Emacs module API `copy_string_contents`, which encodes with `HANDLE-8-BIT=nil` / `HANDLE-OVER-UNI=nil` and signals `unicode-string-p` if the string contains any char that isn't a valid Unicode scalar value — an Emacs "eight-bit" raw byte (`#x3FFF80`–`#x3FFFFF`) or an over-Unicode char (`> #x10FFFF`). A normal Emacs buffer tolerates such chars; the encoder does not, so a single stray raw byte anywhere in the kill makes the whole paste throw.

This happens whenever text with undecoded UTF-8 bytes reaches the kill ring — e.g. yanking from a buffer holding a raw HTTP-response/log body, where an em-dash `E2 80 94` sits as three eight-bit chars instead of a decoded `—`.

## Fix

`ghostel--paste-text` runs the text through a new `ghostel--decode-paste-bytes` before handing it to the encoder:

- Clean text (all valid Unicode) passes through untouched.
- Byte runs that are valid UTF-8 are re-decoded to proper characters.
- Anything still outside the Unicode range becomes `U+FFFD`, so paste can never throw.

## Tests

Four ERT tests cover passthrough, eight-bit repair (multibyte and unibyte carriers), `U+FFFD` replacement of genuinely-invalid bytes, and the `ghostel--paste-text` wiring. `make -j8 all` is green.