### PR TITLE
Upgrade to latest libghostty and Zig 0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Run pure-Zig unit tests
         shell: bash
@@ -184,7 +184,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select Xcode 26.3 for Zig 0.15.2
+      - name: Select Xcode 26.3 for Zig 0.16.0
         if: runner.os == 'macOS'
         run: |
           sudo xcode-select --switch /Applications/Xcode_26.3.app/Contents/Developer
@@ -194,8 +194,8 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
-          cache-key: ${{ matrix.platform }}-zig-0.15.2
+          version: 0.16.0
+          cache-key: ${{ matrix.platform }}-zig-0.16.0
 
       - name: Download ConPTY runtime
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Select Xcode 26.3 for Zig 0.15.2
+      - name: Select Xcode 26.3 for Zig 0.16.0
         if: runner.os == 'macOS'
         run: |
           sudo xcode-select --switch /Applications/Xcode_26.3.app/Contents/Developer
@@ -51,8 +51,8 @@ jobs:
       - name: Install Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
-          cache-key: ${{ matrix.platform }}-zig-0.15.2
+          version: 0.16.0
+          cache-key: ${{ matrix.platform }}-zig-0.16.0
 
       - name: Download ConPTY runtime
         if: runner.os == 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Building the native module now requires exactly Zig 0.16.0.
+
 ## [0.45.0] — 2026-07-23
 
 ### Added

--- a/README.org
+++ b/README.org
@@ -155,7 +155,7 @@ binaries are available for:
 - =aarch64-windows=
 
 If you prefer to build from source or need a different platform, you will also
