### PR TITLE
Support Ubuntu 22.04 release modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
           - os: ubuntu-latest
             platform: x86_64-linux
             suffix: .so
+            target: x86_64-linux-gnu.2.35
           - os: macos-26
             platform: aarch64-macos
             suffix: .dylib
@@ -167,7 +168,7 @@ jobs:
           - os: ubuntu-latest
             platform: aarch64-linux
             suffix: .so
-            target: aarch64-linux-gnu
+            target: aarch64-linux-gnu.2.35
           - os: ubuntu-latest
             platform: x86_64-freebsd
             suffix: .so
@@ -241,7 +242,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             platform: x86_64-linux
             suffix: .so
             emacs_version: '29.4'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
           - os: ubuntu-latest
             platform: x86_64-linux
             suffix: .so
+            target: x86_64-linux-gnu.2.35
           - os: macos-26
             platform: aarch64-macos
             suffix: .dylib
@@ -24,7 +25,7 @@ jobs:
           - os: ubuntu-latest
             platform: aarch64-linux
             suffix: .so
-            target: aarch64-linux-gnu
+            target: aarch64-linux-gnu.2.35
           - os: ubuntu-latest
             platform: x86_64-freebsd
             suffix: .so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ All notable changes to this project will be documented in this file.
 - A saved `ghostel-compile` log reopens in `ghostel-compile-view-mode`. Its
   header named a mode that does not exist, so the file landed in
   `fundamental-mode` without error navigation.
+- Pre-built Linux modules now target glibc 2.35 so they load on Ubuntu 22.04.
 
 ## [0.46.0] — 2026-07-27
 


### PR DESCRIPTION
## Summary

- build x86_64 and aarch64 Linux artifacts against an explicit glibc 2.35 floor
- test the x86_64 artifact on an Ubuntu 22.04 runner
- document the compatibility fix

This prevents Zig 0.16 from selecting `arc4random_buf@GLIBC_2.36` when release modules are built on `ubuntu-latest`.

Fixes #572.

## Verification

- parsed both modified workflow files as YAML
- ran `git diff --check`
- confirmed with a Zig 0.16 shared-library smoke test that `-target x86_64-linux-gnu.2.35` does not emit the GLIBC 2.36 dependency

A full local Ghostel cross-build was not run because its uncached Ghostty dependencies require network access.