### PR TITLE
Forward programmatic buffer inserts to the PTY

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Replace comint's built-in `ansi-color-process-output` with Ghostel's VT parser.
   :hook (after-init . ghostel-comint-global-mode))
 ```
 
-If you use an Emacs Lisp input method (e.g. Korean Hangul), add Ghostel support:
+If you use an Emacs Lisp input method (Korean Hangul, Japanese, Chinese, or any
+other Quail-based method), add Ghostel support:
 ```emacs-lisp
 (use-package ghostel-ime
   :hook (ghostel-mode . ghostel-ime-mode))

--- a/README.org
+++ b/README.org
@@ -1703,26 +1703,28 @@ buffers applies here too - see the docstring of =ghostel-comint-mode=.
 :end:
 #+cindex: input methods
 
-Some Emacs Lisp input methods (=hangul-input-method= is the common example)
-commit text by inserting it into the current buffer instead of returning key
-events.  Inside a ghostel buffer that insert lands in the buffer but is never
-sent to the PTY, so the next redraw erases it.
+Emacs Lisp input methods compose and commit text by editing the current buffer
+instead of returning key events: =hangul-input-method= inserts the composed
+syllable directly, and Quail-based methods (Japanese, Chinese, ...) use the
+buffer for their in-flight preedit as well.  A ghostel buffer is
+terminal-owned, so those edits either fail against the read-only barrier or
+are picked up by insert forwarding and sent to the PTY mid-composition.
 
 =ghostel-ime-mode= is an optional minor mode that wraps the buffer-local
 =input-method-function=.  When the input method commits by buffer insertion, the
 wrapper deletes the transient insert and forwards the committed text to the PTY
 as UTF-8, letting the shell echo it back through the normal redraw path.  While a
-Quail-style composition is in flight it also asks ghostel to defer redraws (via
-=ghostel-inhibit-redraw-functions=) so the renderer does not rewrite the buffer
-mid-composition.  GUI native preedit handling is unaffected.
+composition is in flight it also stands down insert forwarding (via
+=ghostel-inhibit-input-forwarding-functions=) and asks ghostel to defer redraws
+(via =ghostel-inhibit-redraw-functions=) so the renderer does not rewrite the
+buffer mid-composition.  GUI native preedit handling is unaffected.
+
+Enable it for any Emacs Lisp input method:
 
 #+begin_src emacs-lisp
 (use-package ghostel-ime
   :hook (ghostel-mode . ghostel-ime-mode))
 #+end_src
-
-This generalizes to any Lisp input method that uses =quail-overlay= (Korean
-Hangul, Japanese, Chinese, ...).
 
 * Commands
 :properties:

--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -69,6 +69,8 @@
 
 (declare-function ghostel--set-size "ghostel-module")
 (declare-function ghostel--write-vt "ghostel-module")
+(declare-function ghostel--sync-inhibit-read-only "ghostel")
+(defvar ghostel--inhibit-insert-forwarding)
 
 
 ;;; Customization
@@ -539,7 +541,8 @@ local machine happens to have)."
     ;; it — that's how users interact with long-running programs
     ;; (`htop', `less', test prompts, ...) during the compile.
     (with-current-buffer buffer
-      (setq ghostel--process proc))
+      (setq ghostel--process proc)
+      (ghostel--sync-inhibit-read-only))
     (set-process-coding-system proc 'binary 'binary)
     (set-process-window-size proc height width)
     (when compilation-always-kill
@@ -639,7 +642,9 @@ the rendered buffer remains read-only in both cases."
       ;; \\='ghostel-mode\\=') keep working; only input handling changes.
       (unless interactive
         (use-local-map ghostel-compile-view-mode-map)
-        (setq buffer-read-only t))
+        (setq buffer-read-only t)
+        ;; Compilation-style buffers keep the plain read-only barrier.
+        (setq ghostel--inhibit-insert-forwarding t))
       ;; Enable the live toggle (`C-c C-j' / `C-c C-e') in compile
       ;; buffers, regardless of which run mode they're in.  The
       ;; minor-mode keymap takes precedence over the major-mode map
@@ -905,6 +910,8 @@ Bound to \\[ghostel-compile-switch-to-interactive] in
     (setq ghostel-compile--interactive t)
     (use-local-map ghostel-semi-char-mode-map)
     (setq buffer-read-only t)
+    (setq ghostel--inhibit-insert-forwarding nil)
+    (ghostel--sync-inhibit-read-only)
     ;; Place point at the VT cursor so the user's first keystroke
     ;; lands at the prompt, not at wherever they happened to be
     ;; navigating in the read-only buffer.
@@ -934,6 +941,8 @@ Bound to \\[ghostel-compile-switch-to-compilation-style] in
     (setq ghostel-compile--interactive nil)
     (use-local-map ghostel-compile-view-mode-map)
     (setq buffer-read-only t)
+    (setq ghostel--inhibit-insert-forwarding t)
+    (ghostel--sync-inhibit-read-only)
     (ghostel-compile--set-mode-line-running)
     (when ghostel-compile-debug
       (message "ghostel-compile: switched to compilation-style"))))

