### PR TITLE
Size cells from the buffer's font, not the frame's

### DIFF
--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -69,7 +69,6 @@
 
 (declare-function ghostel--redraw "ghostel-module"
                   (term &optional full force-sync))
-(declare-function ghostel--set-size "ghostel-module")
 (declare-function ghostel--write-vt "ghostel-module")
 (declare-function ghostel--sync-read-only "ghostel")
 (defvar ghostel--inhibit-insert-forwarding)
@@ -798,7 +797,7 @@ any other code that walks `compilation-arguments') re-runs via
         (let ((oh (max 1 (with-selected-window outwin
                            (floor (window-screen-lines)))))
               (ow (max 1 (window-max-chars-per-line outwin))))
-          (ghostel--set-size ghostel--term oh ow)))
+          (ghostel--set-size-with-cell-dims ghostel--term oh ow)))
       ;; Render the compilation header into the terminal before spawning
       ;; the command, so the user sees the "Compilation started at ..."
       ;; banner *during* the run rather than only when it finishes (the

--- a/lisp/ghostel-kitty.el
+++ b/lisp/ghostel-kitty.el
@@ -180,8 +180,8 @@ user shouldn't have to trigger one)."
     (condition-case err
         (progn
           (ghostel--kitty-check-source-rect src-x src-y src-w src-h pixel-w pixel-h)
-          (let* ((cw (frame-char-width))
-                 (ch (frame-char-height))
+          (let* ((cw (default-font-width))
+                 (ch (default-font-height))
                  (g-cols (if (> grid-cols 0) grid-cols
                            (max 1 (/ (+ pixel-w cw -1) cw))))
                  (g-rows (if (> grid-rows 0) grid-rows
@@ -234,8 +234,8 @@ DATA is a unibyte string (PNG or PPM).  IS-PNG is non-nil for PNG."
   (when (display-graphic-p)
     (condition-case err
         (let ((placeholder (string #x10EEEE))
-              (cw (frame-char-width))
-              (ch (frame-char-height))
+              (cw (default-font-width))
+              (ch (default-font-height))
               grid-cols grid-rows img)
           (save-excursion
             ;; First pass: measure the grid by walking the buffer line by
@@ -293,9 +293,9 @@ DATA is a unibyte string (PNG or PPM).  IS-PNG is non-nil for PNG."
                         ;; tiles flush and the file-list column on the same
                         ;; line doesn't grow taller than non-image lines.
                         ;; The U+10EEEE fallback font and any Nerd Font
-                        ;; icons would otherwise pull line height above
-                        ;; `frame-char-height', leaving gaps below the
-                        ;; slice and above the next line's content.
+                        ;; icons would otherwise pull line height above the
+                        ;; buffer's default font height, leaving gaps below
+                        ;; the slice and above the next line's content.
                         (when (< line-end (point-max))
                           (add-text-properties line-end (1+ line-end)
                                                (list 'line-height ch

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -292,7 +292,7 @@ This is a heuristic — Emacs has no portable API for the OS-level
 backing scale factor, so exact parity with standalone Ghostty
 \(which measures cell size in real physical pixels via the window
 server) requires setting an explicit number here.  Useful overrides:
-the exact `physical_cell_w / frame-char-width' ratio (e.g. 2.28) for
+the exact `physical_cell_w / default-font-width' ratio (e.g. 2.28) for
 pixel-perfect parity with standalone Ghostty's image rendering, or
 1 to opt out of HiDPI-aware reporting altogether.
 
@@ -4744,12 +4744,14 @@ reported (some multi-monitor setups), letting the caller fall back."
 
 (defun ghostel--reported-cell-width ()
   "Return cell width to report to libghostty, in physical pixels."
-  (round (* (frame-char-width) (ghostel--cell-pixel-scale))))
+  (round (* (default-font-width) (ghostel--cell-pixel-scale))))
 
 (defun ghostel--cell-height ()
   "Return the terminal cell height in logical pixels.
-`frame-char-height' plus the buffer's `line-spacing' in pixels."
-  (+ (frame-char-height)
+The buffer's default font height plus its `line-spacing' in pixels.
+Redisplay scales a float `line-spacing' by the frame's char height, not
+by the buffer's font height."
+  (+ (default-font-height)
      (cond ((not (display-graphic-p)) 0)
            ((integerp line-spacing) (max 0 line-spacing))
            ((floatp line-spacing)

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -4764,7 +4764,8 @@ by the buffer's font height."
 
 (defun ghostel--set-size-with-cell-dims (term rows cols)
   "Resize TERM to ROWS×COLS, including the reported cell pixel dimensions.
-Convenience wrapper to keep the five resize sites consistent."
+Convenience wrapper to keep the resize sites consistent.  Resolves the cell
+dimensions from the current buffer, so call it with TERM's buffer current."
   (ghostel--set-size term rows cols
                      (ghostel--reported-cell-width)
                      (ghostel--reported-cell-height)))

--- a/test/ghostel-compile-test.el
+++ b/test/ghostel-compile-test.el
@@ -1421,14 +1421,17 @@ dimensions available before `display-buffer').  If the compile
 buffer ends up in a smaller window, the PTY's `set-process-window-size'
 agrees with the output window but the VT still thinks it has the
 width of the selected window, so early output wraps at the wrong column.
-`--start' must call `ghostel--set-size' with the output-window
-dimensions *before* rendering the header, and `--spawn' must receive
-the same dimensions so PTY and VT always agree."
+`--start' must resize with the output-window dimensions *before*
+rendering the header, and `--spawn' must receive the same dimensions so
+PTY and VT always agree.  The resize must carry the cell pixel
+dimensions too: `ghostel--set-size' defaults omitted ones to 1 px,
+dropping what `ghostel--init-buffer' seeded."
   (let* ((buf-name "*ghostel-test-compile-size*")
          (set-size-calls nil)
          (spawn-calls nil)
          (call-order nil)
          (inhibit-message t)
+         (ghostel-cell-pixel-scale 1)
          (save-some-buffers-default-predicate (lambda () nil))
          (ghostel-compile-finished-major-mode nil))
     (when (get-buffer buf-name)
@@ -1438,12 +1441,13 @@ the same dimensions so PTY and VT always agree."
         (cl-letf* (((symbol-function 'ghostel--load-module) #'ignore)
                    ((symbol-function 'ghostel--new)
                     (lambda (&rest _) 'fake-term))
-                   ((symbol-function 'ghostel--set-size-with-cell-dims) #'ignore)
                    ((symbol-function 'ghostel--apply-palette) #'ignore)
+                   ((symbol-function 'default-font-width) (lambda () 8))
+                   ((symbol-function 'default-font-height) (lambda () 16))
                    ((symbol-function 'ghostel--set-size)
-                    (lambda (_term rows cols)
+                    (lambda (_term rows cols &optional cell-w cell-h)
                       (push 'set-size call-order)
-                      (push (list rows cols) set-size-calls)))
+                      (push (list rows cols cell-w cell-h) set-size-calls)))
                    ((symbol-function 'ghostel-compile--render-header-live)
                     (lambda (&rest _) (push 'render-header call-order)))
                    (ghostel--cursor-pos (cons 0 0))
@@ -1460,19 +1464,21 @@ the same dimensions so PTY and VT always agree."
           (let ((buf (ghostel-compile--start "true" buf-name
                                              default-directory)))
             (with-current-buffer buf
-              ;; The reconcile call happened.
-              (should set-size-calls)
-              ;; Reconcile must precede the header render *and* the spawn —
-              ;; otherwise the header / early command output wraps at the
-              ;; pre-reconcile column.  `call-order' is LIFO, so chronological
-              ;; order is the reverse.
+              ;; Two resizes: `prepare-buffer' seeds from the selected
+              ;; window, `--start' reconciles to the output window.  Both
+              ;; must precede the header render *and* the spawn — otherwise
+              ;; the header / early command output wraps at the
+              ;; pre-reconcile column.  `call-order' is LIFO, so
+              ;; chronological order is the reverse.
               (let ((chronological (reverse call-order)))
                 (should (equal chronological
-                               '(set-size render-header spawn))))
-              ;; Final VT size equals what was handed to the process.
+                               '(set-size set-size render-header spawn))))
+              ;; Final VT size equals what was handed to the process, and
+              ;; carries the cell pixel dimensions.
               (let ((vt-size (car set-size-calls))
                     (pty-size (car spawn-calls)))
-                (should (equal vt-size pty-size)))
+                (should (equal (seq-take vt-size 2) pty-size))
+                (should (equal (nthcdr 2 vt-size) '(8 16))))
               ;; Clean up the fake process.
               (let ((p ghostel--process))
                 (when (process-live-p p)
@@ -1487,10 +1493,10 @@ the same dimensions so PTY and VT always agree."
   "If `display-buffer' returns nil, reconcile is skipped safely.
 `allow-no-window' permits `display-buffer' to choose not to show the
 buffer at all.  The `(when (and outwin ...))' guard in `--start' must
-gate the `ghostel--set-size' call so we don't crash or pass bogus
-dimensions when no output window exists."
+gate the reconcile so we don't crash or pass bogus dimensions when no
+output window exists — leaving the sizing `prepare-buffer' seeded."
   (let* ((buf-name "*ghostel-test-compile-no-outwin*")
-         (set-size-called nil)
+         (set-size-calls 0)
          (inhibit-message t)
          (save-some-buffers-default-predicate (lambda () nil))
          (ghostel-compile-finished-major-mode nil))
@@ -1501,11 +1507,10 @@ dimensions when no output window exists."
         (cl-letf* (((symbol-function 'ghostel--load-module) #'ignore)
                    ((symbol-function 'ghostel--new)
                     (lambda (&rest _) 'fake-term))
-                   ((symbol-function 'ghostel--set-size-with-cell-dims) #'ignore)
                    ((symbol-function 'ghostel--apply-palette) #'ignore)
                    ((symbol-function 'display-buffer) (lambda (&rest _) nil))
                    ((symbol-function 'ghostel--set-size)
-                    (lambda (&rest _) (setq set-size-called t)))
+                    (lambda (&rest _) (setq set-size-calls (1+ set-size-calls))))
                    ((symbol-function 'ghostel-compile--render-header-live)
                     #'ignore)
                    (ghostel--cursor-pos (cons 0 0))
@@ -1520,7 +1525,8 @@ dimensions when no output window exists."
           (let ((buf (ghostel-compile--start "true" buf-name
                                              default-directory)))
             (should (buffer-live-p buf))
-            (should-not set-size-called)
+            ;; Only `prepare-buffer' sized the VT; no reconcile ran.
+            (should (= set-size-calls 1))
             (with-current-buffer buf
               (let ((p ghostel--process))
                 (when (process-live-p p)

--- a/test/ghostel-kitty-test.el
+++ b/test/ghostel-kitty-test.el
@@ -11,14 +11,18 @@
 
 (defun ghostel-test--kitty-fixture (body)
   "Run BODY in a temp buffer with kitty-related primitives faked.
-Stubs `display-graphic-p', `create-image', `frame-char-width', and
-`frame-char-height' so display callbacks can be exercised in batch."
+Stubs `display-graphic-p', `create-image', and the font/frame cell
+metrics so display callbacks can be exercised in batch.  The frame char
+dimensions deliberately differ from the buffer's font dimensions, as
+they do under a `default' face remap."
   (with-temp-buffer
     (cl-letf (((symbol-function 'display-graphic-p) (lambda () t))
               ((symbol-function 'create-image)
                (lambda (&rest _args) 'fake-image))
-              ((symbol-function 'frame-char-width) (lambda (&rest _) 8))
-              ((symbol-function 'frame-char-height) (lambda (&rest _) 16)))
+              ((symbol-function 'frame-char-width) (lambda (&rest _) 5))
+              ((symbol-function 'frame-char-height) (lambda (&rest _) 10))
+              ((symbol-function 'default-font-width) (lambda () 8))
+              ((symbol-function 'default-font-height) (lambda () 16)))
       (funcall body))))
 
 (ert-deftest ghostel-test-detect-cell-pixel-scale-standard-dpi ()
@@ -88,12 +92,17 @@ Stubs `display-graphic-p', `create-image', `frame-char-width', and
                (lambda () nil)))
       (should (= (ghostel--cell-pixel-scale) 1)))))
 
-(ert-deftest ghostel-test-reported-cell-dims-multiply-frame-by-scale ()
-  "Reported cell width/height = frame char dim * scale, rounded.
+(ert-deftest ghostel-test-reported-cell-dims-multiply-font-by-scale ()
+  "Reported cell width/height = the buffer's font dim * scale, rounded.
+The frame's char dimensions are not used: a `default' face remap
+\(`text-scale-mode', `buffer-face-mode', a `ghostel-default' `:height')
+resizes the buffer's font while they stay put.
 Uses scale 1.4 (not 1.5) to avoid the half-integer boundary where
 Emacs uses banker's rounding."
-  (cl-letf (((symbol-function 'frame-char-width) (lambda (&rest _) 8))
-            ((symbol-function 'frame-char-height) (lambda (&rest _) 16)))
+  (cl-letf (((symbol-function 'frame-char-width) (lambda (&rest _) 5))
+            ((symbol-function 'frame-char-height) (lambda (&rest _) 10))
+            ((symbol-function 'default-font-width) (lambda () 8))
+            ((symbol-function 'default-font-height) (lambda () 16)))
     (let ((ghostel-cell-pixel-scale 2))
       (should (= (ghostel--reported-cell-width) 16))
       (should (= (ghostel--reported-cell-height) 32)))
@@ -114,6 +123,28 @@ The display property and the marker share the same range."
 	 (should ghostel--kitty-active)
 	 ;; Trailing space outside placement (col 4..6) should not be tagged
 	 (should (null (get-text-property 5 'ghostel-kitty))))))
+
+(ert-deftest ghostel-test-kitty-display-image-sized-from-buffer-font ()
+  "Placement pixel geometry comes from the buffer's font, not the frame.
+Sizing the image and its slices off `frame-char-width'/`frame-char-height'
+tiles them at the wrong scale once the `default' face is remapped."
+  (let (image-args)
+    (with-temp-buffer
+      (cl-letf (((symbol-function 'display-graphic-p) (lambda () t))
+                ((symbol-function 'create-image)
+                 (lambda (&rest args) (setq image-args args) 'fake-image))
+                ((symbol-function 'frame-char-width) (lambda (&rest _) 5))
+                ((symbol-function 'frame-char-height) (lambda (&rest _) 10))
+                ((symbol-function 'default-font-width) (lambda () 8))
+                ((symbol-function 'default-font-height) (lambda () 16)))
+        (insert "row1xx\nrow2xx\n")
+        (ghostel--kitty-display-image "data" nil 0 0 4 2 32 32 0 0 0 0)
+        (let ((props (nthcdr 3 image-args)))
+          (should (= (plist-get props :width) 32))    ; 4 cols * 8
+          (should (= (plist-get props :height) 32)))  ; 2 rows * 16
+        (should (equal (car (get-text-property 1 'display))
+                       '(slice 0 0 32 16)))
+        (should (eql (get-text-property 7 'line-height) 16))))))
 
 (ert-deftest ghostel-test-kitty-display-image-empty-line-uses-overlay ()
   "Empty placement range uses an overlay (so the newline isn't eaten)."
@@ -372,19 +403,22 @@ overlays per row by the number of times the image has been visible."
 	 (ghostel--kitty-display-virtual "data" nil)
 	 (should ghostel--kitty-active)
 	 (should (get-text-property 1 'display))
-	 (should (get-text-property 1 'ghostel-kitty)))))
+	 (should (get-text-property 1 'ghostel-kitty))
+	 ;; Slice geometry follows the buffer's font, not the frame's cell.
+	 (should (equal (car (get-text-property 1 'display))
+			'(slice 0 0 24 16))))))
 
 (ert-deftest ghostel-test-kitty-display-image-records-error ()
   "Display-callback errors are captured to a buffer-local variable.
 The error survives past the redraw — not just flashed via `message'."
-  (with-temp-buffer
-	(cl-letf (((symbol-function 'display-graphic-p) (lambda () t))
-			  ((symbol-function 'create-image)
-			   (lambda (&rest _) (error "Boom"))))
-	  (insert "row\n")
-	  (ghostel--kitty-display-image "data" nil 0 0 1 1 8 16 0 0 0 0)
-	  (should ghostel--kitty-last-error)
-	  (should (eq (car ghostel--kitty-last-error) 'error)))))
+  (ghostel-test--kitty-fixture
+   (lambda ()
+     (cl-letf (((symbol-function 'create-image)
+                (lambda (&rest _) (error "Boom"))))
+       (insert "row\n")
+       (ghostel--kitty-display-image "data" nil 0 0 1 1 8 16 0 0 0 0)
+       (should ghostel--kitty-last-error)
+       (should (eq (car ghostel--kitty-last-error) 'error))))))
 
 (ert-deftest ghostel-test-kitty-display-image-rejects-source-rect ()
   "Non-default source rect is recorded as an error rather than silent miss.

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -137,16 +137,18 @@ windows a forced size adjustment; other buffers are untouched."
 
 (ert-deftest ghostel-test-cell-height-includes-line-spacing ()
   "`ghostel--cell-height' adds the buffer's `line-spacing' in pixels.
-Integer spacing adds as-is, float spacing as a rounded fraction of
-`frame-char-height'; unsupported values and non-graphic displays add
-nothing."
-  (cl-letf (((symbol-function 'frame-char-height) (lambda (&optional _) 14))
+The base is the buffer's default font height, so a `default' face remap
+carries through.  Integer spacing adds as-is, float spacing as a rounded
+fraction of `frame-char-height' (what redisplay scales it by);
+unsupported values and non-graphic displays add nothing."
+  (cl-letf (((symbol-function 'default-font-height) (lambda () 14))
+            ((symbol-function 'frame-char-height) (lambda (&optional _) 20))
             ((symbol-function 'display-graphic-p) (lambda (&optional _) t)))
     (with-temp-buffer
       (setq-local line-spacing 3)
       (should (eql (ghostel--cell-height) 17))
       (setq-local line-spacing 0.1)
-      (should (eql (ghostel--cell-height) 15))
+      (should (eql (ghostel--cell-height) 16))
       (setq-local line-spacing 0)
       (should (eql (ghostel--cell-height) 14))
       ;; Emacs 28/29 reject non-number values at `setq-local' time


### PR DESCRIPTION
Follow-up to #589. That PR made `buffer-face-mode` rescale the terminal grid; the cell *pixel* dimensions ghostel reports were still computed from the frame.

## Cells were measured off the wrong thing

`ghostel--reported-cell-width` and `ghostel--cell-height` — the dimensions handed to libghostty and reported to programs through XTWINOPS (`CSI 14 t` / `CSI 16 t`) — used `frame-char-width` / `frame-char-height`. Both are frame-level and ignore a buffer-local `default` face remapping, while the row/column count comes from the remap-aware `window-screen-lines` and `window-max-chars-per-line`. Any local font change (`text-scale-mode`, `buffer-face-mode`, a `ghostel-default` `:height`) therefore left the reported cell at the frame's size while the grid tracked the new font.

The kitty graphics paths shared the base, so a placement asking for 4×2 cells was sized for the frame's cell and drew at the wrong scale inside a scaled grid.

Both now use `default-font-width` / `default-font-height`, which resolve through `face-remapping-alist`.

Two things deliberately keep the frame metric:

- the float `line-spacing` branch, because redisplay scales a float by `FRAME_LINE_HEIGHT` (`xdisp.c`), matching `default-line-height`;
- kitty slice heights, which stay at the font height rather than `default-line-height` — buffer `line-spacing` is applied per glyph, so a spacing-inclusive slice would double-pad image rows.

Measured in a real Emacs before adding any caching: the `default-font-width` + `default-font-height` pair costs ~11 µs even on the `font-info` path, against ~0.06 µs for `frame-char-*`. Not worth caching on the per-placement kitty path.

### Verified live

GUI Emacs 31.0.91 driving a real bash, with a Python helper in the shell reading back the terminal's own `CSI 16 t` / `CSI 14 t` replies. `frame-char-*` stayed 7×14 throughout.

| state | buffer font | term grid | cell (h;w) | text area | kitty image (4c×2r) |
|---|---|---|---|---|---|
| baseline | 7×14 | 34×120 | 22;11 | 748×1320 | `:width 28 :height 28`, `(slice 0 0 28 14)` |
| `text-scale-set 6` | 22×41 | 11×38 | 65;35 | 715×1330 | `:width 88 :height 82`, `(slice 0 0 88 41)` |
| `buffer-face-set '(:height 240)` | 14×28 | 17×60 | 44;22 | 748×1320 | — |
| `line-spacing` 4 | 7×14 | — | cell height 18 logical | — | slices still 14 tall |

Every text-area figure equals rows × cell-height and cols × cell-width. Before the change all four rows reported 22;11 and sized the image at 28×28, so at text-scale 6 an image drew at about a third of its declared cell footprint.

## A compile terminal reset its cell to 1×1 px

Found while reviewing the above; it is an independent pre-existing bug, in the second commit.

`ghostel-compile--start` reconciles the VT to the output window after `display-buffer` may have placed the buffer somewhere other than the window `--prepare-buffer` measured. It called `ghostel--set-size` with only rows and cols, and the native binding defaults omitted cell dimensions to 1 px — wiping the dimensions `ghostel--init-buffer` had just seeded. `ghostel--adjust-size` never repaired it, because it only re-sends when the row/column count changes and the reconcile had just made those match. So a compile terminal reported a 1 px cell for the whole run.

The reconcile now goes through `ghostel--set-size-with-cell-dims` like the other resize sites. Verified live: `M-x ghostel-compile` running a probe that queries `CSI 16 t` on `/dev/tty` reports `6;22;11`, where dropping the dimensions again reports `6;1;1`.

## Tests

Stubs in the kitty fixture and the cell-dimension tests now make the frame dimensions differ from the font dimensions, so a revert to `frame-char-*` fails rather than passing on coincidence. New: `ghostel-test-kitty-display-image-sized-from-buffer-font`.

`ghostel-test-compile-reconciles-vt-size-to-outwin` had been masking the compile bug — it stubbed `ghostel--set-size-with-cell-dims` away and recorded only the three-argument `ghostel--set-size`. Both reconcile tests now let the wrapper run and assert at the native boundary.

`make -j8 all` passes from a clean `.build/tests`.

## Not addressed here

The float `line-spacing` branch rounds where `xdisp.c` and `default-line-height` truncate — up to 1 px of over-report at e.g. `line-spacing` 0.25 with a 14 px font. Predates this work; only the base term changed.