-need *exactly* [[https://ziglang.org/][Zig]] 0.15.2 - older or newer Zig versions will not build.  See
+need *exactly* [[https://ziglang.org/][Zig]] 0.16.0 - older or newer Zig versions will not build.  See
 [[#building-from-source][Building from source]].
 
 * Installation
@@ -265,7 +265,7 @@ Building is only needed if you do not want the pre-built binaries.  Ghostel
 vendors a generated =vendor/emacs-module.h=, so normal builds do not require
 local Emacs headers.
 
-Building requires *exactly* [[https://ziglang.org/][Zig]] 0.15.2 - older or newer Zig versions will not build.
+Building requires *exactly* [[https://ziglang.org/][Zig]] 0.16.0 - older or newer Zig versions will not build.
 Check your installed version with =zig version=.
 
 #+begin_src sh

--- a/build.zig
+++ b/build.zig
@@ -2,11 +2,13 @@ const std = @import("std");
 const builtin = @import("builtin");
 const module_version = @import("src/version.zig").version;
 
+var io: std.Io.Threaded = .init_single_threaded;
+
 // Keep in sync with build.zig.zon (minimum_zig_version) and the CI workflows.
-const required_zig = std.SemanticVersion{ .major = 0, .minor = 15, .patch = 2 };
+const required_zig = std.SemanticVersion{ .major = 0, .minor = 16, .patch = 0 };
 comptime {
     if (builtin.zig_version.order(required_zig) != .eq)
-        @compileError("ghostel requires exactly Zig 0.15.2, found " ++ builtin.zig_version_string);
+        @compileError("ghostel requires exactly Zig 0.16.0, found " ++ builtin.zig_version_string);
 }
 
 const vendored_emacs_module_dir = "vendor";
@@ -21,12 +23,55 @@ pub fn build(b: *std.Build) void {
     ) orelse optimize;
     const is_release = optimize != .Debug;
     const target_os = target.result.os.tag;
-    const emacs_module_dir = resolveEmacsModuleDir(b);
+
     const ghostty_dep = b.dependency("ghostty", .{
         .target = target,
         .optimize = ghostty_optimize,
         .@"emit-lib-vt" = true,
     });
+
+    const ghostty_vt = ghostty_dep.module("ghostty-vt");
+
+    const emacs_module_dir = resolveEmacsModuleDir(b);
+    const translate_emacs = b.addTranslateC(.{
+        .root_source_file = b.path("src/emacs.h"),
+        .target = target,
+        .optimize = optimize,
+    });
+    translate_emacs.addIncludePath(emacs_module_dir);
+    const emacs_c = translate_emacs.createModule();
+
+    const platform_c: std.Build.Module.Import = switch (target_os) {
+        .windows => platform: {
+            const translate_windows = b.addTranslateC(.{
+                .root_source_file = b.path("src/win32.h"),
+                .target = target,
+                .optimize = optimize,
+            });
+            break :platform .{
+                .name = "windows_c",
+                .module = translate_windows.createModule(),
+            };
+        },
+        else => platform: {
+            const translate_posix = b.addTranslateC(.{
+                .root_source_file = b.path("src/posix.h"),
+                .target = target,
+                .optimize = optimize,
+            });
+            break :platform .{
+                .name = "posix_c",
+                .module = translate_posix.createModule(),
+            };
+        },
+    };
+
+    const translate_stb = b.addTranslateC(.{
+        .root_source_file = b.path("vendor/stb/stb_image.h"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const stb_image_c = translate_stb.createModule();
 
     const mod = b.createModule(.{
         .root_source_file = b.path("src/module.zig"),
@@ -35,12 +80,13 @@ pub fn build(b: *std.Build) void {
         .link_libc = true,
         .strip = if (is_release) true else null,
         .omit_frame_pointer = if (is_release) true else null,
+        .imports = &.{
+            .{ .name = "ghostty-vt", .module = ghostty_vt },
+            .{ .name = "emacs_c", .module = emacs_c },
+            platform_c,
+            .{ .name = "stb_image_c", .module = stb_image_c },
+        },
     });
-    mod.addIncludePath(emacs_module_dir);
-    mod.addImport(
-        "ghostty-vt",
-        ghostty_dep.module("ghostty-vt"),
-    );
 
     // stb_image for PNG decoding (kitty graphics)
     mod.addIncludePath(b.path("vendor/stb"));
@@ -62,7 +108,7 @@ pub fn build(b: *std.Build) void {
         }
     }
     if (target_os == .windows) {
-        lib.linkSystemLibrary("kernel32");
+        lib.root_module.linkSystemLibrary("kernel32", .{});
     }
 
     const copy_step = b.addInstallFile(
@@ -98,24 +144,25 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
         .link_libc = true,
+        .imports = &.{
+            .{ .name = "ghostty-vt", .module = ghostty_vt },
+            platform_c,
+            .{ .name = "stb_image_c", .module = stb_image_c },
+        },
     });
     tests_mod.addIncludePath(b.path("vendor/stb"));
     tests_mod.addCSourceFile(.{ .file = b.path("src/stb_image.c") });
-    tests_mod.addImport(
-        "ghostty-vt",
-        ghostty_dep.module("ghostty-vt"),
-    );
     const tests = b.addTest(.{ .root_module = tests_mod });
     test_step.dependOn(&b.addRunArtifact(tests).step);
 }
 
 fn resolveEmacsModuleDir(b: *std.Build) std.Build.LazyPath {
-    if (b.graph.env_map.get("EMACS_INCLUDE_DIR")) |dir| {
+    if (b.graph.environ_map.get("EMACS_INCLUDE_DIR")) |dir| {
         ensureEmacsModuleHeaderExists(b.allocator, "EMACS_INCLUDE_DIR", dir);
         return .{ .cwd_relative = dir };
     }
 
-    if (b.graph.env_map.get("EMACS_BIN_DIR")) |bin_dir| {
+    if (b.graph.environ_map.get("EMACS_BIN_DIR")) |bin_dir| {
         const include_dir = resolveEmacsIncludeDirFromBin(b.allocator, bin_dir) orelse
             std.debug.panic(
                 "EMACS_BIN_DIR={s} does not resolve to a directory containing emacs-module.h",
@@ -165,7 +212,7 @@ fn dirHasEmacsModuleHeader(allocator: std.mem.Allocator, dir: []const u8) bool {
         @panic("out of memory while resolving emacs-module.h");
     defer allocator.free(header_path);
 
-    std.fs.cwd().access(header_path, .{}) catch return false;
+    std.Io.Dir.cwd().access(io.io(), header_path, .{}) catch return false;
     return true;
 }
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,13 +1,13 @@
 .{
     .name = .ghostel,
     .version = "0.45.0",
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .paths = .{""},
     .fingerprint = 0x5a44bdd1198a0f4b,
     .dependencies = .{
         .ghostty = .{
-            .url = "https://github.com/ghostty-org/ghostty/archive/11b9a6ef17e21b89e2ef14dd786992cc5577b69b.tar.gz",
-            .hash = "ghostty-1.3.2-dev-5UdBC_uYGwWN5ZXbjh8tmyawbr5rgTfy9lP8WJKoJLvr",
+            .url = "https://github.com/ghostty-org/ghostty/archive/ab0b9da9e88fcb4b0533a1854e84628f663930af.tar.gz",
+            .hash = "ghostty-1.3.2-dev-5UdBC-mtJAXcrDxuFuetC6X66XQXV8hw_7pevfmFcVKL",
         },
     },
 }

--- a/etc/terminfo/xterm-ghostty.terminfo
+++ b/etc/terminfo/xterm-ghostty.terminfo
@@ -1,4 +1,4 @@
-#	Reconstructed via infocmp from file: /Applications/Ghostty.app/Contents/Resources/terminfo/78/xterm-ghostty
+#	Reconstructed via infocmp from file: /Users/emilsahlen/.emacs.d/elpa/ghostel/etc/terminfo/78/xterm-ghostty
 xterm-ghostty|ghostty|Ghostty,
 	am, bce, ccc, hs, km, mc5i, mir, msgr, npc, xenl, AX, Su, Tc, XT, fullkbd,
 	colors#256, cols#80, it#8, lines#24, pairs#32767,
@@ -52,8 +52,7 @@ xterm-ghostty|ghostty|Ghostty,
 	u8=\E[?%[;0123456789]c, u9=\E[c, vpa=\E[%i%p1%dd,
 	BD=\E[?2004l, BE=\E[?2004h, Clmg=\E[s,
 	Cmg=\E[%i%p1%d;%p2%ds, Dsmg=\E[?69l, E3=\E[3J,
-	Enmg=\E[?69h, PE=\E[201~,
-	PS=\E[200~, RV=\E[>c, Se=\E[2 q,
+	Enmg=\E[?69h, PE=\E[201~, PS=\E[200~, RV=\E[>c, Se=\E[2 q,
 	Setulc=\E[58\:2\:\:%p1%{65536}%/%d\:%p1%{256}%/%{255}%&%d\:%p1%{255}%&%d%;m,
 	Smulx=\E[4\:%p1%dm, Ss=\E[%p1%d q,
 	Sync=\E[?2026%?%p1%{1}%-%tl%eh%;,

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -74,7 +74,7 @@
 ;; Native module:
 ;;
 ;;   A pre-built binary is downloaded automatically on first use.
-;;   To build from source instead (requires exactly Zig 0.15.2), run
+;;   To build from source instead (requires exactly Zig 0.16.0), run
 ;;   zig build --prefix . from the project root, or M-x ghostel-module-compile.
 ;;   M-x ghostel-download-module re-fetches the pre-built binary.
 ;;

--- a/src/ConPtyProcess.zig
+++ b/src/ConPtyProcess.zig
@@ -3,9 +3,7 @@ const Allocator = std.mem.Allocator;
 
 const backend_types = @import("backend_types.zig");
 
-const c = @cImport({
-    @cInclude("windows.h");
-});
+const c = @import("windows_c");
 
 const Self = @This();
 
@@ -180,7 +178,7 @@ pub const EventWriter = struct {
     }
 };
 
-pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: backend_types.ProcessParams) !Self {
+pub fn init(alloc: Allocator, io: std.Io, initial_cols: u16, initial_rows: u16, params: backend_types.ProcessParams) !Self {
     try initApi();
 
     var self: Self = .{ .alloc = alloc };
@@ -195,7 +193,7 @@ pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: back
     self.input_write_event = c.CreateEventW(null, c.TRUE, c.FALSE, null);
     if (self.input_write_event == null) return error.CreateEventFailed;
 
-    try createConPty(&self, initial_rows, initial_cols);
+    try createConPty(&self, io, initial_rows, initial_cols);
     try spawnChild(&self, params);
 
     return self;
@@ -244,7 +242,7 @@ fn readOutput(
         &bytes_read,
         &overlapped,
     ) != 0) {
-        stream.nextSlice(buf[0..bytes_read]);
+        try stream.nextSlice(buf[0..bytes_read]);
         return .ok;
     }
 
@@ -263,7 +261,7 @@ fn readOutput(
         &overlapped,
         wait_result == .interrupted,
     );
-    if (complete_result == .bytes) stream.nextSlice(buf[0..complete_result.bytes]);
+    if (complete_result == .bytes) try stream.nextSlice(buf[0..complete_result.bytes]);
 
     if (wait_result == .interrupted or complete_result != .bytes) return .finished;
     return .ok;
@@ -360,7 +358,13 @@ pub fn write(
         self.input_write_event,
         self.interrupt_event,
     };
-    const timeout = if (cancellation) |token| token.poll_interval_ms else c.INFINITE;
+    const timeout: c.DWORD = if (cancellation) |token|
+        @intCast(@min(
+            token.poll_interval.toMilliseconds(),
+            @as(u32, c.INFINITE - 1),
+        ))
+    else
+        c.INFINITE;
     while (true) {
         const wait_result = c.WaitForMultipleObjects(
             handles.len,
@@ -492,7 +496,7 @@ fn currentModuleDir(module_path_buf: *[32768]u8) ?[]const u8 {
     return std.fs.path.dirname(module_path);
 }
 
-fn createConPty(self: *Self, rows: u16, cols: u16) !void {
+fn createConPty(self: *Self, io: std.Io, rows: u16, cols: u16) !void {
     var in_read: c.HANDLE = c.INVALID_HANDLE_VALUE;
     var in_write: c.HANDLE = c.INVALID_HANDLE_VALUE;
     var out_read: c.HANDLE = c.INVALID_HANDLE_VALUE;
@@ -505,8 +509,10 @@ fn createConPty(self: *Self, rows: u16, cols: u16) !void {
         if (out_write != c.INVALID_HANDLE_VALUE) _ = c.CloseHandle(out_write);
     }
 
-    try createOverlappedPipe(&in_read, &in_write, .write);
-    try createOverlappedPipe(&out_read, &out_write, .read);
+    const random_source: std.Random.IoSource = .{ .io = io };
+    const random = random_source.interface();
+    try createOverlappedPipe(random, &in_read, &in_write, .write);
+    try createOverlappedPipe(random, &out_read, &out_write, .read);
 
     const size = c.COORD{
         .X = @intCast(cols),
@@ -582,6 +588,7 @@ fn clearInterruptEvent(self: *Self) void {
 }
 
 fn createOverlappedPipe(
+    random: std.Random,
     read_handle: *c.HANDLE,
     write_handle: *c.HANDLE,
     overlapped_end: OverlappedPipeEnd,
@@ -591,7 +598,7 @@ fn createOverlappedPipe(
     const pipe_path = std.fmt.bufPrintZ(
         &pipe_path_buf,
         "\\\\.\\pipe\\ghostel-conpty-{d}-{x}",
-        .{ c.GetCurrentProcessId(), std.crypto.random.int(u64) },
+        .{ c.GetCurrentProcessId(), random.int(u64) },
     ) catch unreachable;
 
     const pipe_path_w_len = std.unicode.utf8ToUtf16Le(
@@ -646,7 +653,7 @@ fn spawnChild(self: *Self, params: backend_types.ProcessParams) !void {
         try std.unicode.wtf8ToWtf16LeAllocZ(arena, cwd_path)
     else
         null;
-    const env_block = try buildEnvironmentBlock(arena, params.env);
+    const env_block = try params.env.createWindowsBlock(arena, .{});
 
     var attr_list_size: usize = 0;
     _ = c.InitializeProcThreadAttributeList(null, 1, 0, &attr_list_size);
@@ -689,7 +696,7 @@ fn spawnChild(self: *Self, params: backend_types.ProcessParams) !void {
         null,
         c.FALSE,
         flags,
-        @ptrCast(env_block.ptr),
+        @ptrCast(@constCast(env_block.slice.ptr)),
         if (cwd) |cwd_w| cwd_w.ptr else null,
         &si.StartupInfo,
         &pi,
@@ -760,45 +767,6 @@ fn argvToCommandLineWindows(
     return try std.unicode.wtf8ToWtf16LeAllocZ(allocator, buf.items);
 }
 
-const EnvEntry = struct {
-    key: []const u8,
-    value: []const u8,
-};
-
-fn envEntryLessThan(_: void, lhs: EnvEntry, rhs: EnvEntry) bool {
-    return std.ascii.lessThanIgnoreCase(lhs.key, rhs.key);
-}
-
-fn buildEnvironmentBlock(arena: Allocator, env_map: *const std.process.EnvMap) ![]u16 {
-    var builder = std.ArrayList(u16).empty;
-    errdefer builder.deinit(arena);
-
-    const entries = try arena.alloc(EnvEntry, @intCast(env_map.count()));
-    defer arena.free(entries);
-    var it = env_map.iterator();
-    var i: usize = 0;
-    while (it.next()) |pair| : (i += 1) {
-        entries[i] = .{ .key = pair.key_ptr.*, .value = pair.value_ptr.* };
-    }
-    std.mem.sort(EnvEntry, entries, {}, envEntryLessThan);
-
-    for (entries) |entry| {
-        try appendWtf8AsWtf16(&builder, arena, entry.key);
-        try builder.append(arena, '=');
-        try appendWtf8AsWtf16(&builder, arena, entry.value);
-        try builder.append(arena, 0);
-    }
-    try builder.append(arena, 0);
-    return try builder.toOwnedSlice(arena);
-}
-
-fn appendWtf8AsWtf16(builder: *std.ArrayList(u16), arena: Allocator, value: []const u8) !void {
-    const len = try std.unicode.calcWtf16LeLen(value);
-    const dest = try builder.addManyAsSlice(arena, len);
-    const written = try std.unicode.wtf8ToWtf16Le(dest, value);
-    std.debug.assert(written == len);
-}
-
 test "notify CRT provider follows the CRT that owns Emacs dup" {
     try std.testing.expectEqual(
         EventWriter.NotifyCrtProvider.msvcrt,
@@ -839,45 +807,4 @@ test "argvToCommandLineWindows quotes argv0" {
         "\"c:\\Windows\\System32\\cmd.exe\" /d /c \"echo hi\"",
     );
     try std.testing.expectEqualSlices(u16, expected, command_line);
-}
-
-test "buildEnvironmentBlock writes nul-separated UTF-16 entries" {
-    var env = std.process.EnvMap.init(std.testing.allocator);
-    defer env.deinit();
-    try env.put("FOO", "bar");
-
-    const block = try buildEnvironmentBlock(std.testing.allocator, &env);
-    defer std.testing.allocator.free(block);
-
-    try std.testing.expectEqualSlices(u16, &[_]u16{
-        'F', 'O', 'O', '=', 'b', 'a', 'r', 0,
-        0,
-    }, block);
-}
-
-test "buildEnvironmentBlock sorts entries by environment name" {
-    var env = std.process.EnvMap.init(std.testing.allocator);
-    defer env.deinit();
-    try env.put("ZED", "last");
-    try env.put("ALPHA", "first");
-    try env.put("Path", "middle");
-
-    const block = try buildEnvironmentBlock(std.testing.allocator, &env);
-    defer std.testing.allocator.free(block);
-
-    try std.testing.expectEqualSlices(u16, &[_]u16{
-        'A', 'L', 'P', 'H', 'A', '=', 'f', 'i', 'r', 's', 't', 0,
-        'P', 'a', 't', 'h', '=', 'm', 'i', 'd', 'd', 'l', 'e', 0,
-        'Z', 'E', 'D', '=', 'l', 'a', 's', 't', 0,   0,
-    }, block);
-}
-
-test "EnvMap keeps environment names unique on Windows" {
-    var env = std.process.EnvMap.init(std.testing.allocator);
-    defer env.deinit();
-    try env.put("Path", "first");
-    try env.put("PATH", "second");
-
-    try std.testing.expectEqual(@as(std.process.EnvMap.Size, 1), env.count());
-    try std.testing.expectEqualStrings("second", env.get("path").?);
 }

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -23,6 +23,7 @@ const pty_utils = @import("pty_utils.zig");
 const Self = @This();
 
 alloc: Allocator,
+io: std.Io,
 terminal: gt.Terminal,
 stream: gt.Stream(GhostelHandler(*Self)),
 string_buffer: ?[]u8 = null,
@@ -30,25 +31,24 @@ renderer: Renderer,
 process: ?*NativeProcess = null,
 
 /// Create a new terminal with the given dimensions and scrollback.
-pub fn init(alloc: Allocator, env: emacs.Env, cols: u16, rows: u16, max_scrollback: usize) !*Self {
-    if (cols == 0 or rows == 0) return error.InvalidSize;
+pub fn init(
+    alloc: Allocator,
+    io: std.Io,
+    env: emacs.Env,
+    opts_arg: gt.Terminal.Options,
+) !*Self {
+    if (opts_arg.cols == 0 or opts_arg.rows == 0) return error.InvalidSize;
 
-    const opts = gt.Terminal.Options{
-        .cols = cols,
-        .rows = rows,
-        .max_scrollback = max_scrollback,
-        // Enable grapheme clustering since that is how Emacs will render it anyway
-        .default_modes = .{
-            .grapheme_cluster = true,
-        },
-    };
+    var opts = opts_arg;
+    opts.default_modes = .{ .grapheme_cluster = true };
 
     const term = try alloc.create(Self);
     errdefer alloc.destroy(term);
 
     term.* = Self{
         .alloc = alloc,
-        .terminal = try .init(alloc, opts),
+        .io = io,
+        .terminal = try .init(io, alloc, opts),
         .renderer = undefined,
         .stream = undefined,
     };
@@ -77,7 +77,7 @@ pub fn deinit(self: *Self) void {
 }
 
 pub fn redraw(self: *Self, force_full: bool, force_sync: bool) !bool {
-    self.lockTerm();
+    try self.lockTerm();
     defer self.unlockTerm();
 
     const env = emacs.current_env orelse return false;
@@ -107,40 +107,8 @@ pub fn setColorPalette(self: *Self, palette: gt.color.Palette) void {
     self.terminal.flags.dirty.palette = true;
 }
 
-/// Enable kitty graphics protocol with the given storage limit (bytes).
-///
-/// `medium_file`/`medium_temp_file`/`medium_shared_mem` open additional
-/// image-loading paths beyond the default direct (base64-encoded inline)
-/// medium.  These extra mediums let a remote program instruct ghostel
-/// to read arbitrary local files or shared-memory regions, so leave
-/// them disabled unless the caller explicitly opts in.
-///
-/// Passing `&storage_limit_u64` and `&yes` (stack locals) is safe:
-/// libghostty's terminal_set dereferences the pointer and copies the
-/// value into the screen's image_limits before returning — it never
-/// retains the caller's pointer.  The header declares the storage
-/// limit as `uint64_t*`, so the local is widened to `u64` even when
-/// `usize` happens to be 64 bits on the host (the explicit cast keeps
-/// the ABI contract stable across 32-bit targets).
-pub fn enableKittyGraphics(
-    self: *Self,
-    storage_limit: usize,
-    medium_file: bool,
-    medium_temp_file: bool,
-    medium_shared_mem: bool,
-) !void {
-    var it = self.terminal.screens.all.iterator();
-    while (it.next()) |entry| {
-        const screen = entry.value.*;
-        try screen.kitty_images.setLimit(screen.alloc, screen, storage_limit);
-        screen.kitty_images.image_limits.file = medium_file;
-        screen.kitty_images.image_limits.temporary_file = medium_temp_file;
-        screen.kitty_images.image_limits.shared_memory = medium_shared_mem;
-    }
-}
-
-pub fn vtWrite(self: *Self, data: []const u8) void {
-    self.lockTerm();
+pub fn vtWrite(self: *Self, data: []const u8) !void {
+    try self.lockTerm();
     self.stream.nextSlice(data);
     self.unlockTerm();
 }
@@ -189,7 +157,7 @@ pub fn encode(
     }
 
     // Encode
-    var writer = std.io.Writer.fixed(buf);
+    var writer = std.Io.Writer.fixed(buf);
     try gt.input.encodeKey(&writer, event, options);
     const encoded = writer.buffered();
 
@@ -224,7 +192,7 @@ pub fn encodeMouse(
 
     // Encode
     var buf: [128]u8 = undefined;
-    var writer = std.io.Writer.fixed(&buf);
+    var writer = std.Io.Writer.fixed(&buf);
     try gt.input.encodeMouse(&writer, event, options);
     const encoded = writer.buffered();
 
@@ -236,7 +204,7 @@ pub fn encodeMouse(
 pub fn encodeFocus(self: *Self, gained: bool) !bool {
     const event = if (gained) gt.input.FocusEvent.gained else gt.input.FocusEvent.lost;
     var buf: [8]u8 = undefined;
-    var writer = std.io.Writer.fixed(&buf);
+    var writer = std.Io.Writer.fixed(&buf);
     gt.input.encodeFocus(&writer, event) catch return false;
     const encoded = writer.buffered();
     if (encoded.len == 0) return false;
@@ -263,13 +231,13 @@ pub fn encodePaste(self: *Self, data: []u8) !bool {
 /// to ensure that the we fully render the very latest state in case any rows
 /// get promoted to scrollback due to vertical shrinking of the viewport.
 pub fn resize(self: *Self, cols: u16, rows: u16, cell_w: u16, cell_h: u16) !void {
-    self.lockTerm();
+    try self.lockTerm();
     defer self.unlockTerm();
     try self.renderer.resize(cols, rows, cell_w, cell_h);
 }
 
-pub fn lockTerm(self: *Self) void {
-    if (self.process) |process| process.lockTerm();
+pub fn lockTerm(self: *Self) !void {
+    if (self.process) |process| try process.lockTerm();
 }
 
 pub fn unlockTerm(self: *Self) void {
@@ -279,7 +247,7 @@ pub fn unlockTerm(self: *Self) void {
 pub fn spawnNativeProcess(
     self: *Self,
     command: [][:0]const u8,
-    env: *const std.process.EnvMap,
+    env: *const std.process.Environ.Map,
     cwd: [:0]const u8,
     event_fd: ChannelFd,
 ) !ProcessPid {
@@ -289,6 +257,7 @@ pub fn spawnNativeProcess(
     errdefer self.alloc.destroy(process);
     try process.init(
         self.alloc,
+        self.io,
         self.terminal.cols,
         self.terminal.rows,
         ProcessParams{ .file = command[0], .args = command, .env = env, .cwd = cwd },
@@ -327,10 +296,15 @@ pub fn isPasswordMode(self: *Self) !bool {
 }
 
 var module_alloc: Allocator = undefined;
+var module_io: std.Io = undefined;
+var temp_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+var temp_dir: []const u8 = undefined;
 
-pub fn initModule(allocator: Allocator, env: emacs.Env) void {
+pub fn initModule(allocator: Allocator, io: std.Io, env: emacs.Env) !void {
     module_alloc = allocator;
+    module_io = io;
     env.registerFunctions(&emacs_functions);
+    temp_dir = try env.extractString(env.f("temporary-file-directory", .{}), &temp_dir_buf);
 }
 
 fn terminalFinalize(ptr: ?*anyopaque) callconv(.c) void {
@@ -340,8 +314,8 @@ fn terminalFinalize(ptr: ?*anyopaque) callconv(.c) void {
     }
 }
 
-fn getProcessEnvironment(alloc: Allocator, env: emacs.Env) !std.process.EnvMap {
-    var env_map = std.process.EnvMap.init(alloc);
+fn getProcessEnvironment(alloc: Allocator, env: emacs.Env) !std.process.Environ.Map {
+    var env_map: std.process.Environ.Map = .init(alloc);
     errdefer env_map.deinit();
 
     var display_explicit = false;
@@ -358,7 +332,7 @@ fn getProcessEnvironment(alloc: Allocator, env: emacs.Env) !std.process.EnvMap {
         if (value) |v| {
             try env_map.put(key, v);
         } else {
-            env_map.remove(key);
+            _ = env_map.swapRemove(key);
         }
     }
 
@@ -398,27 +372,6 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
         ,
         .impl = struct {
             pub fn call(env: emacs.Env, nargs: isize, args: [*c]emacs.Value) !emacs.Value {
-                // Reject out-of-range row/col counts rather than wrapping/panicking.
-                const rows = std.math.cast(u16, env.cast(i64, args[0])) orelse {
-                    return error.OutOfRange;
-                };
-                const cols = std.math.cast(u16, env.cast(i64, args[1])) orelse {
-                    return error.OutOfRange;
-                };
-                const max_scrollback: usize = if (nargs > 2 and env.isNotNil(args[2]))
-                    (std.math.cast(usize, env.cast(i64, args[2])) orelse {
-                        return error.OutOfRange;
-                    })
-                else
-                    5 * 1024 * 1024; // ~5 MB, roughly 5k rows on an 80-column terminal
-                // Default 320 MiB; explicit 0 disables kitty graphics entirely
-                // (skips the storage allocation in libghostty's screen state).
-                const kitty_storage_limit: usize = if (nargs > 3 and env.isNotNil(args[3]))
-                    (std.math.cast(usize, env.cast(i64, args[3])) orelse {
-                        return error.OutOfRange;
-                    })
-                else
-                    320 * 1024 * 1024;
                 // Bit 0 = file medium, bit 1 = temp_file, bit 2 = shared_mem.
                 // Default 0 — only the direct medium (base64 inline) is enabled.
                 // The other mediums let a remote program instruct ghostel to read
@@ -427,22 +380,49 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                     (std.math.cast(u32, env.cast(i64, args[4])) orelse 0)
                 else
                     0;
-                const term = try init(module_alloc, env, cols, rows, max_scrollback);
+
+                const opts: gt.Terminal.Options = .{
+                    .rows = std.math.cast(u16, env.cast(i64, args[0])) orelse {
+                        return error.OutOfRange;
+                    },
+
+                    .cols = std.math.cast(u16, env.cast(i64, args[1])) orelse {
+                        return error.OutOfRange;
+                    },
+
+                    .max_scrollback = if (nargs > 2 and env.isNotNil(args[2]))
+                        (std.math.cast(usize, env.cast(i64, args[2])) orelse {
+                            return error.OutOfRange;
+                        })
+                    else
+                        5 * 1024 * 1024,
+
+                    .kitty_image_storage_limit = if (nargs > 3 and env.isNotNil(args[3]))
+                        (std.math.cast(usize, env.cast(i64, args[3])) orelse {
+                            return error.OutOfRange;
+                        })
+                    else
+                        320 * 1024 * 1024,
+
+                    .kitty_image_loading_limits = .{
+                        .file = (kitty_mediums & 0x1) != 0,
+                        .temporary_file = if ((kitty_mediums & 0x2) != 0)
+                            .{ .enabled = .{ .directory = temp_dir } }
+                        else
+                            .disabled,
+
+                        .shared_memory = (kitty_mediums & 0x4) != 0,
+                    },
+                };
+
+                const term = try init(module_alloc, module_io, env, opts);
                 errdefer term.deinit();
                 // Seed protocol defaults for OSC 10/11.  The renderer does
                 // not paint these as cell faces; default text inherits the
                 // buffer's `ghostel-default' remap instead.
                 term.terminal.colors.foreground.default = .{ .r = 204, .g = 204, .b = 204 };
                 term.terminal.colors.background.default = .{ .r = 0, .g = 0, .b = 0 };
-                // Enable kitty graphics protocol if storage limit > 0.
-                if (kitty_storage_limit > 0) {
-                    try term.enableKittyGraphics(
-                        kitty_storage_limit,
-                        (kitty_mediums & 0x1) != 0,
-                        (kitty_mediums & 0x2) != 0,
-                        (kitty_mediums & 0x4) != 0,
-                    );
-                }
+
                 return env.makeUserPtr(terminalFinalize, term);
             }
         },
@@ -459,7 +439,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
             pub fn call(env: emacs.Env, _: isize, args: [*c]emacs.Value) !emacs.Value {
                 const term = env.getUserPtr(Self, args[0]) orelse return error.InvalidTerminalHandle;
                 const raw = try env.extractStringAlloc(module_alloc, args[1], &term.string_buffer);
-                term.vtWrite(raw);
+                try term.vtWrite(raw);
                 return env.nil();
             }
         },
@@ -649,7 +629,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 var str_buf: [2048]u8 = undefined;
                 const colors_str = try env.extractString(args[1], &str_buf);
                 if (colors_str.len < 16 * 7) return error.InvalidPaletteLength;
-                term.lockTerm();
+                try term.lockTerm();
                 defer term.unlockTerm();
                 var palette = term.terminal.colors.palette.current;
                 var idx: usize = 0;
@@ -681,7 +661,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 var bg_buf: [16]u8 = undefined;
                 const fg_str = try env.extractString(args[1], &fg_buf);
                 const bg_str = try env.extractString(args[2], &bg_buf);
-                term.lockTerm();
+                try term.lockTerm();
                 defer term.unlockTerm();
                 term.terminal.colors.foreground.default = try gt.color.RGB.parse(fg_str);
                 term.terminal.colors.background.default = try gt.color.RGB.parse(bg_str);
@@ -731,10 +711,10 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 const mode_int = std.math.cast(u16, raw_int) orelse {
                     return error.InvalidModeValue;
                 };
-                const mode = std.meta.intToEnum(gt.modes.Mode, mode_int) catch {
+                const mode: gt.modes.Mode = gt.modes.modeFromInt(mode_int, false) orelse {
                     return error.InvalidModeValue;
                 };
-                term.lockTerm();
+                try term.lockTerm();
                 defer term.unlockTerm();
                 return if (term.terminal.modes.get(mode)) env.t() else env.nil();
             }
@@ -751,7 +731,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
         .impl = struct {
             pub fn call(env: emacs.Env, _: isize, args: [*c]emacs.Value) !emacs.Value {
                 const term = env.getUserPtr(Self, args[0]) orelse return error.InvalidTerminalHandle;
-                term.lockTerm();
+                try term.lockTerm();
                 defer term.unlockTerm();
                 return if (term.terminal.screens.active_key == .alternate) env.t() else env.nil();
             }
@@ -773,10 +753,10 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                     .unwrap = true,
                     .trim = true,
                 };
-                term.lockTerm();
+                try term.lockTerm();
                 defer term.unlockTerm();
                 var formatter = gt.formatter.TerminalFormatter.init(&term.terminal, options);
-                var writer = std.io.Writer.Allocating.init(module_alloc);
+                var writer = std.Io.Writer.Allocating.init(module_alloc);
                 defer writer.deinit();
                 try formatter.format(&writer.writer);
                 const written = writer.written();

--- a/src/NativeProcess.zig
+++ b/src/NativeProcess.zig
@@ -8,6 +8,7 @@ const backend_types = @import("backend_types.zig");
 const emacs = @import("emacs.zig");
 const GhostelHandler = @import("handler.zig").GhostelHandler;
 const FixedArrayList = @import("fixed_array_list.zig").FixedArrayList;
+const RecursiveMutex = @import("RecursiveMutex.zig");
 
 const Backend = switch (builtin.os.tag) {
     .windows => @import("ConPtyProcess.zig"),
@@ -18,23 +19,25 @@ const EventWriter = Backend.EventWriter;
 const Self = @This();
 
 const log = std.log.scoped(.NativeProcessHandler);
-const CANCELLATION_POLL_INTERVAL_MS = 20;
+const cancellation_poll_interval: std.Io.Duration = .fromMilliseconds(20);
 
 pub const ChannelFd = EventWriter.Fd;
 pub const ProcessParams = backend_types.ProcessParams;
 
-backend_handoff_mutex: std.Thread.Mutex = .{},
-write_mutex: std.Thread.Mutex = .{},
+alloc: Allocator,
+io: std.Io,
+
+backend_handoff_mutex: std.Io.Mutex = .init,
+write_mutex: std.Io.Mutex = .init,
 backend: ?Backend,
 event_writer: EventWriter,
-alloc: Allocator,
 pid: i64,
-replica_name: []u8,
+replica_name: [:0]u8,
 // Buffer event notifications so large terminal updates can be reported with
 // few writes to Emacs.
 event_buf: FixedArrayList(u8, 16 * 1024) = .{},
 
-term_mutex: std.Thread.Mutex.Recursive = .init,
+term_mutex: RecursiveMutex = .{},
 term: *gt.Terminal,
 stream: gt.Stream(GhostelHandler(*Self)),
 
@@ -44,9 +47,9 @@ thread: std.Thread,
 const LockedStream = struct {
     process: *Self,
 
-    pub fn nextSlice(self: *LockedStream, data: []const u8) void {
-        self.process.term_mutex.lock();
-        defer self.process.term_mutex.unlock();
+    pub fn nextSlice(self: *LockedStream, data: []const u8) !void {
+        try self.process.term_mutex.lock(self.process.io);
+        defer self.process.term_mutex.unlock(self.process.io);
         self.process.stream.nextSlice(data);
     }
 };
@@ -54,13 +57,14 @@ const LockedStream = struct {
 pub fn init(
     self: *Self,
     alloc: Allocator,
+    io: std.Io,
     initial_cols: u16,
     initial_rows: u16,
     params: ProcessParams,
     term: *gt.Terminal,
     event_fd: ChannelFd,
 ) !void {
-    var backend = try Backend.init(alloc, initial_cols, initial_rows, params);
+    var backend = try Backend.init(alloc, io, initial_cols, initial_rows, params);
     errdefer _ = backend.deinitAndWait();
 
     var event_writer = try EventWriter.init(event_fd);
@@ -69,13 +73,14 @@ pub fn init(
     var stream: @TypeOf(self.stream) = .initAlloc(alloc, .init(self, term));
     errdefer stream.deinit();
 
-    const replica_name = try alloc.dupe(u8, backend.replicaName());
+    const replica_name = try alloc.dupeZ(u8, backend.replicaName());
     errdefer alloc.free(replica_name);
 
     self.* = .{
+        .alloc = alloc,
+        .io = io,
         .backend = backend,
         .event_writer = event_writer,
-        .alloc = alloc,
         .pid = backend.pidValue(),
         .replica_name = replica_name,
         .term = term,
@@ -85,26 +90,26 @@ pub fn init(
     self.thread = try std.Thread.spawn(.{}, Self.run, .{self});
 }
 
-pub fn lockTerm(self: *Self) void {
-    self.term_mutex.lock();
+pub fn lockTerm(self: *Self) !void {
+    try self.term_mutex.lock(self.io);
 }
 
 pub fn unlockTerm(self: *Self) void {
-    self.term_mutex.unlock();
+    self.term_mutex.unlock(self.io);
 }
 
 pub fn ptyWrite(self: *Self, env: emacs.Env, data: []const u8) !void {
     while (!self.write_mutex.tryLock()) {
         try env.checkQuit();
-        std.Thread.sleep(CANCELLATION_POLL_INTERVAL_MS * std.time.ns_per_ms);
+        try std.Io.sleep(self.io, cancellation_poll_interval, std.Io.Clock.awake);
     }
-    defer self.write_mutex.unlock();
+    defer self.write_mutex.unlock(self.io);
 
     var cancellation_env = env;
     const cancellation = backend_types.CancellationToken{
         .context = &cancellation_env,
         .check_fn = checkEmacsQuit,
-        .poll_interval_ms = CANCELLATION_POLL_INTERVAL_MS,
+        .poll_interval = cancellation_poll_interval,
     };
 
     var offset: usize = 0;
@@ -125,8 +130,8 @@ pub fn ptyWriteFromTerminal(self: *Self, data: []const u8) void {
     // a blocked write through the backend's existing interrupt mechanism.
     const backend = if (self.backend) |*backend| backend else return;
 
-    self.write_mutex.lock();
-    defer self.write_mutex.unlock();
+    self.write_mutex.lock(self.io) catch return;
+    defer self.write_mutex.unlock(self.io);
 
     var offset: usize = 0;
     while (offset < data.len) {
@@ -147,8 +152,8 @@ fn ptyWriteBackend(
     data: []const u8,
     cancellation: ?backend_types.CancellationToken,
 ) !backend_types.WriteResult {
-    self.backend_handoff_mutex.lock();
-    defer self.backend_handoff_mutex.unlock();
+    try self.backend_handoff_mutex.lock(self.io);
+    defer self.backend_handoff_mutex.unlock(self.io);
 
     return if (self.backend) |*backend|
         backend.write(data, cancellation)
@@ -162,8 +167,8 @@ fn checkEmacsQuit(context: *const anyopaque) !void {
 }
 
 pub fn resizePty(self: *Self, cols: u16, rows: u16) !void {
-    self.backend_handoff_mutex.lock();
-    defer self.backend_handoff_mutex.unlock();
+    try self.backend_handoff_mutex.lock(self.io);
+    defer self.backend_handoff_mutex.unlock(self.io);
 
     if (self.backend) |*backend| try backend.resize(cols, rows);
 }
@@ -174,8 +179,8 @@ pub fn effect(self: *Self, comptime func: []const u8, args: anytype) void {
     };
 }
 
-pub fn replicaName(self: *Self) []const u8 {
-    return self.replica_name;
+pub fn replicaName(self: *Self) [*:0]const u8 {
+    return self.replica_name.ptr;
 }
 
 pub fn pidValue(self: *Self) i64 {
@@ -280,8 +285,8 @@ fn loopOnce(self: *Self) !bool {
 }
 
 fn retireBackend(self: *Self) ?Backend {
-    self.backend_handoff_mutex.lock();
-    defer self.backend_handoff_mutex.unlock();
+    self.backend_handoff_mutex.lockUncancelable(self.io);
+    defer self.backend_handoff_mutex.unlock(self.io);
 
     const backend = self.backend orelse return null;
     self.backend = null;
@@ -336,8 +341,8 @@ pub fn deinit(self: *Self) void {
     @atomicStore(bool, &self.quit, true, .monotonic);
 
     {
-        self.backend_handoff_mutex.lock();
-        defer self.backend_handoff_mutex.unlock();
+        self.backend_handoff_mutex.lockUncancelable(self.io);
+        defer self.backend_handoff_mutex.unlock(self.io);
         if (self.backend) |*backend| backend.requestStop(self.thread);
     }
 

--- a/src/PosixPtyProcess.zig
+++ b/src/PosixPtyProcess.zig
@@ -1,67 +1,56 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const posix = std.posix;
+const sys = std.posix.system;
 
 const backend_types = @import("backend_types.zig");
-
-const c = @cImport({
-    @cDefine("_GNU_SOURCE", {});
-    @cInclude("stdlib.h");
-    @cInclude("fcntl.h");
-    @cInclude("signal.h");
-    @cInclude("sys/ioctl.h");
-    @cInclude("sys/wait.h");
-    @cInclude("termios.h");
-});
+const c = @import("posix_c");
 
 const Self = @This();
 const WRITE_CHUNK_SIZE = 4096;
 
+const log = std.log.scoped(.NativeProcessHandler);
+
 const Pty = struct {
     primary_fd: c_int = -1,
     replica_fd: c_int = -1,
-    replica_name: [1024]u8 = undefined,
+    replica_name: [1024:0]u8 = undefined,
 
     pub fn init() !Pty {
         var self: @This() = .{};
         self.primary_fd = c.posix_openpt(c.O_RDWR | c.O_NOCTTY | c.O_CLOEXEC);
-        if (posix.errno(self.primary_fd) != .SUCCESS) {
+        if (sys.errno(self.primary_fd) != .SUCCESS) {
             return error.OpenPtFailed;
         }
-        errdefer posix.close(self.primary_fd);
+        errdefer _ = sys.close(self.primary_fd);
 
-        if (posix.errno(c.grantpt(self.primary_fd)) != .SUCCESS) {
-            return error.OpenPtFailed;
+        if (sys.errno(c.grantpt(self.primary_fd)) != .SUCCESS) {
+            return error.GrantPtFailed;
         }
 
-        if (posix.errno(c.unlockpt(self.primary_fd)) != .SUCCESS) {
-            return error.OpenPtFailed;
+        if (sys.errno(c.unlockpt(self.primary_fd)) != .SUCCESS) {
+            return error.UnlockPtFailed;
         }
 
-        const ptsname_err = posix.errno(c.ptsname_r(
+        const ptsname_err = sys.errno(c.ptsname_r(
             self.primary_fd,
             &self.replica_name,
             self.replica_name.len,
         ));
         if (ptsname_err != .SUCCESS) {
-            return error.OpenPtFailed;
+            return error.PtsNameFailed;
         }
 
-        self.replica_fd = try posix.openZ(
-            @ptrCast(&self.replica_name),
-            .{ .ACCMODE = .RDWR, .NOCTTY = true },
-            0,
-        );
-        errdefer posix.close(self.replica_fd);
+        self.replica_fd = sys.open(&self.replica_name, .{ .ACCMODE = .RDWR, .NOCTTY = true });
+        if (sys.errno(self.replica_fd) != .SUCCESS) return error.OpenReplicaFailed;
+        errdefer _ = sys.close(self.replica_fd);
 
         // Configure the line discipline on the replica. On macOS/BSD the
         // master (ptm) fd rejects termios ioctls with ENOTTY; only the
         // replica carries the terminal attributes, so this must run on
         // `replica_fd', not `primary_fd'.
         var attrs: c.termios = undefined;
-        if (c.tcgetattr(self.replica_fd, &attrs) != 0) {
-            return error.OpenPtFailed;
-        }
+        if (c.tcgetattr(self.replica_fd, &attrs) != 0) return error.TcgetattrFailed;
+
         // Enable UTF-8 mode so backspace erases multi-byte characters.
         attrs.c_iflag |= c.IUTF8;
         // Disable XON/XOFF flow control so C-q (DC1) and C-s (DC3) pass
@@ -69,16 +58,14 @@ const Pty = struct {
         // line discipline. Ghostel's send-next-key escape hatch and the
         // direct C-q binding rely on these bytes reaching the child.
         attrs.c_iflag &= ~@as(@TypeOf(attrs.c_iflag), c.IXON);
-        if (c.tcsetattr(self.replica_fd, c.TCSANOW, &attrs) != 0) {
-            return error.OpenPtFailed;
-        }
+        if (c.tcsetattr(self.replica_fd, c.TCSANOW, &attrs) != 0) return error.TcsetattrFailed;
 
         return self;
     }
 
     pub fn resize(self: *@This(), cols: u16, rows: u16) !void {
         const size = c.winsize{ .ws_col = cols, .ws_row = rows, .ws_xpixel = 0, .ws_ypixel = 0 };
-        switch (posix.errno(c.ioctl(self.primary_fd, c.TIOCSWINSZ, &size))) {
+        switch (sys.errno(c.ioctl(self.primary_fd, c.TIOCSWINSZ, &size))) {
             .SUCCESS, .IO, .NXIO => {},
             else => return error.PtyResizeFailed,
         }
@@ -86,14 +73,14 @@ const Pty = struct {
 
     pub fn closePrimary(self: *@This()) void {
         if (self.primary_fd != -1) {
-            posix.close(self.primary_fd);
+            _ = sys.close(self.primary_fd);
             self.primary_fd = -1;
         }
     }
 
     pub fn closeReplica(self: *@This()) void {
         if (self.replica_fd != -1) {
-            posix.close(self.replica_fd);
+            _ = sys.close(self.replica_fd);
             self.replica_fd = -1;
         }
     }
@@ -103,11 +90,18 @@ const Pty = struct {
     }
 
     pub fn setupReplica(self: *@This()) !void {
-        _ = try posix.setsid();
-        if (posix.errno(c.ioctl(self.replica_fd, c.TIOCSCTTY)) != .SUCCESS) return error.CttyFailed;
-        try posix.dup2(self.replica_fd, posix.STDIN_FILENO);
-        try posix.dup2(self.replica_fd, posix.STDOUT_FILENO);
-        try posix.dup2(self.replica_fd, posix.STDERR_FILENO);
+        if (sys.errno(sys.setsid()) != .SUCCESS) return error.SetSidFailed;
+        if (sys.errno(c.ioctl(self.replica_fd, c.TIOCSCTTY)) != .SUCCESS) return error.CttyFailed;
+
+        if (sys.errno(sys.dup2(self.replica_fd, sys.STDIN_FILENO)) != .SUCCESS) {
+            return error.ReplicaFdSetupFailed;
+        }
+        if (sys.errno(sys.dup2(self.replica_fd, sys.STDOUT_FILENO)) != .SUCCESS) {
+            return error.ReplicaFdSetupFailed;
+        }
+        if (sys.errno(sys.dup2(self.replica_fd, sys.STDERR_FILENO)) != .SUCCESS) {
+            return error.ReplicaFdSetupFailed;
+        }
     }
 
     pub fn deinit(self: *@This()) void {
@@ -117,11 +111,11 @@ const Pty = struct {
 };
 
 pty: Pty,
-pid: posix.pid_t = -1,
-wake_pipe: [2]posix.fd_t = .{ -1, -1 },
+pid: sys.pid_t = -1,
+wake_pipe: [2]sys.fd_t = .{ -1, -1 },
 
 pub const EventWriter = struct {
-    pub const Fd = posix.fd_t;
+    pub const Fd = sys.fd_t;
 
     fd: Fd,
 
@@ -132,45 +126,71 @@ pub const EventWriter = struct {
     pub fn write(self: *EventWriter, data: []const u8) !void {
         var written: usize = 0;
         while (written < data.len) {
-            const n = try posix.write(self.fd, data[written..data.len]);
-            if (n == 0) return error.EventWriteFailed;
-            written += n;
+            const n = writeWithRetry(self.fd, data[written..data.len]);
+            if (n <= 0) return error.EventWriteFailed;
+            written += @intCast(n);
         }
     }
 
     pub fn close(self: *EventWriter) void {
         if (self.fd == -1) return;
-        posix.close(self.fd);
+        _ = sys.close(self.fd);
         self.fd = -1;
     }
 
     pub fn onThreadEnter(self: *EventWriter) void {
-        if (@hasDecl(posix.F, "SETNOSIGPIPE")) {
-            _ = posix.fcntl(self.fd, posix.F.SETNOSIGPIPE, 1) catch |err| {
-                std.log.scoped(.NativeProcessHandler).warn("Unable to set SETNOSIGPIPE: {any}", .{err});
+        if (@hasDecl(sys.F, "SETNOSIGPIPE")) {
+            _ = fcntl(self.fd, sys.F.SETNOSIGPIPE, 1) catch |err| {
+                log.warn("Unable to set SETNOSIGPIPE: {any}", .{err});
             };
         }
 
         var set: c.sigset_t = undefined;
         _ = c.sigemptyset(&set);
-        _ = c.sigaddset(&set, posix.SIG.PIPE);
-        _ = posix.errno(c.pthread_sigmask(c.SIG_BLOCK, &set, null));
+        _ = c.sigaddset(&set, c.SIGPIPE);
+        _ = sys.errno(c.pthread_sigmask(c.SIG_BLOCK, &set, null));
     }
 
     pub fn onThreadExit() void {
         var pending: c.sigset_t = undefined;
         _ = c.sigpending(&pending);
-        if (c.sigismember(&pending, posix.SIG.PIPE) != 0) {
+        if (c.sigismember(&pending, c.SIGPIPE) != 0) {
             var wait_sigs: c.sigset_t = undefined;
             _ = c.sigemptyset(&wait_sigs);
-            _ = c.sigaddset(&wait_sigs, posix.SIG.PIPE);
+            _ = c.sigaddset(&wait_sigs, c.SIGPIPE);
             var sig: c_int = undefined;
             _ = c.sigwait(&wait_sigs, &sig);
         }
     }
 };
 
-pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: backend_types.ProcessParams) !Self {
+fn fcntl(fd: sys.fd_t, cmd: c_int, arg: c_int) !c_int {
+    const result = sys.fcntl(fd, cmd, arg);
+    return if (sys.errno(result) == .SUCCESS) result else error.FcntlFailed;
+}
+
+fn writeWithRetry(fd: sys.fd_t, data: []const u8) isize {
+    while (true) {
+        const written = sys.write(fd, data.ptr, data.len);
+        if (sys.errno(written) != .INTR) return written;
+    }
+}
+
+fn pollWithRetry(pollfds: []sys.pollfd, timeout: c_int) c_int {
+    while (true) {
+        const result = sys.poll(pollfds.ptr, @intCast(pollfds.len), timeout);
+        if (sys.errno(result) != .INTR) return result;
+    }
+}
+
+fn failChild(msg: []const u8, err: []const u8) noreturn {
+    _ = sys.write(sys.STDERR_FILENO, msg.ptr, msg.len);
+    _ = sys.write(sys.STDERR_FILENO, ": ", 2);
+    _ = sys.write(sys.STDERR_FILENO, err.ptr, err.len);
+    std.c._exit(1);
+}
+
+pub fn init(alloc: Allocator, _: std.Io, initial_cols: u16, initial_rows: u16, params: backend_types.ProcessParams) !Self {
     var self = Self{ .pty = try .init() };
     errdefer self.pty.deinit();
     try self.pty.resize(initial_cols, initial_rows);
@@ -179,23 +199,32 @@ pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: back
     defer arena_allocator.deinit();
     const arena = arena_allocator.allocator();
 
-    const env = try std.process.createNullDelimitedEnvMap(arena, params.env);
+    const env = try params.env.createPosixBlock(arena, .{});
     const args = try arena.allocSentinel(?[*:0]const u8, params.args.len, null);
     for (params.args, 0..) |arg, i| args[i] = arg;
 
-    self.wake_pipe = try posix.pipe2(.{ .CLOEXEC = true });
-    errdefer {
-        posix.close(self.wake_pipe[0]);
-        posix.close(self.wake_pipe[1]);
+    if (sys.errno(sys.pipe(&self.wake_pipe)) != .SUCCESS) {
+        return error.PipeCreationFailed;
     }
-    const flags = try posix.fcntl(self.pty.primary_fd, posix.F.GETFL, 0);
-    _ = try posix.fcntl(
+    errdefer {
+        _ = sys.close(self.wake_pipe[0]);
+        _ = sys.close(self.wake_pipe[1]);
+    }
+
+    // This is racy but benign. pipe2 would be better but doesn't exist on macOS.
+    for (self.wake_pipe) |fd| {
+        _ = try fcntl(fd, sys.F.SETFD, sys.FD_CLOEXEC);
+    }
+
+    const flags = try fcntl(self.pty.primary_fd, sys.F.GETFL, 0);
+    _ = try fcntl(
         self.pty.primary_fd,
-        posix.F.SETFL,
-        flags | @as(u32, @bitCast(posix.O{ .NONBLOCK = true })),
+        sys.F.SETFL,
+        flags | @as(u32, @bitCast(sys.O{ .NONBLOCK = true })),
     );
 
-    const pid = try posix.fork();
+    const pid = sys.fork();
+    if (sys.errno(pid) != .SUCCESS) return error.ForkFailed;
     if (pid != 0) {
         // This is the parent, child started successfully.
         self.pty.closeReplica();
@@ -205,22 +234,20 @@ pub fn init(alloc: Allocator, initial_cols: u16, initial_rows: u16, params: back
 
     // This is the child.
     self.pty.setupReplica() catch |err| {
-        _ = posix.write(posix.STDERR_FILENO, "Failed to set up PTY replica: ") catch 0;
-        _ = posix.write(posix.STDERR_FILENO, @errorName(err)) catch 0;
-        std.c._exit(1);
+        failChild("Failed to set up PTY replica", @errorName(err));
     };
 
-    if (params.cwd) |cwd| posix.chdir(cwd) catch |err| {
-        _ = posix.write(posix.STDERR_FILENO, "Failed to change working directory: ") catch 0;
-        _ = posix.write(posix.STDERR_FILENO, @errorName(err)) catch 0;
-        std.c._exit(1);
-    };
+    if (params.cwd) |cwd| {
+        const result = sys.errno(sys.chdir(cwd));
+        if (result != .SUCCESS) {
+            failChild("Failed to change working directory", @tagName(result));
+        }
+    }
 
-    const err = posix.execvpeZ(params.file, args, env);
+    const err = sys.execve(params.file, args, env.slice);
+
     // The above never returns on success, if we're here it means we failed.
-    _ = posix.write(posix.STDERR_FILENO, "Failed to start subprocess: ") catch 0;
-    _ = posix.write(posix.STDERR_FILENO, @errorName(err)) catch 0;
-    std.c._exit(1);
+    failChild("Failed to start subprocess", @tagName(sys.errno(err)));
 }
 
 pub fn pidValue(self: *const Self) i64 {
@@ -240,30 +267,35 @@ pub fn write(
 
     const chunk = data[0..@min(data.len, WRITE_CHUNK_SIZE)];
     while (true) {
-        const written = posix.write(self.pty.primary_fd, chunk) catch |err| switch (err) {
-            error.BrokenPipe,
-            error.InputOutput,
-            error.ProcessNotFound,
-            error.NoDevice,
-            => return .interrupted,
-            error.WouldBlock => {
-                var pollfds = [_]posix.pollfd{
+        const written = writeWithRetry(self.pty.primary_fd, chunk);
+        if (written == 0) return error.IoFailed;
+        switch (sys.errno(written)) {
+            .SUCCESS => return .{ .written = @intCast(written) },
+
+            .PIPE, .IO, .SRCH, .NXIO => return .interrupted,
+
+            .AGAIN => {
+                var pollfds = [_]sys.pollfd{
                     .{
                         .fd = self.pty.primary_fd,
-                        .events = posix.POLL.OUT,
+                        .events = sys.POLL.OUT,
                         .revents = undefined,
                     },
                     .{
                         .fd = self.wake_pipe[0],
-                        .events = posix.POLL.IN,
+                        .events = sys.POLL.IN,
                         .revents = undefined,
                     },
                 };
                 const timeout: i32 = if (cancellation) |token|
-                    @intCast(@min(token.poll_interval_ms, @as(u32, @intCast(std.math.maxInt(i32)))))
+                    @intCast(@min(
+                        token.poll_interval.toMilliseconds(),
+                        @as(u32, @intCast(std.math.maxInt(i32))),
+                    ))
                 else
                     -1;
-                const ready = try posix.poll(&pollfds, timeout);
+                const ready = pollWithRetry(&pollfds, timeout);
+                if (sys.errno(ready) != .SUCCESS) return error.IoFailed;
                 if (ready == 0) {
                     try cancellation.?.check();
                     continue;
@@ -271,40 +303,43 @@ pub fn write(
                 if (pollfds[1].revents != 0) return .interrupted;
                 continue;
             },
-            else => return err,
-        };
-        if (written == 0) return error.IoFailed;
-        return .{ .written = written };
+
+            else => return error.IoFailed,
+        }
     }
 }
 
 pub fn drain(self: *Self, stream: anytype) !bool {
     var buf: [4096]u8 = undefined;
 
-    var pollfds = [_]posix.pollfd{
+    var pollfds = [_]sys.pollfd{
         .{
             .fd = self.pty.primary_fd,
-            .events = posix.POLL.IN,
+            .events = sys.POLL.IN,
             .revents = undefined,
         },
         .{
             .fd = self.wake_pipe[0],
-            .events = posix.POLL.IN,
+            .events = sys.POLL.IN,
             .revents = undefined,
         },
     };
-    _ = try posix.poll(&pollfds, -1);
+    if (sys.errno(pollWithRetry(&pollfds, -1)) != .SUCCESS) {
+        return error.PollFailed;
+    }
     if (pollfds[1].revents != 0) return false;
 
-    const eof = pollfds[0].revents & posix.POLL.HUP != 0;
+    const eof = pollfds[0].revents & sys.POLL.HUP != 0;
     while (true) {
-        const len = posix.read(self.pty.primary_fd, buf[0..]) catch |err| switch (err) {
-            error.WouldBlock => return !eof,
-            error.NotOpenForReading, error.InputOutput => return false,
-            else => return err,
-        };
+        const len = sys.read(self.pty.primary_fd, &buf, buf.len);
         if (len == 0) return !eof;
-        stream.nextSlice(buf[0..len]);
+        switch (sys.errno(len)) {
+            .SUCCESS => try stream.nextSlice(buf[0..@intCast(len)]),
+            .INTR => continue,
+            .AGAIN => return !eof,
+            .BADF, .IO => return false,
+            else => return error.ReadFailed,
+        }
     }
 }
 
@@ -312,7 +347,7 @@ pub fn finishDrain(_: *Self, _: anytype) !void {}
 
 pub fn requestStop(self: *Self, _: std.Thread) void {
     if (self.wake_pipe[1] != -1) {
-        _ = posix.write(self.wake_pipe[1], "X") catch 0;
+        _ = writeWithRetry(self.wake_pipe[1], "X");
     }
 }
 
@@ -323,11 +358,18 @@ pub fn replicaName(self: *Self) []const u8 {
 pub fn deinitAndWait(self: *Self) u32 {
     std.debug.assert(self.pid > 0);
     self.pty.deinit();
-    posix.close(self.wake_pipe[0]);
-    posix.close(self.wake_pipe[1]);
-    const result = posix.waitpid(self.pid, 0);
-    const status: c_int = @bitCast(result.status);
-    if (c.WIFEXITED(status)) return @intCast(c.WEXITSTATUS(status));
-    if (c.WIFSIGNALED(status)) return @intCast(128 + c.WTERMSIG(status));
-    return 255;
+    _ = sys.close(self.wake_pipe[0]);
+    _ = sys.close(self.wake_pipe[1]);
+    while (true) {
+        var status: c_int = undefined;
+        switch (sys.errno(sys.waitpid(self.pid, &status, 0))) {
+            .SUCCESS => {
+                if (c.WIFEXITED(status)) return @intCast(c.WEXITSTATUS(status));
+                if (c.WIFSIGNALED(status)) return @intCast(128 + c.WTERMSIG(status));
+            },
+
+            .INTR => continue,
+            else => return 255,
+        }
+    }
 }

--- a/src/RecursiveMutex.zig
+++ b/src/RecursiveMutex.zig
@@ -1,0 +1,34 @@
+const std = @import("std");
+const Self = @This();
+
+mutex: std.Io.Mutex = .init,
+thread_id: std.Thread.Id = unlocked,
+lock_count: usize = 0,
+
+const unlocked = std.math.maxInt(std.Thread.Id);
+
+pub fn lock(self: *Self, io: std.Io) !void {
+    const current = std.Thread.getCurrentId();
+    if (@atomicLoad(std.Thread.Id, &self.thread_id, .unordered) != current) {
+        try self.mutex.lock(io);
+        @atomicStore(std.Thread.Id, &self.thread_id, current, .unordered);
+    }
+    self.lock_count += 1;
+}
+
+pub fn lockUncancelable(self: *Self, io: std.Io) void {
+    const current = std.Thread.getCurrentId();
+    if (@atomicLoad(std.Thread.Id, &self.thread_id, .unordered) != current) {
+        self.mutex.lockUncancelable(io);
+        @atomicStore(std.Thread.Id, &self.thread_id, current, .unordered);
+    }
+    self.lock_count += 1;
+}
+
+pub fn unlock(self: *Self, io: std.Io) void {
+    self.lock_count -= 1;
+    if (self.lock_count == 0) {
+        @atomicStore(std.Thread.Id, &self.thread_id, unlocked, .unordered);
+        self.mutex.unlock(io);
+    }
+}

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -196,7 +196,7 @@ pub fn redraw(self: *Self, env: emacs.Env, force_full: bool, force_sync: bool) !
 
 fn clearPageDirtyFlags(from_node: *gt.PageList.List.Node) void {
     var node: ?*gt.PageList.List.Node = from_node;
-    while (node) |n| : (node = n.next) n.data.dirty = false;
+    while (node) |n| : (node = n.next) n.page().dirty = false;
 }
 
 fn invalidate(self: *Self, env: emacs.Env) !void {
@@ -312,7 +312,7 @@ fn applyProps(
     env: emacs.Env,
     start: usize,
     end: usize,
-    node: *const gt.PageList.List.Node,
+    node: *gt.PageList.List.Node,
     prop_key: *const CellPropKey,
 ) !void {
     if (start >= end) return;
@@ -330,7 +330,7 @@ fn applyProps(
         });
     }
 
-    const hyperlink = resolveHyperlink(&node.data, prop_key.hyperlink_id);
+    const hyperlink = resolveHyperlink(node.page(), prop_key.hyperlink_id);
     if (hyperlink) |link| {
         _ = env.f("put-text-property", .{
             start_val,
@@ -392,13 +392,13 @@ fn applyProps(
 fn getFace(
     self: *Self,
     env: emacs.Env,
-    node: *const gt.PageList.List.Node,
+    node: *gt.PageList.List.Node,
     key: *const CellPropKey,
 ) !?emacs.Value {
     return if (key.style_id != 0)
         try style_face.buildFacePlist(
             env,
-            node.data.styles.get(node.data.memory, key.style_id),
+            node.page().styles.get(node.page().memory, key.style_id),
             &self.term.colors.palette.current,
             self.bold_config,
         )
@@ -427,7 +427,7 @@ const CellPropKey = struct {
     fn create(page: *const gt.Page, cell: *const gt.page.Cell) ?CellPropKey {
         const hyperlink_id = if (cell.hyperlink) page.lookupHyperlink(cell) else null;
         const bg_color: gt.Style.Color = switch (cell.content_tag) {
-            .bg_color_palette => .{ .palette = cell.content.color_palette },
+            .bg_color_palette => .{ .palette = cell.content.color_palette.data },
             .bg_color_rgb => .{ .rgb = .{
                 .r = cell.content.color_rgb.r,
                 .g = cell.content.color_rgb.g,
@@ -511,7 +511,7 @@ pub const SpanContent = struct {
     cursor_char_pos: ?usize = null,
 
     /// The node this span comes from
-    node: ?*const gt.PageList.List.Node = null,
+    node: ?*gt.PageList.List.Node = null,
 
     pub fn addRow(
         self: *SpanContent,
@@ -537,7 +537,7 @@ pub const SpanContent = struct {
         else
             null;
 
-        const page = &row_pin.node.data;
+        const page = row_pin.node.page();
         const row = row_pin.rowAndCell().row;
         var current_prop_key: ?CellPropKey = null;
         var first_cell = true;
@@ -549,7 +549,7 @@ pub const SpanContent = struct {
 
             // We use a "key" that holds a minimum set of values that are cheap to
             // compare to detect style run breaks.
-            const prop_key = CellPropKey.create(&row_pin.node.data, cell);
+            const prop_key = CellPropKey.create(page, cell);
             if (first_cell or !std.meta.eql(prop_key, current_prop_key)) {
                 try self.runs.append(self.alloc, .{
                     .start_char = self.char_len,
@@ -1018,11 +1018,16 @@ fn commitResize(self: *Self, env: emacs.Env) !void {
         // Pin our saved positions during resize
         self.saved_markers.pin(self.term.screens.active, env);
 
-        try self.term.resize(self.alloc, rz.cols, rz.rows);
-        self.term.width_px = std.math.mul(u32, rz.cols, rz.cell_w) catch
-            std.math.maxInt(u32);
-        self.term.height_px = std.math.mul(u32, rz.rows, rz.cell_h) catch
-            std.math.maxInt(u32);
+        try self.term.resize(self.alloc, .{
+            .cols = rz.cols,
+            .rows = rz.rows,
+            .cell_size_px = .{
+                .width = std.math.mul(u32, rz.cols, rz.cell_w) catch
+                    std.math.maxInt(u32),
+                .height = std.math.mul(u32, rz.rows, rz.cell_h) catch
+                    std.math.maxInt(u32),
+            },
+        });
         self.pending_resize = null;
 
         env.set("ghostel--term-rows", self.term.rows);

--- a/src/backend_types.zig
+++ b/src/backend_types.zig
@@ -3,14 +3,14 @@ const std = @import("std");
 pub const ProcessParams = struct {
     file: [:0]const u8,
     args: [][:0]const u8,
-    env: *const std.process.EnvMap,
-    cwd: ?[]const u8 = null,
+    env: *const std.process.Environ.Map,
+    cwd: ?[:0]const u8 = null,
 };
 
 pub const CancellationToken = struct {
     context: *const anyopaque,
     check_fn: *const fn (*const anyopaque) anyerror!void,
-    poll_interval_ms: u32,
+    poll_interval: std.Io.Duration,
 
     pub fn check(self: CancellationToken) !void {
         try self.check_fn(self.context);
@@ -36,7 +36,7 @@ test "CancellationToken delegates cancellation checks" {
     const token = CancellationToken{
         .context = &context,
         .check_fn = Context.check,
-        .poll_interval_ms = 20,
+        .poll_interval = .fromMilliseconds(20),
     };
     try token.check();
     try std.testing.expect(context.checked);

--- a/src/emacs.h
+++ b/src/emacs.h
@@ -1,0 +1,4 @@
+// Ensure struct timespec is fully defined on Linux (glibc gates it
+// behind _POSIX_C_SOURCE).  Harmless on macOS/BSDs.
+#define _POSIX_C_SOURCE 199309L
+#include <emacs-module.h>

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -5,13 +5,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const builtin = @import("builtin");
-
-pub const c = @cImport({
-    // Ensure struct timespec is fully defined on Linux (glibc gates it
-    // behind _POSIX_C_SOURCE).  Harmless on macOS/BSDs.
-    @cDefine("_POSIX_C_SOURCE", "199309L");
-    @cInclude("emacs-module.h");
-});
+pub const c = @import("emacs_c");
 
 pub const Value = c.emacs_value;
 pub const RawEnv = ?*c.emacs_env;
@@ -35,7 +29,7 @@ const DebugUserPtr = struct {
 /// Tracks all live userptrs in debug builds so the kill-emacs-hook can
 /// explicitly free them before atexit fires. This allows us to check for
 /// memory leaks on exit.
-var debug_userptrs: std.ArrayList(DebugUserPtr) = .{};
+var debug_userptrs: std.ArrayList(DebugUserPtr) = .empty;
 
 pub const FunctionEntry = struct {
     name: [:0]const u8,
@@ -325,7 +319,7 @@ pub const Env = struct {
     }
 
     /// Register a named Elisp function backed by a C function.
-    pub fn registerFunction(self: Env, entry: *const FunctionEntry) void {
+    pub fn registerFunction(self: Env, comptime entry: *const FunctionEntry) void {
         const wrapped_fn = struct {
             fn call(
                 raw_env: RawEnv,
@@ -357,7 +351,7 @@ pub const Env = struct {
     }
 
     /// Register a named Elisp function backed by a C function.
-    pub fn registerFunctions(self: Env, entries: []const FunctionEntry) void {
+    pub fn registerFunctions(self: Env, comptime entries: []const FunctionEntry) void {
         inline for (entries) |*entry| self.registerFunction(entry);
     }
 
@@ -404,11 +398,11 @@ pub const Env = struct {
             if (stack_trace) |trace| {
                 var buffer: [4096]u8 = undefined;
                 var writer = std.Io.Writer.fixed(&buffer);
-                const debug_info = std.debug.getSelfDebugInfo() catch |err| {
-                    self.logError("Unable to get debug info: %s", .{@errorName(err)});
-                    return;
+                const terminal: std.Io.Terminal = .{
+                    .writer = &writer,
+                    .mode = .no_color,
                 };
-                std.debug.writeStackTrace(trace.*, &writer, debug_info, .no_color) catch |err| {
+                std.debug.writeErrorReturnTrace(trace, terminal) catch |err| {
                     self.logError("Unable to print stack trace: %s", .{@errorName(err)});
                     return;
                 };
@@ -563,28 +557,27 @@ const interned_symbols = [_][:0]const u8{
     "space",
     "symbol-value",
     "t",
+    "temporary-file-directory",
     "wave",
     "window-point",
     "window-start",
 };
 
 fn SymbolCache(comptime symbols: []const [:0]const u8) type {
-    var cache_fields: [symbols.len]std.builtin.Type.StructField = undefined;
+    var names: [symbols.len][]const u8 = undefined;
+    var types: [symbols.len]type = undefined;
+    var attrs: [symbols.len]std.builtin.Type.StructField.Attributes = undefined;
+
     for (symbols, 0..) |symbol, i| {
-        cache_fields[i] = .{
-            .name = symbol,
-            .type = Value,
+        names[i] = symbol;
+        types[i] = Value;
+        attrs[i] = .{
+            .@"comptime" = false,
+            .@"align" = @alignOf(Value),
             .default_value_ptr = null,
-            .is_comptime = false,
-            .alignment = @alignOf(Value),
         };
     }
-    return @Type(.{ .@"struct" = .{
-        .layout = .auto,
-        .fields = &cache_fields,
-        .decls = &[_]std.builtin.Type.Declaration{},
-        .is_tuple = false,
-    } });
+    return @Struct(.auto, null, &names, &types, &attrs);
 }
 
 pub var sym: SymbolCache(&interned_symbols) = undefined;

--- a/src/module.zig
+++ b/src/module.zig
@@ -23,6 +23,8 @@ const c = emacs.c;
 var debug_alloc: std.heap.DebugAllocator(.{}) = .init;
 var alloc: Allocator = std.heap.c_allocator;
 
+var io: std.Io.Threaded = .init_single_threaded;
+
 /// Module version — see src/version.zig.  Keep in sync with ghostel.el
 /// and build.zig.zon.
 const version = @import("version.zig").version;
@@ -52,7 +54,7 @@ export fn emacs_module_init(runtime: *c.struct_emacs_runtime) callconv(.c) c_int
     env.registerFunctions(&emacs_functions);
 
     ComintFilter.initModule(alloc, env);
-    GhostelTerm.initModule(alloc, env);
+    GhostelTerm.initModule(alloc, io.io(), env) catch return 1;
 
     gt.sys.decode_png = &png.decode;
 

--- a/src/png.zig
+++ b/src/png.zig
@@ -5,9 +5,7 @@
 /// libghostty `decode_png` callback contract.
 const std = @import("std");
 const gt = @import("ghostty-vt");
-const stb = @cImport({
-    @cInclude("stb_image.h");
-});
+const stb = @import("stb_image_c");
 
 pub const DecodeError = error{
     EmptyData,

--- a/src/posix.h
+++ b/src/posix.h
@@ -1,0 +1,8 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <termios.h>

--- a/src/pty_utils.zig
+++ b/src/pty_utils.zig
@@ -7,6 +7,7 @@
 /// not change the device's state and is safe to run frequently.
 const std = @import("std");
 const builtin = @import("builtin");
+const sys = std.posix.system;
 
 /// Returns true if the tty at PATH is in canonical mode with echo
 /// disabled — the heuristic libghostty uses to decide that the
@@ -22,16 +23,19 @@ const builtin = @import("builtin");
 /// DCD.  Neither flag affects what `tcgetattr` reads.  `RDONLY` is
 /// sufficient — we never write to the slave; reducing the mode means
 /// a stray write through this fd can't garble the child's input.
-pub fn isPasswordMode(path: []const u8) bool {
+pub fn isPasswordMode(path: [*:0]const u8) bool {
     if (builtin.os.tag == .windows) return false;
 
-    const fd = std.posix.open(path, .{
+    const fd = sys.open(path, .{
         .ACCMODE = .RDONLY,
         .NOCTTY = true,
         .NONBLOCK = true,
-    }, 0) catch return false;
-    defer std.posix.close(fd);
+    });
+    if (sys.errno(fd) != .SUCCESS) return false;
+    defer _ = sys.close(fd);
 
-    const tio = std.posix.tcgetattr(fd) catch return false;
+    var tio: sys.termios = undefined;
+    const result = sys.tcgetattr(fd, &tio);
+    if (sys.errno(result) != .SUCCESS) return false;
     return tio.lflag.ICANON and !tio.lflag.ECHO;
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -15,11 +15,10 @@ pub fn cellCharCount(page: *gt.Page, cell: *gt.Cell) usize {
 }
 
 pub fn rowCharOffset(pin: gt.Pin) usize {
-    const page = &pin.node.data;
     var char_count: usize = 0;
     var cells = pin.cells(.left);
     cells.len -= 1;
-    for (cells) |*cell| char_count += cellCharCount(page, cell);
+    for (cells) |*cell| char_count += cellCharCount(pin.node.page(), cell);
     return char_count;
 }
 
@@ -28,7 +27,7 @@ pub fn advanceByCharOffset(pin: gt.Pin, offset: usize) ?gt.Pin {
     var it = pin.cellIterator(.right_down, null);
     while (it.next()) |p| {
         if (char_count >= offset) return p;
-        char_count += cellCharCount(&p.node.data, p.rowAndCell().cell);
+        char_count += cellCharCount(p.node.page(), p.rowAndCell().cell);
     }
 
     return null;

--- a/src/win32.h
+++ b/src/win32.h
@@ -1,0 +1,1 @@
+#include <windows.h>


### PR DESCRIPTION
## Summary

- upgrade the libghostty dependency and require Zig 0.16.0
- migrate the native module to the Zig 0.16 I/O, process, C translation, and synchronization APIs
- update CI, release builds, and source-build documentation for Zig 0.16.0

## Verification

- clean-checkout `zig build`
- clean-checkout `zig build test`
- native process tests: 5 passed
- native render tests: 83 passed
- `git diff --check`