--- a/lisp/ghostel-ime.el
+++ b/lisp/ghostel-ime.el
@@ -23,22 +23,26 @@
 
 ;;; Commentary:
 
-;; Optional integration for Emacs Lisp input methods that commit text by
-;; inserting into the current buffer.  `hangul-input-method' is the common
+;; Optional integration for Emacs Lisp input methods that compose and commit
+;; text by editing the current buffer.  `hangul-input-method' is the common
 ;; example: it calls `self-insert-command' directly for the composed syllable,
 ;; bypassing ghostel's key remapping, so the commit lands in the buffer but is
-;; not sent to the PTY.
+;; not sent to the PTY.  Quail-based methods (Japanese, Chinese, ...) use the
+;; buffer for their in-flight preedit the same way, so enable this mode for
+;; any Emacs Lisp input method used in ghostel buffers.
 ;;
 ;; `ghostel-ime-mode' wraps the buffer-local `input-method-function'.  If the
 ;; input method inserts committed text into the ghostel buffer, the wrapper
 ;; captures that text, deletes the local insert, and forwards the UTF-8 bytes to
 ;; the PTY.  The shell then echoes the text through ghostel's normal redraw path.
 ;;
-;; During an in-flight Lisp IME composition, the mode also asks core ghostel to
-;; defer redraws via `ghostel-inhibit-redraw-functions'.  This keeps the native
-;; redrawer from rewriting the buffer while Quail-style overlays use it as
-;; scratch state.  GUI preedit overlays are left to ghostel.el's native preedit
-;; preservation path.
+;; During an in-flight Lisp IME composition, the mode also stands down insert
+;; forwarding via `ghostel-inhibit-input-forwarding-functions' and asks core
+;; ghostel to defer redraws via `ghostel-inhibit-redraw-functions'.  This keeps
+;; composition edits from being forwarded to the PTY as foreign inserts and the
+;; native redrawer from rewriting the buffer while Quail-style overlays use it
+;; as scratch state.  GUI preedit overlays are left to ghostel.el's native
+;; preedit preservation path.
 
 ;;; Code:
 
@@ -151,8 +155,10 @@ wrapper is back in place before the next key is read."
   "Toggle Emacs Lisp input-method integration in this ghostel buffer.
 
 When enabled, ghostel forwards committed text from Lisp input methods
-that insert directly into the buffer, and defers redraws while a
-Quail-style composition is in flight.  A typical setup is:
+that insert directly into the buffer, and defers redraws and insert
+forwarding while a composition is in flight.  Enable it for any Emacs
+Lisp input method (Hangul, Quail-based Japanese/Chinese, ...).  A
+typical setup is:
 
   (add-hook \='ghostel-mode-hook #\='ghostel-ime-mode)"
   :lighter nil
@@ -162,11 +168,15 @@ Quail-style composition is in flight.  A typical setup is:
         (add-hook 'input-method-deactivate-hook #'ghostel-ime--uninstall nil t)
         (add-hook 'ghostel-inhibit-redraw-functions
                   #'ghostel-ime-lisp-composing-p nil t)
+        (add-hook 'ghostel-inhibit-input-forwarding-functions
+                  #'ghostel-ime-lisp-composing-p nil t)
         (add-hook 'post-command-hook #'ghostel-ime--reassert 90 t)
         (ghostel-ime--install))
     (remove-hook 'input-method-activate-hook #'ghostel-ime--install t)
     (remove-hook 'input-method-deactivate-hook #'ghostel-ime--uninstall t)
     (remove-hook 'ghostel-inhibit-redraw-functions
+                 #'ghostel-ime-lisp-composing-p t)
+    (remove-hook 'ghostel-inhibit-input-forwarding-functions
                  #'ghostel-ime-lisp-composing-p t)
     (remove-hook 'post-command-hook #'ghostel-ime--reassert t)
     (ghostel-ime--uninstall)))

--- a/lisp/ghostel-line-mode.el
+++ b/lisp/ghostel-line-mode.el
@@ -28,6 +28,7 @@
 (declare-function ghostel--redraw "ghostel-module"
                   (term &optional full force-sync))
 (declare-function ghostel--regex-prompt-end "ghostel")
+(declare-function ghostel--sync-inhibit-read-only "ghostel")
 (declare-function ghostel--send-encoded "ghostel")
 (declare-function ghostel--uri-at-pos "ghostel")
 (declare-function ghostel--write-pty "ghostel-module")
@@ -273,7 +274,8 @@ content (a status bar drawn below the prompt, a multi-line UI from
 the shell, etc.) intact."
   (when (string-match-p "\\`[[:space:]]*\\'"
                         (buffer-substring-no-properties start (point-max)))
