### PR TITLE
Translate a lone TTY ESC to the escape key in terminal-input buffers

### DIFF
--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -875,9 +875,11 @@ the default."
 (define-key evil-ghostel-mode-map (kbd "C-c C-r")
             #'evil-ghostel-toggle-send-escape)
 
-;; The <escape> function-key event exists on GUI frames and on ttys with
-;; the kitty keyboard protocol (kkp.el); legacy ttys never generate it,
-;; so this binding cannot shadow the ESC-prefixed C-c M-... keys there.
+;; The <escape> function-key event exists on GUI frames, on ttys with
+;; the kitty keyboard protocol (kkp.el), and on legacy ttys in ghostel
+;; terminal-input buffers via ghostel's lone-ESC `input-decode-map'
+;; filter.  Fast C-c M-... chords still decode as meta there: the
+;; filter sees the pending follow-up byte and leaves ESC alone.
 (define-key evil-ghostel-mode-map (kbd "C-c <escape>")
             #'evil-force-normal-state)
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -672,6 +672,13 @@ These keys pass through to Emacs instead."
          (set-default sym newval)
          (ghostel--rebuild-semi-char-keymap)))
 
+(defcustom ghostel-tty-escape-delay 0.01
+  "Seconds to wait before treating a bare TTY ESC byte as the escape key.
+When nil, the translation is disabled and a lone ESC stays a meta prefix;
+useful on high-latency connections where a split escape sequence
+could otherwise misdecode."
+  :type '(choice (const :tag "Disabled" nil) number))
+
 (defcustom ghostel-ignore-cursor-change nil
   "When non-nil, ignore terminal requests to change cursor shape or visibility.
 Useful when editor-owned cursor behavior should take precedence over
@@ -1217,6 +1224,14 @@ When NO-EXCEPTIONS is non-nil, also bind the keys in
             (define-key map (kbd key-str) #'ghostel--send-event))))))
   ;; M-SPC: `(format "M-%c" ?\s)' yields "M- ", which `kbd' rejects.
   (let ((key-str "M-SPC"))
+    (when (or no-exceptions
+              (not (member key-str ghostel-keymap-exceptions)))
+      (define-key map (kbd key-str) #'ghostel--send-event)))
+  ;; TTY double-tap ESC: a second ESC byte within
+  ;; `ghostel-tty-escape-delay' passes the lone-ESC filter raw as [27 27].
+  ;; Send it as alt+escape (GUI M-<escape> parity) rather than pending
+  ;; on the global `ESC ESC ESC' prefix.
+  (let ((key-str "ESC ESC"))
     (when (or no-exceptions
               (not (member key-str ghostel-keymap-exceptions)))
       (define-key map (kbd key-str) #'ghostel--send-event)))
@@ -4860,6 +4875,66 @@ and the TTY display that needs it off keeps working in parallel)."
       (unless (equal auto-composition-mode tt)
         (setq-local auto-composition-mode tt)))))
 
+(defun ghostel--tty-esc (map)
+  "Translate a lone ESC to `escape' in ghostel terminal-input buffers.
+`menu-item' filter on the ESC entry of a TTY's `input-decode-map'.
+When no follow-up byte arrives within `ghostel-tty-escape-delay',
+yield the `escape' event; otherwise return MAP so escape sequences
+and ESC-as-meta decode as usual."
+  (if (and ghostel-tty-escape-delay
+           (ghostel--terminal-input-mode-p)
+           ghostel--term
+           (let* ((keys (this-single-command-keys))
+                  (len (length keys)))
+             (and (> len 0)
+                  (eq (aref keys (1- len)) ?\e)
+                  ;; The first ESC of a fast pair is already committed
+                  ;; when the second decodes; leave the second raw so
+                  ;; [27 27] reaches the ESC ESC binding instead of
+                  ;; the unbound ESC <escape>.
+                  (not (and (> len 1) (eq (aref keys (- len 2)) ?\e)))))
+           (sit-for ghostel-tty-escape-delay))
+      [escape]
+    map))
+
+(defun ghostel--tty-esc-init (&optional frame)
+  "Install the lone-ESC to `escape' filter on FRAME's terminal.
+Only acts on text terminals; re-wraps if another package later
+replaced the entry.  The wrapped entry may itself be another
+package's filter (e.g. evil's) — nested filters compose, with at
+most one translation delay paid per key.  The filter is inert
+outside ghostel terminal-input buffers, so no uninstall is needed."
+  (let ((term (frame-terminal frame)))
+    (when (eq (terminal-live-p term) t)
+      ;; `input-decode-map' is terminal-local; select the frame to
+      ;; read and modify the right terminal's map.
+      (with-selected-frame (or frame (selected-frame))
+        ;; `lookup-key' resolves menu-item filters to the wrapped map,
+        ;; dropping another package's wrapper — read the entry
+        ;; structurally.
+        (let* ((cell (assq ?\e (cdr input-decode-map)))
+               (raw (if cell (cdr cell)
+                      (lookup-key input-decode-map [?\e]))))
+          ;; Recognize our wrapper by its :filter tag; `define-key'
+          ;; copies the menu-item list, so object identity won't do.
+          (unless (if cell
+                      (and (eq (car-safe raw) 'menu-item)
+                           (eq (cadr (memq :filter raw)) 'ghostel--tty-esc))
+                    (terminal-parameter term 'ghostel--tty-esc-map))
+            (set-terminal-parameter term 'ghostel--tty-esc-map (or raw t))
+            ;; package-lint's reserved-key check matches literal
+            ;; vectors only; a translation-map entry is not a
+            ;; reserved binding.
+            (define-key input-decode-map (vector ?\e)
+              `(menu-item "" ,raw :filter ghostel--tty-esc))))))))
+
+(defun ghostel--tty-esc-window-change (window)
+  "Install the lone-ESC filter on WINDOW's frame terminal.
+Covers ghostel buffers displayed on frames created after the buffer,
+e.g. a later \"emacsclient -t\" session."
+  (when (windowp window)
+    (ghostel--tty-esc-init (window-frame window))))
+
 (defun ghostel--pre-redisplay (_window)
   "Render pending terminal state before displaying this buffer."
   (when ghostel--pending-redraw
@@ -4977,6 +5052,7 @@ may change freely (`ghostel-compile' finalize relies on this)."
   (add-hook 'window-buffer-change-functions #'ghostel--focus-change)
   (add-hook 'window-buffer-change-functions #'ghostel--window-buffer-change nil t)
   (add-hook 'window-buffer-change-functions #'ghostel--sync-tty-composition nil t)
+  (add-hook 'window-buffer-change-functions #'ghostel--tty-esc-window-change nil t)
   (add-hook 'pre-redisplay-functions #'ghostel--pre-redisplay nil t)
   (add-hook 'window-size-change-functions #'ghostel--adjust-size nil t)
   (add-hook 'minibuffer-exit-hook #'ghostel--minibuffer-exit)
@@ -4987,6 +5063,9 @@ may change freely (`ghostel-compile' finalize relies on this)."
   (add-hook 'change-major-mode-hook #'ghostel--change-major-mode-guard nil t)
   ;; Eldoc link echo, thing-at-point providers, file-name-at-point.
   (ghostel-links-setup)
+  ;; Lone-ESC decoding on the creating terminal
+  ;; (later TTY frames are covered by `ghostel--tty-esc-window-change' above).
+  (ghostel--tty-esc-init)
 
   ;; Set up the comint/shell completion plumbing once per buffer so
   ;; `ghostel-line-mode-complete-at-point' has the right

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -941,5 +941,168 @@ External packages may still call the old internal name."
   (with-temp-buffer
     (should-error (ghostel-paste-string "x") :type 'user-error)))
 
+(ert-deftest ghostel-test-tty-esc-filter-translates-lone-esc ()
+  "`ghostel--tty-esc' yields [escape] in terminal-input ghostel buffers."
+  (let ((saved-map (make-sparse-keymap))
+        (fake-keys [?\e])
+        (quiet t))                      ; sit-for result: no pending input
+    (cl-letf (((symbol-function 'this-single-command-keys)
+               (lambda () fake-keys))
+              ((symbol-function 'sit-for) (lambda (_seconds) quiet))
+              ;; Keep the mode body from touching the real terminal.
+              ((symbol-function 'ghostel--tty-esc-init) #'ignore))
+      (with-temp-buffer
+        (ghostel-mode)
+        (setq ghostel--term 'fake)
+        ;; Semi-char (mode default) and char both translate.
+        (should (equal [escape] (ghostel--tty-esc saved-map)))
+        (setq ghostel--input-mode 'char)
+        (should (equal [escape] (ghostel--tty-esc saved-map)))
+        ;; ESC as the trailing byte of a chord (e.g. C-c ESC) translates
+        ;; too; the unbound C-c <escape> falls back through
+        ;; `local-function-key-map' to the meta-prefix behavior.
+        (setq ghostel--input-mode 'semi-char)
+        (setq fake-keys [?\C-c ?\e])
+        (should (equal [escape] (ghostel--tty-esc saved-map)))))))
+
+(ert-deftest ghostel-test-tty-esc-filter-passes-map-through ()
+  "`ghostel--tty-esc' returns the saved map in every non-translating case."
+  (let ((saved-map (make-sparse-keymap))
+        (fake-keys [?\e])
+        (quiet t))
+    (cl-letf (((symbol-function 'this-single-command-keys)
+               (lambda () fake-keys))
+              ((symbol-function 'sit-for) (lambda (_seconds) quiet))
+              ;; Keep the mode body from touching the real terminal.
+              ((symbol-function 'ghostel--tty-esc-init) #'ignore))
+      ;; Non-ghostel buffer (no `ghostel--term').
+      (with-temp-buffer
+        (should (eq saved-map (ghostel--tty-esc saved-map))))
+      (with-temp-buffer
+        (ghostel-mode)
+        (setq ghostel--term 'fake)
+        ;; Disabled via nil delay.
+        (let ((ghostel-tty-escape-delay nil))
+          (should (eq saved-map (ghostel--tty-esc saved-map))))
+        ;; Read-only/line input modes keep ESC as a meta prefix.
+        (dolist (mode '(copy emacs line))
+          (setq ghostel--input-mode mode)
+          (should (eq saved-map (ghostel--tty-esc saved-map))))
+        (setq ghostel--input-mode 'semi-char)
+        ;; Introspection (`lookup-key' etc.) runs the filter with no
+        ;; command keys pending — must not see [escape].
+        (setq fake-keys [])
+        (should (eq saved-map (ghostel--tty-esc saved-map)))
+        ;; Trailing key isn't ESC.
+        (setq fake-keys [?x])
+        (should (eq saved-map (ghostel--tty-esc saved-map)))
+        ;; Fast double-tap: first ESC already committed — leave the
+        ;; second raw so [27 27] reaches the ESC ESC binding.
+        (setq fake-keys [?\e ?\e])
+        (should (eq saved-map (ghostel--tty-esc saved-map)))
+        ;; Follow-up byte arrives within the delay (escape sequence or
+        ;; fast M-<char>): decode as usual.
+        (setq fake-keys [?\e])
+        (setq quiet nil)
+        (should (eq saved-map (ghostel--tty-esc saved-map)))))))
+
+(ert-deftest ghostel-test-tty-esc-init-wraps-esc-entry ()
+  "`ghostel--tty-esc-init' wraps the raw ESC entry and is idempotent."
+  (let* ((term (frame-terminal))
+         (old-raw (cdr (assq ?\e (cdr input-decode-map))))
+         (old-param (terminal-parameter term 'ghostel--tty-esc-map))
+         (fake-inner (make-sparse-keymap)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'terminal-live-p) (lambda (_term) t)))
+          (set-terminal-parameter term 'ghostel--tty-esc-map nil)
+          (define-key input-decode-map [?\e] fake-inner)
+          (ghostel--tty-esc-init)
+          (let ((entry (cdr (assq ?\e (cdr input-decode-map)))))
+            (should (eq (car-safe entry) 'menu-item))
+            (should (eq (nth 2 entry) fake-inner))
+            (should (equal (memq :filter entry) '(:filter ghostel--tty-esc)))
+            (should (eq (terminal-parameter term 'ghostel--tty-esc-map)
+                        fake-inner))
+            ;; Outside ghostel buffers `lookup-key' resolves the filter
+            ;; back to the wrapped entry — introspection unchanged.
+            (should (eq (lookup-key input-decode-map [?\e]) fake-inner))
+            ;; Second call: wrapper intact, no-op (no re-wrap/nesting).
+            (ghostel--tty-esc-init)
+            (should (eq (cdr (assq ?\e (cdr input-decode-map))) entry))
+            (should (eq (nth 2 entry) fake-inner))))
+      (define-key input-decode-map [?\e] old-raw)
+      (set-terminal-parameter term 'ghostel--tty-esc-map old-param))))
+
+(ert-deftest ghostel-test-tty-esc-init-rewraps-replaced-entry ()
+  "`ghostel--tty-esc-init' re-installs after another package took over ESC."
+  (let* ((term (frame-terminal))
+         (old-raw (cdr (assq ?\e (cdr input-decode-map))))
+         (old-param (terminal-parameter term 'ghostel--tty-esc-map))
+         (fake-inner (make-sparse-keymap))
+         (usurper (make-sparse-keymap)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'terminal-live-p) (lambda (_term) t)))
+          (set-terminal-parameter term 'ghostel--tty-esc-map nil)
+          (define-key input-decode-map [?\e] fake-inner)
+          (ghostel--tty-esc-init)
+          ;; Another package (e.g. evil-esc-mode) replaces the entry.
+          (define-key input-decode-map [?\e] usurper)
+          (ghostel--tty-esc-init)
+          (let ((entry (cdr (assq ?\e (cdr input-decode-map)))))
+            (should (eq (car-safe entry) 'menu-item))
+            (should (eq (nth 2 entry) usurper))
+            (should (eq (terminal-parameter term 'ghostel--tty-esc-map)
+                        usurper))))
+      (define-key input-decode-map [?\e] old-raw)
+      (set-terminal-parameter term 'ghostel--tty-esc-map old-param))))
+
+(ert-deftest ghostel-test-tty-esc-init-skips-gui-terminals ()
+  "`ghostel--tty-esc-init' does nothing on non-tty terminals."
+  (let* ((term (frame-terminal))
+         (old-raw (cdr (assq ?\e (cdr input-decode-map))))
+         (old-param (terminal-parameter term 'ghostel--tty-esc-map)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'terminal-live-p) (lambda (_term) 'x)))
+          (set-terminal-parameter term 'ghostel--tty-esc-map nil)
+          (ghostel--tty-esc-init)
+          (should (eq (cdr (assq ?\e (cdr input-decode-map))) old-raw))
+          (should-not (terminal-parameter term 'ghostel--tty-esc-map)))
+      (define-key input-decode-map [?\e] old-raw)
+      (set-terminal-parameter term 'ghostel--tty-esc-map old-param))))
+
+(ert-deftest ghostel-test-tty-esc-mode-integration ()
+  "`ghostel-mode' installs the lone-ESC filter and window-change hook."
+  (let* ((term (frame-terminal))
+         (old-raw (cdr (assq ?\e (cdr input-decode-map))))
+         (old-param (terminal-parameter term 'ghostel--tty-esc-map))
+         (fake-inner (make-sparse-keymap)))
+    (unwind-protect
+        (cl-letf (((symbol-function 'terminal-live-p) (lambda (_term) t)))
+          (set-terminal-parameter term 'ghostel--tty-esc-map nil)
+          (define-key input-decode-map [?\e] fake-inner)
+          (with-temp-buffer
+            (ghostel-mode)
+            (should (memq #'ghostel--tty-esc-window-change
+                          window-buffer-change-functions))
+            (let ((entry (cdr (assq ?\e (cdr input-decode-map)))))
+              (should (eq (car-safe entry) 'menu-item))
+              (should (eq (nth 2 entry) fake-inner))
+              (should (eq (cadr (memq :filter entry)) 'ghostel--tty-esc)))))
+      (define-key input-decode-map [?\e] old-raw)
+      (set-terminal-parameter term 'ghostel--tty-esc-map old-param))))
+
+(ert-deftest ghostel-test-esc-esc-key-binding ()
+  "TTY double-tap ESC routes to `ghostel--send-event' in both input maps."
+  (should (eq (lookup-key ghostel-semi-char-mode-map (kbd "ESC ESC"))
+              #'ghostel--send-event))
+  (should (eq (lookup-key ghostel-char-mode-map (kbd "ESC ESC"))
+              #'ghostel--send-event))
+  ;; `ghostel-keymap-exceptions' is honored.
+  (let ((ghostel-keymap-exceptions '("ESC ESC"))
+        (map (make-sparse-keymap)))
+    (ghostel--define-terminal-keys map)
+    (should-not (eq (lookup-key map (kbd "ESC ESC"))
+                    #'ghostel--send-event))))
+
 (provide 'ghostel-keys-test)
 ;;; ghostel-keys-test.el ends here


### PR DESCRIPTION
## Problem

On a TTY frame, pressing ESC in a ghostel buffer sent nothing: the mode maps bind `<escape>`, a function-key event legacy TTYs never generate, while the TTY delivers the raw byte 27. The `M-<char>` bindings make `[27]` a prefix keymap, and Emacs has no ESC timeout, so `read-key-sequence` blocked with `[27]` pending forever. Collateral: ESC ESC also wedged (global `ESC ESC ESC` prefix), and C-g pressed while ESC was pending completed as `C-M-g`, injecting `^[^G` into the PTY.

## Fix

- New `ghostel-tty-escape-delay` (default 0.01 s, nil disables): a terminal-local `menu-item` `:filter` on `[?\e]` in `input-decode-map` (the evil-esc-mode technique) yields `[escape]` when no follow-up byte arrives within the delay — only in ghostel terminal-input buffers (semi-char/char with a live term). Everywhere else the filter returns the saved map, so escape sequences, ESC-as-meta, and non-ghostel buffers decode byte-identically to before. The translated event goes through the native key encoder, so kitty-protocol children get `CSI 27 u` and legacy children a raw `ESC`.
- Installer runs from the `ghostel-mode` body and from a buffer-local `window-buffer-change-functions` handler (covers later `emacsclient -t` frames). TTY terminals only; idempotent per terminal; re-wraps if another package replaces the entry. It reads the raw entry structurally because `lookup-key` resolves `menu-item` filters (which would drop e.g. evil's wrapper), and detects its own wrapper by the `:filter` tag because `define-key` copies menu-item lists.
- `ESC ESC` is bound to the key encoder as alt+escape: the filter deliberately leaves the second ESC of a fast pair raw, so the pair reaches `[27 27]` instead of pending on the global `keyboard-escape-quit` prefix.
- Composes with evil's `evil-esc` filter in either install order; at most one translation delay is paid per key.

## Verification

- 8 new untagged ERT tests (filter guard matrix, installer wrap/idempotence/re-wrap/GUI-skip, mode-body integration pin, `ESC ESC` bindings); existing ESC decode invariants (`C-[` not hijacked, `ESC [`/`ESC O` unbound) still pass. `make -j8 all` green.
- Live-verified in sandboxed TTY Emacs 31: lone ESC → `^[` promptly in semi-char and char with no pending prefix; C-g clean; fast ESC x → `^[x`; arrows → `^[[A`; slow ESC ESC → two `^[`; fast ESC ESC → `^[^[`; kitty protocol → `^[[27u`; non-ghostel buffers and `M-x` untouched. GUI `<escape>` regression-checked.
- evil-ghostel live matrix: filters compose (ghostel wrapping evil's entry), evil's ESC still works in plain buffers, primary-screen ESC goes to evil, alt-screen ESC goes to the TUI, fast `C-c M-d` still decodes as meta, `C-c` + paused ESC runs `evil-force-normal-state`.

Known limitation (deliberately deferred): no `defining-kbd-macro` fixup à la evil — a macro recording a lone ESC records the raw byte and may not replay as `escape`.