### PR TITLE
Linkify wrapped paths anywhere in scrollback, not just the viewport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,9 +325,35 @@ jobs:
         run: |
           touch ghostel-module.dll
           git clone --depth 1 https://github.com/emacs-compat/compat.git /tmp/compat
-          make \
-            EMACS="timeout 60s emacs" \
-            EMACSFLAGS="-L /tmp/compat" \
+          # Neither stream of this emacs reaches the job log, even
+          # redirected to a file, so ERT results would be invisible.  Have
+          # it write its own *Messages* out through elisp instead, and echo
+          # that from the wrapper below.
+          cat > /tmp/ert-capture.el <<'CAPTURE'
+          (add-hook 'kill-emacs-hook
+                    (lambda ()
+                      (let ((f (getenv "GHOSTEL_ERT_LOG")))
+                        (when f
+                          (write-region (with-current-buffer (messages-buffer)
+                                          (buffer-string))
+                                        nil f 'append 'silent)))))
+          CAPTURE
+          cat > /tmp/emacs-capture.sh <<'WRAPPER'
+          #!/bin/sh
+          GHOSTEL_ERT_LOG=$(mktemp)
+          export GHOSTEL_ERT_LOG
+          timeout 60s emacs "$@"
+          status=$?
+          cat "$GHOSTEL_ERT_LOG"
+          rm -f "$GHOSTEL_ERT_LOG"
+          exit $status
+          WRAPPER
+          chmod +x /tmp/emacs-capture.sh
+          # `-k': the test files run serially here, so without it a failing
+          # one hides every file after it.
+          make -k \
+            EMACS=/tmp/emacs-capture.sh \
+            EMACSFLAGS="-L /tmp/compat -l /tmp/ert-capture.el" \
             test-native
 
   test-hypothesis-cases:

--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -400,6 +400,13 @@ same as in any compilation buffer."
           (when start
             (ghostel-compile--trim-trailing-blanks start))
           (ghostel-compile--teardown-terminal)
+          ;; Owed link detection has to run before the rows are joined,
+          ;; whose `ghostel-wrap' properties it reads, and before the mode
+          ;; switch drops the queue's buffer-locals.  Demoted because
+          ;; `ghostel-compile--finalized' is already set: a signal here
+          ;; would leave the buffer with no footer and no way to retry.
+          (with-demoted-errors "ghostel-compile: link detection failed: %S"
+            (ghostel--flush-plain-link-detection))
           ;; Must follow the teardown: a live renderer would rewrite the
           ;; joined rows on its next redraw.
           (ghostel-compile--unwrap-soft-wraps)
@@ -504,7 +511,9 @@ destroys the grid, so commit it here or lose the output it holds."
                          (with-selected-window window
                            (ghostel--redraw ghostel--term full t))
                        (ghostel--redraw ghostel--term full t))))
