### PR TITLE
Let buffer-face-mode rescale ghostel terminals

### DIFF
--- a/lisp/ghostel-faces.el
+++ b/lisp/ghostel-faces.el
@@ -114,7 +114,7 @@ Used when `cursor-in-non-selected-windows' resolves to box."
   :group 'ghostel)
 
 (defface ghostel-default
-  '((t :inherit default))
+  '((t nil))
   "Base face for default text in ghostel terminal buffers.
 Customize this to give ghostel buffers a different default foreground,
 background, font, or size than the rest of Emacs.  Foreground and

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4828,6 +4828,10 @@ When BUFFER is non-nil, only refit windows showing BUFFER."
 
 (unless (advice-member-p #'ghostel--around-local-font-scale 'text-scale-mode)
   (advice-add 'text-scale-mode :around #'ghostel--around-local-font-scale))
+;; `buffer-face-set', `buffer-face-toggle' and `variable-pitch-mode' all
+;; remap through `buffer-face-mode', which rescales the font.
+(unless (advice-member-p #'ghostel--around-local-font-scale 'buffer-face-mode)
+  (advice-add 'buffer-face-mode :around #'ghostel--around-local-font-scale))
 (when (and (fboundp 'global-text-scale-adjust)
            (not (advice-member-p #'ghostel--around-global-font-scale
                                  'global-text-scale-adjust)))

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -16,6 +16,42 @@
     (should (member 'ghostel-default
                     (cdr (assq 'default face-remapping-alist))))))
 
+(ert-deftest ghostel-test-default-face-specifies-no-attributes ()
+  "`ghostel-default' pins no attribute of its own out of the box.
+`face-remap-add-relative' orders the `default' remappings by how many
+attributes they leave unspecified, giving the most relative one the
+highest precedence.  An attribute pinned here — including `:inherit
+default', which drags in every attribute of `default' — therefore
+outranks and silently masks other `default' remappings in the buffer,
+such as `buffer-face-mode'."
+  (should (seq-every-p (lambda (attr) (eq (cdr attr) 'unspecified))
+                       (face-all-attributes 'ghostel-default))))
+
+(ert-deftest ghostel-test-buffer-face-mode-refits-terminal ()
+  "`buffer-face-mode' resizes the terminal to the rescaled window.
+Its font change leaves the window's pixel geometry untouched, so
+`window-size-change-functions' never fires."
+  (let ((buf (generate-new-buffer " *ghostel-test-buffer-face*"))
+        (orig-buf (window-buffer (selected-window))))
+    (unwind-protect
+        (progn
+          (set-window-buffer (selected-window) buf)
+          (with-current-buffer buf
+            (ghostel-mode)
+            (let ((adjust-args nil))
+              (cl-letf (((symbol-function 'ghostel--window-anchored-p)
+                         (lambda (&rest _) nil))
+                        ((symbol-function 'ghostel--adjust-size)
+                         (lambda (&rest args) (setq adjust-args args))))
+                (buffer-face-set '(:height 2.0))
+                (should (equal (list (selected-window) t) adjust-args))
+                (setq adjust-args nil)
+                (buffer-face-mode -1)
+                (should (equal (list (selected-window) t) adjust-args))))))
+      (when (buffer-live-p orig-buf)
+        (set-window-buffer (selected-window) orig-buf))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-major-mode-change-blocked-while-live ()
   "Changing the major mode signals `user-error' while the terminal runs.
 The switch is aborted before `kill-all-local-variables' wipes the


### PR DESCRIPTION
Fixes #588 — `buffer-face-mode` had no effect in ghostel buffers, for two independent reasons.

## The face remapping was masked

`ghostel-mode` remaps `default` to `ghostel-default`, which was defined as `:inherit default`. `face-remap-add-relative` orders the `default` remappings by how many attributes they leave unspecified, giving the most relative one the highest precedence — and `:inherit default` pins every attribute of `default`. So `ghostel-default` outranked and silently masked any face-name remapping added afterwards: plain `M-x buffer-face-mode` (variable-pitch) was a complete no-op. Plists such as `(:height 240)` tied on the sort key and applied only by virtue of `sort` being stable.

Dropping the inherit is safe: `face-remap-add-relative` already keeps the real `default` face as the base of the remapping entry, and `ghostel--face-hex-color` passes `default` as its INHERIT fallback, so the OSC 10/11 color replies are unchanged (verified live — an `OSC 11 ?` query still answers `rgb:ffff/ffff/ffff` against a White-background default).

## The terminal never resized

Even where the remapping did apply, `buffer-face-mode` rescales the font without changing the window's pixel geometry, so `window-size-change-functions` never fires and the PTY kept its old dimensions: at `(:height 240)` the window fit 16x50 while the shell still saw `33 100`. It is now advised with `ghostel--around-local-font-scale`, the same wrapper `text-scale-mode` already uses; `buffer-face-set`, `buffer-face-toggle` and `variable-pitch-mode` all reach the remapping through `buffer-face-mode`, so one advice covers every entry point. `ghostel--windows` filters on `derived-mode-p 'ghostel-mode`, so it is a no-op in other buffers.

## Verification

`make -j8 all` clean from scratch, 0 unexpected. Two regression tests added in `test/ghostel-modes-test.el`.

Live GUI Emacs 31 driving a real bash, window 100x35:

| action | font | terminal grid | window fits | shell `stty size` |
|---|---|---|---|---|
| baseline | Menlo 12 | 33x100 | 33x100 | `33 100` |
| `M-x buffer-face-mode` | Tahoma 12 | 33x116 | 33x116 | `33 116` |
| `buffer-face-set '(:height 240)` | Menlo 24 | 16x50 | 16x50 | `16 50` |
| `buffer-face-mode -1` | Menlo 12 | 33x100 | 33x100 | `33 100` |
| `text-scale-set 6` | Menlo 36 | 11x31 | 11x31 | `11 31` |
| `text-scale-set 0` | Menlo 12 | 33x100 | 33x100 | `33 100` |

Grid and window agree in every row now, and `text-scale-mode` is unregressed.

## Note

`M-x buffer-face-mode` with its default `variable-pitch` now genuinely applies a proportional font. Ghostel resizes correctly for it (100 → 116 columns from the narrower average glyph), but a proportional font in a character grid still renders ragged — that is now the user's choice rather than a silent no-op.

Not addressed here: `ghostel--reported-cell-width`/`-height` still derive from `frame-char-width`/`frame-char-height`, which are frame-level and blind to any buffer-local remap, so the cell pixel size reported to libghostty (`CSI 14 t`/`CSI 16 t`, `ws_xpixel`/`ws_ypixel`, kitty/sixel scaling) is stale under buffer-face *and* under the already-supported `text-scale-mode`. Pre-existing and separate.