### PR TITLE
Treat soft-wrapped terminal rows as one logical line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- A finished `ghostel-compile` buffer joins the rows the terminal wrapped, so
+  `compilation-mode` error parsing, `next-error`, `ffap` and saving the buffer
+  see whole lines. A path straddling the wrap column used to be recorded as
+  the fragment after the break.
+- A finished `ghostel-compile` buffer follows the user's `truncate-lines`
+  instead of keeping the terminal's. The variable is `permanent-local`, so the
+  terminal's setting survived the mode switch and the joined rows were
+  truncated at the window edge.
+
+### Fixed
+- URLs and `file:line` references that the terminal wrapped across rows are now
+  detected as one link: every row carries the whole target, and link navigation
+  treats the rows as a single link. They also survive the reflow a window
+  resize causes. Fixes
+  [#566](https://github.com/dakra/ghostel/issues/566).
+- `ghostel-compile` no longer loses output from a command that finishes while
+  its buffer is displayed in no window, or while copy mode holds the terminal
+  frozen; a finished buffer is no longer repainted from the terminal grid on a
+  window resize (which discarded the footer).
+- A saved `ghostel-compile` log reopens in `ghostel-compile-view-mode`. Its
+  header named a mode that does not exist, so the file landed in
+  `fundamental-mode` without error navigation.
+
 ## [0.46.0] — 2026-07-27
 
 ### Added

--- a/README.org
+++ b/README.org
@@ -693,6 +693,10 @@ to leave the directory alone.
 - *File path detection* - patterns like =/path/to/file.el:42= become clickable,
   opening the file at the given line (toggle with =ghostel-enable-file-detection=;
   tune the path pattern with =ghostel-file-detection-path-regex=).
+- *Wrapped links* - a URL or path too long for the terminal is split across
+  rows, and each row is clickable for the whole target.  Hyperlink navigation
+  visits such a link once, and a window resize that reflows the terminal
+  leaves it intact.
 
 ** Clipboard
 :properties:
@@ -1496,7 +1500,7 @@ Commands:
 A run looks like a =M-x compile= buffer:
 
 #+begin_example
--*- mode: ghostel-compile -*-
+-*- mode: ghostel-compile-view -*-
 Compilation started at Wed Apr 15 08:30:11
 
 make -j4 test
@@ -1520,8 +1524,11 @@ anything that wants live keystrokes work.  The rendered buffer remains read-only
 
 When the command finishes, the live process and ghostel renderer are torn down
 and the buffer's major mode is switched to =ghostel-compile-view-mode= (derived
-from =compilation-mode=).  =mode-line-process= shows =:run= while the command runs
-and =:exit [N]= afterwards; an interactive run reads =:run/i= instead of =:run=.
+from =compilation-mode=).  Rows the terminal wrapped are joined back into single
+lines at that point, so error parsing, =next-error=, =ffap= and saving the buffer
+see whole paths even when one straddled the wrap column.  =mode-line-process=
+shows =:run= while the command runs and =:exit [N]= afterwards; an interactive
+run reads =:run/i= instead of =:run=.
 
 *** Live mode switching
 

