### PR TITLE
Make dead process operations no-ops

### DIFF
--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -337,7 +337,7 @@ word) can't over-delete past the live input.  END is never below BEG."
   "Drain pending PTY output so cursor state reflects the latest echo.
 Loops `accept-process-output' (capped by
 `evil-ghostel-sync-render-max-iterations'), then flushes any deferred redraw."
-  (when (and ghostel--process (process-live-p ghostel--process))
+  (when ghostel--process
     (let ((iter 0))
       (while (and (< iter evil-ghostel-sync-render-max-iterations)
                   (accept-process-output ghostel--process 0.05 nil t))

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4412,22 +4412,20 @@ writes a final exit status before closing it."
 (defun ghostel--kill-native-processes-on-exit ()
   "Force native children to exit before Emacs disables process sentinels."
   (dolist (process (process-list))
-    (let ((pid (and (process-live-p process)
-                    (process-get process 'ghostel--native-pid))))
-      (when pid
-        (ignore-errors (signal-process pid 9))))))
+    (when-let* ((pid (process-get process 'ghostel--native-pid)))
+      (ignore-errors (signal-process pid 9)))))
 
 (add-hook 'kill-emacs-hook #'ghostel--kill-native-processes-on-exit)
 
 (defun ghostel--kill-native-process-hook ()
   "Detach the native event pipe and request child termination.
 Run from `kill-buffer-hook' in native PTY buffers."
-  (when (process-live-p ghostel--process)
-    ;; Do not let `kill-buffer' delete the pipe early.  Keep the
-    ;; pipe alive until the native reaper reports that the child
-    ;; exited, matching Emacs process lifetime semantics.
-    (set-process-buffer ghostel--process nil)
-    (ghostel--kill-native-process ghostel--term)))
+  ;; Do not let `kill-buffer' delete the pipe early.  Keep the
+  ;; pipe alive until the native reaper reports that the child
+  ;; exited, matching Emacs process lifetime semantics.
+  (when ghostel--process
+    (set-process-buffer ghostel--process nil))
+  (ghostel--kill-native-process ghostel--term))
 
 (defun ghostel--start-process ()
   "Start the configured shell with a PTY.

--- a/src/ConPtyProcess.zig
+++ b/src/ConPtyProcess.zig
@@ -351,7 +351,7 @@ pub fn write(
 
     switch (c.GetLastError()) {
         c.ERROR_IO_PENDING => {},
-        c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => return error.ProcessExited,
+        c.ERROR_BROKEN_PIPE, c.ERROR_INVALID_HANDLE => return .interrupted,
         else => return error.IoFailed,
     }
     errdefer _ = completeOverlapped(self.pty_input, &overlapped, true) catch {};
@@ -384,13 +384,13 @@ pub fn write(
         return switch (complete_result) {
             .bytes => |n| if (n > 0) .{ .written = n } else error.IoFailed,
             .aborted => if (interrupted) .interrupted else error.IoFailed,
-            else => error.IoFailed,
+            .closed => .interrupted,
         };
     }
 }
 
 pub fn resize(self: *Self, cols: u16, rows: u16) !void {
-    const hpc = self.hpc orelse return error.PtyResizeFailed;
+    const hpc = self.hpc orelse return;
     const size = c.COORD{
         .X = @intCast(cols),
         .Y = @intCast(rows),

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -87,14 +87,14 @@ pub fn redraw(self: *Self, force_full: bool, force_sync: bool) !bool {
     try kitty_graphics.emitPlacements(env, self);
     const post_size = .{ self.terminal.cols, self.terminal.rows };
 
-    if (self.isProcessLive() and !std.meta.eql(pre_size, post_size)) {
+    if (!std.meta.eql(pre_size, post_size)) {
         if (self.process) |proc| {
             try proc.resizePty(post_size[0], post_size[1]);
         } else {
-            _ = env.f(
-                "set-process-window-size",
-                .{ env.symbolValue("ghostel--process"), post_size[1], post_size[0] },
-            );
+            const process = env.symbolValue("ghostel--process");
+            if (env.isNotNil(process)) {
+                _ = env.f("set-process-window-size", .{ process, post_size[1], post_size[0] });
+            }
         }
     }
     return true;
@@ -145,26 +145,24 @@ pub fn vtWrite(self: *Self, data: []const u8) void {
 }
 
 pub fn ptyWrite(self: *Self, data: []const u8) !void {
-    if (!self.isProcessLive()) return;
-
     const env = emacs.current_env orelse return error.MissingEmacsEnv;
     if (self.process) |proc| {
         try proc.ptyWrite(env, data);
     } else {
-        _ = env.f(
-            "process-send-string",
-            .{ env.symbolValue("ghostel--process"), data },
+        _ = env.funcall(
+            @field(emacs.sym, "process-send-string"),
+            &env.makeValues(.{ env.symbolValue("ghostel--process"), data }),
         );
+        const exit = env.nonLocalExitGet();
+        if (exit.status == .signal) {
+            env.nonLocalExitClear();
+            if (env.eq(exit.symbol, emacs.sym.quit)) env.nonLocalExitSignal(exit.symbol, exit.data);
+        }
     }
 }
 
-pub fn ptyWriteFromTerminal(_: *Self, data: []const u8) void {
-    if (emacs.current_env) |env| {
-        _ = env.f(
-            "process-send-string",
-            .{ env.symbolValue("ghostel--process"), data },
-        );
-    }
+pub fn ptyWriteFromTerminal(self: *Self, data: []const u8) void {
+    self.ptyWrite(data) catch {};
 }
 
 pub fn effect(_: *Self, comptime func: []const u8, args: anytype) void {
@@ -308,26 +306,13 @@ pub fn killNativeProcess(self: *Self) void {
     }
 }
 
-pub fn isProcessLive(self: *Self) bool {
-    if (self.process) |process| {
-        return process.isBackendAlive();
-    } else if (emacs.current_env) |env| {
-        return env.isNotNil(env.f("process-live-p", .{env.symbolValue("ghostel--process")}));
-    }
-
-    return false;
-}
-
 pub fn isPasswordMode(self: *Self) !bool {
-    if (!self.isProcessLive()) return false;
-
     if (self.process) |process| {
         return pty_utils.isPasswordMode(process.replicaName());
     } else if (emacs.current_env) |env| {
-        const tty_name_val = env.f(
-            "process-tty-name",
-            .{env.symbolValue("ghostel--process")},
-        );
+        const process = env.symbolValue("ghostel--process");
+        if (env.isNil(process)) return false;
+        const tty_name_val = env.f("process-tty-name", .{process});
         if (env.isNil(tty_name_val)) return false;
         const tty_name = try env.extractStringAlloc(
             self.alloc,
@@ -877,7 +862,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
         \\Return t when TERM's foreground PTY appears to be reading a password.
         \\
         \\This checks the active PTY's terminal attributes and returns nil when
-        \\there is no live process or the PTY is not in canonical no-echo mode.
+        \\there is no process or the PTY is not in canonical no-echo mode.
         \\
         \\(ghostel--pty-password-input-p TERM)
         ,

--- a/src/NativeProcess.zig
+++ b/src/NativeProcess.zig
@@ -114,7 +114,7 @@ pub fn ptyWrite(self: *Self, env: emacs.Env, data: []const u8) !void {
                 offset += n;
                 try env.checkQuit();
             },
-            .interrupted => return error.ProcessExited,
+            .interrupted => return,
         }
     }
 }
@@ -153,7 +153,7 @@ fn ptyWriteBackend(
     return if (self.backend) |*backend|
         backend.write(data, cancellation)
     else
-        error.ProcessExited;
+        .interrupted;
 }
 
 fn checkEmacsQuit(context: *const anyopaque) !void {
@@ -166,13 +166,6 @@ pub fn resizePty(self: *Self, cols: u16, rows: u16) !void {
     defer self.backend_handoff_mutex.unlock();
 
     if (self.backend) |*backend| try backend.resize(cols, rows);
-}
-
-pub fn isBackendAlive(self: *Self) bool {
-    self.backend_handoff_mutex.lock();
-    defer self.backend_handoff_mutex.unlock();
-
-    return self.backend != null;
 }
 
 pub fn effect(self: *Self, comptime func: []const u8, args: anytype) void {

--- a/src/PosixPtyProcess.zig
+++ b/src/PosixPtyProcess.zig
@@ -78,8 +78,9 @@ const Pty = struct {
 
     pub fn resize(self: *@This(), cols: u16, rows: u16) !void {
         const size = c.winsize{ .ws_col = cols, .ws_row = rows, .ws_xpixel = 0, .ws_ypixel = 0 };
-        if (posix.errno(c.ioctl(self.primary_fd, c.TIOCSWINSZ, &size)) != .SUCCESS) {
-            return error.PtyResizeFailed;
+        switch (posix.errno(c.ioctl(self.primary_fd, c.TIOCSWINSZ, &size))) {
+            .SUCCESS, .IO, .NXIO => {},
+            else => return error.PtyResizeFailed,
         }
     }
 
@@ -240,6 +241,11 @@ pub fn write(
     const chunk = data[0..@min(data.len, WRITE_CHUNK_SIZE)];
     while (true) {
         const written = posix.write(self.pty.primary_fd, chunk) catch |err| switch (err) {
+            error.BrokenPipe,
+            error.InputOutput,
+            error.ProcessNotFound,
+            error.NoDevice,
+            => return .interrupted,
             error.WouldBlock => {
                 var pollfds = [_]posix.pollfd{
                     .{

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -276,6 +276,19 @@ pub const Env = struct {
         self.raw.non_local_exit_clear.?(self.raw);
     }
 
+    pub fn nonLocalExitGet(self: Env) struct {
+        status: FuncallExit,
+        symbol: Value,
+        data: Value,
+    } {
+        var symbol: Value = undefined;
+        var data: Value = undefined;
+        const status: FuncallExit = @enumFromInt(
+            self.raw.non_local_exit_get.?(self.raw, &symbol, &data),
+        );
+        return .{ .status = status, .symbol = symbol, .data = data };
+    }
+
     pub fn nonLocalExitSignal(self: Env, symbol: Value, data: Value) void {
         self.raw.non_local_exit_signal.?(self.raw, symbol, data);
     }
@@ -530,7 +543,6 @@ const interned_symbols = [_][:0]const u8{
     "point-max",
     "pos-bol",
     "process-environment",
-    "process-live-p",
     "process-send-string",
     "process-tty-name",
     "propertize",

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -1176,8 +1176,7 @@ wrong arrow delta."
            (ghostel--redraw-timer fake-timer)
            (ghostel--process 'fake-proc))
       (unwind-protect
-          (cl-letf (((symbol-function 'process-live-p) (lambda (_) t))
-                    ((symbol-function 'accept-process-output)
+          (cl-letf (((symbol-function 'accept-process-output)
                      (lambda (&rest _) nil))
                     ;; Stubbed redraw stands in for the real
                     ;; `ghostel--redraw-now', which cancels the timer.
@@ -1198,8 +1197,7 @@ current."
     (let ((redraw-calls 0)
           (ghostel--redraw-timer nil)
           (ghostel--process 'fake-proc))
-      (cl-letf (((symbol-function 'process-live-p) (lambda (_) t))
-                ((symbol-function 'accept-process-output)
+      (cl-letf (((symbol-function 'accept-process-output)
                  (lambda (&rest _) nil))
                 ((symbol-function 'ghostel--redraw-now)
                  (lambda (_buf) (cl-incf redraw-calls))))
@@ -1216,8 +1214,7 @@ bounds total wait at ~max-iter × 50 ms."
           (evil-ghostel-sync-render-max-iterations 5)
           (ghostel--redraw-timer nil)
           (ghostel--process 'fake-proc))
-      (cl-letf (((symbol-function 'process-live-p) (lambda (_) t))
-                ((symbol-function 'accept-process-output)
+      (cl-letf (((symbol-function 'accept-process-output)
                  (lambda (&rest _) (cl-incf accept-calls) t))
                 ((symbol-function 'ghostel--redraw-now) #'ignore))
         (evil-ghostel--sync-render)

--- a/test/ghostel-exec-test.el
+++ b/test/ghostel-exec-test.el
@@ -149,6 +149,19 @@ is nil, SIGHUP is ignored."
         (should (string-match-p "GHOSTEL_FINAL_OUTPUT"
                                 (ghostel-test--terminal-text)))))))
 
+(ert-deftest ghostel-test-exec-input-after-exit-is-noop ()
+  "PTY input does not signal after either backend's child exits."
+  :tags '(native)
+  (pcase-let ((`(,program . ,args)
+               (ghostel-test--shell-command "exit 0")))
+    (ghostel-test--with-pty-matrix backend
+      (ghostel-test--with-exec-buffer (_buf proc program args)
+        (ghostel-test--wait-until
+         (lambda () (not (process-live-p proc))) nil 5)
+        (should (ghostel--write-pty ghostel--term "late input"))
+        (ghostel--set-size ghostel--term 9 81)
+        (should (ghostel-test--redraw ghostel--term))))))
+
 (ert-deftest ghostel-test-exec-kill-buffer-sends-sighup ()
   "Killing a `ghostel-exec' buffer sends SIGHUP to the child."
   :tags '(native posix)

--- a/test/ghostel-line-mode-undo-test.el
+++ b/test/ghostel-line-mode-undo-test.el
@@ -142,7 +142,8 @@ correctly against the input's new position."
     ;; prompt is painted.  The renderer rewrites the whole viewport
     ;; (line mode forces full redraws).
     (ghostel--write-vt term "some output\r\n\e]133;A\e\\$ \e]133;B\e\\")
-    (ghostel--redraw-now buf)
+    (let ((ghostel-detect-password-prompts nil))
+      (ghostel--redraw-now buf))
     ;; The input survived snapshot/restore.
     (should (equal (ghostel--line-mode-input-text) "foo"))
     ;; Renderer rewrites did not pollute undo.

--- a/test/ghostel-native-process-test.el
+++ b/test/ghostel-native-process-test.el
@@ -66,12 +66,10 @@ any dynamic bindings needed by the test."
           (delete-process pipe))))))
 
 (ert-deftest ghostel-test-native-process-exit-hook-kills-children ()
-  "Emacs exit signals every live native child with SIGKILL."
+  "Emacs exit attempts to kill every recorded native child."
   (let (signals)
     (cl-letf (((symbol-function 'process-list)
                (lambda () '(pipe-a unrelated pipe-b dead-pipe)))
-              ((symbol-function 'process-live-p)
-               (lambda (process) (not (eq process 'dead-pipe))))
               ((symbol-function 'process-get)
                (lambda (process property)
                  (and (eq property 'ghostel--native-pid)
@@ -83,7 +81,24 @@ any dynamic bindings needed by the test."
                (lambda (pid signal)
                  (push (list pid signal) signals))))
       (ghostel--kill-native-processes-on-exit)
-      (should (equal (nreverse signals) '((101 9) (202 9)))))))
+      (should (equal (nreverse signals) '((101 9) (202 9) (303 9)))))))
+
+(ert-deftest ghostel-test-native-kill-buffer-hook-cleans-up-dead-process ()
+  "Native `kill-buffer' cleanup runs after the event process exits."
+  (let ((buffer (generate-new-buffer " *ghostel-test-native-cleanup*"))
+        cleaned)
+    (unwind-protect
+        (with-current-buffer buffer
+          (let ((pipe (ghostel-test--dummy-process "ghostel-dead-pipe" buffer))
+                (ghostel--term 'term))
+            (delete-process pipe)
+            (setq ghostel--process pipe)
+            (cl-letf (((symbol-function 'ghostel--kill-native-process)
+                       (lambda (term) (setq cleaned term))))
+              (ghostel--kill-native-process-hook))
+            (should (eq cleaned 'term))
+            (should-not (process-buffer pipe))))
+      (kill-buffer buffer))))
 
 (ert-deftest ghostel-test-events-filter-multiple-events-per-chunk ()
   "Native process event filter evaluates multiple events in one chunk."

--- a/test/ghostel-terminal-test.el
+++ b/test/ghostel-terminal-test.el
@@ -31,6 +31,25 @@
       (should (string-match-p "hello world" state))  ; row0 has full first line
       (should (string-match-p "line2" state)))))      ; row1 has line2
 
+(ert-deftest ghostel-test-write-pty-without-process-is-noop ()
+  "PTY input is a no-op when there is no process."
+  :tags '(native)
+  (let ((term (ghostel--new 25 80 1000))
+        (ghostel--process nil))
+    (should (ghostel--write-pty term "input"))))
+
+(ert-deftest ghostel-test-write-pty-preserves-quit ()
+  "PTY input preserves keyboard quit from the Emacs process."
+  :tags '(native)
+  (let ((term (ghostel--new 25 80 1000))
+        (ghostel--process 'fake-process))
+    (cl-letf (((symbol-function 'process-send-string)
+               (lambda (_process _string) (signal 'quit nil))))
+      (should (eq 'quit
+                  (condition-case nil
+                      (ghostel--write-pty term "input")
+                    (quit 'quit)))))))
+
 (ert-deftest ghostel-test-write-input-preserves-bare-lf-on-primary ()
   "On the primary screen, a bare LF preserves the column.
 The emulator never synthesizes a CR: cooked-mode \\n is turned into


### PR DESCRIPTION
## Summary

- handle process disappearance at PTY operation boundaries instead of using racy liveness prechecks
- make input and resize against missing, retired, or closed Emacs/POSIX/ConPTY backends successful no-ops
- preserve keyboard quit and unexpected native I/O failures while retaining lifecycle and diagnostic liveness checks
- keep native cleanup and Evil output draining independent of process-liveness snapshots

## Verification

- `zig build --prefix .`
- `zig build test`
- `zig build -Dtarget=x86_64-windows-gnu`
- native terminal tests (15/15)
- native exec tests (8/8)
- native-process Zig/Elisp tests
- Evil sync-render tests
- runtime ConPTY tests in the Windows VM
- `git diff --check`