### PR TITLE
Echo typed input in interactive ghostel-compile runs

### DIFF
--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -535,16 +535,15 @@ destroys the grid, so commit it here or lose the output it holds."
 
 (defconst ghostel-compile--stty-flags
   (concat ghostel--default-stty " -echo")
-  "`stty' flags for the compile PTY.
-Layers `-echo' on top of `ghostel--default-stty' so we don't render
-an echoed copy of the command (which users already see in the
-header).  `sane' in the baseline turns echo on; the trailing
-`-echo' overrides it.")
+  "`stty' flags for compilation-style compile PTYs.
+Layers `-echo' on top of `ghostel--default-stty': the buffer is a
+pure log, and echoed terminal query replies (DA1, DSR, OSC color
+reports) would render as escape-sequence garbage.")
 
-(defun ghostel-compile--spawn (command buffer height width)
+(defun ghostel-compile--spawn (command buffer height width &optional interactive)
   "Spawn COMMAND in BUFFER via a PTY sized HEIGHT rows by WIDTH columns.
-Installs `ghostel--filter' and `ghostel-compile--sentinel'.  Returns
-the process.
+Installs `ghostel--filter' and `ghostel-compile--sentinel'.
+When INTERACTIVE is non-nil the PTY keeps echo on, so input typed is visible.
 
 COMMAND is passed verbatim to `shell-file-name' via
 `shell-command-switch', so multi-line scripts and shell
@@ -555,7 +554,9 @@ exec'ing the user's shell.
 For remote (TRAMP) `default-directory's, `shell-file-name' and
 `shell-command-switch' are resolved via `with-connection-local-variables'
 so the remote host's shell is used (not whatever zsh/bash path the
-local machine happens to have)."
+local machine happens to have).
+
+Returns the process."
   (let* ((remote-p (file-remote-p default-directory))
          (shell (if remote-p
                     (with-connection-local-variables shell-file-name)
@@ -566,7 +567,9 @@ local machine happens to have)."
          (wrapper
           (list "/bin/sh" "-c"
                 (concat
-                 "stty " ghostel-compile--stty-flags
+                 "stty " (if interactive
+                             ghostel--default-stty
+                           ghostel-compile--stty-flags)
                  (format " rows %d columns %d" height width)
                  " 2>/dev/null; "
                  "exec "
@@ -833,7 +836,8 @@ any other code that walks `compilation-arguments') re-runs via
              (width (max 1 (if outwin
                                (window-max-chars-per-line outwin)
                              (window-max-chars-per-line))))
-             (proc (ghostel-compile--spawn command buffer height width)))
+             (proc (ghostel-compile--spawn command buffer height width
+                                           interactive)))
         ;; Match stock `compilation-start' ordering: hook fires before
         ;; `compilation-in-progress' is updated, so hook functions can
         ;; install filter-hooks / error-regexps before the next
@@ -950,6 +954,26 @@ nothing to send keystrokes to, and a non-compile buffer has no
   (unless (and (boundp 'ghostel--process) (process-live-p ghostel--process))
     (user-error "No live process - recompile with `g' instead")))
 
+(defun ghostel-compile--set-pty-echo (enable)
+  "Flip the live compile PTY's ECHO flag to ENABLE, best-effort.
+Acts on `process-tty-name' with an out-of-band `stty'; local runs
+only.  Enabling is skipped while the tty is in non-canonical mode —
+a full-screen program owns the display then, and echoed keystrokes
+would splatter over it."
+  (when-let* ((tty (and (not (file-remote-p default-directory))
+                        (processp ghostel--process)
+                        (process-live-p ghostel--process)
+                        (process-tty-name ghostel--process))))
+    (ignore-errors
+      (call-process
+       "/bin/sh" nil nil nil "-c"
+       (if enable
+           (format "s=$(stty -a < %s 2>/dev/null) || exit 0; \
+case \"$s\" in *-icanon*) ;; *) stty echo < %s 2>/dev/null ;; esac"
+                   (shell-quote-argument tty) (shell-quote-argument tty))
+         (format "stty -echo < %s 2>/dev/null"
+                 (shell-quote-argument tty)))))))
+
 (defun ghostel-compile-switch-to-interactive ()
   "Switch the current `ghostel-compile' run to interactive mode.
 `ghostel-semi-char-mode-map' is restored so keystrokes reach the running
@@ -969,6 +993,12 @@ Bound to \\[ghostel-compile-switch-to-interactive] in
     (use-local-map ghostel-semi-char-mode-map)
     (setq ghostel--inhibit-insert-forwarding nil)
     (ghostel--sync-read-only)
+    ;; Turn on PTY echo so input typed at a read prompt is visible.
+    ;; Skipped when the cursor row looks like a password prompt: the
+    ;; pty state cannot distinguish a program-set `-echo' from the
+    ;; spawn default, but the prompt text can.
+    (unless (ghostel--password-regex-matches-cursor-row-p)
+      (ghostel-compile--set-pty-echo t))
     ;; Place point at the VT cursor so the user's first keystroke
     ;; lands at the prompt, not at wherever they happened to be
     ;; navigating in the read-only buffer.
@@ -999,6 +1029,7 @@ Bound to \\[ghostel-compile-switch-to-compilation-style] in
     (use-local-map ghostel-compile-view-mode-map)
     (setq ghostel--inhibit-insert-forwarding t)
     (ghostel--sync-read-only)
+    (ghostel-compile--set-pty-echo nil)
     (ghostel-compile--set-mode-line-running)
     (when ghostel-compile-debug
       (message "ghostel-compile: switched to compilation-style"))))

--- a/test/ghostel-compile-test.el
+++ b/test/ghostel-compile-test.el
@@ -1052,7 +1052,7 @@ custom MODE / NAME-FUNCTION / HIGHLIGHT-REGEXP survive a revert."
               ((symbol-function 'ghostel-compile--render-header-live)
                #'ignore)
               ((symbol-function 'ghostel-compile--spawn)
-               (lambda (_cmd buf _h _w)
+               (lambda (_cmd buf _h _w &optional _interactive)
                  (let ((p (ghostel-test--dummy-process
                            "ghostel-test-args" buf)))
                    (set-process-sentinel p #'ignore)
@@ -1087,7 +1087,7 @@ custom MODE / NAME-FUNCTION / HIGHLIGHT-REGEXP survive a revert."
               ((symbol-function 'ghostel-compile--render-header-live)
                #'ignore)
               ((symbol-function 'ghostel-compile--spawn)
-               (lambda (_cmd buf _h _w)
+               (lambda (_cmd buf _h _w &optional _interactive)
                  (let ((p (ghostel-test--dummy-process "ghostel-test-args2" buf)))
                    (set-process-sentinel p #'ignore)
                    (with-current-buffer buf (setq ghostel--process p))
@@ -1374,6 +1374,193 @@ bytes through the process to confirm they land in the buffer."
         (let ((kill-buffer-query-functions nil))
           (kill-buffer buf-name))))))
 
+(ert-deftest ghostel-test-compile-interactive-echoes-typed-input ()
+  "Interactive runs must echo typed input at a read prompt.
+The PTY of an interactive run keeps ECHO on, so bytes typed at a
+canonical-mode prompt (`read', `git push' username, ...) render in
+the buffer as the user types — before the program responds.  The
+script blocks in `read' until it sees a newline, so the typed text
+appearing in the terminal can only come from tty echo, not from
+program output."
+  :tags '(native)
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf-name "*ghostel-test-interactive-echo*")
+         ;; Markers are assembled from fragments so the command line the
+         ;; header echoes never contains the contiguous marker text.
+         (script (concat "printf 'REA%s\\n' DY; IFS= read -r line; "
+                         "printf 'GOT[%s]\\n' \"$line\""))
+         (shell-file-name "/bin/sh")
+         (inhibit-message t)
+         (save-some-buffers-default-predicate (lambda () nil))
+         (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name)))
+    (unwind-protect
+        (let ((buf (ghostel-compile--start script buf-name
+                                           default-directory nil t)))
+          (with-current-buffer buf
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda ()
+               (string-match-p "READY"
+                               (ghostel--copy-all-text ghostel--term))))
+            (process-send-string ghostel--process "vqz7ek")
+            ;; No newline sent yet — `read' is still blocked, so this
+            ;; is the kernel echo, not the program.
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda ()
+               (string-match-p "vqz7ek"
+                               (ghostel--copy-all-text ghostel--term))))
+            (should-not (string-match-p
+                         "GOT\\[vqz7ek" (ghostel--copy-all-text ghostel--term)))
+            (process-send-string ghostel--process "\n")
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () ghostel-compile--finalized) 10)
+            (should (string-match-p "GOT\\[vqz7ek\\]" (buffer-string)))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name))))))
+
+(ert-deftest ghostel-test-compile-switch-to-interactive-enables-echo ()
+  "`ghostel-compile-switch-to-interactive' turns on PTY echo mid-run.
+Compilation-style runs spawn with ECHO off; the toggle flips it on
+out-of-band so input typed at an unexpected prompt is visible."
+  :tags '(native)
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf-name "*ghostel-test-toggle-echo*")
+         ;; Markers are assembled from fragments so the command line the
+         ;; header echoes never contains the contiguous marker text.
+         (script (concat "printf 'REA%s\\n' DY; IFS= read -r line; "
+                         "printf 'GOT[%s]\\n' \"$line\""))
+         (shell-file-name "/bin/sh")
+         (inhibit-message t)
+         (save-some-buffers-default-predicate (lambda () nil))
+         (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name)))
+    (unwind-protect
+        (let ((buf (ghostel-compile--start script buf-name
+                                           default-directory nil nil)))
+          (with-current-buffer buf
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda ()
+               (string-match-p "READY"
+                               (ghostel--copy-all-text ghostel--term))))
+            (ghostel-compile-switch-to-interactive)
+            (process-send-string ghostel--process "kq9zvh")
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda ()
+               (string-match-p "kq9zvh"
+                               (ghostel--copy-all-text ghostel--term))))
+            (process-send-string ghostel--process "\n")
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () ghostel-compile--finalized) 10)
+            (should (string-match-p "GOT\\[kq9zvh\\]" (buffer-string)))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name))))))
+
+(ert-deftest ghostel-test-compile-switch-to-interactive-echo-raw-guard ()
+  "The echo toggle must not force ECHO on while the tty is raw.
+A full-screen program (htop, less) owns the display in non-canonical
+mode; echoed keystrokes would splatter over it.
+`ghostel-compile--set-pty-echo' reads the tty state first and skips
+the flip when ICANON is off."
+  :tags '(native)
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf-name "*ghostel-test-toggle-echo-raw*")
+         ;; Enter raw mode like a TUI would, then block on a 1-byte read.
+         ;; The marker is assembled from fragments so the command line the
+         ;; header echoes never contains the contiguous marker text.
+         (script (concat "stty raw -echo; printf 'RAWREA%s\\n' DY; "
+                         "dd bs=1 count=1 2>/dev/null"))
+         (shell-file-name "/bin/sh")
+         (inhibit-message t)
+         (save-some-buffers-default-predicate (lambda () nil))
+         (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name)))
+    (unwind-protect
+        (let ((buf (ghostel-compile--start script buf-name
+                                           default-directory nil nil)))
+          (with-current-buffer buf
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda ()
+               (string-match-p "RAWREADY"
+                               (ghostel--copy-all-text ghostel--term))))
+            (ghostel-compile-switch-to-interactive)
+            ;; The tty must still have ECHO off: read its state
+            ;; out-of-band, the same way the toggle does.
+            (let ((state
+                   (with-output-to-string
+                     (call-process
+                      "/bin/sh" nil standard-output nil "-c"
+                      (format "stty -a < %s"
+                              (shell-quote-argument
+                               (process-tty-name ghostel--process)))))))
+              (should (string-match-p "-icanon" state))
+              (should (string-match-p "-echo[ \t\n;]" state)))
+            ;; Unblock `dd' so the run can finish.
+            (process-send-string ghostel--process "x")
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () ghostel-compile--finalized) 10)))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name))))))
+
+(ert-deftest ghostel-test-compile-switch-to-interactive-password-prompt-no-echo ()
+  "The echo toggle must not force ECHO while a password prompt is on screen.
+The pty state cannot distinguish a program-set `-echo' (ssh, sudo,
+`read -s') from the compile spawn default, so the toggle matches the
+cursor row against `ghostel-password-prompt-regex' instead and leaves
+ECHO alone on a hit — typed secrets must not render into the buffer."
+  :tags '(native)
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf-name "*ghostel-test-toggle-echo-password*")
+         ;; The prompt is assembled from fragments so the command line the
+         ;; header echoes never contains the contiguous prompt text.
+         (script "printf 'Pass%s: ' word; IFS= read -r line")
+         (shell-file-name "/bin/sh")
+         (inhibit-message t)
+         (save-some-buffers-default-predicate (lambda () nil))
+         (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name)))
+    (unwind-protect
+        (let ((buf (ghostel-compile--start script buf-name
+                                           default-directory nil nil)))
+          (with-current-buffer buf
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda ()
+               (string-match-p "Password:"
+                               (ghostel--copy-all-text ghostel--term))))
+            ;; The render loop must have caught up so the cursor row
+            ;; the toggle inspects shows the prompt.
+            (ghostel--redraw-now buf)
+            (ghostel-compile-switch-to-interactive)
+            ;; Interactive mode is on, but the tty keeps ECHO off.
+            (should ghostel-compile--interactive)
+            (let ((state
+                   (with-output-to-string
+                     (call-process
+                      "/bin/sh" nil standard-output nil "-c"
+                      (format "stty -a < %s"
+                              (shell-quote-argument
+                               (process-tty-name ghostel--process)))))))
+              (should (string-match-p "-echo[ \t\n;]" state)))
+            ;; Unblock `read' so the run can finish.
+            (process-send-string ghostel--process "\n")
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () ghostel-compile--finalized) 10)))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name))))))
+
 (ert-deftest ghostel-test-compile-multiline-end-to-end ()
   "A multi-line shell paragraph must run intact under `ghostel-compile'.
 The paragraph must land in the buffer unmangled and the run must
@@ -1452,7 +1639,7 @@ dropping what `ghostel--init-buffer' seeded."
                     (lambda (&rest _) (push 'render-header call-order)))
                    (ghostel--cursor-pos (cons 0 0))
                    ((symbol-function 'ghostel-compile--spawn)
-                    (lambda (_cmd buf h w)
+                    (lambda (_cmd buf h w &optional _interactive)
                       (push 'spawn call-order)
                       (push (list h w) spawn-calls)
                       (let ((p (ghostel-test--dummy-process
@@ -1515,7 +1702,7 @@ output window exists — leaving the sizing `prepare-buffer' seeded."
                     #'ignore)
                    (ghostel--cursor-pos (cons 0 0))
                    ((symbol-function 'ghostel-compile--spawn)
-                    (lambda (_cmd buf _h _w)
+                    (lambda (_cmd buf _h _w &optional _interactive)
                       (let ((p (ghostel-test--dummy-process
                                 "ghostel-test-nowin-fake" buf)))
                         (set-process-sentinel p #'ignore)


### PR DESCRIPTION
## Problem

Interactive input worked in `ghostel-compile` buffers, but typed characters never appeared: the PTY was always spawned with `-echo`, and the `C-c C-j` toggle (`ghostel-compile-switch-to-interactive`) only swapped keymaps without touching termios. Typing at a `read`-style prompt was invisible.

## Fix

- **Interactive spawns** (`C-u M-x ghostel-compile`) configure the PTY with `ghostel--default-stty` (echo on), so input is visible from the first keystroke.
- **The mid-run toggle** flips ECHO out-of-band on the live PTY via `stty` against `process-tty-name` (Emacs has no termios API). Local runs only — for TRAMP the process tty is the local connection pty, not the remote pty the command reads from.
- The enable is skipped when:
  - the tty is in **non-canonical mode** — a full-screen program (htop, less) owns the display and echoed keystrokes would splatter over it;
  - the cursor row matches **`ghostel-password-prompt-regex`** — the pty state cannot distinguish a program-set `-echo` (ssh, sudo, `read -s`) from the compile spawn default, but the prompt text can. Typed secrets must not render into the buffer.
- Compilation-style runs keep `-echo`: the buffer is a pure log, and echoed terminal query replies (DA1, DSR, OSC color reports) would render as escape-sequence garbage.

Known residual: a password prompt whose text doesn't match the regex and is already on screen at toggle time gets echoed — the same residual every comint-based mode has.

## Tests

Four new native tests: interactive spawn echoes typed input before the program responds (the script blocks in `read`, so the text can only come from tty echo), the toggle enables echo mid-run, the raw-mode guard leaves a TUI's terminal alone, and a `Password:` prompt keeps ECHO off across the toggle. Test markers are assembled from printf fragments so the command line echoed in the buffer header can't satisfy the wait predicates.

Verified live in a TTY Emacs: typed input echoes at the prompt (including DEL erase), and typing at a password prompt after `C-c C-j` renders nothing while still reaching the program.