-      (when rendered (setq ghostel--pending-redraw nil)))))
+      (when rendered
+        (setq ghostel--pending-redraw nil)
+        (ghostel--schedule-link-detection)))))
 
 (defun ghostel-compile--sentinel (process _event)
   "Sentinel for the compile PROCESS: finalize the buffer on exit."

--- a/lisp/ghostel-line-mode.el
+++ b/lisp/ghostel-line-mode.el
@@ -28,6 +28,7 @@
 (declare-function ghostel--redraw "ghostel-module"
                   (term &optional full force-sync))
 (declare-function ghostel--regex-prompt-end "ghostel")
+(declare-function ghostel--schedule-link-detection "ghostel")
 (declare-function ghostel--sync-read-only "ghostel")
 (declare-function ghostel--send-encoded "ghostel")
 (declare-function ghostel--uri-at-pos "ghostel")
@@ -606,7 +607,8 @@ which discards any type-ahead and runs inside `ghostel--redraw-now'."
     (when ghostel--term
       (let ((inhibit-read-only t)
             (inhibit-modification-hooks t))
-        (ghostel--redraw ghostel--term t t)))))
+        (ghostel--redraw ghostel--term t t))
+      (ghostel--schedule-link-detection))))
 
 (defun ghostel--line-mode-pause ()
   "Drop line mode to semi-char while a full-screen app holds the alt screen.

--- a/lisp/ghostel-links.el
+++ b/lisp/ghostel-links.el
@@ -332,7 +332,8 @@ a vector of (STRING-OFFSET . BUFFER-POS) pairs, one per row, ascending.
 
 LIMIT bounds how many rows may be joined into one line, which keeps a
 megabyte-long line of output from becoming one unbroken token for the
-regexps to chew through."
+regexps to chew through.  The count is per logical line: a hard
+newline in the region ends one line and starts the next from zero."
   (let ((chunks nil)
         (parts nil)
         (offset 0)
@@ -348,7 +349,11 @@ regexps to chew through."
                                (t end)))))
         (push (cons offset pos) chunks)
         (push piece parts)
-        (setq rows (if join (1+ rows) 0)
+        ;; A hard newline inside PIECE ended the logical line the count was
+        ;; for; the row being joined now is the first of a new one.
+        (setq rows (cond ((not join) 0)
+                         ((string-search "\n" piece) 1)
+                         (t (1+ rows)))
               offset (+ offset (length piece))
               pos (if wrapped (1+ wrap) end))))
     (cons (string-join (nreverse parts))

--- a/lisp/ghostel-links.el
+++ b/lisp/ghostel-links.el
@@ -127,6 +127,13 @@ at unrelated text.")
   "Queued end bound for redraw-triggered plain-text link detection.
 A marker, for the reason given at `ghostel--plain-link-detection-begin'.")
 
+(defvar ghostel--inhibit-active-line-skip nil
+  "When non-nil, `ghostel--detect-urls' scans the cursor's line too.
+That line is normally left alone as the prompt being typed at.  A
+terminal that has exited has no prompt, and its last row is ordinary
+output — often the one row a command that printed no trailing
+newline ended on.")
+
 (defconst ghostel--link-detection-chunk 100000
   "Characters `ghostel--run-queued-plain-link-detection' scans per tick.
 A single redraw can materialize megabytes of output at once; scanning
@@ -517,11 +524,13 @@ bounds widened to whole logical lines."
          ;; `ghostel--cursor-char-pos' is the live terminal cursor after a redraw;
          ;; its line is the prompt the user is currently editing.  Capture as
          ;; buffer-position bounds so the per-match skip check is O(1).
-         (active-pos (or ghostel--cursor-char-pos (point)))
-         (active-bounds (cons (ghostel--soft-wrap-line-beginning
-                               active-pos ghostel--soft-wrap-row-limit)
-                              (ghostel--soft-wrap-line-end
-                               active-pos ghostel--soft-wrap-row-limit)))
+         (active-bounds
+          (unless ghostel--inhibit-active-line-skip
+            (let ((active-pos (or ghostel--cursor-char-pos (point))))
+              (cons (ghostel--soft-wrap-line-beginning
+                     active-pos ghostel--soft-wrap-row-limit)
+                    (ghostel--soft-wrap-line-end
+                     active-pos ghostel--soft-wrap-row-limit)))))
          (joined (ghostel--wrap-joined-region
                   begin end ghostel--soft-wrap-row-limit))
          (text (car joined))
@@ -797,6 +806,18 @@ caught up on afterwards, then re-arms while anything is left."
                     (run-with-timer ghostel-plain-link-detection-delay nil
                                     #'ghostel--run-queued-plain-link-detection
                                     buffer)))))))))
+
+(defun ghostel--flush-plain-link-detection ()
+  "Drain the queued plain-text link detection to completion, now.
+For a terminal at the end of its life: no later redraw will repaint
+its text, so ticks still owed would never run, and the row the cursor
+stopped on is output rather than a prompt to leave alone."
+  (let ((ghostel--inhibit-active-line-skip t))
+    (while ghostel--plain-link-detection-begin
+      (when ghostel--plain-link-detection-timer
+        (cancel-timer ghostel--plain-link-detection-timer)
+        (setq ghostel--plain-link-detection-timer nil))
+      (ghostel--run-queued-plain-link-detection (current-buffer)))))
 
 (defun ghostel--queue-plain-link-detection (begin end)
   "Coalesce redraw-triggered plain-text link detection for BEGIN..END."

--- a/lisp/ghostel-links.el
+++ b/lisp/ghostel-links.el
@@ -118,10 +118,21 @@ buffer positions.")
   "Timer for delayed redraw-triggered plain-text link detection.")
 
 (defvar-local ghostel--plain-link-detection-begin nil
-  "Queued start bound for redraw-triggered plain-text link detection.")
+  "Queued start bound for redraw-triggered plain-text link detection.
+A marker: scrollback eviction deletes from the buffer start between
+the queue and the scan, which would leave a plain position pointing
+at unrelated text.")
 
 (defvar-local ghostel--plain-link-detection-end nil
-  "Queued end bound for redraw-triggered plain-text link detection.")
+  "Queued end bound for redraw-triggered plain-text link detection.
+A marker, for the reason given at `ghostel--plain-link-detection-begin'.")
+
+(defconst ghostel--link-detection-chunk 100000
+  "Characters `ghostel--run-queued-plain-link-detection' scans per tick.
+A single redraw can materialize megabytes of output at once; scanning
+all of it in one pass would block Emacs for as long as that takes.
+The drain takes this much from the newest end of the queued range and
+re-arms for the rest.")
 
 
 ;;; Hyperlinks (OSC 8)
@@ -485,7 +496,10 @@ Bounding the scan keeps streaming output from re-scanning the entire
 materialized scrollback on every redraw.
 Binds `inhibit-read-only' and suppresses modification hooks so the scan
 can attach text properties when called from the deferred-detection timer
-outside the redraw scope."
+outside the redraw scope.
+
+Returns the (BEGIN . END) actually covered, which the caller-supplied
+bounds widened to whole logical lines."
   (let* (;; Whole logical lines: a value the terminal split across rows is
          ;; only recognisable once the rows are joined, and starting mid-line
          ;; would let the `^' anchor below match where there is no line start.
@@ -579,7 +593,8 @@ outside the redraw scope."
                        (concat "fileref:" abs-path))
                      raw)))))))))
     (ghostel--drop-stranded-links
-     begin end matched ghostel-enable-url-detection files)))
+     begin end matched ghostel-enable-url-detection files)
+    (cons begin end)))
 
 
 ;;; thing-at-point and ffap across soft-wrapped rows