--- a/bench/ghostel-bench.el
+++ b/bench/ghostel-bench.el
@@ -152,7 +152,9 @@ include GC or hook overhead that production redraws suppress."
   "Generate ~SIZE bytes of output containing URLs and file:line refs.
 Simulates compiler output or build logs with linkifiable content."
   (let ((lines '("/usr/src/app/main.c:42: error: undeclared identifier\r\n"
-                 "  at Object.<anonymous> (/home/user/project/index.js:17:5)\r\n"
+                 ;; Not under `/home': macOS maps it through autofs, where a
+                 ;; `file-exists-p' miss costs ~8 ms and swamps the scan.
+                 "  at Object.<anonymous> (/opt/user/project/index.js:17:5)\r\n"
                  "See https://example.com/docs/errors/E0042 for details\r\n"
                  "PASS ./tests/test_utils.py:88 test_parse_url\r\n"
                  "warning: unused variable at ./src/render.zig:156:13\r\n"
@@ -168,6 +170,29 @@ Simulates compiler output or build logs with linkifiable content."
       (let ((line (nth (% (/ total 60) (length lines)) lines)))
         (push line parts)
         (setq total (+ total (length line)))))
+    (apply #'concat (nreverse parts))))
+
+(defun ghostel-bench--gen-wrapped-links (size)
+  "Generate ~SIZE bytes of log lines whose links straddle a soft-wrap break.
+Every line is wider than the 80-column bench terminal, so the renderer
+splits it across rows and the URL and file:line patterns run past the
+break.  A rotating indent shifts each line so the breaks land at many
+different offsets inside the links instead of always the same one."
+  (let ((lines '("INFO  resolver: fetching https://registry.example.com/api/v3/packages/@scope/build-toolkit/-/build-toolkit-4.11.2.tgz for the workspace root\r\n"
+                 "  at Module._compile (/Users/ci/builds/agent-7/workspace/project-frontend/node_modules/@scope/toolkit/dist/cjs/internal/resolver.js:1284:17)\r\n"
+                 "ERROR unable to verify signature, see https://docs.example.org/guides/troubleshooting/signature-verification-failures#step-3-trusted-keys now\r\n"
+                 "  compiling crate `render-core' at /Users/ci/builds/agent-7/workspace/project-backend/crates/render-core/src/pipeline/rasterizer.rs:912:28\r\n"
+                 "warn  deprecated endpoint https://api.example.net/v1/legacy/accounts/lookup?include=profile,settings,billing&format=json will be removed soon\r\n"
+                 "  File '/Users/ci/builds/agent-7/workspace/project-tools/vendor/python3.12/site-packages/example_pkg/internal/serializers/base.py', line 431\r\n"))
+        (parts nil)
+        (total 0)
+        (n 0))
+    (while (< total size)
+      (let ((line (concat (make-string (% n 11) ?\s)
+                          (nth (% n (length lines)) lines))))
+        (push line parts)
+        (setq total (+ total (length line))
+              n (1+ n))))
     (apply #'concat (nreverse parts))))
 
 (defun ghostel-bench--gen-mixed-emoji-cjk-ascii (size)
@@ -552,6 +577,31 @@ process filter, which both parses and renders in one call."
           (when ghostel-bench-include-term
             (ghostel-bench--measure
              "e2e/urls/term" ghostel-bench-data-size ghostel-bench-iterations
+             (lambda () (ghostel-bench--e2e-term data-file)))))
+      (delete-file data-file)))
+  ;; --- Links that straddle a soft-wrap break: the logical-line join path ---
+  (let ((data-file (ghostel-bench--write-data-file
+                    #'ghostel-bench--gen-wrapped-links)))
+    (unwind-protect
+        (progn
+          (message "  [links straddling a soft-wrap break]")
+          (ghostel-bench--measure
+           "e2e/wrapped/ghostel" ghostel-bench-data-size ghostel-bench-iterations
+           (lambda () (ghostel-bench--e2e-ghostel data-file t)))
+          (ghostel-bench--measure
+           "e2e/wrapped/ghostel-nodetect" ghostel-bench-data-size ghostel-bench-iterations
+           (lambda () (ghostel-bench--e2e-ghostel data-file nil)))
+          (when ghostel-bench-include-vterm
+            (ghostel-bench--measure
+             "e2e/wrapped/vterm" ghostel-bench-data-size ghostel-bench-iterations
+             (lambda () (ghostel-bench--e2e-vterm data-file))))
+          (when ghostel-bench-include-eat
+            (ghostel-bench--measure
+             "e2e/wrapped/eat" ghostel-bench-data-size ghostel-bench-iterations
+             (lambda () (ghostel-bench--e2e-eat data-file))))
+          (when ghostel-bench-include-term
+            (ghostel-bench--measure
+             "e2e/wrapped/term" ghostel-bench-data-size ghostel-bench-iterations
              (lambda () (ghostel-bench--e2e-term data-file)))))
       (delete-file data-file)))
   ;; --- Mixed emoji/CJK/ASCII: exercises wide-char and grapheme-cluster paths ---
@@ -1218,6 +1268,56 @@ real-world performance (see the end-to-end and backend benchmarks)."
          (format "engine/%s" name) raw-data 24 80
          ghostel-bench-iterations t)))))
 
+;; =========================================================================
+;; SECTION 5: Plain-text link detection (`ghostel--detect-urls')
+;; =========================================================================
+;;
+;; The `e2e/*' section coalesces detection into a single call over the last
+;; dirty region, so it cannot resolve this cost.  Here the scan is measured
+;; on its own, over a buffer the renderer materialized, which is what the
+;; idle timer sees after a burst of output.
+;; =========================================================================
+
+(defconst ghostel-bench--link-properties
+  '(help-echo nil mouse-face nil keymap nil
+              ghostel-link-id nil ghostel-link-text nil)
+  "Properties `ghostel--linkify' attaches, for `remove-text-properties'.")
+
+(defun ghostel-bench--detect-scan (name gen-fn)
+  "Measure `ghostel--detect-urls' over data from GEN-FN, recorded as NAME.
+Renders `ghostel-bench-data-size' bytes into a 24x80 terminal, then times
+repeated whole-buffer scans.  Each iteration first strips the properties
+the previous one attached, so every scan linkifies from scratch instead of
+recognizing its own work and skipping."
+  (ghostel-bench--with-bench-buffer
+    (let ((term (ghostel-bench--make-ghostel 24 80))
+          (ghostel-enable-url-detection t)
+          (ghostel-enable-file-detection t)
+          (inhibit-read-only t))
+      (ghostel--write-vt term (ghostel-bench--encode-for-backend
+                               (funcall gen-fn ghostel-bench-data-size)
+                               'ghostel))
+      (ghostel-bench--redraw term nil)
+      (ghostel-bench--measure
+       name (- (point-max) (point-min)) ghostel-bench-iterations
+       (lambda ()
+         (remove-text-properties (point-min) (point-max)
+                                 ghostel-bench--link-properties)
+         (ghostel--detect-urls))))))
+
+(defun ghostel-bench--run-detect-scenarios ()
+  "Run the plain-text link-detection benchmarks."
+  (require 'ghostel)
+  (message "\n--- Link Detection (`ghostel--detect-urls', whole rendered buffer) ---")
+  (message "  plain:   no link candidates at all — the pattern-scan floor")
+  (message "  urls:    URLs and file:line refs, none crossing a row break")
+  (message "  wrapped: every link straddles a soft-wrap break")
+  (message "  %-50s %5s  %8s  %10s  %8s" "SCENARIO" "ITERS" "TOTAL(s)" "ITER(ms)" "MB/s")
+  (message "  %s" (make-string 90 ?-))
+  (dolist (shape '("plain" "urls" "wrapped"))
+    (ghostel-bench--detect-scan (format "detect/%s" shape)
+                                (ghostel-bench--case-generator shape))))
+
 ;; ---------------------------------------------------------------------------
 ;; Header / summary
 ;; ---------------------------------------------------------------------------
@@ -1321,6 +1421,7 @@ real-world performance (see the end-to-end and backend benchmarks)."
   (ghostel-bench--run-tui-scenarios)
   (ghostel-bench--run-tui-partial-scenarios)
   (ghostel-bench--run-engine-scenarios)
+  (ghostel-bench--run-detect-scenarios)
   (ghostel-bench--print-summary))
 
 (defun ghostel-bench-run-quick ()
@@ -1370,11 +1471,19 @@ backend-include flags do not apply."
     "e2e/urls/vterm"
     "e2e/urls/eat"
     "e2e/urls/term"
+    "e2e/wrapped/ghostel"
+    "e2e/wrapped/ghostel-nodetect"
+    "e2e/wrapped/vterm"
+    "e2e/wrapped/eat"
+    "e2e/wrapped/term"
     "e2e/mixed/ghostel"
     "e2e/mixed/ghostel-nodetect"
     "e2e/mixed/vterm"
     "e2e/mixed/eat"
     "e2e/mixed/term"
+    "detect/plain"
+    "detect/urls"
+    "detect/wrapped"
     "typing/native"
     "typing/emacs")
   "Named benchmark cases accepted by `ghostel-bench-run-one'.")
@@ -1390,6 +1499,7 @@ backend-include flags do not apply."
   "Return the data generator for benchmark SHAPE."
   (or (cdr (assoc shape `(("plain" . ghostel-bench--gen-plain-ascii)
                           ("urls" . ghostel-bench--gen-urls-and-paths)
+                          ("wrapped" . ghostel-bench--gen-wrapped-links)
                           ("mixed" . ghostel-bench--gen-mixed-emoji-cjk-ascii))))
       (error "Unknown benchmark data shape: %s" shape)))
 
@@ -1550,6 +1660,10 @@ Use `ghostel-bench-list-cases' to list valid case names."
      (ghostel-bench--print-summary))
     (`("tui-partial" ,size)
      (ghostel-bench--run-one-tui-partial size)
+     (ghostel-bench--print-summary))
+    (`("detect" ,shape)
+     (require 'ghostel)
+     (ghostel-bench--detect-scan case (ghostel-bench--case-generator shape))
      (ghostel-bench--print-summary))
     (`("typing" ,backend)
      (ghostel-bench--run-one-typing backend))

--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -67,6 +67,8 @@
 (require 'ghostel)
 (require 'compile)
 
+(declare-function ghostel--redraw "ghostel-module"
+                  (term &optional full force-sync))
 (declare-function ghostel--set-size "ghostel-module")
 (declare-function ghostel--write-vt "ghostel-module")
 (declare-function ghostel--sync-inhibit-read-only "ghostel")
@@ -201,6 +203,9 @@ the same keys work while the command is still executing."
   ;; Make sure point lands at the top after a successful recompile (and
   ;; that future input doesn't inherit ghostel's terminal-style behaviour).
   (setq-local window-point-insertion-type nil)
+  ;; `truncate-lines' is `permanent-local': the terminal's t would survive
+  ;; the mode switch and truncate the joined rows at the window edge.
+  (kill-local-variable 'truncate-lines)
   ;; The buffer text inherited from the ghostel run carries per-cell `face'
   ;; text-properties written by the native module.  `compilation-mode'
   ;; installs font-lock keywords for error highlighting, and the default
@@ -231,10 +236,10 @@ Matches the format used by `M-x compile'."
 
 (defun ghostel-compile--header-text (command start-time)
   "Return the header string for COMMAND started at START-TIME.
-Plain text, matching the `M-x compile' header format — including
-the `default-directory' file-local spec, so reloading the buffer
-restores its compilation directory."
-  (format "-*- mode: ghostel-compile; default-directory: %s -*-\n\
+Plain text, matching the `M-x compile' header format.  Its file-local
+spec makes a saved log reopen in `ghostel-compile-view-mode' with the
+compilation directory restored."
+  (format "-*- mode: ghostel-compile-view; default-directory: %s -*-\n\
 Compilation started at %s\n\n%s\n"
           (prin1-to-string (abbreviate-file-name default-directory))
           (substring (current-time-string start-time) 0 19)
@@ -295,27 +300,51 @@ into our buffer."
     (set-process-sentinel ghostel--process #'ignore)
     (set-process-filter ghostel--process #'ignore)
     (set-process-query-on-exit-flag ghostel--process nil)
-    (delete-process ghostel--process)
-    (setq ghostel--process nil))
+    (delete-process ghostel--process))
+  ;; Also drop an already-exited process: `ghostel--adjust-size' only checks
+  ;; that the variable is non-nil, so a dead object left here would repaint
+  ;; the finished buffer from the terminal grid on the next window resize.
+  (setq ghostel--process nil)
   (when (bound-and-true-p ghostel--redraw-timer)
     (cancel-timer ghostel--redraw-timer)
-    (setq ghostel--redraw-timer nil)))
+    (setq ghostel--redraw-timer nil))
+  ;; Detach the redisplay-driven renderer too.  A redraw the sentinel could
+  ;; not run (buffer not displayed at exit) stays pending on `ghostel--term',
+  ;; and would repaint the buffer the next time it is displayed.
+  (remove-hook 'pre-redisplay-functions #'ghostel--pre-redisplay t)
+  (setq ghostel--pending-redraw nil))
 
 (defun ghostel-compile--trim-trailing-blanks (start)
   "Delete trailing whitespace-only content in START..(point-max).
 The ghostel renderer commits the full terminal grid to the buffer,
-so a short command (`echo test') leaves ~24 rows of trailing
-spaces and newlines that would otherwise wedge the footer far
-below the real output.  Find the last non-whitespace position in
-the scan region and delete everything after it, leaving a single
-trailing newline so the footer's leading `\\n' produces a blank
-separator line — matching `M-x compile's output format."
+so a short command (`echo test') leaves ~24 rows of trailing spaces and newlines
+that would otherwise wedge the footer far below the real output.
+Delete everything after the last non-whitespace-position."
   (save-excursion
     (goto-char (point-max))
     (skip-chars-backward " \t\n" start)
     (when (not (eobp))
       (delete-region (point) (point-max))
       (insert "\n"))))
+
+(defun ghostel-compile--unwrap-soft-wraps ()
+  "Join rows the terminal soft-wrapped back into single buffer lines.
+The renderer commits one buffer line per terminal row, so output longer than the
+terminal is width-split by real newlines, which breaks `compilation-mode' error
+parsing, `ffap' and saving the buffer whenever a path straddles the wrap column.
+Only newlines carrying the `ghostel-wrap' property (rows the terminal wrapped)
+are removed; newlines the command itself emitted stay."
+  (let ((inhibit-read-only t)
+        (inhibit-modification-hooks t))
+    (save-excursion
+      (save-restriction
+        (widen)
+        (let ((pos (point-min)))
+          (while (setq pos (text-property-not-all pos (point-max)
+                                                  'ghostel-wrap nil))
+            (if (eq (char-after pos) ?\n)
+                (delete-region pos (1+ pos))
+              (setq pos (1+ pos)))))))))
 
 (defun ghostel-compile--render-header-live (header)
   "Feed HEADER to the ghostel terminal and commit the render synchronously.
@@ -353,8 +382,9 @@ same as in any compilation buffer."
     (with-current-buffer buffer
       (unless ghostel-compile--finalized
         (setq ghostel-compile--finalized t)
-        (let* ((start (and ghostel-compile--scan-marker
-                           (marker-position ghostel-compile--scan-marker)))
+        (let* (;; A marker, not a position: `--unwrap-soft-wraps' deletes
+               ;; newlines in the header, above the scan point.
+               (start ghostel-compile--scan-marker)
                (start-time ghostel-compile--start-time)
                (command ghostel-compile--command)
                (directory ghostel-compile--directory)
@@ -368,6 +398,9 @@ same as in any compilation buffer."
           (when start
             (ghostel-compile--trim-trailing-blanks start))
           (ghostel-compile--teardown-terminal)
+          ;; Must follow the teardown: a live renderer would rewrite the
+          ;; joined rows on its next redraw.
+          (ghostel-compile--unwrap-soft-wraps)
           ;; Switch major mode now that the process is dead.  Preserve state
           ;; that `kill-all-local-variables' would otherwise wipe.  A
           ;; per-buffer override (set by the `compilation-start' advice
@@ -451,6 +484,25 @@ same as in any compilation buffer."
 
 ;;; Spawning
 
+(defun ghostel-compile--commit-pending-frame (buffer)
+  "Render BUFFER's terminal grid when `ghostel--redraw-now' declined to.
+It declines while copy mode holds the terminal frozen, while the
+program has a synchronized-output batch open, and when no window
+supplies render metrics.  The process has exited and the teardown
+destroys the grid, so commit it here or lose the output it holds."
+  (when ghostel--pending-redraw
+    (let* ((inhibit-read-only t)
+           (inhibit-modification-hooks t)
+           (window (ghostel--get-render-window buffer))
+           (full (eq ghostel--input-mode 'line))
+           ;; Selecting a window that shows some other buffer would render
+           ;; into it, so render unselected when this buffer has none.
+           (rendered (if window
+                         (with-selected-window window
+                           (ghostel--redraw ghostel--term full t))
+                       (ghostel--redraw ghostel--term full t))))
+      (when rendered (setq ghostel--pending-redraw nil)))))
+
 (defun ghostel-compile--sentinel (process _event)
   "Sentinel for the compile PROCESS: finalize the buffer on exit."
   (when (memq (process-status process) '(exit signal))
@@ -462,7 +514,7 @@ same as in any compilation buffer."
             (message "ghostel-compile: sentinel exit=%S status=%S"
                      exit (process-status process)))
           ;; Cancel any scheduled redraw and commit the current terminal state
-		  ;; to the buffer synchronously.  Without this, a short-lived
+          ;; to the buffer synchronously.  Without this, a short-lived
           ;; command (`echo`, `false`, `exit 7`) finishes before the
           ;; ~16 ms redraw timer fires and its output is lost when
           ;; `--teardown-terminal' destroys the renderer.
@@ -470,7 +522,8 @@ same as in any compilation buffer."
             (when ghostel--redraw-timer
               (cancel-timer ghostel--redraw-timer)
               (setq ghostel--redraw-timer nil))
-            (ghostel--redraw-now buffer))
+            (ghostel--redraw-now buffer)
+            (ghostel-compile--commit-pending-frame buffer))
           (setq compilation-in-progress
                 (delq process compilation-in-progress))
           (when (fboundp 'compilation--update-in-progress-mode-line)

--- a/lisp/ghostel-line-mode.el
+++ b/lisp/ghostel-line-mode.el
@@ -345,7 +345,7 @@ status bar)."
                 (end-pos (marker-position ghostel--line-input-end)))
             (ghostel--line-mode-apply-readonly start-pos)
             ;; Mark the line-mode input region with `ghostel-input' so
-            ;; `ghostel--detect-urls-skip-p' skips it on the cursor's
+            ;; `ghostel--skip-match-p' skips it on the cursor's
             ;; line — without this, a path the user typed locally
             ;; (e.g. `cd src/main.rs') would get linkified and RET
             ;; would open the file instead of running

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1045,6 +1045,11 @@ local code should not assume it is signalable unless the process is local.")
 (defvar-local ghostel--pending-redraw nil
   "Non-nil when redraw is needed when buffer is displayed again.")
 
+(defvar-local ghostel--link-id-counter 0
+  "Source of `ghostel-link-id' values for detected multi-row links.
+Counts up so an id stays unique after scrollback eviction shifts
+buffer positions.")
+
 (defvar-local ghostel--plain-link-detection-timer nil
   "Timer for delayed redraw-triggered plain-text link detection.")
 
@@ -3010,16 +3015,206 @@ Wraps to `point-max' when no link is found before point."
 
 (eldoc-add-command #'ghostel-next-hyperlink #'ghostel-previous-hyperlink)
 
-(defun ghostel--detect-urls-skip-p (pos active-bounds)
-  "Return non-nil if link detection should leave POS alone.
-Skips spans already linkified (any `help-echo'), the shell's prompt
-decoration (`ghostel-prompt') and the cursor's current line.
+(defconst ghostel--soft-wrap-row-limit 50
+  "How many rows `ghostel--detect-urls' joins into one logical line.
+Output like a minified JSON blob is a single line megabytes long;
+joining all of it would cost more than any link is worth, and would hand the
+patterns a match candidate long enough to overflow the regexp matcher.
+Past the limit a row break is kept and joining starts over,
+so a link straddling that break resolves to one side of it.")
+
+(defun ghostel--soft-wrap-line-beginning (pos limit)
+  "Return the start of POS's logical line, crossing soft-wrap newlines.
+A line the terminal split to fit its width continues on the next
+buffer line; the newline between them carries `ghostel-wrap'.
+LIMIT caps how many rows the search walks back."
+  (save-excursion
+    (goto-char pos)
+    (beginning-of-line)
+    (let ((rows 0))
+      (while (and (< rows limit)
+                  (> (point) (point-min))
+                  (get-text-property (1- (point)) 'ghostel-wrap))
+        (forward-line -1)
+        (setq rows (1+ rows))))
+    (point)))
+
+(defun ghostel--soft-wrap-line-end (pos limit)
+  "Return the end of POS's logical line, crossing soft-wrap newlines.
+LIMIT caps how many rows the search walks forward."
+  (save-excursion
+    (goto-char pos)
+    (end-of-line)
+    (let ((rows 0))
+      (while (and (< rows limit)
+                  (get-text-property (point) 'ghostel-wrap))
+        (forward-line 1)
+        (end-of-line)
+        (setq rows (1+ rows))))
+    (point)))
+
+(defun ghostel--wrap-joined-region (begin end limit)
+  "Return (STRING . CHUNKS) for BEGIN..END with soft-wrap newlines removed.
+STRING is the region's text as the terminal program wrote it, so a
+value split across rows matches as one token.  CHUNKS maps it back:
+a vector of (STRING-OFFSET . BUFFER-POS) pairs, one per row, ascending.
+
+LIMIT bounds how many rows may be joined into one line, which keeps a
+megabyte-long line of output from becoming one unbroken token for the
+regexps to chew through."
+  (let ((chunks nil)
+        (parts nil)
+        (offset 0)
+        (rows 0)
+        (pos begin))
+    (while (< pos end)
+      (let* ((wrap (text-property-not-all pos end 'ghostel-wrap nil))
+             (wrapped (and wrap (eq (char-after wrap) ?\n)))
+             (join (and wrapped (< rows limit)))
+             (piece (buffer-substring-no-properties
+                     pos (cond (join wrap)
+                               (wrapped (1+ wrap))
+                               (t end)))))
+        (push (cons offset pos) chunks)
+        (push piece parts)
+        (setq rows (if join (1+ rows) 0)
+              offset (+ offset (length piece))
+              pos (if wrapped (1+ wrap) end))))
+    (cons (string-join (nreverse parts))
+          (vconcat (nreverse chunks)))))
+
+(defun ghostel--wrap-offset-to-pos (offset chunks)
+  "Return the buffer position for STRING OFFSET given CHUNKS.
+CHUNKS is the map returned by `ghostel--wrap-joined-region'.
+Binary search, so a region with thousands of rows stays cheap to map."
+  (unless (zerop (length chunks))
+    (let ((low 0)
+          (high (1- (length chunks))))
+      (while (< low high)
+        (let ((mid (/ (+ low high 1) 2)))
+          (if (<= (car (aref chunks mid)) offset)
+              (setq low mid)
+            (setq high (1- mid)))))
+      (let ((chunk (aref chunks low)))
+        (+ (cdr chunk) (- offset (car chunk)))))))
+
+(defun ghostel--wrap-fragments (beg end)
+  "Return the buffer ranges covering BEG..END, split at soft-wrap newlines.
+Each element is a (START . STOP) cons; the wrap newlines themselves
+are left out so link properties never cover a row break."
+  (let ((fragments nil)
+        (pos beg))
+    (while (< pos end)
+      (let ((wrap (text-property-not-all pos end 'ghostel-wrap nil)))
+        (if (and wrap (eq (char-after wrap) ?\n))
+            (progn
+              (when (< pos wrap) (push (cons pos wrap) fragments))
+              (setq pos (1+ wrap)))
+          (push (cons pos end) fragments)
+          (setq pos end))))
+    (nreverse fragments)))
+
+(defun ghostel--url-link-p (pos)
+  "Non-nil when POS carries a URL link this scan attached.
+The file pattern also matches the `//host/path' half of a URL, so the file
+pass has to recognise a URL link to leave it alone, including one an earlier
+scan attached, when URL detection has since been switched off."
+  (let ((echo (get-text-property pos 'help-echo)))
+    (and (ghostel--detected-link-p pos)
+         (stringp echo)
+         (not (string-prefix-p "fileref:" echo)))))
+
+(defun ghostel--range-overlaps-p (beg end ranges)
+  "Non-nil when BEG..END overlaps any (START . STOP) cons in RANGES."
+  (and (seq-find (lambda (range)
+                   (and (< beg (cdr range)) (> end (car range))))
+                 ranges)
+       t))
+
+(defun ghostel--linkify (fragments uri raw)
+  "Mark FRAGMENTS as a hyperlink to URI.
+FRAGMENTS is the buffer ranges of one match, as `ghostel--wrap-fragments'
+returns them.  RAW is the text the match was made of, kept so a later
+scan can tell this link from one whose text has since changed.
+A range broken by soft wraps is marked one row at a time, with a
+shared `ghostel-link-id' so link navigation treats the rows as one
+link.  The id is a cons, which never `equal's an OSC 8 id (those
+are strings or integers)."
+  (let ((props (list 'help-echo uri
+                     'mouse-face 'highlight
+                     'keymap ghostel-link-map
+                     'ghostel-link-text raw
+                     'ghostel-link-id (cons 'ghostel-detected
+                                            (cl-incf ghostel--link-id-counter)))))
+    (pcase-dolist (`(,start . ,stop) fragments)
+      (add-text-properties start stop props))))
+
+(defun ghostel--detected-link-p (pos)
+  "Non-nil when the link at POS is one this scan attached earlier."
+  (eq (car-safe (get-text-property pos 'ghostel-link-id)) 'ghostel-detected))
+
+(defun ghostel--foreign-link-p (beg end)
+  "Non-nil when BEG..END overlaps a link this scan did not attach.
+An OSC 8 span keeps its own target even where a path pattern also
+matches, so the whole range is checked, not just its first cell."
+  (let ((pos beg)
+        (foreign nil))
+    (while (and (not foreign) (< pos end))
+      (let ((echo (get-text-property pos 'help-echo)))
+        (when (and echo (not (ghostel--detected-link-p pos)))
+          (setq foreign t))
+        (setq pos (next-single-property-change pos 'help-echo nil end))))
+    foreign))
+
+(defun ghostel--skip-match-p (fragments raw active-bounds)
+  "Return non-nil if the link over FRAGMENTS should not be applied.
+RAW is the text this match is made of.  Leaves alone what another
+source owns (an OSC 8 span), the prompt, the line the cursor is on,
+and a match whose link already covers this same text.  A match whose
+text changed, or that is only partly marked, is re-applied: the
+renderer repaints the rows that changed, so the rows of a wrapped
+link that did not change would otherwise keep pointing at text they
+no longer hold.  The test is on the text rather than on the resolved
+target, so a `cd' — which moves `default-directory' under output that
+never changed — leaves existing links pointing where they did.
 ACTIVE-BOUNDS is a (BOL . EOL) cons covering the cursor's line."
-  (or (get-text-property pos 'help-echo)
-      (get-text-property pos 'ghostel-prompt)
-      (and active-bounds
-           (>= pos (car active-bounds))
-           (<= pos (cdr active-bounds)))))
+  (let ((skip nil)
+        (current t))
+    (pcase-dolist (`(,start . ,stop) fragments)
+      (when (or (get-text-property start 'ghostel-prompt)
+                (and active-bounds
+                     (>= start (car active-bounds))
+                     (<= start (cdr active-bounds)))
+                (ghostel--foreign-link-p start stop))
+        (setq skip t))
+      (unless (and (ghostel--detected-link-p start)
+                   (equal raw (get-text-property start 'ghostel-link-text)))
+        (setq current nil)))
+    (or skip current)))
+
+(defun ghostel--drop-stranded-links (begin end matched urls files)
+  "Remove this scan's links in BEGIN..END that no match covers.
+MATCHED is the list of (START . STOP) ranges the scan matched, whatever
+it then did with them.  A row repainted on its own can leave the other
+rows of a wrapped link behind, pointing at text that is gone.
+URLS and FILES say which patterns ran: a link of a kind that was not
+scanned for is unexamined, not stranded."
+  (let ((pos begin))
+    (while (setq pos (text-property-not-all pos end 'ghostel-link-id nil))
+      (let* ((stop (next-single-property-change pos 'ghostel-link-id nil end))
+             (echo (get-text-property pos 'help-echo))
+             (scanned (if (and (stringp echo)
+                               (string-prefix-p "fileref:" echo))
+                          files
+                        urls)))
+        (when (and scanned
+                   (ghostel--detected-link-p pos)
+                   (not (ghostel--range-overlaps-p pos stop matched)))
+          (remove-text-properties pos stop
+                                  '(help-echo nil mouse-face nil keymap nil
+                                              ghostel-link-id nil
+                                              ghostel-link-text nil)))
+        (setq pos stop)))))
 
 (defun ghostel--detect-urls (&optional begin end)
   "Scan a buffer region for plain-text URLs and file:line references.
@@ -3031,68 +3226,102 @@ materialized scrollback on every redraw.
 Binds `inhibit-read-only' and suppresses modification hooks so the scan
 can attach text properties when called from the deferred-detection timer
 outside the redraw scope."
-  (let* ((begin (or begin (point-min)))
-         (end (or end (point-max)))
+  (let* (;; Whole logical lines: a value the terminal split across rows is
+         ;; only recognisable once the rows are joined, and starting mid-line
+         ;; would let the `^' anchor below match where there is no line start.
+         (begin (ghostel--soft-wrap-line-beginning
+                 (or begin (point-min)) ghostel--soft-wrap-row-limit))
+         (end (ghostel--soft-wrap-line-end
+               (or end (point-max)) ghostel--soft-wrap-row-limit))
          (inhibit-read-only t)
          (inhibit-modification-hooks t)
          ;; `ghostel--cursor-char-pos' is the live terminal cursor after a redraw;
          ;; its line is the prompt the user is currently editing.  Capture as
          ;; buffer-position bounds so the per-match skip check is O(1).
          (active-pos (or ghostel--cursor-char-pos (point)))
-         (active-bounds (save-excursion
-                          (goto-char active-pos)
-                          (cons (line-beginning-position)
-                                (line-end-position)))))
-    (save-excursion
-      ;; Pass 1: http(s) URLs
-      (when ghostel-enable-url-detection
-        (goto-char begin)
-        (while (re-search-forward
+         (active-bounds (cons (ghostel--soft-wrap-line-beginning
+                               active-pos ghostel--soft-wrap-row-limit)
+                              (ghostel--soft-wrap-line-end
+                               active-pos ghostel--soft-wrap-row-limit)))
+         (joined (ghostel--wrap-joined-region
+                  begin end ghostel--soft-wrap-row-limit))
+         (text (car joined))
+         (chunks (cdr joined))
+         ;; Disable file detection over TRAMP
+         (files (and ghostel-enable-file-detection
+                     (not (file-remote-p default-directory))))
+         ;; Every range a pattern matched, whether or not it was linkified.
+         ;; What no pattern covers any more is a leftover to clear.
+         (matched nil)
+         (url-ranges nil))
+    ;; Pass 1: http(s) URLs
+    (when ghostel-enable-url-detection
+      (let ((offset 0))
+        (while (string-match
                 "https?://[^ \t\n\r\"<>]*[^ \t\n\r\"<>.,;:!?)>]"
-                end t)
-          (let ((beg (match-beginning 0))
-                (mend (match-end 0)))
-            (unless (ghostel--detect-urls-skip-p beg active-bounds)
-              (let ((url (match-string-no-properties 0)))
-                (put-text-property beg mend 'help-echo url)
-                (put-text-property beg mend 'mouse-face 'highlight)
-                (put-text-property beg mend 'keymap ghostel-link-map))))))
-      ;; Pass 2: file:line[:col] references (e.g. "./foo.el:42",
-      ;; "/tmp/bar.rs:10", or bare relative paths like "src/main.rs:42:4"
-      ;; from compiler output).  The full regex is assembled from fixed anchor
-      ;; + user-tunable path + fixed `:LINE[:COL]' tail so group 1 (path) and
-      ;; group 2 (line[:col]) are always present — no nil-guarding needed in
-      ;; the hot loop.  A small hash memoizes `file-exists-p' so repeated paths
-      ;; in a redraw (common in multi-line compiler diagnostics) don't re-stat.
-      ;; Skip entirely over TRAMP: every candidate would `expand-file-name' to
-      ;; a remote path and `file-exists-p' would do a network round-trip on
-      ;; every redraw, stalling the timer on high-latency links.
-      (when (and ghostel-enable-file-detection
-                 (not (file-remote-p default-directory)))
-        (goto-char begin)
-        (let ((full-regex (concat ghostel--file-detection-leading-anchor
-                                  "\\(" ghostel-file-detection-path-regex "\\)"
-                                  "\\(" ghostel--file-detection-tail "\\)"))
-              (seen (make-hash-table :test 'equal)))
-          (while (re-search-forward full-regex end t)
-            (let ((beg (match-beginning 1))
-                  (mend (match-end 2)))
-              (unless (ghostel--detect-urls-skip-p beg active-bounds)
-                (let* ((path (match-string-no-properties 1))
-                       (loc (match-string-no-properties 2))
-                       (abs-path (expand-file-name path))
+                text offset)
+          (setq offset (match-end 0))
+          (let* ((beg (ghostel--wrap-offset-to-pos (match-beginning 0) chunks))
+                 (mend (ghostel--wrap-offset-to-pos (match-end 0) chunks))
+                 (url (match-string-no-properties 0 text))
+                 (fragments (ghostel--wrap-fragments beg mend))
+                 (range (cons beg mend)))
+            (push range url-ranges)
+            (push range matched)
+            (unless (ghostel--skip-match-p fragments url active-bounds)
+              (ghostel--linkify fragments url url))))))
+    ;; Pass 2: file:line[:col] references (e.g. "./foo.el:42",
+    ;; "/tmp/bar.rs:10", or bare relative paths like "src/main.rs:42:4"
+    ;; from compiler output).  The full regex is assembled from fixed anchor
+    ;; + user-tunable path + fixed `:LINE[:COL]' tail so group 1 (path) and
+    ;; group 2 (line[:col]) are always present — no nil-guarding needed in
+    ;; the hot loop.  A small hash memoizes `file-exists-p' so repeated paths
+    ;; in a redraw (common in multi-line compiler diagnostics) don't re-stat.
+    (when files
+      (let ((full-regex (concat ghostel--file-detection-leading-anchor
+                                "\\(" ghostel-file-detection-path-regex "\\)"
+                                "\\(" ghostel--file-detection-tail "\\)"))
+            (seen (make-hash-table :test 'equal))
+            (offset 0))
+        (while (string-match full-regex text offset)
+          (setq offset (match-end 2))
+          (let* ((beg (ghostel--wrap-offset-to-pos (match-beginning 1) chunks))
+                 (mend (ghostel--wrap-offset-to-pos (match-end 2) chunks))
+                 (path (match-string-no-properties 1 text))
+                 (loc (match-string-no-properties 2 text))
+                 (raw (concat path loc))
+                 (fragments (ghostel--wrap-fragments beg mend)))
+            ;; A URL owns its whole span: its `//host/path' half also looks
+            ;; like a path, and re-marking it would replace the link with a
+            ;; local file — and stat that file on every scan.
+            (unless (or (ghostel--range-overlaps-p beg mend url-ranges)
+                        ;; With the URL pass switched off nothing recorded a
+                        ;; range, so fall back to the link already there.
+                        ;; When it did run its ranges are the whole truth,
+                        ;; and a leftover URL link is about to be cleared.
+                        (and (not ghostel-enable-url-detection)
+                             (ghostel--url-link-p beg)))
+              (if (ghostel--skip-match-p fragments raw active-bounds)
+                  ;; Whatever is there stays; it must not count as stranded.
+                  (push (cons beg mend) matched)
+                (let* ((abs-path (expand-file-name path))
                        (cached (gethash abs-path seen 'unset))
                        (exists (if (eq cached 'unset)
                                    (puthash abs-path (file-exists-p abs-path) seen)
                                  cached)))
+                  ;; A candidate that names no file leaves the range
+                  ;; uncovered, so a link left over from the text it used
+                  ;; to hold is cleared.
                   (when exists
-                    (put-text-property beg mend 'help-echo
-                                       (if (> (length loc) 0)
-                                           (concat "fileref:" abs-path ":"
-                                                   (substring loc 1))
-                                         (concat "fileref:" abs-path)))
-                    (put-text-property beg mend 'mouse-face 'highlight)
-                    (put-text-property beg mend 'keymap ghostel-link-map)))))))))))
+                    (push (cons beg mend) matched)
+                    (ghostel--linkify
+                     fragments
+                     (if (> (length loc) 0)
+                         (concat "fileref:" abs-path ":" (substring loc 1))
+                       (concat "fileref:" abs-path))
+                     raw)))))))))
+    (ghostel--drop-stranded-links
+     begin end matched ghostel-enable-url-detection files)))
 
 (defun ghostel--run-queued-plain-link-detection (buffer)
   "Run any queued redraw-triggered plain-text link detection for BUFFER."
@@ -4677,16 +4906,15 @@ timer.  Hidden output remains pending until the buffer is displayed."
         (forward-line (- tr))
         (line-beginning-position)))))
 
-(defun ghostel--schedule-link-detection (&optional begin end)
-  "Schedule deferred plain-text link detection over BEGIN..END.
-BEGIN defaults to the current viewport start (or `point-min' if the
-buffer has no viewport yet).  END defaults to `point-max'.  Covers
+(defun ghostel--schedule-link-detection ()
+  "Schedule deferred plain-text link detection over the viewport.
+Falls back to `point-min' when the buffer has no viewport yet.  Covers
 plain-text URL and file:line detection; native OSC-8 hyperlink spans
 remain handled inside the renderer."
   (when (or ghostel-enable-url-detection ghostel-enable-file-detection)
     (ghostel--queue-plain-link-detection
-     (or begin (ghostel--viewport-start) (point-min))
-     (or end (point-max)))))
+     (or (ghostel--viewport-start) (point-min))
+     (point-max))))
 
 (defun ghostel--daemon-dummy-frame-p (frame)
   "Non-nil if FRAME is the daemon's invisible initial frame.
@@ -4927,8 +5155,7 @@ them during synchronized output or when BUFFER has no render window."
                     (ghostel--write-pty ghostel--term input))
                   (message
                    "ghostel: line-mode prompt lost; input forwarded raw")))
-              (ghostel--schedule-link-detection
-               (ghostel--viewport-start) (point-max)))
+              (ghostel--schedule-link-detection))
             ;; Resume line mode if alt-screen just turned off, and update the
             ;; alt-screen-prev cache for the next cycle.
             (ghostel--line-mode-post-redraw)

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -650,6 +650,11 @@ fn adjustGlyphs(
     if (self.font_info == null) return;
     const window = env.f("selected-window", .{});
     if (env.isNil(window)) return;
+    // Metrics come from `font-at', which signals unless WINDOW displays the
+    // buffer being rendered.  A redraw of a buffer no window shows (the final
+    // flush when a `ghostel-compile' run ends hidden) has no such window, so
+    // leave the glyphs at their default size rather than fail the render.
+    if (!env.eq(env.f("window-buffer", .{window}), env.f("current-buffer", .{}))) return;
 
     for (self.span.adjust_cells.items) |*cell| {
         try self.adjustGlyph(env, window, span_start, cell);

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -451,6 +451,7 @@ const interned_symbols = [_][:0]const u8{
     "clrhash",
     "composition-get-gstring",
     "cons",
+    "current-buffer",
     "dash",
     "default",
     "default-directory",
@@ -559,6 +560,7 @@ const interned_symbols = [_][:0]const u8{
     "t",
     "temporary-file-directory",
     "wave",
+    "window-buffer",
     "window-point",
     "window-start",
 };

--- a/test/ghostel-compile-test.el
+++ b/test/ghostel-compile-test.el
@@ -73,7 +73,7 @@ pre-rendered state by inserting the header directly into the buffer."
   (ghostel-test--with-compile-buffer buf
     (let ((inhibit-read-only t)
           (ghostel-compile-finished-major-mode nil))
-      (insert "-*- mode: ghostel-compile -*-\n"
+      (insert "-*- mode: ghostel-compile-view -*-\n"
               "Compilation started at fake-time\n\n"
               "make -j4 test\n")
       (setq ghostel-compile--command "make -j4 test"
@@ -275,7 +275,7 @@ another window.  RET/`compile-goto-error' is for opening."
     (let ((inhibit-read-only t))
       ;; Simulate the pre-rendered header, then errors below it —
       ;; matches the geometry the real flow leaves for `--finalize'.
-      (insert "-*- mode: ghostel-compile -*-\n"
+      (insert "-*- mode: ghostel-compile-view -*-\n"
               "Compilation started at fake-time\n\n"
               "make\n")
       (setq ghostel-compile--command "make"
@@ -344,6 +344,48 @@ scrolled below the window."
     (should buffer-read-only)                                   ; read-only
     (should (eq next-error-function #'compilation-next-error-function))
     (should (equal "true" ghostel-compile--command))))          ; state preserved
+
+(ert-deftest ghostel-test-compile-finalize-drops-terminal-truncate-lines ()
+  "The finished buffer follows the user's global `truncate-lines'.
+The terminal needs it t so Emacs adds no continuation lines of its own,
+and it is `permanent-local', so the mode switch alone would leave the
+joined rows truncated at the window edge."
+  (ghostel-test--with-compile-buffer buf
+    (setq ghostel-compile--command "true"
+          ghostel-compile--start-time (current-time)
+          ghostel-compile--scan-marker (copy-marker (point-max)))
+    (should truncate-lines)
+    (should (local-variable-p 'truncate-lines))
+    (ghostel-compile--finalize buf 0 (current-time))
+    (should-not (local-variable-p 'truncate-lines))
+    (should (eq truncate-lines (default-value 'truncate-lines)))))
+
+(ert-deftest ghostel-test-compile-saved-log-reopens-in-view-mode ()
+  "A saved log reopens in `ghostel-compile-view-mode' with its directory.
+Both come from the header's file-local spec, so the mode it names
+has to be one Emacs can actually find."
+  (let* ((dir (file-name-as-directory (make-temp-file "ghostel-log-dir" t)))
+         (file (expand-file-name "build.log" dir))
+         (header (let ((default-directory dir))
+                   (ghostel-compile--header-text "make -j4 test"
+                                                 (current-time))))
+         (buf nil))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert header "output\n"))
+          ;; A different `default-directory' than the header names, so the
+          ;; assertion below can only pass via the file-local spec.
+          (let ((default-directory temporary-file-directory))
+            (setq buf (find-file-noselect file)))
+          (with-current-buffer buf
+            (should (derived-mode-p 'ghostel-compile-view-mode))
+            (should (equal (file-truename dir)
+                           (file-truename default-directory)))))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf (set-buffer-modified-p nil))
+        (kill-buffer buf))
+      (delete-directory dir t))))
 
 (ert-deftest ghostel-test-compile-view-mode-recompile-key-binding ()
   "`g' in `ghostel-compile-view-mode-map' is bound to `ghostel-recompile'."
@@ -1630,6 +1672,178 @@ ghostel's own `INSIDE_EMACS=...,compile' marker."
               (set-process-sentinel proc #'ignore)
               (delete-process proc))))))))
 
+
+;;; Soft-wrap joining
+
+(ert-deftest ghostel-test-compile-unwrap-soft-wraps ()
+  "`--unwrap-soft-wraps' removes only the terminal's own wrap newlines.
+Newlines the command printed stay, and the text properties on the
+joined rows survive so colouring and links are not cut in half."
+  (with-temp-buffer
+    (insert (propertize "/tmp/a" 'face 'bold))
+    (insert (propertize "\n" 'ghostel-wrap t))
+    (insert (propertize "bc.c:1: error" 'face 'bold))
+    (insert "\nsecond line\n")
+    (ghostel-compile--unwrap-soft-wraps)
+    (should (equal "/tmp/abc.c:1: error\nsecond line\n"
+                   (buffer-substring-no-properties (point-min) (point-max))))
+    (should-not (text-property-not-all (point-min) (point-max)
+                                       'ghostel-wrap nil))
+    ;; The join must not disturb properties carried by the rows.
+    (should (eq 'bold (get-text-property (point-min) 'face)))
+    (should (eq 'bold (get-text-property (+ (point-min) 8) 'face)))))
+
+(ert-deftest ghostel-test-compile-unwrap-soft-wraps-no-op ()
+  "Output without wrapped rows is left exactly as it was."
+  (with-temp-buffer
+    (insert "one\ntwo\nthree\n")
+    (ghostel-compile--unwrap-soft-wraps)
+    (should (equal "one\ntwo\nthree\n"
+                   (buffer-substring-no-properties (point-min) (point-max))))))
+
+(ert-deftest ghostel-test-compile-copy-mode-at-exit-keeps-output ()
+  "Output produced while copy mode froze the terminal survives the exit.
+Copy mode makes `ghostel--redraw-now' decline, so everything the
+command printed after the freeze lives only in the terminal grid
+that the teardown then destroys."
+  :tags '(native)
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf-name "*ghostel-test-compile-copy*")
+         (shell-file-name "/bin/sh")
+         ;; Assemble the markers from fragments so the echoed command
+         ;; line cannot satisfy the assertions on its own.
+         (script (concat "a=BEF; b=ORE; c=AFT; d=ER; "
+                         "printf '%s%s\\n' \"$a\" \"$b\"; sleep 1; "
+                         "printf '%s%s\\n' \"$c\" \"$d\""))
+         (inhibit-message t)
+         (save-some-buffers-default-predicate (lambda () nil)))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil))
+        (kill-buffer buf-name)))
+    (unwind-protect
+        (let ((buf (ghostel-compile--start script buf-name
+                                           default-directory)))
+          (with-current-buffer buf
+            (set-window-buffer (selected-window) buf)
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () (save-excursion
+                          (goto-char (point-min))
+                          (search-forward "BEFORE" nil t)))
+             10)
+            (ghostel-copy-mode)
+            (should (eq ghostel--input-mode 'copy))
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () ghostel-compile--finalized)
+             10)
+            (let ((text (buffer-substring-no-properties (point-min)
+                                                        (point-max))))
+              (should (string-match-p "BEFORE" text))
+              ;; Printed after the freeze — the case that used to be lost.
+              (should (string-match-p "AFTER" text))
+              (should (string-match-p "Compilation finished" text)))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil))
+          (kill-buffer buf-name))))))
+
+(ert-deftest ghostel-test-compile-hidden-run-keeps-output ()
+  "A run whose buffer no window shows still records all its output.
+Without a window `ghostel--redraw-now' has no metrics reference and
+declines, so the last output lives only in the terminal grid that
+the teardown then destroys."
+  :tags '(native)
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf-name "*ghostel-test-compile-hidden*")
+         (shell-file-name "/bin/sh")
+         (script "printf 'first\\n'; printf 'second\\n'")
+         (inhibit-message t)
+         (save-some-buffers-default-predicate (lambda () nil))
+         ;; `allow-no-window' lets `display-buffer' leave the buffer hidden.
+         (display-buffer-alist
+          (list (cons (regexp-quote buf-name)
+                      (cons #'display-buffer-no-window
+                            '((allow-no-window . t)))))))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil))
+        (kill-buffer buf-name)))
+    (unwind-protect
+        (let ((buf (ghostel-compile--start script buf-name
+                                           default-directory)))
+          (with-current-buffer buf
+            (should-not (get-buffer-window-list buf nil t))
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () ghostel-compile--finalized)
+             10)
+            (let ((text (buffer-substring-no-properties (point-min)
+                                                        (point-max))))
+              (should (string-match-p "first" text))
+              (should (string-match-p "second" text))
+              (should (string-match-p "Compilation finished" text)))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil))
+          (kill-buffer buf-name))))))
+
+(ert-deftest ghostel-test-compile-wrapped-error-parses-end-to-end ()
+  "A wrapped error path resolves to the real file after finalize.
+Regression test for #566: the renderer splits a path longer than
+the terminal across rows, which used to make `compilation-mode'
+record the fragment after the break as the file name."
+  :tags '(native)
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf-name "*ghostel-test-compile-wrap*")
+         (shell-file-name "/bin/sh")
+         (root (make-temp-file "ghostel-wrap-" t))
+         ;; The path must be longer than the terminal, so the row break is
+         ;; guaranteed to fall inside it whatever width the test frame has.
+         (dir (expand-file-name (mapconcat #'identity
+                                           (make-list 8 "deeply-nested-dir")
+                                           "/")
+                                root))
+         (file (expand-file-name "some_test.c" dir))
+         (script (format "printf '%%s\\n' '%s:42:5: error: boom'" file))
+         (inhibit-message t)
+         (cols nil)
+         (save-some-buffers-default-predicate (lambda () nil)))
+    (make-directory dir t)
+    (with-temp-file file (insert "x\n"))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil))
+        (kill-buffer buf-name)))
+    (unwind-protect
+        (let ((buf (ghostel-compile--start script buf-name
+                                           default-directory)))
+          (with-current-buffer buf
+            (setq cols ghostel--term-cols)
+            (should (> (length file) cols))
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () ghostel-compile--finalized)
+             10)
+            ;; Nothing may remain split: the error line and the header's
+            ;; echoed command are both longer than a test terminal.
+            (should-not (text-property-not-all (point-min) (point-max)
+                                               'ghostel-wrap nil))
+            (goto-char (point-min))
+            (should (re-search-forward (regexp-quote (concat file ":42:5:"))
+                                       nil t))
+            ;; The line is longer than the terminal, so the renderer must
+            ;; have split it — finding it whole proves the join ran.
+            (should (> (- (line-end-position) (line-beginning-position))
+                       cols))
+            ;; And `compilation-mode' resolves it to the real file.
+            (goto-char (point-min))
+            (compilation-next-error 1)
+            (let ((msg (get-text-property (point) 'compilation-message)))
+              (should msg)
+              (should (equal file
+                             (caar (compilation--loc->file-struct
+                                    (compilation--message->loc msg))))))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil))
+          (kill-buffer buf-name)))
+      (delete-directory root t))))
 
 (provide 'ghostel-compile-test)
 ;;; ghostel-compile-test.el ends here

--- a/test/ghostel-line-mode-test.el
+++ b/test/ghostel-line-mode-test.el
@@ -1531,7 +1531,7 @@ ambiguous)."
 
 (ert-deftest ghostel-test-line-mode-restore-marks-ghostel-input ()
   "`ghostel--line-mode-restore' marks the input region with `ghostel-input'.
-This makes `ghostel--detect-urls-skip-p' skip the user's typed
+This makes `ghostel--skip-match-p' skip the user's typed
 input on the cursor's line so a path the user typed locally does
 not get linkified (which would steal RET from line-mode-send)."
   (let ((buf (generate-new-buffer " *ghostel-test-line-input-prop*")))

--- a/test/ghostel-links-test.el
+++ b/test/ghostel-links-test.el
@@ -934,5 +934,503 @@ attached."
       (kill-buffer buf))))
 
 
+;;; Soft-wrapped links
+
+(defun ghostel-test--wrap-split (text column)
+  "Insert TEXT into the current buffer, wrapped at COLUMN like the terminal.
+The break is a real newline carrying `ghostel-wrap', matching what
+the renderer commits for a row the terminal wrapped."
+  (insert (substring text 0 column))
+  (insert (propertize "\n" 'ghostel-wrap t))
+  (insert (substring text column)))
+
+(defun ghostel-test--link-runs ()
+  "Return a list of (TEXT URI ID) for every `help-echo' run in the buffer."
+  (save-excursion
+    (let ((pos (point-min))
+          runs)
+      (while (setq pos (text-property-not-all pos (point-max) 'help-echo nil))
+        (let ((end (or (next-single-property-change pos 'help-echo)
+                       (point-max))))
+          (push (list (buffer-substring-no-properties pos end)
+                      (get-text-property pos 'help-echo)
+                      (get-text-property pos 'ghostel-link-id))
+                runs)
+          (setq pos end)))
+      (nreverse runs))))
+
+(ert-deftest ghostel-test-detect-file-across-soft-wrap ()
+  "A path the terminal split across rows is detected as one link.
+Both rows carry the whole `fileref:' URI and a shared
+`ghostel-link-id', and the wrap newline itself stays unmarked."
+  (let* ((file (locate-library "ghostel"))
+         (default-directory (file-name-directory file)))
+    (with-temp-buffer
+      (insert "see ")
+      (ghostel-test--wrap-split (concat file ":42") 20)
+      (insert " end\n")
+      (ghostel--detect-urls)
+      (let ((runs (ghostel-test--link-runs)))
+        (should (= 2 (length runs)))                        ; one run per row
+        (should (equal (list (concat "fileref:" file ":42")
+                             (concat "fileref:" file ":42"))
+                       (mapcar #'cadr runs)))               ; whole URI on both
+        (should (equal (nth 2 (car runs)) (nth 2 (cadr runs)))) ; shared id
+        (should (nth 2 (car runs))))                        ; and it is set
+      ;; The row break must stay clickable-free, or copying the link would
+      ;; drag the newline in.
+      (let ((wrap (text-property-not-all (point-min) (point-max)
+                                         'ghostel-wrap nil)))
+        (should wrap)
+        (should-not (get-text-property wrap 'help-echo))))))
+
+(ert-deftest ghostel-test-detect-url-across-soft-wrap ()
+  "A URL split across rows is detected as one link."
+  (with-temp-buffer
+    (insert "go ")
+    (ghostel-test--wrap-split "https://example.com/very/long/path" 22)
+    (insert " end\n")
+    (let ((ghostel-enable-url-detection t))
+      (ghostel--detect-urls))
+    (let ((runs (ghostel-test--link-runs)))
+      (should (= 2 (length runs)))
+      (should (equal '("https://example.com/very/long/path"
+                       "https://example.com/very/long/path")
+                     (mapcar #'cadr runs)))
+      (should (equal (nth 2 (car runs)) (nth 2 (cadr runs)))))))
+
+(ert-deftest ghostel-test-detect-ignores-hard-newline ()
+  "A path broken by a real newline is not joined.
+Only `ghostel-wrap' newlines come from terminal wrapping; a
+newline the program printed separates two unrelated lines."
+  (let* ((file (locate-library "ghostel"))
+         (default-directory (file-name-directory file)))
+    (with-temp-buffer
+      (insert "see " (substring file 0 20) "\n" (substring file 20) ":42 end\n")
+      (ghostel--detect-urls)
+      (should-not (seq-find (lambda (run) (equal (cadr run)
+                                                 (concat "fileref:" file ":42")))
+                            (ghostel-test--link-runs))))))
+
+(ert-deftest ghostel-test-soft-wrapped-link-navigates-as-one ()
+  "Link navigation treats the rows of a wrapped link as a single link.
+`ghostel--find-next-link' skips the continuation row via the shared
+`ghostel-link-id', and separate occurrences keep separate ids so the
+second one is still reachable."
+  (let* ((file (locate-library "ghostel"))
+         (default-directory (file-name-directory file)))
+    (with-temp-buffer
+      (insert "one ")
+      (ghostel-test--wrap-split (concat file ":1") 20)
+      (insert " x\ntwo ")
+      (ghostel-test--wrap-split (concat file ":2") 20)
+      (insert " y\n")
+      (ghostel--detect-urls)
+      (let* ((first (ghostel--find-next-link (point-min)))
+             (second (and first (ghostel--find-next-link first))))
+        (should first)
+        (should second)
+        ;; Two links, not four: each pair of rows counts once.
+        (should-not (ghostel--find-next-link second))
+        (should-not (equal (get-text-property first 'ghostel-link-id)
+                           (get-text-property second 'ghostel-link-id)))))))
+
+(ert-deftest ghostel-test-detect-skips-wrapped-cursor-line ()
+  "The whole line being typed is skipped, not just the cursor's row.
+A long command line occupies several rows; the path sits on the
+first one while the cursor is still on the last, and none of it may
+be linkified while the user is editing it."
+  (let* ((file (locate-library "ghostel"))
+         (default-directory (file-name-directory file)))
+    (with-temp-buffer
+      ;; Path complete on row 1, cursor down on row 2.
+      (insert "echo " file ":42 ")
+      (insert (propertize "\n" 'ghostel-wrap t))
+      (insert "still typing")
+      (let ((ghostel--cursor-char-pos (point-max)))
+        (ghostel--detect-urls))
+      (should-not (text-property-not-all (point-min) (point-max)
+                                         'help-echo nil)))))
+
+(ert-deftest ghostel-test-detect-extends-region-to-logical-line ()
+  "Scanning from a continuation row still sees the whole link.
+The live scan starts at the viewport's first row, which can be the
+middle of a line the terminal wrapped."
+  (let* ((file (locate-library "ghostel"))
+         (default-directory (file-name-directory file)))
+    (with-temp-buffer
+      (insert "see ")
+      (ghostel-test--wrap-split (concat file ":42") 20)
+      (insert " end\n")
+      (goto-char (point-max))
+      (let ((row2 (save-excursion (goto-char (point-min))
+                                  (forward-line 1)
+                                  (point))))
+        ;; Region starts mid-link, as `ghostel--viewport-start' can.
+        (ghostel--detect-urls row2 (point-max))
+        (let ((runs (ghostel-test--link-runs)))
+          (should (= 2 (length runs)))
+          (should (equal (list (concat "fileref:" file ":42"))
+                         (seq-uniq (mapcar #'cadr runs)))))
+        ;; And symmetrically when the region ends mid-link.
+        (let ((inhibit-read-only t))
+          (remove-text-properties (point-min) (point-max)
+                                  '(help-echo nil mouse-face nil keymap nil
+                                              ghostel-link-id nil
+                                              ghostel-link-text nil)))
+        (ghostel--detect-urls (point-min) (1- row2))
+        (let ((runs (ghostel-test--link-runs)))
+          (should (= 2 (length runs)))
+          (should (equal (list (concat "fileref:" file ":42"))
+                         (seq-uniq (mapcar #'cadr runs)))))))))
+
+(ert-deftest ghostel-test-detect-file-across-three-rows ()
+  "A link spanning more than two rows is still one link.
+Every row carries the whole URI and they share one id, so the
+offset mapping is exercised with several chunks."
+  (let* ((file (locate-library "ghostel"))
+         (default-directory (file-name-directory file))
+         (target (concat file ":42"))
+         (third (/ (length target) 3)))
+    (with-temp-buffer
+      (insert "see " (substring target 0 third))
+      (insert (propertize "\n" 'ghostel-wrap t))
+      (insert (substring target third (* 2 third)))
+      (insert (propertize "\n" 'ghostel-wrap t))
+      (insert (substring target (* 2 third)) " end\n")
+      (ghostel--detect-urls)
+      (let ((runs (ghostel-test--link-runs)))
+        (should (= 3 (length runs)))
+        (should (seq-every-p (lambda (run)
+                               (equal (cadr run) (concat "fileref:" target)))
+                             runs))
+        (should (= 1 (length (seq-uniq (mapcar (lambda (run) (nth 2 run))
+                                               runs)))))))))
+
+(ert-deftest ghostel-test-detect-bounds-huge-joined-line ()
+  "Joining stops before a line grows into a regexp stack overflow.
+A megabyte of unbroken output — a minified blob, base64 — is one
+logical line; joining all of it would hand the URL pattern a match
+candidate hundreds of thousands of characters long."
+  (with-temp-buffer
+    (insert "https://example.com/")
+    (dotimes (_ 4000)
+      (insert (make-string 80 ?x))
+      (insert (propertize "\n" 'ghostel-wrap t)))
+    (let ((ghostel-enable-url-detection t))
+      ;; The failure mode is a signal, not a wrong result.
+      (should (progn (ghostel--detect-urls) t))
+      ;; Joining restarts at the row limit, so the rows past it are scanned
+      ;; on their own instead of being swallowed into one link.
+      (should-not (get-text-property (- (point-max) 2) 'help-echo)))))
+
+(defmacro ghostel-test--with-link-fixture (spec &rest body)
+  "Run BODY with DIR bound to a temp directory holding a one-line FILE.
+SPEC is (DIR FILE).  `default-directory' is the temp directory, so a
+detected path resolves there and nothing depends on where this
+checkout happens to live."
+  (declare (indent 1))
+  (pcase-let ((`(,dir ,file) spec))
+    `(let* ((,dir (file-name-as-directory (make-temp-file "ghostel-link-" t)))
+            (,file (expand-file-name "a.el" ,dir))
+            (default-directory ,dir))
+       (unwind-protect
+           (progn (with-temp-file ,file (insert "x\n"))
+                  ,@body)
+         (delete-directory ,dir t)))))
+
+(ert-deftest ghostel-test-detect-refreshes-partly-repainted-link ()
+  "A link whose target changed is re-evaluated, not left as it was.
+The renderer rewrites only the rows that changed, so the rows of a
+wrapped link that did not change would otherwise keep pointing at
+text they no longer hold — here the line number shrinks from 912 to
+9 when the continuation row loses its digits."
+  (ghostel-test--with-link-fixture (dir file)
+    (with-temp-buffer
+      (insert "see " file ":9")
+      (insert (propertize "\n" 'ghostel-wrap t))
+      (insert "12 rest\n")
+      (goto-char (point-max))
+      (ghostel--detect-urls)
+      (should (equal (concat "fileref:" file ":912")
+                     (get-text-property 5 'help-echo)))
+      (save-excursion
+        (goto-char (point-min))
+        (forward-line 1)
+        (delete-region (point) (line-end-position))
+        (insert " rest"))
+      (goto-char (point-max))
+      (ghostel--detect-urls)
+      (should (equal (concat "fileref:" file ":9")
+                     (get-text-property 5 'help-echo))))))
+
+(ert-deftest ghostel-test-detect-drops-stranded-link ()
+  "A link no match covers any more is removed, not left behind.
+Repainting the continuation row can leave the first row of a wrapped
+link pointing at a path that is no longer on screen."
+  (ghostel-test--with-link-fixture (dir file)
+    (with-temp-buffer
+      (insert "see " (substring file 0 (- (length file) 3)))
+      (insert (propertize "\n" 'ghostel-wrap t))
+      (insert (substring file (- (length file) 3)) ":9 rest\n")
+      (goto-char (point-max))
+      (ghostel--detect-urls)
+      (should (equal (concat "fileref:" file ":9")
+                     (get-text-property 5 'help-echo)))
+      (save-excursion
+        (goto-char (point-min))
+        (forward-line 1)
+        (delete-region (point) (line-end-position))
+        (insert "hello world"))
+      (goto-char (point-max))
+      (ghostel--detect-urls)
+      (should-not (get-text-property 5 'help-echo))
+      (should-not (get-text-property 5 'keymap))
+      (should-not (get-text-property 5 'mouse-face))
+      (should-not (get-text-property 5 'ghostel-link-id))
+      (should-not (get-text-property 5 'ghostel-link-text)))))
+
+(ert-deftest ghostel-test-detect-keeps-link-across-directory-change ()
+  "Output already linkified keeps its target when the shell changes directory.
+Directory tracking moves `default-directory' as the user `cd's, but a
+line printed earlier still refers to where it was printed — and a
+same-named file in the new directory must not silently take over."
+  (ghostel-test--with-link-fixture (dir _file)
+    (let ((from (expand-file-name "from/src/" dir))
+          (to (expand-file-name "to/src/" dir)))
+      (make-directory from t)
+      (make-directory to t)
+      (with-temp-file (expand-file-name "main.rs" from) (insert "x\n"))
+      (with-temp-file (expand-file-name "main.rs" to) (insert "y\n"))
+      (with-temp-buffer
+        (insert "error at src/main.rs:42 boom\n")
+        (goto-char (point-max))
+        (let ((default-directory (expand-file-name "from/" dir)))
+          (ghostel--detect-urls))
+        (let ((target (concat "fileref:" (expand-file-name "main.rs" from)
+                              ":42")))
+          (should (equal target (get-text-property 10 'help-echo)))
+          (let ((default-directory (expand-file-name "to/" dir)))
+            (ghostel--detect-urls))
+          (should (equal target (get-text-property 10 'help-echo))))))))
+
+(ert-deftest ghostel-test-detect-keeps-unscanned-links ()
+  "A scan with one pattern switched off leaves the other's links alone.
+Clearing links no match covers must not mistake `not scanned for'
+for `no longer there'."
+  (ghostel-test--with-link-fixture (dir file)
+    (with-temp-buffer
+      (insert "go https://example.com/x end\n")
+      (goto-char (point-max))
+      (ghostel--detect-urls)
+      (should (equal "https://example.com/x" (get-text-property 4 'help-echo)))
+      (let ((ghostel-enable-url-detection nil))
+        (ghostel--detect-urls))
+      (should (equal "https://example.com/x" (get-text-property 4 'help-echo))))
+    (with-temp-buffer
+      (insert "see " file ":9 end\n")
+      (goto-char (point-max))
+      (ghostel--detect-urls)
+      (should (equal (concat "fileref:" file ":9")
+                     (get-text-property 5 'help-echo)))
+      (let ((ghostel-enable-file-detection nil))
+        (ghostel--detect-urls))
+      (should (equal (concat "fileref:" file ":9")
+                     (get-text-property 5 'help-echo))))))
+
+(ert-deftest ghostel-test-detect-url-wins-over-path-inside-it ()
+  "A URL keeps its link even when its own text looks like a path.
+`http://tmp/x' contains `//tmp/x', which the file pattern matches and
+which may name a real file — the URL must not be replaced by it, and
+the file must not be stat'ed on every scan."
+  (ghostel-test--with-link-fixture (dir _file)
+    (let* ((url (concat "http:/" dir "a.el")))
+      ;; The URL's path half is exactly the fixture file, which exists.
+      (with-temp-buffer
+        (insert "get " url " done\n")
+        (goto-char (point-max))
+        (let ((stats 0))
+          (cl-letf* ((real (symbol-function 'file-exists-p))
+                     ((symbol-function 'file-exists-p)
+                      (lambda (f) (setq stats (1+ stats)) (funcall real f))))
+            (dotimes (_ 3) (ghostel--detect-urls)))
+          (should (equal url (get-text-property 5 'help-echo)))
+          ;; One run, not a URL prefix followed by a fileref.
+          (should (= 1 (length (ghostel-test--link-runs))))
+          (should (zerop stats)))
+        ;; Still protected once URL detection is switched off, so toggling
+        ;; the option cannot turn an existing URL link into a file link.
+        ;; Assert past `http:', where a file match would start.
+        (let ((ghostel-enable-url-detection nil))
+          (ghostel--detect-urls))
+        (should (equal url (get-text-property 12 'help-echo)))
+        (should (= 1 (length (ghostel-test--link-runs))))))))
+
+(ert-deftest ghostel-test-detect-url-owns-the-path-inside-it ()
+  "A URL keeps the file pass out of the `//host/path' half it contains.
+The path inside this URL names a file that exists, so only the URL's
+claim on the span stops it becoming a local-file link."
+  (ghostel-test--with-link-fixture (dir file)
+    (with-temp-buffer
+      (insert " https:/" file ":9 end\n")
+      (goto-char (point-max))
+      (ghostel--detect-urls)
+      (should-not (seq-find (lambda (run)
+                              (string-prefix-p "fileref:" (cadr run)))
+                            (ghostel-test--link-runs)))
+      (ignore dir))))
+
+(ert-deftest ghostel-test-detect-replaces-stale-url-link-in-one-scan ()
+  "A leftover URL link over what is now a path becomes the path link.
+One scan is enough: the file pass must not treat a URL link no URL
+match covers as a URL that still owns the text."
+  (ghostel-test--with-link-fixture (dir file)
+    (with-temp-buffer
+      (insert "x " file ":9 end\n")
+      (goto-char (point-max))
+      ;; Simulate the leftover an earlier scan would have attached.
+      (let ((beg 3)
+            (end (+ 3 (length file))))
+        (put-text-property beg end 'help-echo "http://old.example")
+        (put-text-property beg end 'ghostel-link-text "http://old.example")
+        (put-text-property beg end 'ghostel-link-id
+                           (cons 'ghostel-detected 99)))
+      (ghostel--detect-urls)
+      (should (equal (concat "fileref:" file ":9")
+                     (get-text-property 3 'help-echo)))
+      (ignore dir))))
+
+(ert-deftest ghostel-test-detect-keeps-osc8-links-when-sweeping ()
+  "Clearing stranded links never touches a link ghostel did not detect."
+  (with-temp-buffer
+    (insert "plain text here\n")
+    (put-text-property 1 6 'help-echo "https://osc8.example")
+    (put-text-property 1 6 'ghostel-link-id "A")
+    (goto-char (point-max))
+    (ghostel--detect-urls)
+    (should (equal "https://osc8.example" (get-text-property 1 'help-echo)))
+    (should (equal "A" (get-text-property 1 'ghostel-link-id)))))
+
+(ert-deftest ghostel-test-detect-keeps-link-across-repeated-scans ()
+  "Rescanning unchanged output leaves its links exactly as they are."
+  (ghostel-test--with-link-fixture (dir file)
+    (with-temp-buffer
+      (insert "see " file ":9 end\n")
+      (goto-char (point-max))
+      (ghostel--detect-urls)
+      (let ((id (get-text-property 5 'ghostel-link-id)))
+        (dotimes (_ 5) (ghostel--detect-urls))
+        (should (equal (concat "fileref:" file ":9")
+                       (get-text-property 5 'help-echo)))
+        ;; A fresh id every pass would mean the link is rewritten each time.
+        (should (equal id (get-text-property 5 'ghostel-link-id)))))))
+
+(ert-deftest ghostel-test-detect-leaves-foreign-link-alone ()
+  "An OSC 8 span overlapping a detected match keeps its own target.
+Checked wherever the span falls: over the start of the match, inside
+the first row, and on the continuation row."
+  (ghostel-test--with-link-fixture (dir file)
+    (dolist (spot '(start middle continuation))
+      (with-temp-buffer
+        (insert "see " (substring file 0 12))
+        (insert (propertize "\n" 'ghostel-wrap t))
+        (insert (substring file 12) ":9 end\n")
+        (let ((row2 (save-excursion (goto-char (point-min))
+                                    (forward-line 1)
+                                    (point))))
+          (pcase spot
+            ('start (put-text-property 5 12 'help-echo "https://osc8.example"))
+            ('middle (put-text-property 8 14 'help-echo "https://osc8.example"))
+            ('continuation (put-text-property row2 (+ row2 3)
+                                              'help-echo "https://osc8.example")))
+          (goto-char (point-max))
+          (ghostel--detect-urls)
+          ;; The foreign span is untouched and the match is left alone.
+          (should (equal "https://osc8.example"
+                         (get-text-property
+                          (pcase spot ('start 5) ('middle 8) ('continuation row2))
+                          'help-echo)))
+          (should-not (equal (concat "fileref:" file ":9")
+                             (get-text-property 5 'help-echo))))))))
+
+(ert-deftest ghostel-test-soft-wrapped-link-survives-unwrap ()
+  "Rows linkified live merge into one run once the rows are joined.
+`ghostel-compile' joins soft-wrapped rows when a run finishes; the
+link must not end up with a gap where the row break was."
+  (let* ((file (locate-library "ghostel"))
+         (default-directory (file-name-directory file)))
+    (with-temp-buffer
+      (insert "err ")
+      (ghostel-test--wrap-split (concat file ":42") 20)
+      (insert " boom\n")
+      (ghostel--detect-urls)
+      (should (= 2 (length (ghostel-test--link-runs))))
+      (ghostel-compile--unwrap-soft-wraps)
+      (let ((runs (ghostel-test--link-runs)))
+        (should (= 1 (length runs)))
+        (should (equal (concat file ":42") (car (car runs))))
+        ;; Clickable end to end, including where the break used to be.
+        (let ((start (text-property-not-all (point-min) (point-max)
+                                            'help-echo nil)))
+          (dotimes (i (length (concat file ":42")))
+            (should (get-text-property (+ start i) 'keymap))
+            (should (get-text-property (+ start i) 'mouse-face))))))))
+
+(ert-deftest ghostel-test-detect-file-across-soft-wrap-native ()
+  "The renderer's own wrap newlines make a long path detectable.
+Drives a narrow terminal so libghostty wraps the path itself,
+rather than relying on a hand-built `ghostel-wrap' newline."
+  :tags '(native)
+  ;; Half the line, so the path spans several rows however deep this
+  ;; checkout sits.
+  (let* ((file (locate-library "ghostel"))
+         (line (concat "see " file ":42 end"))
+         (cols (/ (length line) 2)))
+    (ghostel-test--with-terminal-buffer (_buf term 10 cols 1000)
+      (let* ((default-directory (file-name-directory file))
+             (inhibit-read-only t))
+        (ghostel--write-vt term (concat line "\r\n"))
+        (ghostel--redraw term t)
+        (ghostel--detect-urls)
+        (let ((runs (ghostel-test--link-runs)))
+          (should (> (length runs) 1))  ; the renderer split the path
+          (should (seq-every-p (lambda (run)
+                                 (equal (cadr run)
+                                        (concat "fileref:" file ":42")))
+                               runs))
+          (should (= 1 (length (seq-uniq (mapcar (lambda (run) (nth 2 run))
+                                                 runs))))))))))
+
+(ert-deftest ghostel-test-detect-file-survives-reflow-native ()
+  "A link keeps working after a resize reflows the terminal.
+Narrowing the terminal re-splits a path that fitted on one row,
+which used to drop the link entirely."
+  :tags '(native)
+  ;; Both widths follow the path: it has to fit on one row before the
+  ;; resize and need several after, wherever this checkout sits.
+  (let* ((file (locate-library "ghostel"))
+         (wide (+ (length file) 10))
+         (narrow (/ (length file) 2)))
+    (ghostel-test--with-terminal-buffer (_buf term 10 wide 1000)
+      (let* ((default-directory (file-name-directory file))
+             (uri (concat "fileref:" file ":42"))
+             (inhibit-read-only t))
+        (ghostel--write-vt term (concat file ":42\r\n"))
+        (ghostel--redraw term t)
+        (ghostel--detect-urls)
+        (should (= 1 (length (ghostel-test--link-runs)))) ; one row before
+        (should (equal (list uri)
+                       (seq-uniq (mapcar #'cadr (ghostel-test--link-runs)))))
+        ;; Reflow: the same output now needs several rows.
+        (ghostel--set-size term 10 narrow)
+        (ghostel--redraw term t)
+        (ghostel--detect-urls)
+        (let ((runs (ghostel-test--link-runs)))
+          (should (> (length runs) 1))
+          (should (equal (list uri) (seq-uniq (mapcar #'cadr runs))))
+          ;; The rows must still form one link, not several.
+          (should (= 1 (length (seq-uniq (mapcar (lambda (run) (nth 2 run))
+                                                 runs))))))))))
+
 (provide 'ghostel-links-test)
 ;;; ghostel-links-test.el ends here

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -2293,7 +2293,7 @@ scanner skips them."
 (ert-deftest ghostel-test-osc133-prompt-stops-at-input ()
   "`ghostel-prompt' must end where `ghostel-input' begins on the row.
 Without this, the historical prompt row carries `ghostel-prompt'
-across the typed command, and `ghostel--detect-urls-skip-p' refuses
+across the typed command, and `ghostel--skip-match-p' refuses
 to linkify paths in past commands — even though they are outside the
 active input range."
   :tags '(native)


### PR DESCRIPTION
Fixes #566.

The renderer commits one buffer line per terminal row, so a path or URL longer
than the terminal is split by a real newline. `compilation-mode` recorded the
fragment after the break as the file name, and plain link detection matched only
the fragment that fit on a row. `M-x compile` has neither problem, which is what
the reporter was comparing against.

## `ghostel-compile` joins wrapped rows

When a run finalizes, newlines carrying the `ghostel-wrap` property are removed,
so error parsing, `next-error`, `ffap` and saving the buffer see whole lines.
Newlines the command itself emitted stay.

## Link detection is wrap-aware

Detection scans logical lines with those newlines removed and marks every row of
a match with the whole target and a shared `ghostel-link-id`, so navigation
treats the rows as one link and the reflow a window resize causes leaves it
intact. Joined lines are capped at `ghostel--soft-wrap-scan-limit`; a match cut
by the cap keeps its span rather than resolving to a truncated target.

Links stay correct as the screen changes: refreshed when their text changes,
cleared when no match covers them, left alone across a `cd`, and OSC 8 links are
never swept.

## Pre-existing bugs the join exposed

These are on `main` today and are fixed here:

- A command finishing while its buffer is displayed in no window, or while copy
  mode holds the terminal frozen, lost the output that lived only in the
  terminal grid. Measured on the worst case (50 lines rendered, freeze, 200 more
  lines scrolling through a 10-row grid): 50/250 lines before, 250/250 after.
- A window resize repainted a finished compile buffer from the grid, discarding
  the footer.
- Rendering a buffer that no window displays signalled from `font-at` on the
  first glyph needing metrics, wedging the run at `:run`.
- A saved compile log reopens in `ghostel-compile-view-mode`. The header named
  `ghostel-compile-mode`, which does not exist, so the file landed in
  `fundamental-mode` without error navigation.

## Testing

18 new tests, each mutation-verified to fail when its fix is reverted. Elisp and
native suites and `make lint` pass. `make test-zig` was not run on the rebased
base.
