### PR TITLE
Add ghostel-send-escape command

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1806,6 +1806,19 @@ overlay clears the way \\`keyboard-quit' would in other buffers."
   (deactivate-mark)
   (ghostel--send-encoded "g" "ctrl"))
 
+(defun ghostel-send-escape ()
+  "Send Escape to the terminal, encoded for its current keyboard mode.
+Routed through the key encoder, so it is `\\e[27u' when the foreground
+program has the Kitty keyboard protocol on and a bare `\\e' otherwise.
+
+Useful under TTY Emacs, where a lone Esc is claimed as the Meta prefix
+and never reaches the terminal, so \"Esc to close\" in an agent's modal
+does nothing.  Bind this to a reachable key to send one deliberately.
+Under GUI Emacs the Esc key already works and this is not needed."
+  (interactive)
+  (ghostel--on-user-input)
+  (ghostel--send-encoded "escape" ""))
+
 
 ;;; Paste / yank
 

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -941,5 +941,18 @@ External packages may still call the old internal name."
   (with-temp-buffer
     (should-error (ghostel-paste-string "x") :type 'user-error)))
 
+(ert-deftest ghostel-test-send-escape ()
+  "`ghostel-send-escape' routes Escape through the mode-aware encoder,
+so the encoder emits CSI-u under the Kitty keyboard protocol and a bare
+ESC otherwise."
+  (let (captured-key captured-mods)
+    (cl-letf (((symbol-function 'ghostel--on-user-input) #'ignore)
+              ((symbol-function 'ghostel--send-encoded)
+               (lambda (key mods &optional _utf8)
+                 (setq captured-key key captured-mods mods))))
+      (ghostel-send-escape)
+      (should (equal "escape" captured-key))
+      (should (equal "" captured-mods)))))
+
 (provide 'ghostel-keys-test)
 ;;; ghostel-keys-test.el ends here


### PR DESCRIPTION
Part of #592.

Adds an interactive `ghostel-send-escape` alongside the existing `ghostel-send-C-*` commands. It routes Escape through the mode-aware key encoder, so the bytes are `\e[27u` when the foreground program has the Kitty keyboard protocol enabled and a bare `\e` otherwise.

**Why:** a bindable, reliable Escape. Handy under TTY Emacs, where a lone Esc is claimed as the Meta prefix and never reaches the terminal, so "Esc to close" in agents like Claude Code does nothing. Equivalent to `(ghostel-send-key "escape")`, but a proper interactive command in the send-key family. Left intentionally unbound — happy to add a binding wherever you'd prefer.

**Tests:** `ghostel-test-send-escape` in `test/ghostel-keys-test.el` (mirrors `ghostel-test-send-event`) asserts it hands `"escape"`/`""` to the encoder.

Sibling PR adds an opt-in `ghostel-tty-escape-mode`; both reference #592.