@@ -744,29 +759,51 @@ file deleted since detection falls back as well."
       (require 'ffap)
       (call-interactively #'find-file-at-point))))
 
+(defun ghostel--clear-plain-link-detection-bounds ()
+  "Drop the queued detection bounds, releasing their markers."
+  (when ghostel--plain-link-detection-begin
+    (set-marker ghostel--plain-link-detection-begin nil))
+  (when ghostel--plain-link-detection-end
+    (set-marker ghostel--plain-link-detection-end nil))
+  (setq ghostel--plain-link-detection-begin nil
+        ghostel--plain-link-detection-end nil))
+
 (defun ghostel--run-queued-plain-link-detection (buffer)
-  "Run any queued redraw-triggered plain-text link detection for BUFFER."
+  "Scan one chunk of BUFFER's queued plain-text link detection range.
+Takes `ghostel--link-detection-chunk' characters off the newest end of
+the range, so what is on screen is linkified first and a backlog is
+caught up on afterwards, then re-arms while anything is left."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
+      (setq ghostel--plain-link-detection-timer nil)
       (let ((begin ghostel--plain-link-detection-begin)
             (end ghostel--plain-link-detection-end))
-        (setq ghostel--plain-link-detection-timer nil
-              ghostel--plain-link-detection-begin nil
-              ghostel--plain-link-detection-end nil)
-        (when (and begin end (<= begin end))
-          (ghostel--detect-urls begin end))))))
+        (when (and begin end (<= (marker-position begin) (marker-position end)))
+          (let* ((stop (marker-position end))
+                 (start (max (marker-position begin)
+                             (- stop ghostel--link-detection-chunk)))
+                 ;; The scan widens to whole logical lines; resume from where
+                 ;; it really started rather than rescanning that line.
+                 (next (car (ghostel--detect-urls start stop))))
+            (if (<= next (marker-position begin))
+                (ghostel--clear-plain-link-detection-bounds)
+              (set-marker end next)
+              (setq ghostel--plain-link-detection-timer
+                    (run-with-timer ghostel-plain-link-detection-delay nil
+                                    #'ghostel--run-queued-plain-link-detection
+                                    buffer)))))))))
 
 (defun ghostel--queue-plain-link-detection (begin end)
   "Coalesce redraw-triggered plain-text link detection for BEGIN..END."
   (when (and begin end (<= begin end))
-    (setq ghostel--plain-link-detection-begin
-          (if ghostel--plain-link-detection-begin
-              (min ghostel--plain-link-detection-begin begin)
-            begin)
-          ghostel--plain-link-detection-end
-          (if ghostel--plain-link-detection-end
-              (max ghostel--plain-link-detection-end end)
-            end))
+    (if ghostel--plain-link-detection-begin
+        (when (< begin ghostel--plain-link-detection-begin)
+          (set-marker ghostel--plain-link-detection-begin begin))
+      (setq ghostel--plain-link-detection-begin (copy-marker begin)))
+    (if ghostel--plain-link-detection-end
+        (when (> end ghostel--plain-link-detection-end)
+          (set-marker ghostel--plain-link-detection-end end))
+      (setq ghostel--plain-link-detection-end (copy-marker end)))
     (unless ghostel--plain-link-detection-timer
       (if (<= ghostel-plain-link-detection-delay 0)
           (ghostel--run-queued-plain-link-detection (current-buffer))

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -964,6 +964,7 @@ Matches Ghostty 1.2.0's `bold-color' configuration."
                (let ((inhibit-read-only t)
                      (inhibit-modification-hooks t))
                  (ghostel--redraw ghostel--term t t))
+               (ghostel--schedule-link-detection)
                (ghostel--apply-cursor-style))))))
 
 (defvar-local ghostel--cursor-pos nil
@@ -1699,6 +1700,7 @@ restoring the terminal contents, with point realigned to the VT cursor."
     (if (> old-len 0)
         (progn
           (ghostel--redraw ghostel--term t t)
+          (ghostel--schedule-link-detection)
           ;; The reverted edit must not move point either; realign it.
           (when ghostel--cursor-char-pos
             (goto-char ghostel--cursor-char-pos)))

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -992,6 +992,12 @@ otherwise hide its cursor for whatever buffer it shows next.")
 Values match libghostty's cursor style enum: 0=bar, 1=block,
 2=underline, 3=hollow-block, or nil for hidden.")
 
+(defvar-local ghostel--repainted-region nil
+  "Buffer range the last redraw rewrote, as a (MIN . MAX) cons, or nil.
+Published by the renderer, which inserts every character of terminal
+output.  Every redraw that renders sets it: nil when it painted
+nothing, so the value never outlives the redraw that produced it.")
+
 (defvar-local ghostel--input-mode 'semi-char
   "Current input mode.
 One of `semi-char', `char', `copy', `emacs', or `line'.  See
@@ -3629,11 +3635,6 @@ EVENT is the state-change description passed by Emacs."
   (let ((buf (process-buffer process)))
     (when (buffer-live-p buf)
       (with-current-buffer buf
-        (when ghostel--plain-link-detection-timer
-          (cancel-timer ghostel--plain-link-detection-timer)
-          (setq ghostel--plain-link-detection-timer nil
-                ghostel--plain-link-detection-begin nil
-                ghostel--plain-link-detection-end nil))
         (ghostel--cancel-password-confirm-timer)
         (ghostel--spinner-stop)
         (remove-hook 'pre-redisplay-functions #'ghostel--fake-cursor-update t)
@@ -4419,14 +4420,17 @@ timer.  Hidden output remains pending until the buffer is displayed."
         (line-beginning-position)))))
 
 (defun ghostel--schedule-link-detection ()
-  "Schedule deferred plain-text link detection over the viewport.
-Falls back to `point-min' when the buffer has no viewport yet.  Covers
-plain-text URL and file:line detection; native OSC-8 hyperlink spans
-remain handled inside the renderer."
-  (when (or ghostel-enable-url-detection ghostel-enable-file-detection)
-    (ghostel--queue-plain-link-detection
-     (or (ghostel--viewport-start) (point-min))
-     (point-max))))
+  "Schedule deferred plain-text link detection over the repainted region.
+The renderer publishes the buffer range it rewrote in
+`ghostel--repainted-region', and every character of terminal output
+goes through it, so queueing that range scans each row exactly once —
+including rows a flood pushed past the viewport between two redraws.
+Covers plain-text URL and file:line detection; native OSC-8 hyperlink
+spans remain handled inside the renderer."
+  (when-let* ((region ghostel--repainted-region))
+    (setq ghostel--repainted-region nil)
+    (when (or ghostel-enable-url-detection ghostel-enable-file-detection)
+      (ghostel--queue-plain-link-detection (car region) (cdr region)))))
 
 (defun ghostel--daemon-dummy-frame-p (frame)
   "Non-nil if FRAME is the daemon's invisible initial frame.
@@ -5051,6 +5055,7 @@ spawn after initialization."
       (cancel-timer ghostel--redraw-timer))
     (when ghostel--plain-link-detection-timer
       (cancel-timer ghostel--plain-link-detection-timer))
+    (ghostel--clear-plain-link-detection-bounds)
     ;; Reinitialization may reuse an existing ghostel buffer that was in
     ;; line mode; reset it to the renderer-owned default before erasing.
     (setq buffer-read-only t)
@@ -5069,11 +5074,10 @@ spawn after initialization."
           ghostel--redraw-timer nil
           ghostel--pending-redraw nil
           ghostel--plain-link-detection-timer nil
-          ghostel--plain-link-detection-begin nil
-          ghostel--plain-link-detection-end nil
           ghostel--force-next-redraw nil
           ghostel--cursor-pos nil
-          ghostel--cursor-char-pos nil)
+          ghostel--cursor-char-pos nil
+          ghostel--repainted-region nil)
     (let* ((w (or (get-buffer-window buffer t) (selected-window)))
            (height (max 1 (or rows
                               (if (window-live-p w)

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -60,7 +60,16 @@ bold_config: ?gt.Style.BoldColor = null,
 /// rendering passes to avoid allocations.
 saved_markers: SavedBufferMarkers = .{},
 
+/// Buffer range rewritten by the redraw in progress, or null when it has
+/// painted nothing yet. Published so elisp can scan exactly what changed.
+repainted: ?BufferRegion = null,
+
 const PageSerial = @FieldType(gt.PageList.List.Node, "serial");
+
+const BufferRegion = struct {
+    min: usize,
+    max: usize,
+};
 
 const ScreenId = struct {
     key: gt.ScreenSet.Key,
@@ -160,6 +169,8 @@ pub fn redraw(self: *Self, env: emacs.Env, force_full: bool, force_sync: bool) !
     self.is_rendering = true;
     defer self.is_rendering = false;
 
+    self.repainted = null;
+
     const screen = self.term.screens.active;
     try self.saved_markers.save(self.alloc, env);
     defer self.saved_markers.restoreAndClear(screen, env);
@@ -191,6 +202,12 @@ pub fn redraw(self: *Self, env: emacs.Env, force_full: bool, force_sync: bool) !
         screen.pages.rows
     else
         screen.pages.total_rows;
+
+    if (self.repainted) |r| {
+        env.set("ghostel--repainted-region", env.cons(r.min, r.max));
+    } else {
+        env.set("ghostel--repainted-region", env.nil());
+    }
     return true;
 }
 
@@ -865,6 +882,12 @@ fn flushSpan(self: *Self, env: emacs.Env) !void {
 
     const span_start = env.cast(usize, env.f("point", .{}));
     _ = env.f("insert", .{self.span.text.items});
+
+    const span_end = span_start + self.span.char_len;
+    self.repainted = if (self.repainted) |r| .{
+        .min = @min(r.min, span_start),
+        .max = @max(r.max, span_end),
+    } else .{ .min = span_start, .max = span_end };
 
     for (self.span.runs.items) |*run| {
         if (run.key) |*key| {

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -501,6 +501,7 @@ const interned_symbols = [_][:0]const u8{
     "ghostel--process",
     "ghostel--query-font-cache",
     "ghostel--rendered-font",
+    "ghostel--repainted-region",
     "ghostel--set-title",
     "ghostel--term-cols",
     "ghostel--term-rows",

--- a/test/ghostel-compile-test.el
+++ b/test/ghostel-compile-test.el
@@ -2039,5 +2039,71 @@ record the fragment after the break as the file name."
           (kill-buffer buf-name)))
       (delete-directory root t))))
 
+(ert-deftest ghostel-test-compile-finalize-drains-queued-link-detection ()
+  "Finalizing must not drop link detection the run still owes.
+The mode switch drops the buffer-locals holding the queued scan, and
+nothing repaints a finished compile buffer, so a scan left pending
+would never run.  The path here is soft-wrapped, so it is only
+detectable while the wrap properties `--unwrap-soft-wraps' removes are
+still in place."
+  :tags '(native)
+  (ghostel-test--with-long-path-file file
+    (let ((uri (concat "fileref:" file ":42")))
+      (ghostel-test--with-terminal-buffer (buf term 5 40 100000)
+        (let ((inhibit-read-only t)
+              (inhibit-modification-hooks t)
+              (default-directory (file-name-directory file))
+              (ghostel-enable-url-detection nil)
+              (ghostel-enable-file-detection t)
+              ;; Long enough that no tick fires before finalize does.
+              (ghostel-plain-link-detection-delay 60))
+          (should (> (length file) 40))
+          (setq-local ghostel-compile--scan-marker (copy-marker (point-min)))
+          (ghostel--write-vt term (format "%s:42\r\ndone\r\n" file))
+          (ghostel--redraw term)
+          (ghostel--schedule-link-detection)
+          (should ghostel--plain-link-detection-timer)
+          (goto-char (point-min))
+          (should-not (text-property-not-all (point-min) (point-max)
+                                             'help-echo nil))
+          (ghostel-compile--finalize buf 0 (current-time))
+          (should (eq major-mode 'ghostel-compile-view-mode))
+          ;; Unwrapping joined the rows, so the whole path is one run now.
+          ;; Probed at its last character: a Windows drive prefix sits
+          ;; outside the span, which starts at the leading `/'.
+          (goto-char (point-min))
+          (should (search-forward file nil t))
+          (should (equal uri (get-text-property (1- (match-end 0))
+                                                'help-echo))))))))
+
+(ert-deftest ghostel-test-compile-finalize-links-the-cursor-row ()
+  "A command printing no trailing newline still gets its last row linked.
+Detection leaves the cursor's line alone as the prompt being typed
+at, but a finished compile has no prompt and this is its last scan
+ever, so that row would keep its link forever otherwise."
+  :tags '(native)
+  (ghostel-test--with-long-path-file file
+    (let ((uri (concat "fileref:" file ":42")))
+      (ghostel-test--with-terminal-buffer (buf term 5 40 100000)
+        (let ((inhibit-read-only t)
+              (inhibit-modification-hooks t)
+              (default-directory (file-name-directory file))
+              (ghostel-enable-url-detection nil)
+              (ghostel-enable-file-detection t)
+              (ghostel-plain-link-detection-delay 60))
+          (setq-local ghostel-compile--scan-marker (copy-marker (point-min)))
+          ;; No trailing newline: the VT cursor stops on the path's own row.
+          (ghostel--write-vt term (format "done\r\n%s:42" file))
+          (ghostel--redraw term)
+          (ghostel--schedule-link-detection)
+          (should ghostel--cursor-char-pos)
+          (ghostel-compile--finalize buf 0 (current-time))
+          ;; Probed at the path's last character: a Windows drive prefix
+          ;; sits outside the span, which starts at the leading `/'.
+          (goto-char (point-min))
+          (should (search-forward file nil t))
+          (should (equal uri (get-text-property (1- (match-end 0))
+                                                'help-echo))))))))
+
 (provide 'ghostel-compile-test)
 ;;; ghostel-compile-test.el ends here

--- a/test/ghostel-links-test.el
+++ b/test/ghostel-links-test.el
@@ -1641,6 +1641,25 @@ Return the (BEGIN . END) each tick asked for, oldest first."
     (should (< ticks 500)))
   (setq ghostel-test--link-regions (nreverse ghostel-test--link-regions)))
 
+(ert-deftest ghostel-test-soft-wrap-row-limit-is-per-logical-line ()
+  "`ghostel--soft-wrap-row-limit' bounds rows joined into one logical line.
+Counting a whole scan region's wraps cumulatively instead stopped
+joining at every LIMIT-th wrapped line in the region, losing that
+line's path."
+  (let* ((file (locate-library "ghostel"))
+         (default-directory (file-name-directory file))
+         (lines (+ ghostel--soft-wrap-row-limit 10)))
+    (with-temp-buffer
+      (dotimes (i lines)
+        (insert (format "%3d see " i))
+        (ghostel-test--wrap-split (concat file ":42") 20)
+        (insert " end\n"))
+      (let ((ghostel-enable-url-detection nil)
+            (ghostel-enable-file-detection t))
+        (ghostel--detect-urls))
+      ;; Two runs per line: the path is split across its two rows.
+      (should (= (* 2 lines) (length (ghostel-test--link-runs)))))))
+
 (ert-deftest ghostel-test-plain-link-detection-drains-in-chunks ()
   "The queued scan covers its whole range across bounded ticks."
   (let* ((file (locate-library "ghostel"))

--- a/test/ghostel-links-test.el
+++ b/test/ghostel-links-test.el
@@ -538,10 +538,13 @@ E.g. `compilation-mode' error loci in `ghostel-compile-view-mode'."
                                timer-args args)
                          'ghostel-test-link-timer))
                       ((symbol-function 'ghostel--redraw)
-                       (lambda (&rest _) t))
-                      ((symbol-function 'ghostel--window-anchored-p) #'ignore)
-                      ((symbol-function 'ghostel--viewport-start)
-                       (lambda () nil)))
+                       (lambda (&rest _)
+                         ;; What the real renderer publishes: the buffer
+                         ;; range it just rewrote.
+                         (setq ghostel--repainted-region
+                               (cons (point-min) (point-max)))
+                         t))
+                      ((symbol-function 'ghostel--window-anchored-p) #'ignore))
               (set-window-buffer (selected-window) buf)
               (let ((inhibit-read-only t))
                 (insert "see https://example.com here\n"))
@@ -587,10 +590,11 @@ E.g. `compilation-mode' error loci in `ghostel-compile-view-mode'."
                                timer-args args)
                          'ghostel-test-link-timer))
                       ((symbol-function 'ghostel--redraw)
-                       (lambda (&rest _) t))
-                      ((symbol-function 'ghostel--window-anchored-p) #'ignore)
-                      ((symbol-function 'ghostel--viewport-start)
-                       (lambda () nil)))
+                       (lambda (&rest _)
+                         (setq ghostel--repainted-region
+                               (cons (point-min) (point-max)))
+                         t))
+                      ((symbol-function 'ghostel--window-anchored-p) #'ignore))
               (set-window-buffer (selected-window) buf)
               (let ((inhibit-read-only t))
                 (insert "first https://first.example\n"))
@@ -690,8 +694,10 @@ E.g. `compilation-mode' error loci in `ghostel-compile-view-mode'."
                                (get-text-property url-beg 'help-echo)))))))
       (kill-buffer buf))))
 
-(ert-deftest ghostel-test-sentinel-cancels-plain-link-detection-timer ()
-  "Process exit should cancel queued plain-text link detection timers."
+(ert-deftest ghostel-test-sentinel-keeps-plain-link-detection-draining ()
+  "Process exit must not drop a partly drained link scan.
+A program that floods and then exits leaves a backlog that nothing
+will ever repaint, so the remaining ticks have to run."
   (let ((buf (generate-new-buffer " *ghostel-test-sentinel-links*")))
     (unwind-protect
         (let ((proc (make-pipe-process :name "ghostel-test-sentinel-links"
@@ -701,9 +707,13 @@ E.g. `compilation-mode' error loci in `ghostel-compile-view-mode'."
             (setq ghostel-kill-buffer-on-exit nil
                   ghostel--plain-link-detection-timer
                   (run-with-timer 60 nil #'ignore))
+            (insert "backlog\n")
+            (ghostel--queue-plain-link-detection (point-min) (point-max))
             (cl-letf (((symbol-function 'ghostel--kill-native-process) #'ignore))
               (ghostel--sentinel proc "finished\n"))
-            (should-not ghostel--plain-link-detection-timer))
+            (should ghostel--plain-link-detection-timer)
+            (should ghostel--plain-link-detection-begin)
+            (should ghostel--plain-link-detection-end))
           (when (process-live-p proc)
             (delete-process proc)))
       (when (buffer-live-p buf)
@@ -1589,6 +1599,251 @@ Off a link it falls back to `find-file-at-point'."
           (ghostel-find-file-at-point))
         (should fallback)
         (should-not opened)))))
+
+
+;;; Link detection coverage
+
+(defvar ghostel-test--link-timer nil
+  "Captured (FN . ARGS) of the pending plain-link detection tick, or nil.")
+
+(defvar ghostel-test--link-regions nil
+  "The (BEGIN . END) each drained detection tick asked for, newest first.")
+
+(defmacro ghostel-test--with-link-timers (&rest body)
+  "Run BODY with plain-link detection timers captured, not scheduled.
+BODY queues detection; `ghostel-test--drain-link-detection' then runs
+the queue to completion."
+  (declare (indent 0))
+  `(let ((ghostel-test--link-timer nil)
+         (ghostel-test--link-regions nil)
+         (ghostel-test--real-detect-urls
+          (symbol-function 'ghostel--detect-urls)))
+     (cl-letf (((symbol-function 'run-with-timer)
+                (lambda (_delay _repeat fn &rest args)
+                  (setq ghostel-test--link-timer (cons fn args))
+                  'ghostel-test-link-timer))
+               ((symbol-function 'ghostel--detect-urls)
+                (lambda (&optional begin end)
+                  (push (cons begin end) ghostel-test--link-regions)
+                  (funcall ghostel-test--real-detect-urls begin end))))
+       ,@body)))
+
+(defun ghostel-test--drain-link-detection ()
+  "Run captured plain-link detection ticks until the queue is empty.
+Return the (BEGIN . END) each tick asked for, oldest first."
+  (let ((ticks 0))
+    (while (and ghostel-test--link-timer (< ticks 500))
+      (let ((call ghostel-test--link-timer))
+        (setq ghostel-test--link-timer nil
+              ticks (1+ ticks))
+        (apply (car call) (cdr call))))
+    ;; A drain that never empties would otherwise hang the suite.
+    (should (< ticks 500)))
+  (setq ghostel-test--link-regions (nreverse ghostel-test--link-regions)))
+
+(ert-deftest ghostel-test-plain-link-detection-drains-in-chunks ()
+  "The queued scan covers its whole range across bounded ticks."
+  (let* ((file (locate-library "ghostel"))
+         (default-directory (file-name-directory file))
+         (lines 40))
+    (with-temp-buffer
+      (dotimes (i lines)
+        (insert (format "line %d see %s:42 end\n" i file)))
+      (goto-char (point-max))
+      (let ((ghostel-enable-url-detection nil)
+            (ghostel-enable-file-detection t)
+            (ghostel-plain-link-detection-delay 0.1)
+            (ghostel--link-detection-chunk 200)
+            regions)
+        (ghostel-test--with-link-timers
+          (ghostel--queue-plain-link-detection (point-min) (point-max))
+          (setq regions (ghostel-test--drain-link-detection)))
+        (should (> (length regions) 3))
+        ;; Newest end first: tick 1 covers the tail, not the whole range.
+        (should (= (cdr (car regions)) (point-max)))
+        (should (> (car (car regions)) (point-min)))
+        ;; Each tick resumes where the previous one started, walking down
+        ;; to the queued begin with no row left between two ticks.
+        (cl-loop for (this next) on regions
+                 while next
+                 do (should (<= (cdr next) (car this)))
+                    (should (< (car next) (car this))))
+        (should (= (car (car (last regions))) (point-min)))
+        (should (= lines (length (ghostel-test--link-runs))))
+        ;; And the queue released its bounds once drained.
+        (should-not ghostel--plain-link-detection-begin)
+        (should-not ghostel--plain-link-detection-end)))))
+
+(ert-deftest ghostel-test-plain-link-detection-bounds-survive-eviction ()
+  "Queued bounds follow the scrollback eviction that deletes buffer text.
+The renderer evicts whole pages off the front of the buffer between
+the redraw that queued a scan and the tick that runs it; plain
+positions queued before the deletion point at unrelated text after it."
+  (let* ((file (locate-library "ghostel"))
+         (default-directory (file-name-directory file))
+         (evicted-lines 20))
+    (with-temp-buffer
+      (dotimes (_ evicted-lines) (insert "evicted\n"))
+      (let ((link-line (point)))
+        (insert (format "see %s:42 end\n" file))
+        (insert "tail\n")
+        (goto-char (point-max))
+        (let ((ghostel-enable-url-detection nil)
+              (ghostel-enable-file-detection t)
+              (ghostel-plain-link-detection-delay 0.1))
+          (ghostel-test--with-link-timers
+            (ghostel--queue-plain-link-detection link-line (point-max))
+            ;; What `evictScrollback' does before the tick fires.
+            (delete-region (point-min) (- link-line 1))
+            (ghostel-test--drain-link-detection)))
+        (goto-char (point-min))
+        (should (search-forward (substring file 0 20) nil t))
+        (should (string-prefix-p
+                 "fileref:"
+                 (get-text-property (match-beginning 0) 'help-echo)))))))
+
+(ert-deftest ghostel-test-plain-link-detection-zero-delay-rearms-via-timer ()
+  "A zero delay re-arms the drain through a timer instead of recursing."
+  (let* ((file (locate-library "ghostel"))
+         (default-directory (file-name-directory file))
+         (lines 20))
+    (with-temp-buffer
+      (dotimes (i lines)
+        (insert (format "line %d see %s:42 end\n" i file)))
+      (goto-char (point-max))
+      (let ((ghostel-enable-url-detection nil)
+            (ghostel-enable-file-detection t)
+            (ghostel-plain-link-detection-delay 0)
+            (ghostel--link-detection-chunk 100)
+            (depth 0)
+            (max-depth 0)
+            regions)
+        (ghostel-test--with-link-timers
+          (let ((real (symbol-function 'ghostel--detect-urls)))
+            (cl-letf (((symbol-function 'ghostel--detect-urls)
+                       (lambda (&optional begin end)
+                         (setq depth (1+ depth)
+                               max-depth (max max-depth depth))
+                         (prog1 (funcall real begin end)
+                           (setq depth (1- depth))))))
+              (ghostel--queue-plain-link-detection (point-min) (point-max))
+              ;; The synchronous first tick must not have run the backlog.
+              (should ghostel-test--link-timer)
+              (setq regions (ghostel-test--drain-link-detection)))))
+        (should (> (length regions) 3))
+        (should (= 1 max-depth))
+        (should (= lines (length (ghostel-test--link-runs))))))))
+
+(ert-deftest ghostel-test-renderer-publishes-repainted-region ()
+  "The renderer publishes the buffer range it rewrote."
+  :tags '(native)
+  (ghostel-test--with-terminal-buffer (_buf term 5 80 1000)
+    (let ((inhibit-read-only t))
+      (ghostel--write-vt term "one\r\ntwo\r\nthree\r\n")
+      (setq ghostel--repainted-region nil)
+      (ghostel--redraw term)
+      (let ((region ghostel--repainted-region))
+        (should (consp region))
+        (goto-char (point-min))
+        (should (search-forward "one" nil t))
+        (should (<= (car region) (match-beginning 0)))
+        (should (search-forward "three" nil t))
+        (should (>= (cdr region) (match-end 0))))
+      ;; A redraw that repaints a couple of rows publishes less than the
+      ;; whole viewport, not the `point-max'-minus-term-rows guess.
+      (setq ghostel--repainted-region nil)
+      (ghostel--write-vt term "four\r\n")
+      (ghostel--redraw term)
+      (let ((region ghostel--repainted-region))
+        (should (consp region))
+        (should (< (- (cdr region) (car region))
+                   (- (point-max) (point-min))))
+        (goto-char (point-min))
+        (should (search-forward "four" nil t))
+        (should (<= (car region) (match-beginning 0)))
+        (should (>= (cdr region) (match-end 0))))
+      ;; Nothing written, nothing dirty: the previous region is cleared
+      ;; rather than left behind for a later redraw to consume as its own.
+      (should ghostel--repainted-region)
+      (ghostel--redraw term)
+      (should-not ghostel--repainted-region))))
+
+(ert-deftest ghostel-test-flood-linkifies-rows-pushed-past-the-viewport ()
+  "Wrapped paths a flood pushed past the viewport still linkify.
+One write materializes far more rows than the terminal has, so the
+scan region can no longer be guessed from the live viewport."
+  :tags '(native)
+  (ghostel-test--with-long-path-file file
+    (let* ((uri (concat "fileref:" file ":42"))
+           (occurrences 30)
+           ;; Narrower than the path but wider than half of it, so an
+           ;; occurrence takes exactly two rows however long the name the
+           ;; temp directory contributed is.
+           (cols (- (length file) 10)))
+      (ghostel-test--with-terminal-buffer (_buf term 5 cols 2000)
+        (let ((inhibit-read-only t)
+              (default-directory (file-name-directory file))
+              (ghostel-enable-url-detection nil)
+              (ghostel-enable-file-detection t)
+              (ghostel-plain-link-detection-delay 0.1)
+              (ghostel--input-mode 'emacs))
+          ;; Too long for one row, short enough for two.
+          (should (> (+ (length file) 3) cols))
+          (should (<= (+ (length file) 3) (* 2 cols)))
+          (dotimes (i (* occurrences 10))
+            (ghostel--write-vt term
+                               (if (zerop (% i 10))
+                                   (format "%s:42\r\n" file)
+                                 (format "filler %d\r\n" i))))
+          (setq ghostel--repainted-region nil)
+          (ghostel--redraw term)
+          (ghostel-test--with-link-timers
+            (ghostel--schedule-link-detection)
+            (ghostel-test--drain-link-detection))
+          (let ((runs (seq-filter (lambda (run) (equal uri (cadr run)))
+                                  (ghostel-test--link-runs))))
+            ;; Two rows per occurrence, each carrying the whole target.
+            (should (= (* 2 occurrences) (length runs))))
+          ;; And every one of them is reachable by hyperlink navigation.
+          (goto-char (point-max))
+          (let ((ids nil))
+            (dotimes (_ occurrences)
+              (ghostel-previous-hyperlink)
+              (push (get-text-property (point) 'ghostel-link-id) ids))
+            (should (= occurrences (length (seq-uniq ids))))))))))
+
+(ert-deftest ghostel-test-pending-wrap-path-links-once-completed ()
+  "A path that exactly fills a row links up once its next row arrives.
+The row's wrap flag is only set when the terminal prints past the
+last column, which happens in a later write than the one that filled
+the row."
+  :tags '(native)
+  (ghostel-test--with-long-path-file file
+    (let* ((text (concat file ":42"))
+           (uri (concat "fileref:" file ":42"))
+           (cols 40))
+      (ghostel-test--with-terminal-buffer (_buf term 5 cols 1000)
+        (let ((inhibit-read-only t)
+              (default-directory (file-name-directory file))
+              (ghostel-enable-url-detection nil)
+              (ghostel-enable-file-detection t)
+              (ghostel-plain-link-detection-delay 0.1))
+          (should (> (length text) cols))
+          ;; Row filled exactly: pending wrap, row flag not set yet.
+          (ghostel--write-vt term (substring text 0 cols))
+          (ghostel--redraw term)
+          (ghostel--write-vt term (concat (substring text cols) "\r\ndone\r\n"))
+          (setq ghostel--repainted-region nil)
+          (ghostel--redraw term)
+          (ghostel-test--with-link-timers
+            (ghostel--schedule-link-detection)
+            (ghostel-test--drain-link-detection))
+          (let* ((runs (seq-filter (lambda (run) (equal uri (cadr run)))
+                                   (ghostel-test--link-runs)))
+                 (ids (seq-uniq (mapcar (lambda (run) (nth 2 run)) runs))))
+            ;; Split across rows, but joined into a single link.
+            (should (> (length runs) 1))
+            (should (= 1 (length ids)))))))))
 
 (provide 'ghostel-links-test)
 ;;; ghostel-links-test.el ends here

--- a/test/ghostel-links-test.el
+++ b/test/ghostel-links-test.el
@@ -1603,8 +1603,8 @@ Off a link it falls back to `find-file-at-point'."
 
 ;;; Link detection coverage
 
-(defvar ghostel-test--link-timer nil
-  "Captured (FN . ARGS) of the pending plain-link detection tick, or nil.")
+(defvar ghostel-test--link-timers nil
+  "Captured (FN . ARGS) of every pending plain-link detection tick.")
 
 (defvar ghostel-test--link-regions nil
   "The (BEGIN . END) each drained detection tick asked for, newest first.")
@@ -1612,16 +1612,27 @@ Off a link it falls back to `find-file-at-point'."
 (defmacro ghostel-test--with-link-timers (&rest body)
   "Run BODY with plain-link detection timers captured, not scheduled.
 BODY queues detection; `ghostel-test--drain-link-detection' then runs
-the queue to completion."
+the queue to completion.
+
+Every tick is kept, not just the newest: a customize `:set' handler
+redraws each ghostel buffer in the session, so more than one can queue
+inside one BODY.  The stub hands back a real but already cancelled
+timer for the same reason — the value lands in those buffers' timer
+slots, where `cancel-timer' later runs on it."
   (declare (indent 0))
-  `(let ((ghostel-test--link-timer nil)
+  `(let ((ghostel-test--link-timers nil)
          (ghostel-test--link-regions nil)
+         (ghostel-test--real-run-with-timer
+          (symbol-function 'run-with-timer))
          (ghostel-test--real-detect-urls
           (symbol-function 'ghostel--detect-urls)))
      (cl-letf (((symbol-function 'run-with-timer)
                 (lambda (_delay _repeat fn &rest args)
-                  (setq ghostel-test--link-timer (cons fn args))
-                  'ghostel-test-link-timer))
+                  (push (cons fn args) ghostel-test--link-timers)
+                  (let ((timer (funcall ghostel-test--real-run-with-timer
+                                        3600 nil #'ignore)))
+                    (cancel-timer timer)
+                    timer)))
                ((symbol-function 'ghostel--detect-urls)
                 (lambda (&optional begin end)
                   (push (cons begin end) ghostel-test--link-regions)
@@ -1629,13 +1640,12 @@ the queue to completion."
        ,@body)))
 
 (defun ghostel-test--drain-link-detection ()
-  "Run captured plain-link detection ticks until the queue is empty.
+  "Run captured plain-link detection ticks until none are pending.
 Return the (BEGIN . END) each tick asked for, oldest first."
   (let ((ticks 0))
-    (while (and ghostel-test--link-timer (< ticks 500))
-      (let ((call ghostel-test--link-timer))
-        (setq ghostel-test--link-timer nil
-              ticks (1+ ticks))
+    (while (and ghostel-test--link-timers (< ticks 500))
+      (let ((call (pop ghostel-test--link-timers)))
+        (setq ticks (1+ ticks))
         (apply (car call) (cdr call))))
     ;; A drain that never empties would otherwise hang the suite.
     (should (< ticks 500)))
@@ -1747,7 +1757,7 @@ positions queued before the deletion point at unrelated text after it."
                            (setq depth (1- depth))))))
               (ghostel--queue-plain-link-detection (point-min) (point-max))
               ;; The synchronous first tick must not have run the backlog.
-              (should ghostel-test--link-timer)
+              (should ghostel-test--link-timers)
               (setq regions (ghostel-test--drain-link-detection)))))
         (should (> (length regions) 3))
         (should (= 1 max-depth))
@@ -1830,6 +1840,37 @@ scan region can no longer be guessed from the live viewport."
               (ghostel-previous-hyperlink)
               (push (get-text-property (point) 'ghostel-link-id) ids))
             (should (= occurrences (length (seq-uniq ids))))))))))
+
+(ert-deftest ghostel-test-bold-config-change-keeps-detected-links ()
+  "Changing a bold setting must not leave the buffer without links.
+Its `:set' rebuilds every ghostel buffer from libghostty, and
+re-inserting the rows drops the properties detection attached."
+  :tags '(native)
+  (ghostel-test--with-long-path-file file
+    (let ((saved ghostel-bold-color))
+      (ghostel-test--with-terminal-buffer (_buf term 5 40 100000)
+        (unwind-protect
+            (let ((inhibit-read-only t)
+                  (inhibit-modification-hooks t)
+                  (default-directory (file-name-directory file))
+                  (ghostel-enable-url-detection nil)
+                  (ghostel-enable-file-detection t)
+                  (ghostel-plain-link-detection-delay 0.1))
+              (dotimes (i 40)
+                (ghostel--write-vt term (if (zerop (% i 10))
+                                            (format "%s:42\r\n" file)
+                                          (format "filler %d\r\n" i))))
+              (ghostel--redraw term)
+              (ghostel-test--with-link-timers
+                (ghostel--schedule-link-detection)
+                (ghostel-test--drain-link-detection))
+              (let ((before (length (ghostel-test--link-runs))))
+                (should (> before 0))
+                (ghostel-test--with-link-timers
+                  (customize-set-variable 'ghostel-bold-color 'bright)
+                  (ghostel-test--drain-link-detection))
+                (should (= before (length (ghostel-test--link-runs))))))
+          (customize-set-variable 'ghostel-bold-color saved))))))
 
 (ert-deftest ghostel-test-pending-wrap-path-links-once-completed ()
   "A path that exactly fills a row links up once its next row arrives.

--- a/test/ghostel-test-helpers.el
+++ b/test/ghostel-test-helpers.el
@@ -31,6 +31,31 @@
            ,@body)
        (kill-buffer ,var))))
 
+(defmacro ghostel-test--with-long-path-file (var &rest body)
+  "Run BODY with VAR bound to an existing file with a long absolute name.
+A test that needs the terminal to soft-wrap a path cannot take one
+from `locate-library': its length depends on where the checkout
+lives, and CI checks out into a path short enough on Windows
+\(`D:\\a\\ghostel\\ghostel') that the name fits a 40-column row
+unwrapped.
+
+Created under `default-directory' rather than in the system temp
+directory: `ghostel-file-detection-path-regex' does not match a
+`C:' drive prefix, so a detected path resolves against whichever
+drive is current, and only a file on that drive resolves back to
+itself.  The file and the directory holding it are deleted
+afterwards."
+  (declare (indent 1))
+  `(let* ((temporary-file-directory default-directory)
+          (long-path-dir (make-temp-file "ghostel-test-longpath-" t))
+          (,var (expand-file-name (concat (make-string 48 ?a) ".txt")
+                                  long-path-dir)))
+     (unwind-protect
+         (progn
+           (with-temp-file ,var (insert "x\n"))
+           ,@body)
+       (delete-directory long-path-dir t))))
+
 (defmacro ghostel-test--with-terminal-buffer (spec &rest body)
   "Run BODY in a fresh ghostel buffer with a terminal attached.
 SPEC is (BUFFER TERM ROWS COLS SCROLLBACK).  The terminal is created


### PR DESCRIPTION
Fixes #582.

Paths that the terminal soft-wraps across two rows were not clickable and not
even mouse-highlighted in `rails test` output. Two independent causes, one
commit each.

## Scan coverage

`ghostel--schedule-link-detection` queued only the live viewport — `point-max`
minus `ghostel--term-rows` lines. Between two queue events a flood materializes
far more rows than that, and everything above the new viewport was never
scanned by any cycle, because nothing rescans. Those rows carry no `help-echo`,
`mouse-face` or `keymap`, which is exactly the reported "not clickable, doesn't
even highlight" — and it also defeats the `ghostel-previous-hyperlink`
workaround from the issue thread, since that searches for the `help-echo` a
scan was supposed to have applied.

The renderer already knows which buffer range it rewrote, so it publishes that
instead. Every character of terminal output is inserted by `flushSpan`, which
makes coverage gapless by construction. It also closes the cursor-line skip for
free — `isRowDirty` repaints the row the cursor left, so a match skipped as
active input is republished and rescanned — and it is cheaper than before when
output is slow: a two-row repaint queues two rows, not the whole viewport.

Supporting changes the new region size forces:

- The queued bounds become markers. `evictScrollback` deletes from the buffer
  start on almost every redraw during a sustained flood, which rots integer
  bounds queued 0.1 s earlier.
- The scan drains at most `ghostel--link-detection-chunk` characters per tick,
  taken from the newest end, so one redraw materializing megabytes no longer
  blocks Emacs for as long as scanning all of it takes, and rows on screen are
  linkified before the backlog. Re-arming always goes through a timer, so
  `ghostel-plain-link-detection-delay` of 0 cannot recurse through it.
- Process exit no longer cancels a partly drained scan: the program that
  flooded has exited, so nothing will ever repaint that text again.

## Row limit

`ghostel--wrap-joined-region` counted joined rows against
`ghostel--soft-wrap-row-limit` cumulatively across the whole scan region
instead of restarting at each hard newline, so a region holding more wrapped
lines than the limit stopped joining at every 50th one and lost that line's
link. Harmless while scans covered ~34 rows; load-bearing once a scan covers
whatever the renderer repainted.

## Testing

`make -j8 all` passes at both commits, so the first is not a broken
intermediate.

New elisp tests (no module): per-logical-line row limit, chunked drain reaching
the whole pending range, bounds surviving front deletion, zero delay re-arming
through a timer instead of recursing. New native tests: `ghostel--repainted-region`
publication, a regression test writing far more than `term-rows` lines in one
write, and pending-wrap completion across two redraws. Each new test was
confirmed to fail against the pre-fix code.

Verified live under elate as well — bash in a ghostel buffer, `cat` of a
2000-line log with 200 wrapped 121-character paths. Post-fix: 200/200 linkified
across three runs, every link carrying the full joined target, and
`ghostel-previous-hyperlink` reaching all 200 from `point-max`. Isolating the
two bugs against that harness gives 3 misses per run at identical offsets for
the row-limit bug, and 192–193 of 200 missing for the coverage gap at
`ghostel-plain-link-detection-delay` 0. Revealing a buffer that flooded while
hidden scans the visible rows on the first tick and walks the backlog down over
the next seven.

## Known follow-ups, not addressed here

- Line mode passes `full=t` on every redraw (to rebuild the prompt row after the
  input snapshot), which erases and re-renders the entire scrollback — 3.1 ms at
  a saturated default scrollback versus 0.005 ms incremental. That now queues the
  whole buffer for scanning too. It is correct rather than wasteful, since a full
  redraw wipes every detected link (measured: 40 → 0), which the old viewport-only
  scan never restored outside the visible rows — but the root fix is to stop
  forcing full redraws in line mode.
- `ghostel-compile--commit-pending-frame` publishes a region nothing consumes, so
  a compile buffer's final frame is never link-scanned. Pre-existing.
