### PR TITLE
Stop routing keys to an exited terminal in evil-ghostel

### DIFF
--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -95,21 +95,20 @@ Each iteration waits up to 50 ms, bounding the total wait at ~500 ms."
 
 ;; Guard predicates
 
-(defun evil-ghostel--active-p ()
-  "Return non-nil when evil-ghostel PTY routing should intercept.
-True in `semi-char' input mode and outside alt-screen — the only state in
-which `evil-ghostel-*' commands send PTY keys rather than running `evil-*'."
-  (and evil-ghostel-mode
-       ghostel--term
-       (not (ghostel-alt-screen-p))
-       (eq ghostel--input-mode 'semi-char)))
+(defun evil-ghostel--prompt-active-p ()
+  "Return non-nil when evil-ghostel drives the shell's line editor.
+`evil-ghostel--terminal-live-p' on the main screen (not an alt-screen TUI):
+the state in which `evil-ghostel-*' commands route keys to the PTY instead of
+running `evil-*'."
+  (and (evil-ghostel--terminal-live-p)
+       (not (ghostel-alt-screen-p))))
 
-(defun evil-ghostel--ctrl-passthrough-active-p ()
-  "Return non-nil when insert-state Ctrl keys should reach the terminal.
-Active even in alt-screen, unlike `evil-ghostel--active-p', so a TUI's
-readline-style Ctrl keys are not eaten by evil."
+(defun evil-ghostel--terminal-live-p ()
+  "Return non-nil while a live semi-char terminal can receive keys.
+Gates raw passthrough keys (Ctrl, Delete) a TUI still wants."
   (and evil-ghostel-mode
        ghostel--term
+       ghostel--process (process-live-p ghostel--process)
        (eq ghostel--input-mode 'semi-char)))
 
 (defun evil-ghostel--line-mode-active-p ()
@@ -210,7 +209,7 @@ alt-screen and when the native renderer defers synchronized output."
 A `ghostel-inhibit-anchor-functions' entry: returns non-nil in a motion-capable
 evil state with point off the cursor, unless FORCE."
   (and (not force)
-       (evil-ghostel--active-p)
+       (evil-ghostel--prompt-active-p)
        (memq evil-state '(normal visual operator motion))
        ghostel--cursor-char-pos
        (/= (point) ghostel--cursor-char-pos)))
@@ -237,7 +236,7 @@ ORIG-FN is the advised setter (STYLE, VISIBLE); deferred to in alt-screen."
 On a different row, snap point back to the cursor instead — up/down arrows
 would be read as shell history navigation."
   (when (and (derived-mode-p 'ghostel-mode)
-             (evil-ghostel--active-p))
+             (evil-ghostel--prompt-active-p))
     (let ((trow (cdr ghostel--cursor-pos))
           (erow (or (evil-ghostel--point-viewport-row) 0)))
       (if (= erow trow)
@@ -410,7 +409,7 @@ STRING through bracketed paste.  Only meaningful in `semi-char' mode."
 (evil-define-motion evil-ghostel-first-non-blank ()
   "Move to the first input character after the prompt."
   :type exclusive
-  (if (or (evil-ghostel--active-p)
+  (if (or (evil-ghostel--prompt-active-p)
           (evil-ghostel--line-mode-active-p))
       (ghostel-beginning-of-input-or-line)
     (evil-first-non-blank)))
@@ -421,7 +420,7 @@ Like `evil-end-of-line' but stops before a trailing autosuggestion,
 right-aligned prompt, or padding (ghostel paints the whole row, so vanilla
 $ would walk into non-typed cells).  Off the cursor row, unchanged."
   :type inclusive
-  (let ((input-end (and (evil-ghostel--active-p)
+  (let ((input-end (and (evil-ghostel--prompt-active-p)
                         (ghostel-point-on-cursor-row-p)
                         (evil-ghostel--input-end))))
     (evil-end-of-line count)
@@ -433,7 +432,7 @@ $ would walk into non-typed cells).  Off the cursor row, unchanged."
 (evil-define-motion evil-ghostel-next-line (count)
   "Move COUNT lines down, but not past the terminal cursor's row."
   :type line
-  (if (not (evil-ghostel--active-p))
+  (if (not (evil-ghostel--prompt-active-p))
       (evil-next-line count)
     (let ((cursor-line (and ghostel--cursor-pos
                             (save-excursion
@@ -455,7 +454,7 @@ $ would walk into non-typed cells).  Off the cursor row, unchanged."
   ;; expand/contract from reverting the jumped point.
   :type line
   :jump t
-  (if (evil-ghostel--active-p)
+  (if (evil-ghostel--prompt-active-p)
       (evil-ghostel--reset-cursor-point)
     (evil-goto-line count)))
 
@@ -466,7 +465,7 @@ $ would walk into non-typed cells).  Off the cursor row, unchanged."
   "Enter insert state at point, driving the shell cursor to match."
   (interactive)
   (cond
-   ((not (evil-ghostel--active-p))
+   ((not (evil-ghostel--prompt-active-p))
     (call-interactively #'evil-insert))
    ((not (ghostel-point-on-cursor-row-p))
     (when-let* ((target (ghostel-input-start-point)))
@@ -482,7 +481,7 @@ $ would walk into non-typed cells).  Off the cursor row, unchanged."
   "Move to the start of input on the current line, then enter insert."
   (interactive)
   (cond
-   ((evil-ghostel--active-p)
+   ((evil-ghostel--prompt-active-p)
     (when-let* ((target (ghostel-input-start-point)))
       (evil-ghostel-goto-input-position target))
     (evil-insert-state 1))
@@ -495,7 +494,7 @@ $ would walk into non-typed cells).  Off the cursor row, unchanged."
   "Append after point, driving the shell cursor to match."
   (interactive)
   (cond
-   ((not (evil-ghostel--active-p))
+   ((not (evil-ghostel--prompt-active-p))
     (call-interactively #'evil-append))
    ((not (ghostel-point-on-cursor-row-p))
     (when-let* ((target (ghostel-input-start-point)))
@@ -518,7 +517,7 @@ $ would walk into non-typed cells).  Off the cursor row, unchanged."
   "Move to the end of input on the current line, then enter insert."
   (interactive)
   (cond
-   ((evil-ghostel--active-p)
+   ((evil-ghostel--prompt-active-p)
     (when-let* ((target (evil-ghostel--input-end)))
       (evil-ghostel-goto-input-position target))
     (evil-insert-state 1))
@@ -536,7 +535,7 @@ $ would walk into non-typed cells).  Off the cursor row, unchanged."
 Ranges are limited to the current input, including per-row handling for
 block deletes.  Covers d, dd, x, and X."
   (interactive "<R><x><y>")
-  (if (not (evil-ghostel--active-p))
+  (if (not (evil-ghostel--prompt-active-p))
       (evil-delete beg end type register yank-handler)
     (let* ((clamped (evil-ghostel--clamp beg end))
            (beg (car clamped))
@@ -561,7 +560,7 @@ Covers D."
   :motion nil
   :keep-visual t
   (interactive "<R><x><y>")
-  (if (not (evil-ghostel--active-p))
+  (if (not (evil-ghostel--prompt-active-p))
       (evil-delete-line beg end type register yank-handler)
     (let* ((beg (or beg (point)))
            (end (or end beg))
@@ -603,7 +602,7 @@ PTY-routed in semi-char, else `evil-change'.  `evil-ghostel-insert'
 drives the cursor itself, so empty ranges need no extra sync.
 Covers c, cc, s."
   (interactive "<R><x><y>")
-  (if (not (evil-ghostel--active-p))
+  (if (not (evil-ghostel--prompt-active-p))
       (evil-change beg end type register yank-handler delete-func)
     (evil-ghostel-delete beg end type register yank-handler)
     (evil-ghostel-insert)))
@@ -615,7 +614,7 @@ Covers c, cc, s."
 Covers C."
   :motion evil-end-of-line-or-visual-line
   (interactive "<R><x><y>")
-  (if (not (evil-ghostel--active-p))
+  (if (not (evil-ghostel--prompt-active-p))
       (evil-change-line beg end type register yank-handler)
     (evil-ghostel-delete-line beg end type register yank-handler)
     (evil-ghostel-insert)))
@@ -653,7 +652,7 @@ clamped range and pastes the replacement so the count matches."
                      (evil-refresh-cursor)
                      (list (evil-read-key)))
                  (evil-refresh-cursor)))
-  (if (not (evil-ghostel--active-p))
+  (if (not (evil-ghostel--prompt-active-p))
       (evil-replace beg end type char)
     (when char
       (let* ((clamped (evil-ghostel--clamp beg end))
@@ -686,7 +685,7 @@ unless at end-of-input, where a right arrow would accept a suggestion."
   "Paste after the cursor via bracketed paste COUNT times from REGISTER.
 YANK-HANDLER is used by Evil outside live terminal input.  Covers p."
   (interactive "P")
-  (if (evil-ghostel--active-p)
+  (if (evil-ghostel--prompt-active-p)
       (evil-ghostel--do-paste count register t)
     (evil-paste-after count register yank-handler)))
 
@@ -694,7 +693,7 @@ YANK-HANDLER is used by Evil outside live terminal input.  Covers p."
   "Paste before the cursor via bracketed paste COUNT times from REGISTER.
 YANK-HANDLER is used by Evil outside live terminal input.  Covers P."
   (interactive "P")
-  (if (evil-ghostel--active-p)
+  (if (evil-ghostel--prompt-active-p)
       (evil-ghostel--do-paste count register nil)
     (evil-paste-before count register yank-handler)))
 
@@ -704,7 +703,7 @@ YANK-HANDLER is used by Evil outside live terminal input.  Covers P."
 (defun evil-ghostel-undo (count)
   "Send Ctrl-_ (readline undo) COUNT times.  Covers u."
   (interactive "p")
-  (if (not (evil-ghostel--active-p))
+  (if (not (evil-ghostel--prompt-active-p))
       (evil-undo count)
     (dotimes (_ (or count 1))
       (ghostel--send-encoded "_" "ctrl"))))
@@ -712,7 +711,7 @@ YANK-HANDLER is used by Evil outside live terminal input.  Covers P."
 (defun evil-ghostel-redo (count)
   "Run Evil redo COUNT times when not editing live terminal input."
   (interactive "p")
-  (if (not (evil-ghostel--active-p))
+  (if (not (evil-ghostel--prompt-active-p))
       (evil-redo count)
     (message "Redo not supported in terminal")))
 
@@ -745,7 +744,7 @@ PTY passthrough is inactive.  KEYS is a key vector."
   "Send Ctrl+KEY to the terminal PTY, else fall back to evil's binding.
 Off semi-char the local map wins first, so line mode's own \\`C-a' →
 `ghostel-beginning-of-input-or-line' beats evil's default."
-  (if (evil-ghostel--ctrl-passthrough-active-p)
+  (if (evil-ghostel--terminal-live-p)
       (ghostel--send-encoded key "ctrl")
     (evil-ghostel--fallback-key (kbd (concat "C-" key)))))
 
@@ -764,7 +763,7 @@ Off semi-char the local map wins first, so line mode's own \\`C-a' →
 Evil binds the delete key to `delete-char', which would edit buffer text
 rather than forward-delete in the shell."
   (interactive)
-  (if (evil-ghostel--ctrl-passthrough-active-p)
+  (if (evil-ghostel--terminal-live-p)
       (ghostel--send-encoded "delete" "")
     (evil-ghostel--fallback-key (kbd "<delete>"))))
 

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -23,6 +23,12 @@
   (let ((inhibit-read-only t))
     (apply #'insert args)))
 
+(defun evil-ghostel-test--live-process ()
+  "Return a live process to bind to `ghostel--process'.
+The guard predicates call `process-live-p', so a sentinel will not do; a pipe
+process is live without spawning anything.  Callers must `delete-process' it."
+  (make-pipe-process :name "evil-ghostel-test" :buffer nil :noquery t))
+
 (defmacro evil-ghostel-test--with-buffer (rows cols text &rest body)
   "Create a ghostel buffer with ROWS x COLS, feed TEXT, render, then run BODY.
 The buffer has evil-mode and evil-ghostel-mode active.
@@ -34,10 +40,12 @@ Requires the native module; without it the test is skipped
      (skip-unless (fboundp 'ghostel--new))
      (let* ((ghostel-max-scrollback 100)
             (buf (ghostel--create " *evil-ghostel-test*" nil ,rows ,cols))
-            (term (buffer-local-value 'ghostel--term buf)))
+            (term (buffer-local-value 'ghostel--term buf))
+            (proc (evil-ghostel-test--live-process)))
        (unwind-protect
 		   (with-selected-window (display-buffer buf)
 			 (with-current-buffer buf
+               (setq-local ghostel--process proc)
                (ghostel--write-vt term ,text)
                (evil-local-mode 1)
                (evil-ghostel-mode 1)
@@ -45,7 +53,8 @@ Requires the native module; without it the test is skipped
 				 (ghostel--redraw term t))
                (cl-macrolet ((insert (&rest args)
                                `(evil-ghostel-test--insert ,@args)))
-				 ,@body)))
+                 ,@body)))
+         (delete-process proc)
          (when (buffer-live-p buf)
            (kill-buffer buf))))))
 
@@ -61,11 +70,14 @@ Uses mocks for native functions."
      ;; `insert's — the scrollback-offset computation then collapses to
      ;; zero and matches pre-scrollback-fix behaviour.
      (setq-local ghostel--term-rows 100)
+     (setq-local ghostel--process (evil-ghostel-test--live-process))
      (evil-local-mode 1)
      (evil-ghostel-mode 1)
-     (cl-macrolet ((insert (&rest args)
-                     `(evil-ghostel-test--insert ,@args)))
-       ,@body)))
+     (unwind-protect
+         (cl-macrolet ((insert (&rest args)
+                         `(evil-ghostel-test--insert ,@args)))
+           ,@body)
+       (delete-process ghostel--process))))
 
 ;; -----------------------------------------------------------------------
 ;; Test: mode activation
@@ -457,7 +469,7 @@ it still snaps point to the cursor."
 
 (ert-deftest evil-ghostel-test-anchor-inhibit-predicate ()
   "`evil-ghostel--anchor-inhibit' vetoes only when roaming off the cursor.
-Fires only where evil-ghostel drives PTY input (`evil-ghostel--active-p':
+Fires only where evil-ghostel drives PTY input (`evil-ghostel--prompt-active-p':
 semi-char, outside alt-screen).  There: non-nil in a motion-capable state with
 point off the live cursor and no FORCE; nil on the cursor, under FORCE, or in
 insert state.  Inert (never vetoes) when not active, e.g. in alt-screen."
@@ -575,7 +587,7 @@ TYPE is `line' or `char'.  Reproduces #485 without `execute-kbd-macro'."
   "Regression for #485: `VG' extends the line-visual selection to the cursor.
 Pre-fix this reverted point to the start line; a linewise motion keeps it."
   (evil-ghostel-test--with-buffer 8 40 "r1\r\nr2\r\nr3\r\nr4\r\nr5\r\nr6"
-    (should (evil-ghostel--active-p))
+    (should (evil-ghostel--prompt-active-p))
     (let ((cursor-line (save-excursion
                          (evil-ghostel--reset-cursor-point)
                          (line-number-at-pos))))
@@ -606,7 +618,7 @@ This case always worked; keep it working while fixing the line-visual one."
 `evil-goto-line': honor a count, else go to the last line."
   (evil-ghostel-test--with-buffer 8 40 "r1\r\nr2\r\nr3\r\nr4\r\nr5\r\nr6"
     (setq-local ghostel--input-mode 'line)
-    (should-not (evil-ghostel--active-p))
+    (should-not (evil-ghostel--prompt-active-p))
     ;; With a count: jump to that line.
     (goto-char (point-min))
     (evil-ghostel-goto-cursor 3)
@@ -816,6 +828,46 @@ terminal cursor to point's buffer position."
                   (lambda (&rest _) (setq sync-called t))))
          (evil-ghostel-append))
        (should sync-called)))))
+
+(ert-deftest evil-ghostel-test-dead-process-falls-back-to-plain-evil ()
+  "After the child exits, evil-ghostel stops driving the terminal (issue #555).
+`evil-ghostel--terminal-live-p' and `evil-ghostel--prompt-active-p' turn off once
+the process is gone, so insert/append/ctrl keys run plain evil instead of
+encoding to the closed PTY."
+  (with-temp-buffer
+    (ghostel-mode)
+    (evil-local-mode 1)
+    (evil-ghostel-mode 1)
+    (setq-local ghostel--term t
+                ghostel--term-rows 100
+                ghostel--input-mode 'semi-char)
+    (let ((proc (evil-ghostel-test--live-process)))
+      (setq-local ghostel--process proc)
+      (cl-letf (((symbol-function 'ghostel--alt-screen-p) (lambda (&rest _) nil)))
+        ;; Live process: PTY routing is active.
+        (should (evil-ghostel--terminal-live-p))
+        (should (evil-ghostel--prompt-active-p))
+        ;; Child exits; the buffer lingers for scrollback.
+        (delete-process proc)
+        (should-not (evil-ghostel--terminal-live-p))
+        (should-not (evil-ghostel--prompt-active-p))
+        (let ((pty nil) (fell-back nil))
+          (cl-letf (((symbol-function 'ghostel--send-encoded)
+                     (lambda (&rest _) (setq pty t)))
+                    ((symbol-function 'evil-ghostel-goto-input-position)
+                     (lambda (&rest _) (setq pty t)))
+                    ((symbol-function 'evil-insert)
+                     (lambda (&rest _) (interactive) (setq fell-back t)))
+                    ((symbol-function 'evil-append)
+                     (lambda (&rest _) (interactive) (setq fell-back t)))
+                    ((symbol-function 'evil-ghostel--fallback-key)
+                     (lambda (&rest _) (setq fell-back t))))
+            (evil-ghostel-insert)
+            (evil-ghostel-append)
+            (evil-ghostel--passthrough-ctrl "a")
+            (evil-ghostel--passthrough-delete))
+          (should fell-back)
+          (should-not pty))))))
 
 (ert-deftest evil-ghostel-test-append-at-cursor-does-not-advance ()
   "Regression: `evil-ghostel-append' at the terminal cursor does not forward-char.
@@ -1051,7 +1103,8 @@ commands.  Mocks the terminal handle and viewport so the
 input-region helpers can derive prompt boundaries and viewport rows
 without a real native module."
   (declare (indent 2))
-  `(let ((buf (generate-new-buffer " *evil-ghostel-test-input*")))
+  `(let ((buf (generate-new-buffer " *evil-ghostel-test-input*"))
+         (proc (evil-ghostel-test--live-process)))
      (unwind-protect
          (with-current-buffer buf
            (ghostel-mode)
@@ -1060,6 +1113,7 @@ without a real native module."
              (insert ,input))
            (setq ghostel--term 'fake)
            (setq ghostel--term-rows 1)
+           (setq ghostel--process proc)
            (setq ghostel--cursor-char-pos (point))
            (setq ghostel--cursor-pos (cons (current-column) 0))
            (evil-local-mode 1)
@@ -1067,6 +1121,7 @@ without a real native module."
            (cl-letf (((symbol-function 'ghostel--alt-screen-p)
                       (lambda (&rest _) nil)))
              ,@body))
+       (delete-process proc)
        (kill-buffer buf))))
 
 (ert-deftest evil-ghostel-test-goto-input-position-sends-arrows-unit ()
@@ -1098,7 +1153,8 @@ with `ghostel--cursor-char-pos' at the TYPED/TRAIL boundary so TRAIL occupies
 cells to the right of the cursor.  Runs BODY with evil + `evil-ghostel-mode'
 on and the terminal mocked."
   (declare (indent 3))
-  `(let ((buf (generate-new-buffer " *evil-ghostel-test-cursor*")))
+  `(let ((buf (generate-new-buffer " *evil-ghostel-test-cursor*"))
+         (proc (evil-ghostel-test--live-process)))
      (unwind-protect
          (with-current-buffer buf
            (ghostel-mode)
@@ -1110,11 +1166,13 @@ on and the terminal mocked."
              (insert (propertize ,trail 'ghostel-input t)))
            (setq ghostel--term 'fake)
            (setq ghostel--term-rows 1)
+           (setq ghostel--process proc)
            (evil-local-mode 1)
            (evil-ghostel-mode 1)
            (cl-letf (((symbol-function 'ghostel--alt-screen-p)
                       (lambda (&rest _) nil)))
              ,@body))
+       (delete-process proc)
        (kill-buffer buf))))
 
 ;; The color-based suggestion detection (`suggestion-p'/`greyed-out-p') is not
@@ -1460,7 +1518,7 @@ live-terminal detection."
   (evil-ghostel-test--with-evil-buffer
    (setq buffer-read-only t)
    (let (pasted)
-     (cl-letf (((symbol-function 'evil-ghostel--active-p) (lambda () t))
+     (cl-letf (((symbol-function 'evil-ghostel--prompt-active-p) (lambda () t))
                ((symbol-function 'evil-ghostel--do-paste)
                 (lambda (&rest _) (setq pasted t))))
        (call-interactively #'evil-ghostel-paste-after)
@@ -1492,7 +1550,7 @@ live-terminal detection."
 
 (ert-deftest evil-ghostel-test-ctrl-passthrough-sends-in-alt-screen ()
   "Insert-state Ctrl passthrough remains active in alt-screen TUIs.
-`evil-ghostel--active-p' excludes alt-screen so normal-mode editing
+`evil-ghostel--prompt-active-p' excludes alt-screen so normal-mode editing
 falls through there, but C-u/C-w/etc. must still go to the terminal
 instead of invoking Evil's insert-state editing commands."
   (evil-ghostel-test--with-evil-buffer
@@ -1500,8 +1558,8 @@ instead of invoking Evil's insert-state editing commands."
    (setq-local ghostel--input-mode 'semi-char)
    (cl-letf (((symbol-function 'ghostel--alt-screen-p)
               (lambda (_term) t)))
-     (should-not (evil-ghostel--active-p))
-     (should (evil-ghostel--ctrl-passthrough-active-p))
+     (should-not (evil-ghostel--prompt-active-p))
+     (should (evil-ghostel--terminal-live-p))
      (let (sent)
        (cl-letf (((symbol-function 'ghostel--send-encoded)
                   (lambda (key mods &rest _)
@@ -1586,7 +1644,7 @@ become `ghostel--line-input-start' / `--line-input-end'."
   "`evil-ghostel--line-mode-active-p' is true with markers in line mode."
   (evil-ghostel-test--with-line-mode "$ echo hello" 3 13
     (should (evil-ghostel--line-mode-active-p))
-    (should-not (evil-ghostel--active-p))))
+    (should-not (evil-ghostel--prompt-active-p))))
 
 (ert-deftest evil-ghostel-test-line-mode-active-p-needs-markers ()
   "Predicate returns nil in line mode if the input markers are unset."
@@ -2142,7 +2200,7 @@ prompt."
 (ert-deftest evil-ghostel-test-next-line-falls-through-outside-semi-char ()
   "Outside semi-char `evil-ghostel-next-line' delegates to vanilla."
   (evil-ghostel-test--with-evil-buffer
-   ;; ghostel--term nil → evil-ghostel--active-p returns nil.
+   ;; ghostel--term nil → evil-ghostel--prompt-active-p returns nil.
    (let ((inhibit-read-only t))
      (insert "a\nb\nc\nd\ne\n"))
    (evil-normal-state)


### PR DESCRIPTION
## Problem

With `evil-ghostel` active and a native-pty child kept alive after exit
(`ghostel-kill-buffer-on-exit` nil), moving point away from the buffer end and
entering evil insert (`a`/`i`) raised:

```
ghostel--send-encoded: ghostel: error in ghostel--encode-key: NotOpenForWriting
```

Insert entry drives the terminal cursor to point by sending a burst of arrow
keys over the PTY; nothing on that path checked whether the child was still
alive, so once the process had exited the burst hit the closed channel. Point
at the buffer end sends no arrows, which is why the reported workaround avoided
it.

## Fix

Gate PTY routing on process liveness. `evil-ghostel--terminal-live-p` (the base
predicate) and its non-alt-screen narrowing `evil-ghostel--prompt-active-p` now
require a running `ghostel--process`. Once the child exits, the buffer's
`evil-ghostel-*` commands fall back to plain `evil-*` instead of encoding keys
to the dead terminal.

The two guard predicates are also renamed to describe their roles now that one
derives from the other: `terminal-live-p` is the base (live semi-char terminal,
any screen — gates Ctrl/Delete passthrough); `prompt-active-p` is it narrowed to
the main screen (where evil-ghostel drives the shell's line editor).

## Tests

- New regression test drives the real liveness path both ways: with a live
  process routing is on; after the process is deleted both predicates go nil and
  insert/append/Ctrl keys fall back with no PTY write.
- The shared fixtures now bind `ghostel--process` to a real (pipe) process so
  the inlined `process-live-p` check reflects a live terminal, cleaned up on
  teardown.

`make -j8 all` is green (131 evil tests, full suite + lint).

Related: #555