-    (let ((inhibit-read-only t))
+    (let ((inhibit-read-only t)
+          (inhibit-modification-hooks t))
       (delete-region start (point-max)))))
 
 (defun ghostel--line-mode-snapshot ()
@@ -423,6 +425,7 @@ in line mode (the interactive entry validates these)."
       (setq ghostel--line-mode-on-alt-screen (ghostel-alt-screen-p))
       (setq ghostel--line-mode-paused nil)
       (setq ghostel--input-mode 'line)
+      (ghostel--sync-inhibit-read-only)
       (use-local-map ghostel-line-mode-map)
       (setq ghostel--mode-line-tag (ghostel--mode-line-tag-make 'line ":Line"))
       (ghostel--mode-line-refresh)
@@ -583,7 +586,8 @@ which discards any type-ahead and runs inside `ghostel--redraw-now'."
     (setq ghostel--line-mode-saved-cursor-type nil))
   (unless pause
     (when ghostel--term
-      (let ((inhibit-read-only t))
+      (let ((inhibit-read-only t)
+            (inhibit-modification-hooks t))
         (ghostel--redraw ghostel--term t t)))))
 
 (defun ghostel--line-mode-pause ()
@@ -594,6 +598,7 @@ re-enters line mode at the new prompt."
   (ghostel--line-mode-teardown 'pause)
   (setq ghostel--char-mode-override-active nil)
   (setq ghostel--input-mode 'semi-char)
+  (ghostel--sync-inhibit-read-only)
   (use-local-map ghostel-semi-char-mode-map)
   (setq ghostel--mode-line-tag nil)
   (ghostel--mode-line-refresh)

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -344,6 +344,14 @@ buffer during transient states such as Emacs Lisp input-method
 composition."
   :type 'hook)
 
+(defcustom ghostel-inhibit-input-forwarding-functions nil
+  "Abnormal hook to veto forwarding a foreign buffer edit to the PTY.
+Each function is called with no arguments, the ghostel buffer
+current.  A non-nil return leaves the edit alone.  Add-on features
+use this to protect their own buffer insertions, e.g. `ghostel-ime'
+during an Emacs Lisp input-method composition."
+  :type 'hook)
+
 (defcustom ghostel-inhibit-anchor-functions nil
   "Abnormal hook to veto per-window anchoring after a redraw.
 Each function is called with (WINDOW FORCE), WINDOW's buffer current.
@@ -978,7 +986,8 @@ Matches Ghostty 1.2.0's `bold-color' configuration."
            (with-current-buffer buf
              (when (and (derived-mode-p 'ghostel-mode) ghostel--term)
                (ghostel--apply-bold-config ghostel--term)
-               (let ((inhibit-read-only t))
+               (let ((inhibit-read-only t)
+                     (inhibit-modification-hooks t))
                  (ghostel--redraw ghostel--term t t))
                (ghostel--apply-cursor-style))))))
 
@@ -1678,6 +1687,54 @@ Detect that case via `this-command-keys-vector' and re-inject meta."
                    mods ",")))
     (when key-name
       (ghostel--send-encoded key-name mod-str))))
+
+
+;;; Programmatic insert forwarding
+
+(defvar-local ghostel--inhibit-insert-forwarding nil
+  "Non-nil disables insert forwarding (e.g. compilation-style runs).")
+
+(defsubst ghostel--insert-forwarding-live-p ()
+  "Non-nil in a terminal-input mode with a live process and forwarding on."
+  (and (not ghostel--inhibit-insert-forwarding)
+       (ghostel--terminal-input-mode-p)
+       ghostel--term
+       (process-live-p ghostel--process)))
+
+(defun ghostel--forward-inserts-p ()
+  "Non-nil when foreign buffer edits should be intercepted."
+  (and (ghostel--insert-forwarding-live-p)
+       (not (run-hook-with-args-until-success
+             'ghostel-inhibit-input-forwarding-functions))))
+
+(defun ghostel--forward-inserts-after-change (beg end old-len)
+  "Forward a foreign insertion BEG..END to the PTY and remove it from the buffer.
+Text containing a line break is sent as a bracketed paste.  An edit that removed
+renderer-owned text (OLD-LEN non-zero) is instead repaired by a full redraw
+restoring the terminal contents, with point realigned to the VT cursor."
+  (when (ghostel--forward-inserts-p)
+    (if (> old-len 0)
+        (progn
+          (ghostel--redraw ghostel--term t t)
+          ;; The reverted edit must not move point either; realign it.
+          (when ghostel--cursor-char-pos
+            (goto-char ghostel--cursor-char-pos)))
+      (when (> end beg)
+        (let ((text (buffer-substring-no-properties beg end)))
+          (delete-region beg end)
+          (ghostel--on-user-input)
+          (if (string-match-p "[\n\r]" text)
+              (ghostel--paste-text text)
+            (ghostel--send-string (encode-coding-string text 'utf-8))))))))
+
+(defun ghostel--sync-inhibit-read-only ()
+  "Set buffer-local `inhibit-read-only' from the terminal state.
+Non-nil in terminal-input modes with a live process, so
+`(interactive \"*\")' commands run and the after-change hook
+forwards their insertions while `buffer-read-only' stays non-nil;
+nil restores the plain read-only barrier."
+  (setq-local inhibit-read-only
+              (and (ghostel--insert-forwarding-live-p) t)))
 
 
 ;;; Public input API
@@ -2389,6 +2446,7 @@ Most keys are sent to the terminal; keys in
       ('line  (ghostel--line-mode-teardown)))
     (setq ghostel--char-mode-override-active nil)
     (setq ghostel--input-mode 'semi-char)
+    (ghostel--sync-inhibit-read-only)
     (use-local-map ghostel-semi-char-mode-map)
     (setq ghostel--mode-line-tag nil)
     (ghostel--mode-line-refresh)
@@ -2417,6 +2475,7 @@ Even keys listed in `ghostel-keymap-exceptions' (\\`C-c', \\`C-x',
       ('emacs (ghostel--leave-readonly-state))
       ('line  (ghostel--line-mode-teardown)))
     (setq ghostel--input-mode 'char)
+    (ghostel--sync-inhibit-read-only)
     ;; Route char mode through `emulation-mode-map-alists' so it
     ;; overrides minor-mode keymaps (without this, a minor mode that
     ;; binds a prefix like \\`C-c' would steal those keys before
@@ -2484,6 +2543,7 @@ a non-read-only mode."
       (when ghostel--term
         (ghostel--invalidate)))
     (setq ghostel--input-mode mode)
+    (ghostel--sync-inhibit-read-only)
     (use-local-map (ghostel--readonly-keymap))
     (setq ghostel--mode-line-tag (ghostel--mode-line-tag-make mode label))
     (ghostel--mode-line-refresh)
@@ -3838,6 +3898,8 @@ EVENT is the state-change description passed by Emacs."
         (remove-hook 'pre-redisplay-functions #'ghostel--fake-cursor-update t)
         (ghostel--fake-cursor-clear)
         (run-hook-with-args 'ghostel-exit-functions buf event)
+        ;; Dead terminal: restore the plain read-only barrier.
+        (ghostel--sync-inhibit-read-only)
         (if ghostel-kill-buffer-on-exit
             (kill-buffer buf)
           (let ((inhibit-read-only t))
@@ -4354,7 +4416,9 @@ TRAMP can manage the remote shell."
                     (ghostel--spawn-via-emacs program program-args remote-p))))
     (when (processp process)
       (process-put process 'adjust-window-size-function #'ignore))
-    (setq ghostel--process process)))
+    (setq ghostel--process process)
+    (ghostel--sync-inhibit-read-only)
+    process))
 
 (defun ghostel--spawn-via-emacs (program program-args &optional remote-p)
   "Spawn PROGRAM with PROGRAM-ARGS through Emacs process machinery.
@@ -5093,6 +5157,12 @@ may change freely (`ghostel-compile' finalize relies on this)."
   ;; The terminal renderer owns the buffer contents.  User-editable
   ;; modes are exceptional and must opt in explicitly.
   (setq buffer-read-only t)
+  ;; Terminal-input modes forward foreign insertions to the PTY and
+  ;; repair foreign deletions; see `ghostel--sync-inhibit-read-only'.
+  ;; Depth 90 so other hook members still see an insertion before the
+  ;; forwarding removes it.
+  (add-hook 'after-change-functions
+            #'ghostel--forward-inserts-after-change 90 t)
   (setq-local scroll-margin 0)
   (setq-local auto-hscroll-mode nil)
   (setq-local hscroll-margin 0)

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -20,7 +20,8 @@
 
 (defun evil-ghostel-test--insert (&rest args)
   "Insert ARGS as renderer-owned test setup text."
-  (let ((inhibit-read-only t))
+  (let ((inhibit-read-only t)
+        (inhibit-modification-hooks t))
     (apply #'insert args)))
 
 (defun evil-ghostel-test--live-process ()
@@ -49,7 +50,8 @@ Requires the native module; without it the test is skipped
                (ghostel--write-vt term ,text)
                (evil-local-mode 1)
                (evil-ghostel-mode 1)
-               (let ((inhibit-read-only t))
+               (let ((inhibit-read-only t)
+                     (inhibit-modification-hooks t))
 				 (ghostel--redraw term t))
                (cl-macrolet ((insert (&rest args)
                                `(evil-ghostel-test--insert ,@args)))
@@ -258,7 +260,8 @@ The mock erases and reinserts the same text so these tests exercise
   `(cl-letf (((symbol-function 'ghostel--redraw)
               (lambda (_term &optional _full _force-sync)
                 (let ((text (buffer-string))
-                      (inhibit-read-only t))
+                      (inhibit-read-only t)
+                      (inhibit-modification-hooks t))
                   (erase-buffer)
                   (insert text)
                   t)))
@@ -407,7 +410,8 @@ advice must not restore point or visual markers there."
    (cl-letf (((symbol-function 'ghostel--redraw)
               (lambda (_term &optional _full _force-sync)
                 (let ((text (buffer-string))
-                      (inhibit-read-only t))
+                      (inhibit-read-only t)
+                      (inhibit-modification-hooks t))
                   (erase-buffer)
                   (insert text)
                   (goto-char (point-min))
@@ -542,7 +546,8 @@ point in the scrollback region instead of the visible viewport."
    (dotimes (i 12)
      (ghostel--write-vt term (format "row-%02d\r\n" i)))
    (ghostel--write-vt term "last-11")
-   (let ((inhibit-read-only t))
+   (let ((inhibit-read-only t)
+         (inhibit-modification-hooks t))
      (ghostel--redraw term t))
    ;; Walk point back into the scrollback region.
    (goto-char (point-min))
@@ -671,7 +676,8 @@ diffing — otherwise dy is wrong by the scrollback line count."
       (ghostel--write-vt term "tail")
       (evil-local-mode 1)
       (evil-ghostel-mode 1)
-      (let ((inhibit-read-only t))
+      (let ((inhibit-read-only t)
+            (inhibit-modification-hooks t))
         (ghostel--redraw term t))
       ;; Terminal cursor is on the last viewport row; target a
       ;; buffer position on the previous viewport row, same column.
@@ -712,7 +718,8 @@ cursor only while parked exactly on it (and in insert / emacs state)."
                                   (should (= 3 (current-column)))
                                   (should (= 1 (line-number-at-pos)))
                                   ;; Redraw — should NOT move point back to terminal cursor
-                                  (let ((inhibit-read-only t))
+                                  (let ((inhibit-read-only t)
+                                        (inhibit-modification-hooks t))
                                     (ghostel--redraw term t))
                                   (should (= 3 (current-column)))
                                     (should (= 1 (line-number-at-pos))))))
@@ -724,7 +731,8 @@ The whole burst lands in a single redraw, like fast un-throttled output."
   (dotimes (i 8)
     (ghostel--write-vt term (format "out-%d\r\n" i)))
   (ghostel--write-vt term "$ ")
-  (let ((inhibit-read-only t))
+  (let ((inhibit-read-only t)
+        (inhibit-modification-hooks t))
     (ghostel--redraw term nil)))
 
 (ert-deftest evil-ghostel-test-redraw-tracks-cursor-when-parked ()
@@ -775,7 +783,8 @@ column on the row where the cursor lands."
                                   ;; Move point away from terminal cursor
                                   (goto-char (point-min))
                                   ;; Redraw — should snap point to terminal cursor (col 11)
-                                  (let ((inhibit-read-only t))
+                                  (let ((inhibit-read-only t)
+                                        (inhibit-modification-hooks t))
                                     (ghostel--redraw term t))
                                   (should (= 11 (current-column)))))
 
@@ -790,7 +799,8 @@ redrawing elsewhere."
                                   ;; Move point away from terminal cursor
                                   (goto-char (point-min))
                                   ;; Redraw — should snap point to terminal cursor (col 11)
-                                  (let ((inhibit-read-only t))
+                                  (let ((inhibit-read-only t)
+                                        (inhibit-modification-hooks t))
                                     (ghostel--redraw term t))
                                   (should (= 11 (current-column)))))
 
@@ -2142,7 +2152,8 @@ sticks."
                                   (should (= 0 (current-column)))
                                   (should (= 1 (line-number-at-pos)))
                                   ;; Redraw without growing scrollback (single-line update).
-                                  (let ((inhibit-read-only t))
+                                  (let ((inhibit-read-only t)
+                                        (inhibit-modification-hooks t))
                                     (ghostel--redraw term nil))
                                   ;; Point stays where the user navigated.
                                   (should (= 0 (current-column)))
@@ -2504,7 +2515,8 @@ end (else `D'/`C'/`$' under-act)."
 (ert-deftest evil-ghostel-test-clamp-trims-end-past-input ()
   "`evil-ghostel--clamp' lowers END to the end of typed input."
   (evil-ghostel-test--with-input-fixture "$ " "hello"
-    (let ((inhibit-read-only t))
+    (let ((inhibit-read-only t)
+          (inhibit-modification-hooks t))
       (save-excursion (insert "   ")))  ; renderer padding past the cursor
     (let ((clamped (evil-ghostel--clamp 3 (+ ghostel--cursor-char-pos 3))))
       (should (= 3 (car clamped)))
@@ -2563,7 +2575,8 @@ does not push BEG up to the cursor and collapse the range."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "$ command")
-   (let ((inhibit-read-only t))
+   (let ((inhibit-read-only t)
+         (inhibit-modification-hooks t))
      (put-text-property 1 3 'ghostel-prompt t))
    (cl-letf (((symbol-function 'ghostel--alt-screen-p) (lambda (&rest _) nil)))
      (evil-normal-state)

--- a/test/ghostel-ime-test.el
+++ b/test/ghostel-ime-test.el
@@ -67,6 +67,8 @@ The buffer must not be redrawn while a feature inhibits it."
       (should (eq input-method-function #'ghostel-ime--wrap-input-method))
       (should (memq #'ghostel-ime-lisp-composing-p
                     ghostel-inhibit-redraw-functions))
+      (should (memq #'ghostel-ime-lisp-composing-p
+                    ghostel-inhibit-input-forwarding-functions))
       (should (memq #'ghostel-ime--install input-method-activate-hook))
       (should (memq #'ghostel-ime--uninstall input-method-deactivate-hook))
       (should (memq #'ghostel-ime--reassert post-command-hook))
@@ -76,6 +78,8 @@ The buffer must not be redrawn while a feature inhibits it."
       (should (null ghostel-ime--original-input-method-function))
       (should-not (memq #'ghostel-ime-lisp-composing-p
                         ghostel-inhibit-redraw-functions))
+      (should-not (memq #'ghostel-ime-lisp-composing-p
+                        ghostel-inhibit-input-forwarding-functions))
       (should-not (memq #'ghostel-ime--reassert post-command-hook)))))
 
 (ert-deftest ghostel-test-ime-reasserts-wrapper-after-external-reset ()

--- a/test/ghostel-insert-forward-test.el
+++ b/test/ghostel-insert-forward-test.el
@@ -1,0 +1,190 @@
+;;; ghostel-insert-forward-test.el --- Tests for ghostel: insert forwarding -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Programmatic insert forwarding: foreign buffer insertions in
+;; terminal-input modes are routed to the PTY (`emoji-insert',
+;; `insert-char', …), deletions are repaired by a full redraw, and the
+;; read-only barrier comes back in copy/Emacs modes and on process
+;; exit.
+
+;;; Code:
+
+(require 'ghostel-test-helpers)
+
+(defmacro ghostel-insert-forward-test--with-live-buffer (&rest body)
+  "Run BODY in a semi-char ghostel buffer with a live dummy process.
+Binds SENT and PASTED to lists collecting forwarded strings (newest
+first) and PROC to the dummy process.  The terminal handle is fake
+and the PTY writers are stubbed, so no native module is needed."
+  (declare (indent 0) (debug t))
+  `(with-temp-buffer
+     (let ((ghostel-scroll-on-input nil)
+           (sent '())
+           (pasted '())
+           (proc nil))
+       (ignore sent pasted)
+       (unwind-protect
+           (progn
+             (ghostel-mode)
+             (setq proc (ghostel-test--dummy-process
+                         "ghostel-insert-forward" (current-buffer)))
+             (setq-local ghostel--process proc)
+             (setq-local ghostel--term 'fake)
+             (ghostel--sync-inhibit-read-only)
+             (cl-letf (((symbol-function 'ghostel--send-string)
+                        (lambda (s) (push s sent)))
+                       ((symbol-function 'ghostel--paste-text)
+                        (lambda (s) (push s pasted))))
+               ,@body))
+         (when (process-live-p proc)
+           (delete-process proc))))))
+
+(ert-deftest ghostel-test-insert-forward-single-line ()
+  "A foreign insertion is sent to the PTY as UTF-8, not kept in the buffer."
+  (ghostel-insert-forward-test--with-live-buffer
+    (ghostel-test--insert-rendered "user@host$ ")
+    (insert "😀")
+    (should (equal (buffer-string) "user@host$ "))
+    (should (equal sent (list (encode-coding-string "😀" 'utf-8))))
+    (should (null pasted))))
+
+(ert-deftest ghostel-test-insert-forward-multiline-uses-paste ()
+  "A multi-line insertion is forwarded as a bracketed paste."
+  (ghostel-insert-forward-test--with-live-buffer
+    (insert "echo a\necho b")
+    (should (equal (buffer-string) ""))
+    (should (equal pasted '("echo a\necho b")))
+    (should (null sent))))
+
+(ert-deftest ghostel-test-insert-forward-star-spec-commands-run ()
+  "`(interactive \"*\")' commands run: the read-only barrier is lifted.
+`buffer-read-only' itself stays non-nil so packages gating on the
+variable (e.g. meow's `meow--allow-modify-p') still see protection."
+  (ghostel-insert-forward-test--with-live-buffer
+    (should buffer-read-only)
+    (barf-if-buffer-read-only)
+    (call-interactively
+     (lambda () (interactive "*") (insert "hi")))
+    (should (equal (buffer-string) ""))
+    (should (equal sent '("hi")))))
+
+(ert-deftest ghostel-test-insert-forward-repairs-deletions ()
+  "Deleting renderer-owned text triggers a full repair redraw.
+Nothing is forwarded to the PTY, point is realigned to the VT cursor,
+and the change hook stays armed for subsequent insertions."
+  (ghostel-insert-forward-test--with-live-buffer
+    (ghostel-test--insert-rendered "abc")
+    (setq ghostel--cursor-char-pos 4)
+    (let ((redraws '()))
+      (cl-letf (((symbol-function 'ghostel--redraw)
+                 (lambda (term full force-sync)
+                   (push (list term full force-sync) redraws)
+                   (erase-buffer)
+                   (insert "abc"))))
+        (goto-char (point-min))
+        (delete-region (point-min) (point-max))
+        (should (equal redraws '((fake t t))))
+        (should (equal (buffer-string) "abc"))
+        (should (= (point) 4))
+        (should (null sent))
+        (insert "z")
+        (should (equal sent '("z")))
+        (should (equal redraws '((fake t t))))))))
+
+(ert-deftest ghostel-test-insert-forward-repairs-replacements ()
+  "A replacement of renderer-owned text is repaired, never forwarded."
+  (ghostel-insert-forward-test--with-live-buffer
+    (ghostel-test--insert-rendered "abc")
+    (setq ghostel--cursor-char-pos 4)
+    (let ((redraws '()))
+      (cl-letf (((symbol-function 'ghostel--redraw)
+                 (lambda (term full force-sync)
+                   (push (list term full force-sync) redraws)
+                   (erase-buffer)
+                   (insert "abc"))))
+        (goto-char (point-min))
+        (search-forward "b")
+        (replace-match "X")
+        (should (equal redraws '((fake t t))))
+        (should (equal (buffer-string) "abc"))
+        (should (null sent))
+        (should (null pasted))))))
+
+(ert-deftest ghostel-test-insert-forward-cr-uses-paste ()
+  "A carriage return in a foreign insertion is paste-protected.
+Sent raw, a \\r would execute the pending input in the shell."
+  (ghostel-insert-forward-test--with-live-buffer
+    (insert "echo a\r")
+    (should (equal pasted '("echo a\r")))
+    (should (null sent))))
+
+(ert-deftest ghostel-test-insert-forward-repair-restores-render ()
+  "The repair redraw re-renders foreign-deleted text from the native grid."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-repair*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (ghostel-mode)
+          (let ((proc (ghostel-test--dummy-process "ghostel-repair" buf)))
+            (unwind-protect
+                (progn
+                  (setq-local ghostel--term (ghostel--new 5 40 100))
+                  (setq-local ghostel--process proc)
+                  (ghostel--sync-inhibit-read-only)
+                  (ghostel--write-vt ghostel--term "\e[H\e[2Jhello world")
+                  (ghostel-test--redraw ghostel--term t)
+                  (let ((before (buffer-string)))
+                    (should (string-match-p "hello world" before))
+                    (delete-region (point-min) (point-max))
+                    (should (equal (buffer-string) before))
+                    (should (= (point) ghostel--cursor-char-pos))))
+              (when (process-live-p proc)
+                (delete-process proc)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-insert-forward-opt-out ()
+  "Setting the opt-out flag restores the plain read-only barrier."
+  (ghostel-insert-forward-test--with-live-buffer
+    (setq ghostel--inhibit-insert-forwarding t)
+    (ghostel--sync-inhibit-read-only)
+    (should-error (insert "x") :type 'buffer-read-only)
+    (should (null sent))))
+
+(ert-deftest ghostel-test-insert-forward-copy-mode-restores-barrier ()
+  "Copy mode restores the plain read-only barrier; exiting lifts it again."
+  (ghostel-insert-forward-test--with-live-buffer
+    (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+              ((symbol-function 'ghostel--anchor-window) #'ignore)
+              ((symbol-function 'ghostel-force-redraw) #'ignore)
+              ((symbol-function 'ghostel--adjust-size) #'ignore))
+      (ghostel-copy-mode)
+      (should-error (insert "x") :type 'buffer-read-only)
+      (should-error (barf-if-buffer-read-only) :type 'buffer-read-only)
+      (ghostel-readonly-exit)
+      (should (eq ghostel--input-mode 'semi-char))
+      (insert "y")
+      (should (equal sent '("y")))
+      (should (equal (buffer-string) "")))))
+
+(ert-deftest ghostel-test-insert-forward-inhibit-hook ()
+  "A `ghostel-inhibit-input-forwarding-functions' veto exempts an edit.
+This is the seam `ghostel-ime' uses to protect its composition inserts."
+  (ghostel-insert-forward-test--with-live-buffer
+    (add-hook 'ghostel-inhibit-input-forwarding-functions
+              (lambda () t) nil t)
+    (insert "ㅎ")
+    (should (equal (buffer-string) "ㅎ"))
+    (should (null sent))))
+
+(ert-deftest ghostel-test-insert-forward-process-exit-restores-barrier ()
+  "After the terminal process dies the buffer is plainly read-only again."
+  (ghostel-insert-forward-test--with-live-buffer
+    (let ((ghostel-kill-buffer-on-exit nil))
+      (delete-process proc)
+      (ghostel--sentinel proc "finished\n")
+      (should-error (insert "x") :type 'buffer-read-only)
+      (should (null sent)))))
+
+(provide 'ghostel-insert-forward-test)
+;;; ghostel-insert-forward-test.el ends here

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -944,7 +944,7 @@ scrolling libghostty's viewport."
           (ghostel-clear)
           ;; Simulate what delayed-redraw does after `ghostel-clear' invalidates.
           (let ((inhibit-read-only t))
-            (ghostel--redraw ghostel--term t))
+            (ghostel-test--redraw ghostel--term t))
           ;; Scrollback rows live in the buffer above the cleared
           ;; viewport — search for any clear-test output to confirm.
           (let ((content (buffer-substring-no-properties (point-min) (point-max))))
@@ -963,14 +963,14 @@ scrolling libghostty's viewport."
             ;; Fill screen + scrollback with 10 lines
             (dotimes (i 10)
               (ghostel--write-vt ghostel--term (format "line %d\r\n" i)))
-            (ghostel--redraw ghostel--term t)
+            (ghostel-test--redraw ghostel--term t)
             ;; Verify lines materialized in the buffer
             (let ((content (buffer-substring-no-properties (point-min) (point-max))))
               (should (string-match-p "line 0" content))
               (should (string-match-p "line 9" content)))
             ;; Clear scrollback (sends CSI 3J to libghostty)
             (ghostel-clear-scrollback)
-            (ghostel--redraw ghostel--term t)
+            (ghostel-test--redraw ghostel--term t)
             ;; Screen and scrollback should be empty
             (let ((content (buffer-substring-no-properties (point-min) (point-max))))
               (should-not (string-match-p "line [0-9]" content)))))
@@ -1745,7 +1745,7 @@ app redraws all rows at new width via the filter pipeline."
                   (dotimes (i 6)
                     (ghostel--write-vt ghostel--term
                                        (format "\e[%d;1H%-80s" (1+ i) (format "WIDE-R%02d" i))))
-                  (ghostel--redraw ghostel--term t)
+                  (ghostel-test--redraw ghostel--term t)
                   (let ((c (buffer-substring-no-properties (point-min) (point-max))))
                     (should (string-match-p "WIDE-R00" c))
                     ;; Row 1 is at most `cols' chars wide after the
@@ -1811,14 +1811,14 @@ rendered by `ghostel--redraw-now'.  This is the exact real-world path."
                   (dotimes (i 10)
                     (ghostel--write-vt ghostel--term
                                        (format "\e[%d;1H%-40s" (1+ i) (format "OLD-%02d" i))))
-                  (ghostel--redraw ghostel--term t)
+                  (ghostel-test--redraw ghostel--term t)
                   (should (string-match-p "OLD-00"
                                           (buffer-substring-no-properties (point-min) (point-max))))
 
                   ;; Resize (as our resize function does).
                   (ghostel--set-size ghostel--term 6 40)
                   (set-process-window-size proc 6 40)
-                  (ghostel--redraw ghostel--term t)
+                  (ghostel-test--redraw ghostel--term t)
                   (setq ghostel--force-next-redraw t)
 
                   ;; Simulate app's SIGWINCH response arriving through the filter.

--- a/test/ghostel-shell-test.el
+++ b/test/ghostel-shell-test.el
@@ -696,8 +696,7 @@ below it."
 									 ;; scrollback.
 									 (ghostel-test--wait-until
 									  (lambda ()
-									    (let ((inhibit-read-only t))
-									      (ghostel--redraw ghostel--term t))
+									    (ghostel-test--redraw ghostel--term t)
 									    (let ((pos ghostel--cursor-pos)
 										  (vp-start (ghostel--viewport-start)))
 									      (and pos vp-start
@@ -789,8 +788,7 @@ checks that the most recent prompt's `top-line' row carries the
 											    (ghostel-test--rendered-terminal-text)))
 									  proc 15)
 									 (sleep-for 0.2)
-									 (let ((inhibit-read-only t))
-									   (ghostel--redraw ghostel--term t))
+									 (ghostel-test--redraw ghostel--term t)
 									 ;; After the rearrange settles, the WRAP fires INLINE with
 									 ;; PROMPT expansion (cycle 2+) — so 133;A fires before the
 									 ;; prompt content is drawn.  libghostty sets `.prompt'

--- a/test/ghostel-test-helpers.el
+++ b/test/ghostel-test-helpers.el
@@ -70,7 +70,8 @@ through the production `ghostel--create' path."
 (defmacro ghostel-test--with-rendered-output (&rest body)
   "Run BODY while mutating fake renderer-owned buffer text."
   (declare (indent 0) (debug t))
-  `(let ((inhibit-read-only t))
+  `(let ((inhibit-read-only t)
+         (inhibit-modification-hooks t))
      ,@body))
 
 (defun ghostel-test--insert-rendered (&rest args)


### PR DESCRIPTION
ghostel buffers are read-only, so any command that inserts text at point (`emoji-insert` via `C-x 8 e r`, `insert-char`, other `(interactive "*")` commands) failed with "Buffer is read-only".

In terminal-input modes with a live process, lift the read-only barrier via buffer-local `inhibit-read-only` while keeping `buffer-read-only` t, and intercept foreign edits through a buffer-local after-change hook:

- **Insertions** are captured, removed from the buffer, and forwarded to the PTY — as a bracketed paste when the text contains a line break (`\n` or `\r`), raw UTF-8 otherwise.
- **Edits that remove renderer-owned text** are repaired by a full forced redraw restoring the terminal contents from the native grid and scrollback, with point realigned to the VT cursor.

Copy/Emacs/line modes, dead terminals, and compilation-style compile buffers keep the plain read-only barrier (`ghostel--sync-inhibit-read-only`).

Composition-aware forwarding is decoupled from core via the `ghostel-inhibit-input-forwarding-functions` abnormal hook; ghostel-ime registers `ghostel-ime-lisp-composing-p` on it so Lisp input-method composition stands down without core referencing any ime symbol.

Known limitation: commands that reposition point themselves after the change hooks run (`upcase-word`, `replace-match`) still end up with point off the VT cursor, which drops the buffer into copy mode — consistent with how any point movement off the cursor already behaves.

Tested with new `test/ghostel-insert-forward-test.el` (forwarding, paste protection, repair redraw incl. a native end-to-end test, opt-out, veto hook, mode/exit barrier restoration).