### PR TITLE
Build the native module for Android/Termux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,13 @@ jobs:
             platform: x86_64-freebsd
             suffix: .so
             target: x86_64-freebsd
+          # Termux (bionic).  The runner image ships an Android SDK, and
+          # build.zig locates its NDK through ANDROID_HOME.
+          # API 24 is Termux's minimum.
+          - os: ubuntu-latest
+            platform: aarch64-android
+            suffix: .so
+            target: aarch64-linux-android.24
           - os: windows-latest
             platform: x86_64-windows
             suffix: .dll

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,13 @@ jobs:
             platform: x86_64-freebsd
             suffix: .so
             target: x86_64-freebsd
+          # Termux (bionic).  The runner image ships an Android SDK, and
+          # build.zig locates its NDK through ANDROID_HOME.
+          # API 24 is Termux's minimum.
+          - os: ubuntu-latest
+            platform: aarch64-android
+            suffix: .so
+            target: aarch64-linux-android.24
           - os: windows-latest
             platform: x86_64-windows
             suffix: .dll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
   `copy`/`emacs`/`nil` settings on the trigger options behave as before.
   `ghostel-mode` is also marked mode-class `special` (like `term-mode`), so
   `view-read-only` can no longer pull `view-mode` into a terminal buffer.
+- Android/Termux support: releases now ship an `aarch64-android` module built
+  against bionic at API level 24, and the installer picks it for Emacs builds
+  with an `*-linux-android` configuration. Cross-compiling needs the Android
+  NDK, located through `ANDROID_NDK_HOME`, `ANDROID_HOME`, or
+  `ANDROID_SDK_ROOT`; on-device compilation in Termux needs only `pkg
+  install zig ndk-sysroot`.
 
 ### Changed
 - Live terminal-input modes (semi-char, char, interactive `ghostel-compile`)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Check the [documentation](https://dakra.github.io/ghostel/#features) for a full 
 
 ## Quick Start
 
-**Requirements:** Emacs 28.1+ with dynamic module support, on macOS, Linux, FreeBSD, or native Windows.
+**Requirements:** Emacs 28.1+ with dynamic module support, on macOS, Linux, FreeBSD, Android/Termux, or native Windows.
 The native module is a prebuilt binary that **auto-downloads on first use**.
 No toolchain or build step required.
 

--- a/README.org
+++ b/README.org
@@ -145,7 +145,7 @@ mark.
 #+cindex: requirements
 
 - Emacs 28.1+ with dynamic module support
-- macOS, Linux, FreeBSD, or native Windows
+- macOS, Linux, FreeBSD, Android/Termux, or native Windows
 
 The native module is *automatically downloaded* on first use.  Pre-built
 binaries are available for:
@@ -155,6 +155,7 @@ binaries are available for:
 - =x86_64-linux=
 - =aarch64-linux=
 - =x86_64-freebsd=
+- =aarch64-android= (Termux)
 - =x86_64-windows=
 - =aarch64-windows=
 
@@ -230,6 +231,34 @@ package tree (for example =~/.config/emacs/ghostel/=).
 :properties:
 :custom_id: platform-notes
 :end:
+
+*** Android (Termux)
+:properties:
+:custom_id: android-platform-notes
+:end:
+
+Termux's Emacs is built with dynamic module support, so Ghostel runs there.  The
+pre-built =aarch64-android= module links against bionic at API level 24 (Android
+7.0, Termux's minimum) and is *not* interchangeable with the glibc
+=aarch64-linux= module.
+
+Terminal spawns go through =/bin/sh=.  Inside a normal Termux session Termux's
+=exec= shim rewrites that to =$PREFIX/bin/sh=; without the shim it resolves to
+Android's own =sh= (Android 9+) or fails (Android 7 and 8).
+
+The kitty graphics shared-memory transmission medium is unavailable because
+bionic has no POSIX shared memory; file and direct transmission work.
+
+Compiling on-device works with Termux's packages: =pkg install zig
+ndk-sysroot=, then =M-x ghostel-module-compile= (or =zig build=).  Without an
+NDK installed, =build.zig= uses the bionic sysroot that the =ndk-sysroot=
+package provides under =$PREFIX= and builds ghostty's scalar (non-SIMD)
+code paths.  Cross-compiling from a desktop needs the Android NDK;
+=build.zig= finds it through =ANDROID_NDK_HOME=, =ANDROID_HOME=,
+=ANDROID_SDK_ROOT=, or the default SDK location.
+
+Android is built in CI but no test suite runs against it, so support is
+best-effort.
 
 *** Windows
 :properties:

--- a/build.zig
+++ b/build.zig
@@ -23,11 +23,19 @@ pub fn build(b: *std.Build) void {
     ) orelse optimize;
     const is_release = optimize != .Debug;
     const target_os = target.result.os.tag;
+    const android_libc: ?AndroidLibC = if (target.result.abi.isAndroid())
+        resolveAndroidLibC(b, target.result)
+    else
+        null;
 
+    // On-device Termux builds have no NDK, whose sysroot ghostty's vendored
+    // simdutf/highway C++ builds require; use ghostty's scalar path there.
+    const ghostty_simd = if (android_libc) |libc| libc.source != .termux else true;
     const ghostty_dep = b.dependency("ghostty", .{
         .target = target,
         .optimize = ghostty_optimize,
         .@"emit-lib-vt" = true,
+        .simd = ghostty_simd,
     });
 
     const ghostty_vt = ghostty_dep.module("ghostty-vt");
@@ -39,6 +47,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     translate_emacs.addIncludePath(emacs_module_dir);
+    if (android_libc) |libc| addAndroidIncludes(translate_emacs, libc);
     const emacs_c = translate_emacs.createModule();
 
     const platform_c: std.Build.Module.Import = switch (target_os) {
@@ -59,6 +68,7 @@ pub fn build(b: *std.Build) void {
                 .target = target,
                 .optimize = optimize,
             });
+            if (android_libc) |libc| addAndroidIncludes(translate_posix, libc);
             break :platform .{
                 .name = "posix_c",
                 .module = translate_posix.createModule(),
@@ -71,6 +81,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    if (android_libc) |libc| addAndroidIncludes(translate_stb, libc);
     const stb_image_c = translate_stb.createModule();
 
     const mod = b.createModule(.{
@@ -109,6 +120,11 @@ pub fn build(b: *std.Build) void {
     }
     if (target_os == .windows) {
         lib.root_module.linkSystemLibrary("kernel32", .{});
+    }
+    if (android_libc) |libc| {
+        // Support 16kb page sizes, required for Android 15+.
+        lib.link_z_max_page_size = 16384;
+        setAndroidLibCFile(b, lib, libc);
     }
 
     const copy_step = b.addInstallFile(
@@ -221,6 +237,188 @@ fn moduleOutputName(target_os: std.Target.Os.Tag) []const u8 {
         .macos => "ghostel-module.dylib",
         .windows => "ghostel-module.dll",
         else => "ghostel-module.so",
+    };
+}
+
+/// Bionic libc paths for an Android target.  Zig bundles no bionic, so
+/// headers and crt objects come from an external sysroot.
+const AndroidLibC = struct {
+    source: enum { ndk, termux },
+    include_dir: []const u8,
+    sys_include_dir: []const u8,
+    crt_dir: []const u8,
+    /// Directory holding libraries that carry no API level
+    /// (`libc++_shared.so' and friends).
+    lib_dir: []const u8,
+};
+
+/// Resolve the bionic sysroot for TARGET.  Cross builds use the NDK,
+/// located through `ANDROID_NDK_HOME`, or the newest `ndk/<version>`
+/// under `ANDROID_HOME`/`ANDROID_SDK_ROOT`.  On-device builds in Termux
+/// (no NDK) fall back to the `$PREFIX` sysroot that Termux's
+/// `ndk-sysroot` package provides.
+fn resolveAndroidLibC(b: *std.Build, target: std.Target) AndroidLibC {
+    if (findAndroidNdk(b)) |ndk_dir| return androidNdkLibC(b, target, ndk_dir);
+    if (termuxLibC(b)) |libc| return libc;
+    std.debug.panic(
+        "Android builds need the Android NDK (set ANDROID_NDK_HOME or ANDROID_HOME); " ++
+            "inside Termux, `pkg install ndk-sysroot` instead",
+        .{},
+    );
+}
+
+fn androidNdkLibC(b: *std.Build, target: std.Target, ndk_dir: []const u8) AndroidLibC {
+    const triple = androidTriple(target.cpu.arch) orelse std.debug.panic(
+        "unsupported Android architecture: {s}",
+        .{@tagName(target.cpu.arch)},
+    );
+    const host = androidNdkHost() orelse std.debug.panic(
+        "unsupported host for Android cross-compilation: {s}",
+        .{@tagName(builtin.os.tag)},
+    );
+
+    const sysroot = b.pathJoin(&.{ ndk_dir, "toolchains", "llvm", "prebuilt", host, "sysroot" });
+    const lib_dir = b.pathJoin(&.{ sysroot, "usr", "lib", triple });
+    return .{
+        .source = .ndk,
+        .include_dir = b.pathJoin(&.{ sysroot, "usr", "include" }),
+        .sys_include_dir = b.pathJoin(&.{ sysroot, "usr", "include", triple }),
+        .crt_dir = b.pathJoin(&.{ lib_dir, b.fmt("{d}", .{target.os.version_range.linux.android}) }),
+        .lib_dir = lib_dir,
+    };
+}
+
+/// Termux's `ndk-sysroot` package installs the bionic headers merged into
+/// `$PREFIX/include` and the crt objects into `$PREFIX/lib`.
+fn termuxLibC(b: *std.Build) ?AndroidLibC {
+    if (b.graph.environ_map.get("TERMUX_VERSION") == null) return null;
+    const prefix = b.graph.environ_map.get("PREFIX") orelse return null;
+    if (prefix.len == 0) return null;
+
+    const include_dir = b.pathJoin(&.{ prefix, "include" });
+    if (!dirHasHeader(b.allocator, include_dir, "errno.h")) return null;
+    const lib_dir = b.pathJoin(&.{ prefix, "lib" });
+
+    // ghostty's vendored android-ndk helper insists on an NDK directory
+    // at graph construction time, although none of the artifacts that
+    // link through it are built here (simd is disabled on-device).  A
+    // stub keeps the graph constructible without an NDK.
+    b.graph.environ_map.put("ANDROID_NDK_HOME", prefix) catch @panic("OOM");
+    return .{
+        .source = .termux,
+        .include_dir = include_dir,
+        .sys_include_dir = include_dir,
+        .crt_dir = lib_dir,
+        .lib_dir = lib_dir,
+    };
+}
+
+fn dirHasHeader(allocator: std.mem.Allocator, dir: []const u8, header: []const u8) bool {
+    const path = std.fs.path.join(allocator, &.{ dir, header }) catch
+        @panic("out of memory while resolving libc header");
+    defer allocator.free(path);
+    std.Io.Dir.cwd().access(io.io(), path, .{}) catch return false;
+    return true;
+}
+
+fn setAndroidLibCFile(b: *std.Build, lib: *std.Build.Step.Compile, libc: AndroidLibC) void {
+    const wf = b.addWriteFiles();
+    const libc_file = wf.add("android-libc.txt", b.fmt(
+        \\include_dir={s}
+        \\sys_include_dir={s}
+        \\crt_dir={s}
+        \\msvc_lib_dir=
+        \\kernel32_lib_dir=
+        \\gcc_dir=
+        \\
+    , .{ libc.include_dir, libc.sys_include_dir, libc.crt_dir }));
+
+    lib.setLibCFile(libc_file);
+    lib.root_module.addLibraryPath(.{ .cwd_relative = libc.lib_dir });
+}
+
+/// `zig translate-c` finds no bionic headers on its own (the libc file
+/// only reaches the compile step), so Android sysroot includes are fed
+/// to every translate-c step explicitly.
+fn addAndroidIncludes(translate_c: *std.Build.Step.TranslateC, libc: AndroidLibC) void {
+    translate_c.addSystemIncludePath(.{ .cwd_relative = libc.include_dir });
+    if (!std.mem.eql(u8, libc.sys_include_dir, libc.include_dir))
+        translate_c.addSystemIncludePath(.{ .cwd_relative = libc.sys_include_dir });
+    // translate-c's aro frontend lacks the clang extensions bionic
+    // annotates its declarations with: nullability specifiers inside
+    // array declarators and the `__overloadable' ioctl redeclaration.
+    translate_c.defineCMacro("_Nonnull", "");
+    translate_c.defineCMacro("_Nullable", "");
+    translate_c.defineCMacro("_Null_unspecified", "");
+    translate_c.defineCMacro("BIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD", "1");
+}
+
+fn findAndroidNdk(b: *std.Build) ?[]const u8 {
+    if (b.graph.environ_map.get("ANDROID_NDK_HOME")) |dir| {
+        if (dir.len > 0) return dir;
+    }
+
+    for ([_][]const u8{ "ANDROID_HOME", "ANDROID_SDK_ROOT" }) |env_name| {
+        const sdk_dir = b.graph.environ_map.get(env_name) orelse continue;
+        if (sdk_dir.len == 0) continue;
+        if (findLatestAndroidNdk(b, sdk_dir)) |dir| return dir;
+    }
+
+    // Default SDK location, mirroring the ghostty dependency's search.
+    const home_env = if (builtin.os.tag == .windows) "LOCALAPPDATA" else "HOME";
+    const home = b.graph.environ_map.get(home_env) orelse return null;
+    const default_sdk = b.pathJoin(&.{
+        home,
+        switch (builtin.os.tag) {
+            .linux => "Android/sdk",
+            .macos => "Library/Android/Sdk",
+            .windows => "Android/Sdk",
+            else => return null,
+        },
+    });
+    return findLatestAndroidNdk(b, default_sdk);
+}
+
+fn findLatestAndroidNdk(b: *std.Build, sdk_dir: []const u8) ?[]const u8 {
+    const ndk_root = b.pathJoin(&.{ sdk_dir, "ndk" });
+    var dir = std.Io.Dir.cwd().openDir(io.io(), ndk_root, .{ .iterate = true }) catch return null;
+    defer dir.close(io.io());
+
+    var latest: ?struct {
+        name: []const u8,
+        version: std.SemanticVersion,
+    } = null;
+    var it = dir.iterate();
+    while (it.next(io.io()) catch null) |entry| {
+        if (entry.kind != .directory) continue;
+        const version = std.SemanticVersion.parse(entry.name) catch continue;
+        if (latest) |current| {
+            if (version.order(current.version) != .gt) continue;
+        }
+        latest = .{ .name = b.dupe(entry.name), .version = version };
+    }
+
+    const found = latest orelse return null;
+    return b.pathJoin(&.{ ndk_root, found.name });
+}
+
+fn androidTriple(arch: std.Target.Cpu.Arch) ?[]const u8 {
+    return switch (arch) {
+        .arm => "arm-linux-androideabi",
+        .aarch64 => "aarch64-linux-android",
+        .x86 => "i686-linux-android",
+        .x86_64 => "x86_64-linux-android",
+        else => null,
+    };
+}
+
+fn androidNdkHost() ?[]const u8 {
+    return switch (builtin.os.tag) {
+        .linux => "linux-x86_64",
+        // Every macOS host uses the same prebuilt toolchain.
+        .macos => "darwin-x86_64",
+        .windows => "windows-x86_64",
+        else => null,
     };
 }
 

--- a/lisp/ghostel-module-install.el
+++ b/lisp/ghostel-module-install.el
@@ -83,6 +83,13 @@ Returns nil if the platform is not recognized."
                  (_ raw-arch)))
          (os (cond
               ((eq system-type 'darwin) "macos")
+              ;; Termux builds Emacs with an `*-linux-android' triple;
+              ;; `system-type' is `android' there, but older Emacs
+              ;; versions report `gnu/linux', so check both.  Bionic
+              ;; modules are not interchangeable with glibc ones.
+              ((or (eq system-type 'android)
+                   (string-match-p "android" system-configuration))
+               "android")
               ((eq system-type 'gnu/linux) "linux")
               ((eq system-type 'windows-nt) "windows")
               (t nil))))

--- a/test/ghostel-module-test.el
+++ b/test/ghostel-module-test.el
@@ -1021,5 +1021,23 @@ both the .so/.dylib and ghostel-module.version next to it."
         (system-type 'windows-nt))
     (should (equal (ghostel--module-platform-tag) "aarch64-windows"))))
 
+(ert-deftest ghostel-test-platform-tag-detects-android ()
+  "Test that Termux/Android builds get an `android' tag, not `linux'."
+  ;; Emacs 30+ sets `system-type' to `android' for *-linux-android hosts.
+  (let ((system-configuration "aarch64-linux-android")
+        (system-type 'android))
+    (should (equal (ghostel--module-platform-tag) "aarch64-android")))
+  ;; Older Emacs versions report `gnu/linux' for the same host triple.
+  (let ((system-configuration "aarch64-linux-android")
+        (system-type 'gnu/linux))
+    (should (equal (ghostel--module-platform-tag) "aarch64-android")))
+  (let ((system-configuration "x86_64-linux-android")
+        (system-type 'android))
+    (should (equal (ghostel--module-platform-tag) "x86_64-android")))
+  ;; A glibc host must keep the `linux' tag.
+  (let ((system-configuration "aarch64-unknown-linux-gnu")
+        (system-type 'gnu/linux))
+    (should (equal (ghostel--module-platform-tag) "aarch64-linux"))))
+
 (provide 'ghostel-module-test)
 ;;; ghostel-module-test.el ends here

--- a/vendor/emacs-module.h
+++ b/vendor/emacs-module.h
@@ -43,9 +43,11 @@ with local changes applied:
    padding expressions that Zig's translate-c cannot parse, producing
    an opaque type.  Pre-define a plain struct that is ABI-compatible
    (tv_sec is time_t, tv_nsec is long, padded to 2 * sizeof(time_t))
-   and set the musl guard macro so <time.h> skips its version.  */
+   and set the musl guard macro so <time.h> skips its version.
+   Bionic is also non-glibc but parses cleanly and has no
+   <bits/alltypes.h>, so Android is excluded.  */
 #ifndef __DEFINED_struct_timespec
-#if defined(__linux__) && !defined(__GLIBC__)
+#if defined(__linux__) && !defined(__GLIBC__) && !defined(__ANDROID__)
 #define __NEED_time_t
 #include <bits/alltypes.h>
 #define __DEFINED_struct_timespec


### PR DESCRIPTION
Adds `aarch64-android` as a supported platform: CI and release builds produce a bionic module, the installer resolves it for Termux's Emacs, and the module can be built on-device inside Termux itself.

## Building

Zig ships no bionic libc, so Android targets need an external sysroot. Two paths are supported:

- **Cross-compiling** uses the NDK, found via `ANDROID_NDK_HOME`, the newest `ndk/<version>` under `ANDROID_HOME`/`ANDROID_SDK_ROOT`, or the default SDK location — the same search the ghostty dependency already performs. GitHub's Linux runners export `ANDROID_NDK_HOME`, so the CI/release rows need no setup step.
- **On-device in Termux** (`pkg install zig ndk-sysroot`) uses the bionic sysroot under `$PREFIX`. ghostty's vendored simdutf/highway require an NDK to compile, so this path builds ghostty's scalar code instead and stubs `ANDROID_NDK_HOME` for the lib-vt artifact its build graph constructs but never builds here.

Two Zig 0.16 specifics worth flagging for review: the libc file only reaches the compile step, so sysroot includes are passed to each `translate-c` step separately; and translate-c's aro frontend rejects two clang extensions bionic uses (nullability inside array declarators, the `__overloadable` ioctl redeclaration), suppressed with `-D_Nonnull=` and `-DBIONIC_IOCTL_NO_SIGNEDNESS_OVERLOAD` for the translation only — the clang invocation that compiles the C sources is untouched. The module also links with a 16 KB max page size for Android 15.

## Elisp and CI

`ghostel--module-platform-tag` returns `aarch64-android` rather than falling through to the glibc `linux` tag, which is not loadable under bionic. Emacs 30 reports `system-type` as `android` for `*-linux-android` hosts while older versions report `gnu/linux`, so both are recognised. The vendored `emacs-module.h` musl workaround was guarded on non-glibc Linux, which bionic also satisfies; it now excludes Android.

Unrelated build hygiene rides along: byte-compilation sets `load-prefer-newer`.

## Verification

Cross-compiled with NDK r27c and, separately, against a simulated Termux `$PREFIX` sysroot. Both artifacts were then checked on a headless arm64 Android 14 emulator running Termux's own Emacs 30.2 (`system-configuration` = `aarch64-unknown-linux-android`):

- both `.so` variants `dlopen` with `RTLD_NOW` and `module-load` cleanly, reporting version 0.46.0
- the full native ERT suite runs on-device: **328 tests, 0 unexpected failures** (7 skipped: Windows-only and zsh-absent), including PTY spawn, `TIOCSWINSZ` winsize delivery, resize redraw, and shell integration
- a live `(ghostel)` session with Termux's bash echoed a command back through the whole keystroke → PTY → VT-parse → render pipeline

Not covered: the emulator uses 4 KB pages, so the 16 KB-page linking is built but unexercised; testing went through `run-as` rather than an interactive Termux session, so the `termux-exec` shim path is untouched. The kitty graphics shared-memory medium stays unavailable on Android (bionic has no POSIX shared memory); file and direct transmission work. No test suite runs against Android in CI, so support is best-effort.
