### PR TITLE
Decode Windows process inputs using the ANSI code page

### DIFF
--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -13,6 +13,7 @@ const input = @import("input.zig");
 const kitty_graphics = @import("kitty_graphics.zig");
 const utils = @import("utils.zig");
 const parseHexColor = utils.parseHexColor;
+const platform = @import("platform.zig");
 const NativeProcess = @import("NativeProcess.zig");
 const ChannelFd = NativeProcess.ChannelFd;
 const ProcessParams = NativeProcess.ProcessParams;
@@ -355,9 +356,6 @@ fn terminalFinalize(ptr: ?*anyopaque) callconv(.c) void {
 }
 
 fn getProcessEnvironment(alloc: Allocator, env: emacs.Env) !std.process.EnvMap {
-    var buf: ?[]u8 = null;
-    defer if (buf) |b| alloc.free(b);
-
     var env_map = std.process.EnvMap.init(alloc);
     errdefer env_map.deinit();
 
@@ -365,7 +363,8 @@ fn getProcessEnvironment(alloc: Allocator, env: emacs.Env) !std.process.EnvMap {
     var penv = env.f("reverse", .{env.symbolValue("process-environment")});
     while (!env.isNil(penv)) : (penv = env.f("cdr", .{penv})) {
         const item = env.f("car", .{penv});
-        const str = try env.extractStringAlloc(alloc, item, &buf);
+        const str = try platform.extractProcessStringAlloc(alloc, env, item);
+        defer alloc.free(str);
         const key, const value = if (std.mem.indexOfScalar(u8, str, '=')) |pos|
             .{ str[0..pos], str[(pos + 1)..str.len] }
         else
@@ -381,7 +380,9 @@ fn getProcessEnvironment(alloc: Allocator, env: emacs.Env) !std.process.EnvMap {
     if (!display_explicit and env.isNotNil(env.f("display-graphic-p", .{}))) {
         const display = env.f("getenv", .{env.makeString("DISPLAY")});
         if (env.isNotNil(display)) {
-            try env_map.put("DISPLAY", try env.extractStringAlloc(alloc, display, &buf));
+            const value = try platform.extractProcessStringAlloc(alloc, env, display);
+            defer alloc.free(value);
+            try env_map.put("DISPLAY", value);
         }
     }
 
@@ -822,22 +823,23 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                     for (cmd.items) |item| module_alloc.free(item);
                     cmd.deinit(module_alloc);
                 }
-                var buf: ?[]u8 = null;
-                defer if (buf) |b| module_alloc.free(b);
                 while (env.isNotNil(cmd_list)) : (cmd_list = env.f("cdr", .{cmd_list})) {
                     const arg = env.f("car", .{cmd_list});
-                    try cmd.append(
+                    const arg_string = try platform.extractProcessStringAlloc(
                         module_alloc,
-                        try module_alloc.dupeZ(u8, try env.extractStringAlloc(module_alloc, arg, &buf)),
+                        env,
+                        arg,
                     );
+                    errdefer module_alloc.free(arg_string);
+                    try cmd.append(module_alloc, arg_string);
                 }
                 var process_env = try getProcessEnvironment(module_alloc, env);
                 defer process_env.deinit();
-                const cwd = try module_alloc.dupeZ(u8, try env.extractStringAlloc(
+                const cwd = try platform.extractProcessStringAlloc(
                     module_alloc,
+                    env,
                     env.f("expand-file-name", .{env.symbolValue("default-directory")}),
-                    &buf,
-                ));
+                );
                 defer module_alloc.free(cwd);
                 const pid = try term.spawnNativeProcess(
                     cmd.items,

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -523,6 +523,7 @@ const interned_symbols = [_][:0]const u8{
     "message",
     "min-width",
     "mouse-face",
+    "multibyte-string-p",
     "nil",
     "nth",
     "numberp",

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+
+const emacs = @import("emacs.zig");
+
+const windows = if (builtin.os.tag == .windows) struct {
+    const w32 = std.os.windows;
+
+    const CP_ACP: w32.UINT = 0;
+    const MB_ERR_INVALID_CHARS: w32.DWORD = 0x00000008;
+
+    extern "kernel32" fn MultiByteToWideChar(
+        code_page: w32.UINT,
+        flags: w32.DWORD,
+        input: [*]const u8,
+        input_len: c_int,
+        output: ?[*]u16,
+        output_len: c_int,
+    ) callconv(.winapi) c_int;
+
+    fn ansiToUtf8AllocZ(allocator: Allocator, bytes: []const u8) ![:0]u8 {
+        if (bytes.len == 0) return allocator.dupeZ(u8, "");
+        if (bytes.len > std.math.maxInt(c_int)) return error.StringTooLong;
+
+        const wide_len = MultiByteToWideChar(
+            CP_ACP,
+            MB_ERR_INVALID_CHARS,
+            bytes.ptr,
+            @intCast(bytes.len),
+            null,
+            0,
+        );
+        if (wide_len == 0) return error.InvalidSystemEncoding;
+
+        const wide = try allocator.alloc(u16, @intCast(wide_len));
+        defer allocator.free(wide);
+        if (MultiByteToWideChar(
+            CP_ACP,
+            MB_ERR_INVALID_CHARS,
+            bytes.ptr,
+            @intCast(bytes.len),
+            wide.ptr,
+            wide_len,
+        ) != wide_len) return error.InvalidSystemEncoding;
+
+        return std.unicode.utf16LeToUtf8AllocZ(allocator, wide);
+    }
+} else struct {};
+
+/// Extract a Lisp string for use as an operating-system process input.
+/// On Windows, unibyte strings use the system ANSI code page, while
+/// multibyte strings use the module API's UTF-8 representation.
+pub fn extractProcessStringAlloc(
+    allocator: Allocator,
+    env: emacs.Env,
+    value: emacs.Value,
+) ![:0]u8 {
+    var storage: ?[]u8 = null;
+    errdefer if (storage) |s| allocator.free(s);
+    const bytes = try env.extractStringAlloc(allocator, value, &storage);
+
+    if (builtin.os.tag == .windows) {
+        if (env.isNil(env.f("multibyte-string-p", .{value}))) {
+            const result = try windows.ansiToUtf8AllocZ(allocator, bytes);
+            allocator.free(storage.?);
+            return result;
+        }
+    }
+    return bytes;
+}

--- a/test/ghostel-native-process-test.el
+++ b/test/ghostel-native-process-test.el
@@ -36,14 +36,14 @@ returning the number of redraw invalidations requested."
       (when (buffer-live-p buffer)
         (kill-buffer buffer)))))
 
-(defun ghostel-test-native-process--env-output (env-command &optional spawn-wrapper)
-  "Spawn ENV-COMMAND through the native primitive and return its output.
-ENV-COMMAND is a command argv list.  SPAWN-WRAPPER, when non-nil, is
-called with the zero-argument spawn function and should call it under
-any dynamic bindings needed by the test."
+(defun ghostel-test-native-process--command-output (command &optional spawn-wrapper)
+  "Spawn COMMAND through the native primitive and return its output.
+COMMAND is an argv list.  SPAWN-WRAPPER, when non-nil, is called with
+and should call the zero-argument spawn function under any dynamic
+bindings needed by the test."
   (ghostel-test--with-terminal-buffer (buf _term 200 32767 2000000)
     (let ((pipe (make-pipe-process
-                 :name "ghostel-native-env-test"
+                 :name "ghostel-native-command-test"
                  :buffer (current-buffer)
                  :filter #'ghostel--events-filter
                  :noquery t))
@@ -52,7 +52,7 @@ any dynamic bindings needed by the test."
           (progn
             (let ((spawn (lambda ()
                            (setq pid (ghostel--spawn-native-process
-                                      ghostel--term env-command pipe)))))
+                                      ghostel--term command pipe)))))
               (if spawn-wrapper
                   (funcall spawn-wrapper spawn)
                 (funcall spawn)))
@@ -153,6 +153,61 @@ must not leave `ghostel--event-buf' in a poisoned state."
                     ghostel-test-native-process--events))
      (should (null ghostel--event-buf)))))
 
+(ert-deftest ghostel-test-native-process-decodes-windows-unibyte-inputs ()
+  "Native spawn decodes Windows unibyte process inputs with the ANSI code page."
+  :tags '(native windows)
+  (skip-unless (ghostel-test--windows-p))
+  (let* ((python (ghostel-test--python))
+         (acp-coding-system
+          (or (coding-system-from-name (format "cp%d" w32-ansi-code-page))
+              (ert-fail (format "No coding system for Windows code page %d"
+                                w32-ansi-code-page))))
+         (unicode-value
+          (or (cl-find-if
+               (lambda (candidate)
+                 (let ((bytes (encode-coding-string candidate acp-coding-system)))
+                   (and (not (multibyte-string-p bytes))
+                        (seq-some (lambda (char) (> char 127)) bytes)
+                        (equal candidate
+                               (decode-coding-string bytes acp-coding-system)))))
+               '("â" "Ž" "Ж" "Ω" "İ" "א" "ا" "ก" "あ" "中" "한" "€"))
+              (ert-fail (format "No non-ASCII fixture for Windows code page %d"
+                                w32-ansi-code-page))))
+         (unibyte-value
+          (encode-coding-string unicode-value acp-coding-system))
+         (unicode-directory
+          (file-name-as-directory
+           (make-temp-file
+            (expand-file-name (format "ghostel-%s-" unicode-value)
+                              temporary-file-directory)
+            t)))
+         (unibyte-directory
+          (encode-coding-string unicode-directory acp-coding-system))
+         (environment-entry (concat "GHOSTEL_ACP_TEST=" unibyte-value))
+         (script
+          (concat
+           "import os, sys\n"
+           "ok = (sys.argv[1] == sys.argv[2] and "
+           "os.environ.get('GHOSTEL_ACP_TEST') == sys.argv[2] and "
+           "os.path.normcase(os.getcwd()) == os.path.normcase(sys.argv[3]))\n"
+           "print('GHOSTEL_ACP_OK' if ok else 'GHOSTEL_ACP_BAD')\n")))
+    (unwind-protect
+        (progn
+          (let* ((process-environment
+                  (cons environment-entry
+                        (ghostel-test--base-process-environment)))
+                 (default-directory (ghostel-test--temp-directory))
+                 (text
+                  (ghostel-test-native-process--command-output
+                   (list python "-c" script unibyte-value unicode-value
+                         (directory-file-name unicode-directory))
+                   (lambda (spawn)
+                     (cl-letf (((symbol-function 'expand-file-name)
+                                (lambda (&rest _) unibyte-directory)))
+                       (funcall spawn))))))
+            (should (ghostel-test--terminal-text-line-p "GHOSTEL_ACP_OK" text))))
+      (delete-directory unicode-directory t))))
+
 (ert-deftest ghostel-test-native-process-adds-display-for-graphical-frame ()
   "Native env builder mirrors Emacs' DISPLAY fallback for graphical frames."
   :tags '(native)
@@ -161,7 +216,7 @@ must not leave `ghostel--event-buf' in a poisoned state."
     (let* ((process-environment (append '("DISPLAY_FOO=1")
                                         (ghostel-test--base-process-environment)))
            (default-directory (ghostel-test--temp-directory))
-           (text (ghostel-test-native-process--env-output
+           (text (ghostel-test-native-process--command-output
                   env-command
                   (lambda (spawn)
                     (cl-letf (((symbol-function 'display-graphic-p)
@@ -180,7 +235,7 @@ must not leave `ghostel--event-buf' in a poisoned state."
     (skip-unless (car env-command))
     (let* ((process-environment (ghostel-test--base-process-environment))
            (default-directory (ghostel-test--temp-directory))
-           (text (ghostel-test-native-process--env-output
+           (text (ghostel-test-native-process--command-output
                   env-command
                   (lambda (spawn)
                     (cl-letf (((symbol-function 'display-graphic-p)
@@ -202,7 +257,7 @@ must not leave `ghostel--event-buf' in a poisoned state."
                                           "GHOSTEL_ENV_TEST_DUP=later")
                                         (ghostel-test--base-process-environment)))
            (default-directory (ghostel-test--temp-directory))
-           (text (ghostel-test-native-process--env-output env-command)))
+           (text (ghostel-test-native-process--command-output env-command)))
       (should-not (ghostel-test--terminal-text-line-prefix-p
                    "GHOSTEL_ENV_TEST_UNSET=" text))
       (should (ghostel-test--terminal-text-line-p
@@ -218,7 +273,7 @@ must not leave `ghostel--event-buf' in a poisoned state."
     (let* ((process-environment (cons "DISPLAY"
                                       (ghostel-test--base-process-environment)))
            (default-directory (ghostel-test--temp-directory))
-           (text (ghostel-test-native-process--env-output
+           (text (ghostel-test-native-process--command-output
                   env-command
                   (lambda (spawn)
                     (cl-letf (((symbol-function 'display-graphic-p)

--- a/test/ghostel-test-helpers.el
+++ b/test/ghostel-test-helpers.el
@@ -241,7 +241,7 @@ to the lifecycle process returned by `ghostel-exec'; see
   "Cached Python 3 executable used by integration tests.")
 
 (defun ghostel-test--python ()
-  "Return a Python 3 executable, or skip the current test."
+  "Return a Python 3 executable, or fail the current test."
   (when (eq ghostel-test--python-executable :unknown)
     (setq ghostel-test--python-executable
           (cl-find-if
@@ -253,7 +253,7 @@ to the lifecycle process returned by `ghostel-exec'; see
            (list (executable-find "python3")
                  (executable-find "python")))))
   (or ghostel-test--python-executable
-      (ert-skip "Python 3 is unavailable")))
+      (ert-fail "Python 3 is unavailable")))
 
 (defun ghostel-test--fixture-directory ()
   "Return the absolute path of the test fixture directory."
@@ -477,7 +477,7 @@ runs are unaffected."
   "Return the ERT selector for pure Elisp tests on the current platform."
   (if (ghostel-test--windows-p)
       '(and (not (tag native)) (not (tag posix)))
-    '(not (tag native))))
+    '(and (not (tag native)) (not (tag windows)))))
 
 (defun ghostel-test-run-elisp ()
   "Run only pure Elisp tests for this platform."
@@ -487,7 +487,7 @@ runs are unaffected."
   "Return the ERT selector for native tests on the current platform."
   (if (ghostel-test--windows-p)
       '(and (tag native) (not (tag posix)))
-    '(tag native)))
+    '(and (tag native) (not (tag windows)))))
 
 (defun ghostel-test-run-native ()
   "Run only tests that require the native module for this platform."
@@ -497,7 +497,7 @@ runs are unaffected."
   "Return the ERT selector for all tests on the current platform."
   (if (ghostel-test--windows-p)
       '(and "^ghostel-test-" (not (tag posix)))
-    "^ghostel-test-"))
+    '(and "^ghostel-test-" (not (tag windows)))))
 
 (defun ghostel-test-run ()
   "Run all ghostel tests for this platform."


### PR DESCRIPTION
## Summary

- preserve the Emacs unibyte/multibyte distinction when extracting native process inputs
- decode Windows unibyte environment entries, argv, and working directories through `CP_ACP` before converting them to UTF-16
- add Windows regression coverage that verifies all three values in the spawned child
- add a Windows ERT tag so platform-specific tests are excluded symmetrically

Fixes #553.

## Verification

- `zig build test`
- `zig build -Dtarget=x86_64-windows-gnu -Doptimize=ReleaseFast -Dcpu=baseline`
- regression test confirmed red on unchanged `main` (`InvalidWtf8`) and green with this change in the Windows VM
- `ghostel-test-native-process-decodes-windows-unibyte-inputs` passes in the Windows VM