### PR TITLE
Encode modified character keys through the kitty keyboard protocol

### DIFF
--- a/lisp/ghostel-debug.el
+++ b/lisp/ghostel-debug.el
@@ -1163,11 +1163,7 @@ omit it when the connection itself is the suspected fault."
                         (pcase-let* ((`(,key ,mods ,label) chord)
                                      ;; Mirror `ghostel--send-encoded': try
                                      ;; encoder, fall back to the
-                                     ;; raw-key-sequence path on nil.  Encoder
-                                     ;; skips plain Meta+letter when no utf8
-                                     ;; is supplied (live keystrokes don't
-                                     ;; supply it either) - the fallback
-                                     ;; produces ESC + char.
+                                     ;; raw-key-sequence path on nil.
                                      (sent (or (ghostel--encode-key probe key mods nil)
                                                (ghostel--raw-key-sequence key mods))))
                           (format "  %-13s → %s\n"

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1186,7 +1186,8 @@ When NO-EXCEPTIONS is non-nil, also bind the keys in
   (define-key map (kbd "DEL") #'ghostel--send-event)
   ;; Emacs reports S-TAB as <backtab>
   (define-key map (kbd "<backtab>") #'ghostel--send-event)
-  ;; Control keys - bind all C-<letter> to send ASCII control codes.
+  ;; Control keys - bind all C-<letter> to go through the key encoder
+  ;; (C0 byte in legacy mode, CSI-u when kitty mode is active).
   ;; C-i = TAB and C-m = RET are equivalent to <tab>/<return> (bound above).
   ;; C-y is reserved for ghostel-yank in semi-char mode.
   ;; C-g is bound separately via `ghostel--rebuild-semi-char-keymap'.
@@ -1196,10 +1197,7 @@ When NO-EXCEPTIONS is non-nil, also bind the keys in
         (unless (or (memq c skip)
                     (and (not no-exceptions)
                          (member key-str ghostel-keymap-exceptions)))
-          (define-key map (kbd key-str)
-                      (let ((code (- c 96)))
-                        (lambda () (interactive)
-                          (ghostel--send-string (string code)))))))))
+          (define-key map (kbd key-str) #'ghostel--send-event)))))
   ;; Meta keys - bind M-<printable ASCII> so the full set reaches the terminal.
   ;; Skip ?\[ and ?O: those are escape-sequence prefixes (CSI / SS3)
   ;; used by Emacs input decoding for arrow/function keys in TTY mode.
@@ -1232,15 +1230,12 @@ When NO-EXCEPTIONS is non-nil, also bind the keys in
   ;; Ctrl+Space is NUL. A TTY delivers it as `C-@'.  GUI Emacs as the distinct
   ;; event `C-SPC', which only char mode captures.  In semi-char `C-SPC' falls
   ;; through to the global map so mark commands run there.
-  (define-key map (kbd "C-@")
-              (lambda () (interactive) (ghostel--send-string "\x00")))
+  (define-key map (kbd "C-@") #'ghostel--send-event)
   ;; Char mode extras: also bind non-letter exception keys so nothing
   ;; gets stolen by Emacs while a TUI app runs.
   (when no-exceptions
-    (define-key map (kbd "C-SPC")
-                (lambda () (interactive) (ghostel--send-string "\x00")))
-    (define-key map (kbd "C-\\")
-                (lambda () (interactive) (ghostel--send-string "\x1c")))
+    (define-key map (kbd "C-SPC") #'ghostel--send-event)
+    (define-key map (kbd "C-\\") #'ghostel--send-event)
     (define-key map (kbd "M-:") #'ghostel--send-event)))
 
 (defvar-keymap ghostel-mode-map
@@ -1517,12 +1512,16 @@ Returns the sequence string, or nil for unknown keys."
      ;; Ctrl + a single ASCII char with a C0 control code.  Both a-z and
      ;; the @ A-Z [ \ ] ^ _ range fold to (char & #x1f): ctrl-a=1,
      ;; ctrl-z=26, ctrl-^=#x1e, ctrl-_=#x1f (readline / zle undo).
+     ;; Meta additionally prefixes the C0 byte with ESC.
      ((and (= (length key-name) 1)
            (let ((c (aref key-name 0)))
              (or (and (<= ?a c) (<= c ?z))
                  (and (<= ?@ c) (<= c ?_))))
            (> (logand mod-num 4) 0))        ; ctrl bit
-      (string (logand (aref key-name 0) #x1f)))
+      (let ((c0 (string (logand (aref key-name 0) #x1f))))
+        (if (> (logand mod-num 2) 0)        ; alt/meta bit
+            (concat "\e" c0)
+          c0)))
      ;; Meta + printable ASCII → ESC + char (legacy alt encoding)
      ((and (= (length key-name) 1)
            (let ((c (aref key-name 0)))
@@ -1620,14 +1619,30 @@ Detect that case via `this-command-keys-vector' and re-inject meta."
          (mods (if (and via-esc (not (memq 'meta mods)))
                    (cons 'meta mods)
                  mods))
+         ;; Raw C0 bytes for RET/TAB/ESC are ambiguous with C-m/C-i/C-[
+         ;; and Emacs decodes them as ctrl+letter.  Treat them as the
+         ;; functional key and drop the artifact ctrl modifier so Enter
+         ;; encodes as CR, not as a fixterms CSI-u sequence.
+         (c0-key (and (memq event '(?\r ?\t ?\e))
+                      (cdr (assq event '((?\r . "return")
+                                         (?\t . "tab")
+                                         (?\e . "escape"))))))
+         (mods (if c0-key (remq 'control mods) mods))
          (key-name (cond
+                    (c0-key c0-key)
                     ;; backtab is Emacs's name for S-TAB
                     ((eq base 'backtab) "tab")
                     ;; Terminal mode sends ASCII 127 for the backspace key
                     ((and (integerp base) (= base 127)) "backspace")
-                    ;; Integer base (character key)
+                    ;; Integer base (character key).  Uppercase chords
+                    ;; arrive as lowercase base + shift; restore the case
+                    ;; so the encoder emits the shifted character.
                     ((integerp base)
-                     (and (< base 128) (string base)))
+                     (and (< base 128)
+                          (string (if (and (memq 'shift mods)
+                                           (<= ?a base ?z))
+                                      (upcase base)
+                                    base))))
                     ((eq base 'deletechar) "delete")
                     ;; Normal function key symbol
                     ((and base (symbolp base)) (symbol-name base))
@@ -1744,16 +1759,20 @@ paste rather than character-by-character typed keystrokes."
 ;;; Terminal control commands (C-c prefix)
 
 (defun ghostel-send-C-c ()
-  "Send interrupt signal to the terminal."
+  "Send interrupt signal to the terminal.
+Sends the raw byte so the tty line discipline raises SIGINT even
+when the foreground program has kitty keyboard mode active."
   (interactive)
   (ghostel--on-user-input)
-  (ghostel--send-encoded "c" "ctrl"))
+  (ghostel--send-string "\x03"))
 
 (defun ghostel-send-C-z ()
-  "Send suspend signal to the terminal."
+  "Send suspend signal to the terminal.
+Sends the raw byte so the tty line discipline raises SIGTSTP even
+when the foreground program has kitty keyboard mode active."
   (interactive)
   (ghostel--on-user-input)
-  (ghostel--send-encoded "z" "ctrl"))
+  (ghostel--send-string "\x1a"))
 
 (defun ghostel-send-C-backslash ()
   "Send C-\\ (quit) to the terminal."
@@ -1762,10 +1781,12 @@ paste rather than character-by-character typed keystrokes."
   (ghostel--send-string "\x1c"))
 
 (defun ghostel-send-C-d ()
-  "Send EOF to the terminal."
+  "Send EOF to the terminal.
+Sends the raw byte so the tty line discipline sees EOF even when
+the foreground program has kitty keyboard mode active."
   (interactive)
   (ghostel--on-user-input)
-  (ghostel--send-encoded "d" "ctrl"))
+  (ghostel--send-string "\x04"))
 
 (defun ghostel-send-C-g ()
   "Send \\`C-g' to the terminal.
@@ -1775,7 +1796,7 @@ overlay clears the way \\`keyboard-quit' would in other buffers."
   (interactive)
   (setq quit-flag nil)
   (deactivate-mark)
-  (ghostel--send-string (string 7)))
+  (ghostel--send-encoded "g" "ctrl"))
 
 
 ;;; Paste / yank

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -146,15 +146,12 @@ pub fn effect(_: *Self, comptime func: []const u8, args: anytype) void {
 pub fn encode(
     self: *Self,
     buf: []u8,
-    key: gt.input.Key,
-    mods: gt.input.KeyMods,
-    utf8: ?[]const u8,
+    event: gt.input.KeyEvent,
 ) !?[]const u8 {
-    const options = gt.input.KeyEncodeOptions.fromTerminal(&self.terminal);
-    var event = gt.input.KeyEvent{ .action = .press, .key = key, .mods = mods };
-    if (utf8) |text| {
-        event.utf8 = text;
-    }
+    var options = gt.input.KeyEncodeOptions.fromTerminal(&self.terminal);
+    // Emacs resolves option-vs-meta before the event reaches us, so a
+    // meta modifier always means alt.
+    options.macos_option_as_alt = .true;
 
     // Encode
     var writer = std.Io.Writer.fixed(buf);
@@ -529,6 +526,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
         \\
         \\(ghostel--encode-key TERM KEY MODS &optional UTF8)
         \\
+        \\For a single-character KEY, UTF8 defaults to KEY itself.
         \\Writes the encoded bytes to the PTY and returns them as a unibyte
         \\string, or nil when the encoder produced no output.
         ,
@@ -545,10 +543,9 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                     env.extractString(args[3], &utf8_buf) catch null
                 else
                     null;
-                const key = input.mapKey(key_name);
-                const mods = input.parseMods(mod_str);
+                const event = input.keyEvent(key_name, mod_str, utf8);
                 var encode_buf: [128]u8 = undefined;
-                const sent = try term.encode(&encode_buf, key, mods, utf8);
+                const sent = try term.encode(&encode_buf, event);
                 return if (sent) |bytes|
                     env.makeUnibyteString(bytes) orelse env.t()
                 else

--- a/src/input.zig
+++ b/src/input.zig
@@ -5,8 +5,6 @@
 /// (application cursor keys, Kitty keyboard protocol, etc.).
 const std = @import("std");
 const gt = @import("ghostty-vt");
-const emacs = @import("emacs.zig");
-const GhostelTerm = @import("GhostelTerm.zig");
 
 /// Map an Emacs key name to a GhosttyKey.
 /// Returns GHOSTTY_KEY_UNIDENTIFIED for unknown keys.
@@ -85,4 +83,125 @@ pub fn parseMods(mod_str: []const u8) gt.input.KeyMods {
         }
     }
     return mods;
+}
+
+/// Build a key event from an Emacs key name, modifier string, and
+/// optional generated text.
+///
+/// Single printable-ASCII character keys carry their unshifted codepoint
+/// and (unless UTF8 is given) the character as generated text; the
+/// encoder needs both to produce CSI-u and alt-prefixed sequences.
+/// Uppercase letters fold to the lowercase codepoint with shift added as
+/// a consumed modifier.
+pub fn keyEvent(key_name: []const u8, mod_str: []const u8, utf8: ?[]const u8) gt.input.KeyEvent {
+    var event: gt.input.KeyEvent = .{
+        .action = .press,
+        .key = mapKey(key_name),
+        .mods = parseMods(mod_str),
+    };
+    if (utf8) |text| event.utf8 = text;
+    if (key_name.len == 1 and key_name[0] >= ' ' and key_name[0] <= '~') {
+        const ch = key_name[0];
+        if (std.ascii.isUpper(ch)) {
+            event.mods.shift = true;
+            event.consumed_mods.shift = true;
+            event.unshifted_codepoint = std.ascii.toLower(ch);
+        } else {
+            event.unshifted_codepoint = ch;
+        }
+        if (event.utf8.len == 0) event.utf8 = key_name;
+    }
+    return event;
+}
+
+fn testEncode(buf: []u8, event: gt.input.KeyEvent, opts: gt.input.KeyEncodeOptions) ![]const u8 {
+    var writer = std.Io.Writer.fixed(buf);
+    try gt.input.encodeKey(&writer, event, opts);
+    return writer.buffered();
+}
+
+const test_kitty_opts: gt.input.KeyEncodeOptions = .{
+    .kitty_flags = .{ .disambiguate = true },
+    .alt_esc_prefix = true,
+    .macos_option_as_alt = .true,
+};
+
+const test_legacy_opts: gt.input.KeyEncodeOptions = .{
+    .alt_esc_prefix = true,
+    .macos_option_as_alt = .true,
+};
+
+test "kitty: modified character keys encode as CSI-u" {
+    var buf: [64]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "\x1b[116;3u",
+        try testEncode(&buf, keyEvent("t", "meta", null), test_kitty_opts),
+    );
+    try std.testing.expectEqualStrings(
+        "\x1b[115;5u",
+        try testEncode(&buf, keyEvent("s", "ctrl", null), test_kitty_opts),
+    );
+    try std.testing.expectEqualStrings(
+        "\x1b[115;7u",
+        try testEncode(&buf, keyEvent("s", "ctrl,meta", null), test_kitty_opts),
+    );
+    // Uppercase folds to the unshifted codepoint with shift reported.
+    try std.testing.expectEqualStrings(
+        "\x1b[116;4u",
+        try testEncode(&buf, keyEvent("T", "meta", null), test_kitty_opts),
+    );
+    try std.testing.expectEqualStrings(
+        "\x1b[116;6u",
+        try testEncode(&buf, keyEvent("T", "shift,ctrl", null), test_kitty_opts),
+    );
+    // Unmapped punctuation uses the character itself as codepoint.
+    try std.testing.expectEqualStrings(
+        "\x1b[33;3u",
+        try testEncode(&buf, keyEvent("!", "meta", null), test_kitty_opts),
+    );
+}
+
+test "kitty: unmodified character keys stay plain text" {
+    var buf: [64]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "t",
+        try testEncode(&buf, keyEvent("t", "", null), test_kitty_opts),
+    );
+    try std.testing.expectEqualStrings(
+        "T",
+        try testEncode(&buf, keyEvent("T", "", null), test_kitty_opts),
+    );
+}
+
+test "legacy: modified character keys keep legacy sequences" {
+    var buf: [64]u8 = undefined;
+    try std.testing.expectEqualStrings(
+        "\x1bt",
+        try testEncode(&buf, keyEvent("t", "meta", null), test_legacy_opts),
+    );
+    try std.testing.expectEqualStrings(
+        "\x1bT",
+        try testEncode(&buf, keyEvent("T", "meta", null), test_legacy_opts),
+    );
+    try std.testing.expectEqualStrings(
+        "\x13",
+        try testEncode(&buf, keyEvent("s", "ctrl", null), test_legacy_opts),
+    );
+    // Ctrl+Meta keeps the meta bit as an ESC prefix on the C0 byte.
+    try std.testing.expectEqualStrings(
+        "\x1b\x13",
+        try testEncode(&buf, keyEvent("s", "ctrl,meta", null), test_legacy_opts),
+    );
+    // Control punctuation resolves through the unshifted codepoint.
+    try std.testing.expectEqualStrings(
+        "\x00",
+        try testEncode(&buf, keyEvent("@", "ctrl", null), test_legacy_opts),
+    );
+    // Fixterms: ctrl+i/m/[ encode as CSI-u to stay distinguishable from
+    // tab/enter/escape.  `ghostel--send-event' maps the raw C0 bytes a
+    // TTY delivers to the functional keys before they reach this path.
+    try std.testing.expectEqualStrings(
+        "\x1b[109;5u",
+        try testEncode(&buf, keyEvent("m", "ctrl", null), test_legacy_opts),
+    );
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -5,6 +5,7 @@ test {
     _ = @import("png.zig");
     _ = @import("GlyphMetricsCache.zig");
     _ = @import("fixed_array_list.zig");
+    _ = @import("input.zig");
     if (builtin.os.tag == .windows) {
         _ = @import("ConPtyProcess.zig");
     } else {

--- a/test/ghostel-debug-test.el
+++ b/test/ghostel-debug-test.el
@@ -762,13 +762,12 @@ report to the tail of the key-encoding table."
 
 (ert-deftest ghostel-test-encode-key-returns-bytes ()
   "`ghostel--encode-key' returns the encoded bytes as a unibyte string.
-nil means the encoder produced nothing (plain Meta+letter without utf8
-defers to the elisp raw fallback)."
+Character keys encode natively, including modified ones."
   :tags '(native)
   (with-temp-buffer
     (let ((probe (ghostel--new 25 80 100)))
       (should (equal (ghostel--encode-key probe "backspace" "" nil) "\x7f"))
-      (should-not (ghostel--encode-key probe "f" "meta" nil)))))
+      (should (equal (ghostel--encode-key probe "f" "meta" nil) "\ef")))))
 
 (provide 'ghostel-debug-test)
 ;;; ghostel-debug-test.el ends here

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -54,6 +54,12 @@ Covers punctuation, digits, uppercase, space, and lowercase letters."
   ;; Lowercase letters still work (existing behavior)
   (should (equal "\eb" (ghostel--raw-key-sequence "b" "meta"))))
 
+(ert-deftest ghostel-test-raw-key-ctrl-meta ()
+  "Ctrl+Meta char keeps the meta bit as an ESC prefix on the C0 byte."
+  (should (equal "\C-s" (ghostel--raw-key-sequence "s" "ctrl")))
+  (should (equal "\e\C-s" (ghostel--raw-key-sequence "s" "ctrl,meta")))
+  (should (equal "\e\C-a" (ghostel--raw-key-sequence "a" "meta,ctrl"))))
+
 (ert-deftest ghostel-test-modifier-number ()
   "Test modifier bitmask parsing."
   (should (equal 0 (ghostel--modifier-number "")))            ; no mods
@@ -96,9 +102,23 @@ Covers punctuation, digits, uppercase, space, and lowercase letters."
         (sim (aref (kbd "C-S-<return>") 0) "return"   "ctrl,shift")
         (sim (aref (kbd "M-.") 0)  "."  "meta")
         (sim (aref (kbd "M-1") 0)  "1"  "meta")
+        ;; Uppercase chords arrive as lowercase base + shift; the key
+        ;; name restores the case so the encoder sends the shifted char.
+        (sim ?\M-T  "T" "shift,meta")
+        (sim ?\C-\S-t "T" "shift,ctrl")
         ;; Control + non-letter punctuation decomposes to base + ctrl.
         (sim ?\C-]      "]" "ctrl")
         (sim ?\M-\C-]   "]" "ctrl,meta")
+        ;; Control letters decompose to letter + ctrl.
+        (sim ?\C-s      "s" "ctrl")
+        ;; NUL (TTY C-@/C-SPC, GUI C-@) decomposes to @ + ctrl.
+        (sim 0          "@" "ctrl")
+        ;; Raw C0 bytes for RET/TAB/ESC (as a TTY delivers them) map to
+        ;; the functional key, not to C-m/C-i/C-[ — the encoder would
+        ;; fixterms-encode those as CSI-u and break Enter/Tab.
+        (sim ?\r        "return" "")
+        (sim ?\t        "tab"    "")
+        (sim ?\e        "escape" "")
         ;; backtab (Emacs's name for S-TAB)
         (sim (aref (kbd "<backtab>") 0)   "tab"       "shift")))))
 
@@ -150,6 +170,60 @@ SETUP, when non-nil, is called before sending the key."
   :tags '(native posix)
   (ghostel-test--with-pty-matrix backend
     (should (equal "7f" (ghostel-test--send-key-and-read-hex "backspace" "" 1)))))
+
+(defun ghostel-test--kitty-disambiguate ()
+  "Enable the kitty keyboard protocol (disambiguate flag) on the terminal."
+  (ghostel--write-vt ghostel--term "\e[=1u"))
+
+(ert-deftest ghostel-test-encode-key-kitty-meta-char ()
+  "M-<letter> encodes as CSI-u when kitty keyboard mode is active."
+  :tags '(native posix)
+  (ghostel-test--with-pty-matrix backend
+    ;; \e[116;3u
+    (should (equal "1b5b3131363b3375"
+                   (ghostel-test--send-key-and-read-hex
+                    "t" "meta" 8 #'ghostel-test--kitty-disambiguate)))))
+
+(ert-deftest ghostel-test-encode-key-kitty-ctrl-char ()
+  "C-<letter> encodes as CSI-u instead of a C0 byte under kitty mode."
+  :tags '(native posix)
+  (ghostel-test--with-pty-matrix backend
+    ;; \e[115;5u
+    (should (equal "1b5b3131353b3575"
+                   (ghostel-test--send-key-and-read-hex
+                    "s" "ctrl" 8 #'ghostel-test--kitty-disambiguate)))))
+
+(ert-deftest ghostel-test-encode-key-kitty-ctrl-meta-char ()
+  "C-M-<letter> encodes as CSI-u with both modifiers under kitty mode."
+  :tags '(native posix)
+  (ghostel-test--with-pty-matrix backend
+    ;; \e[115;7u
+    (should (equal "1b5b3131353b3775"
+                   (ghostel-test--send-key-and-read-hex
+                    "s" "ctrl,meta" 8 #'ghostel-test--kitty-disambiguate)))))
+
+(ert-deftest ghostel-test-encode-key-kitty-shifted-meta-char ()
+  "M-<uppercase letter> encodes the unshifted codepoint plus shift mod."
+  :tags '(native posix)
+  (ghostel-test--with-pty-matrix backend
+    ;; \e[116;4u
+    (should (equal "1b5b3131363b3475"
+                   (ghostel-test--send-key-and-read-hex
+                    "T" "meta" 8 #'ghostel-test--kitty-disambiguate)))))
+
+(ert-deftest ghostel-test-encode-key-legacy-meta-char ()
+  "M-<letter> keeps the legacy ESC prefix without kitty mode."
+  :tags '(native posix)
+  (ghostel-test--with-pty-matrix backend
+    ;; ESC t
+    (should (equal "1b74" (ghostel-test--send-key-and-read-hex "t" "meta" 2)))))
+
+(ert-deftest ghostel-test-encode-key-legacy-ctrl-meta-char ()
+  "C-M-<letter> keeps the meta bit as ESC + C0 byte without kitty mode."
+  :tags '(native posix)
+  (ghostel-test--with-pty-matrix backend
+    ;; ESC DC3
+    (should (equal "1b13" (ghostel-test--send-key-and-read-hex "s" "ctrl,meta" 2)))))
 
 (ert-deftest ghostel-test-filter-writes-vt-and-invalidates ()
   "`ghostel--filter' feeds output to the terminal and triggers a redraw.
@@ -377,13 +451,13 @@ SETUP, when non-nil, is called before sending the paste."
         (ghostel-readonly-fast-exit t))
     (cl-letf (((symbol-function 'ghostel-readonly-exit)
                (lambda () (push 'exit call-order)))
-              ((symbol-function 'ghostel--send-encoded)
-               (lambda (key mods &rest _)
-                 (setq send-args (list key mods))
+              ((symbol-function 'ghostel--send-string)
+               (lambda (str)
+                 (setq send-args str)
                  (push 'send call-order))))
       (ghostel-send-C-c)
       (should (equal '(send exit) call-order))
-      (should (equal '("c" "ctrl") send-args)))))
+      (should (equal "\x03" send-args)))))
 
 (ert-deftest ghostel-test-c-c-no-fast-exit-stays-readonly ()
   "The interrupt prefix stays in copy/Emacs mode when fast exit is off."
@@ -392,7 +466,7 @@ SETUP, when non-nil, is called before sending the paste."
         (ghostel-readonly-fast-exit nil))
     (cl-letf (((symbol-function 'ghostel-readonly-exit)
                (lambda () (setq exit-called t)))
-              ((symbol-function 'ghostel--send-encoded) #'ignore))
+              ((symbol-function 'ghostel--send-string) #'ignore))
       (ghostel-send-C-c)
       (should-not exit-called))))
 
@@ -400,6 +474,21 @@ SETUP, when non-nil, is called before sending the paste."
   "The fast-exit map still routes the interrupt prefix through its command."
   (should (eq (lookup-key ghostel-readonly-fast-exit-mode-map (kbd "C-c C-c"))
               #'ghostel-send-C-c)))
+
+(ert-deftest ghostel-test-terminal-control-commands-send-raw-bytes ()
+  "The \\`C-c' prefix rescue commands bypass the key encoder.
+Their bytes must reach the tty line discipline (SIGINT, SIGTSTP,
+EOF, SIGQUIT) even when a hung foreground program still has kitty
+keyboard mode active — a CSI-u sequence would never get there."
+  (let (sent)
+    (cl-letf (((symbol-function 'ghostel--send-string)
+               (lambda (s) (push s sent)))
+              ((symbol-function 'ghostel--on-user-input) #'ignore))
+      (ghostel-send-C-c)
+      (ghostel-send-C-z)
+      (ghostel-send-C-d)
+      (ghostel-send-C-backslash))
+    (should (equal (nreverse sent) '("\x03" "\x1a" "\x04" "\x1c")))))
 
 (ert-deftest ghostel-test-inhibit-quit ()
   "`ghostel-mode' should set `inhibit-quit' buffer-locally."
@@ -431,22 +520,22 @@ side effects have to happen explicitly inside the command."
           (goto-char (point-max))
           (should (region-active-p))
           (setq quit-flag t)
-          (cl-letf (((symbol-function 'ghostel--send-string)
-                     (lambda (s) (push s sent))))
+          (cl-letf (((symbol-function 'ghostel--send-encoded)
+                     (lambda (key mods &optional _utf8)
+                       (push (cons key mods) sent))))
             (ghostel-send-C-g))
           (should-not (region-active-p))
           (should-not quit-flag)
-          (should (equal sent (list (string 7)))))
+          (should (equal sent '(("g" . "ctrl")))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-c-g-binding-routes-through-send-handler ()
   "Quit binding must route through the quit handler in both live input modes.
-`ghostel--define-terminal-keys' binds every control-letter to a
-lambda that sends the raw control code.  Without skipping the
-quit binding, that lambda shadows the parent `ghostel-mode-map'
-override and the function `deactivate-mark' plus the `quit-flag'
-clear vanish on real keypresses (regression of #200 introduced
-by the input-mode refactor)."
+`ghostel--define-terminal-keys' binds every control-letter to
+`ghostel--send-event'.  Without skipping the quit binding, that
+binding shadows the parent `ghostel-mode-map' override and the
+function `deactivate-mark' plus the `quit-flag' clear vanish on
+real keypresses (regression of the input-mode refactor)."
   :tags '(native)
   (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "C-g"))
               #'ghostel-send-C-g))
@@ -536,14 +625,10 @@ Only keys that the ghostty encoder maps to a terminal byte are forwarded."
                 #'ghostel--send-event))))
 
 (ert-deftest ghostel-test-control-punct-char-mode ()
-  "Char mode forwards C-]/C-/ but keeps the explicit C-\\ lambda."
-  (dolist (key-str '("C-]" "C-/" "C-M-]" "C-M-/"))
+  "Char mode forwards C-]/C-/ and C-\\ through `ghostel--send-event'."
+  (dolist (key-str '("C-]" "C-/" "C-M-]" "C-M-/" "C-\\"))
     (should (eq (lookup-key ghostel-char-mode-map (kbd key-str))
                 #'ghostel--send-event)))
-  ;; C-\ in char mode keeps its explicit \x1c lambda (not send-event).
-  (should (commandp (lookup-key ghostel-char-mode-map (kbd "C-\\"))))
-  (should-not (eq (lookup-key ghostel-char-mode-map (kbd "C-\\"))
-                  #'ghostel--send-event))
   ;; ESC still must not be hijacked in char mode either.
   (should-not (eq (lookup-key ghostel-char-mode-map (kbd "C-["))
                   #'ghostel--send-event)))
@@ -574,7 +659,7 @@ encoder recognizes is forwarded; see `ghostel--define-terminal-keys'.)"
                      (ghostel-test--send-key-and-read-hex name mods count))))))
 
 (ert-deftest ghostel-test-send-encoded-meta-period ()
-  "M-. sends ESC + period via raw fallback (legacy alt encoding)."
+  "M-. falls back to ESC + period when the encoder produces no output."
   :tags '(native)
   (let ((ghostel--term 'fake)
         sent)


### PR DESCRIPTION
Closes #579

## Problem

When a TUI enables the kitty keyboard protocol, ghostel still encoded modified character keys with legacy sequences: `M-<letter>` went out as `ESC <letter>` (rejected as ambiguous by kitty-mode programs) and `C-M-<letter>` dropped meta entirely, sending the bare control byte. Modified functional keys (backspace, return, arrows) already encoded correctly.

## Root cause

The native encoder built libghostty key events with only `key` and `mods`. libghostty resolves *character* keys through `unshifted_codepoint` and the generated text (`utf8`), so every modified character key produced **no output at all** — in both kitty and legacy modes — and fell through to the kitty-unaware elisp fallback `ghostel--raw-key-sequence`, whose ctrl branch also drops meta. Additionally, `macos_option_as_alt` defaulted to false on macOS builds, suppressing alt handling even with the codepoint present.

## Fix

- `input.keyEvent` builder: single printable-ASCII keys carry their unshifted codepoint and the character as generated text; uppercase names fold to the lowercase codepoint with shift as a consumed modifier. Named/functional keys are untouched.
- `macos_option_as_alt = .true`: Emacs resolves option-vs-meta before the event reaches the module, so meta always means alt.
- `C-<letter>`, `C-@`, `C-SPC`, `C-\` and `ghostel-send-C-g` now route through the encoder instead of raw-byte closures — legacy bytes are provably identical (libghostty's `ctrlSeq` yields the same C0 codes), kitty mode gets CSI-u.
- Raw C0 events 13/9/27 are remapped to `return`/`tab`/`escape` in `ghostel--send-event` (with the artifact ctrl modifier stripped): a TTY delivers RET as `C-m`, which the encoder would otherwise fixterms-encode as CSI-u and break Enter/Tab.
- Uppercase chords (delivered as lowercase base + shift) restore their case: `M-T` sends `ESC T` in legacy mode and reports the shifted alternate (`\e[116:84;4u`) under kitty flags=5.
- `ghostel-send-C-c`/`-C-z`/`-C-d` deliberately stay raw bytes so SIGINT/SIGTSTP/EOF reach the tty line discipline even while a hung program holds kitty mode.
- The elisp fallback's ctrl branch now ESC-prefixes when meta is set, so it no longer silently drops the modifier either.

**API note:** `ghostel-send-key` with `"m"`/`"i"`/`"["` plus ctrl now yields the fixterms CSI-u sequence (matching upstream ghostty) instead of a C0 byte; live keystrokes are unaffected thanks to the C0 remap.

## Testing

- 8 zig unit tests against the vendored encoder (kitty CSI-u, plain-text passthrough, legacy sequences, fixterms cases); `src/input.zig` is now emacs-free and part of `zig build test`.
- 6 native PTY byte-level ERT tests (kitty and legacy, meta/ctrl/ctrl-meta/shift chords) plus fallback, sim, and rescue-byte elisp tests.
- Live-verified in six sandboxed Emacs sessions with real keystrokes (TTY and GUI-shaped events): the issue's exact repro (`printf '\e[>1u'; cat -v`), TTY Enter/Tab/arrows, ESC-prefixed meta chords, readline editing, less/vi, and the rescue hatches interrupting a program that holds kitty mode.
- `make -j8 all` green.