### PR TITLE
Route send-next-key through the key encoder

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1462,48 +1462,19 @@ Drives the `emulation-mode-map-alists' entry that makes
 This is an escape hatch for sending keys that are normally
 intercepted by Emacs (e.g., interrupt or prefix keys).
 Uses `read-event' so that prefix keys return immediately instead
-of waiting for a continuation keystroke."
+of waiting for a continuation keystroke.  The event goes through
+the terminal's key encoder, so a child that enabled the kitty
+keyboard protocol receives the protocol-correct sequence."
   (interactive)
-  (let ((event (read-event "Send key: ")))
+  (let* ((event (read-event "Send key: "))
+         (spec (ghostel--event-key-spec event)))
     (cond
-     ;; Control character (C-@=0, C-a=1 through C-_=31)
-     ((and (integerp event) (<= event 31))
-      (ghostel--send-string (string event)))
-     ;; ASCII (32-127)
-     ((and (integerp event) (<= event 127))
-      (ghostel--send-string (string event)))
+     (spec
+      (ghostel--send-encoded (car spec) (cdr spec)))
      ;; Non-ASCII character without modifier bits — send as UTF-8
      ((and (integerp event) (< event #x400000))
       (ghostel--send-string (encode-coding-string (string event) 'utf-8)))
-     ;; Modified key (M-x, C-M-a, etc.) or function key — use encoder
-     (t
-      (let* ((base (event-basic-type event))
-             (mods (event-modifiers event))
-             (key-name (cond
-                        ((eq base 'backtab) "tab")
-                        ((integerp base)
-                         (and (< base 128) (string base)))
-                        ((eq base 'deletechar) "delete")
-                        ((and base (symbolp base)) (symbol-name base))
-                        ((and (null base) (symbolp event))
-                         (replace-regexp-in-string
-                          "\\`\\(?:[CMSHs]-\\)*" "" (symbol-name event)))
-                        (t nil)))
-             (mods (if (eq base 'backtab) (cons 'shift mods) mods))
-             (mod-str (mapconcat
-                       #'identity
-                       (delq nil
-                             (mapcar
-                              (lambda (m)
-                                (pcase m
-                                  ('shift "shift") ('control "ctrl")
-                                  ('meta "meta") ('alt "alt")
-                                  ('hyper "hyper") ('super "super")))
-                              mods))
-                       ",")))
-        (if key-name
-            (ghostel--send-encoded key-name mod-str)
-          (message "ghostel: unrecognized key %S" event)))))))
+     (t (message "ghostel: unrecognized key %S" event)))))
 
 (defun ghostel--send-string (string)
   "Send STRING as raw bytes to the terminal's PTY.
@@ -1622,23 +1593,13 @@ Returns the sequence string, or nil for unknown keys."
                 (encode-coding-string (string char) 'utf-8))))
     (ghostel--send-string str)))
 
-(defun ghostel--send-event ()
-  "Send the current key event to the terminal via the key encoder.
-Extracts the base key name and modifiers from `last-command-event'
-and routes through the ghostty key encoder, which respects terminal
-modes (application cursor keys, Kitty keyboard protocol, etc.).
-
-In TTY Emacs, `M-<key>' arrives as two events (ESC then <key>) via
-`esc-map'; `last-command-event' is just <key> and has no meta bit.
-Detect that case via `this-command-keys-vector' and re-inject meta."
-  (interactive)
-  (ghostel--on-user-input)
-  (let* ((event last-command-event)
-         (keys (this-command-keys-vector))
-         (via-esc (and (> (length keys) 1) (eq (aref keys 0) 27)))
-         (base (event-basic-type event))
+(defun ghostel--event-key-spec (event &optional meta)
+  "Decode EVENT into a (KEY-NAME . MOD-STRING) cons for the key encoder.
+Non-nil META adds the meta modifier unless EVENT already carries it.
+Returns nil when EVENT has no encoder representation."
+  (let* ((base (event-basic-type event))
          (mods (event-modifiers event))
-         (mods (if (and via-esc (not (memq 'meta mods)))
+         (mods (if (and meta (not (memq 'meta mods)))
                    (cons 'meta mods)
                  mods))
          ;; Raw C0 bytes for RET/TAB/ESC are ambiguous with C-m/C-i/C-[
@@ -1678,14 +1639,33 @@ Detect that case via `this-command-keys-vector' and re-inject meta."
          ;; backtab needs shift added back since it's baked into the name
          (mods (if (eq base 'backtab) (cons 'shift mods) mods))
          (mod-str (mapconcat
-                   (lambda (m)
-                     (pcase m
-                       ('shift "shift") ('control "ctrl")
-                       ('meta "meta") ('hyper "hyper")
-                       ('super "super") (_ nil)))
-                   mods ",")))
-    (when key-name
-      (ghostel--send-encoded key-name mod-str))))
+                   #'identity
+                   (delq nil
+                         (mapcar (lambda (m)
+                                   (pcase m
+                                     ('shift "shift") ('control "ctrl")
+                                     ('meta "meta") ('alt "alt")
+                                     ('hyper "hyper") ('super "super")))
+                                 mods))
+                   ",")))
+    (when key-name (cons key-name mod-str))))
+
+(defun ghostel--send-event ()
+  "Send the current key event to the terminal via the key encoder.
+Routes `last-command-event' through the ghostty key encoder, which
+respects terminal modes (application cursor keys, Kitty keyboard
+protocol, etc.).
+
+In TTY Emacs, `M-<key>' arrives as two events (ESC then <key>) via
+`esc-map'; `last-command-event' is just <key> and has no meta bit.
+Detect that case via `this-command-keys-vector' and re-inject meta."
+  (interactive)
+  (ghostel--on-user-input)
+  (let* ((keys (this-command-keys-vector))
+         (via-esc (and (> (length keys) 1) (eq (aref keys 0) 27)))
+         (spec (ghostel--event-key-spec last-command-event via-esc)))
+    (when spec
+      (ghostel--send-encoded (car spec) (cdr spec)))))
 
 
 ;;; Programmatic insert forwarding

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -823,31 +823,74 @@ survive a rebuild."
       (customize-set-variable 'ghostel-keymap-exceptions orig))))
 
 (ert-deftest ghostel-test-send-next-key-control-x ()
-  "Send-next-key sends the prefix key as raw byte 24 (not intercepted by Emacs)."
-  (let (sent-key)
-    (cl-letf (((symbol-function 'ghostel--send-string)
-               (lambda (str) (setq sent-key str))))
+  "Send-next-key routes the prefix key through the encoder as ctrl+x."
+  (let (captured-key captured-mods
+                     (ghostel--term 'fake))
+    (cl-letf (((symbol-function 'ghostel--send-encoded)
+               (lambda (key mods &optional _utf8)
+                 (setq captured-key key captured-mods mods))))
       (let ((unread-command-events (list ?\C-x)))
         (ghostel-send-next-key))
-      (should (equal (string 24) sent-key)))))
+      (should (equal "x" captured-key))
+      (should (equal "ctrl" captured-mods)))))
 
 (ert-deftest ghostel-test-send-next-key-control-h ()
-  "Send-next-key sends the help key as raw byte 8."
-  (let (sent-key)
-    (cl-letf (((symbol-function 'ghostel--send-string)
-               (lambda (str) (setq sent-key str))))
+  "Send-next-key routes the help key through the encoder as ctrl+h."
+  (let (captured-key captured-mods
+                     (ghostel--term 'fake))
+    (cl-letf (((symbol-function 'ghostel--send-encoded)
+               (lambda (key mods &optional _utf8)
+                 (setq captured-key key captured-mods mods))))
       (let ((unread-command-events (list ?\C-h)))
         (ghostel-send-next-key))
-      (should (equal (string 8) sent-key)))))
+      (should (equal "h" captured-key))
+      (should (equal "ctrl" captured-mods)))))
 
 (ert-deftest ghostel-test-send-next-key-regular-char ()
-  "Send-next-key sends a regular character as-is."
-  (let (sent-key)
-    (cl-letf (((symbol-function 'ghostel--send-string)
-               (lambda (str) (setq sent-key str))))
+  "Send-next-key routes a regular character through the encoder."
+  (let (captured-key captured-mods
+                     (ghostel--term 'fake))
+    (cl-letf (((symbol-function 'ghostel--send-encoded)
+               (lambda (key mods &optional _utf8)
+                 (setq captured-key key captured-mods mods))))
       (let ((unread-command-events (list ?a)))
         (ghostel-send-next-key))
-      (should (equal "a" sent-key)))))
+      (should (equal "a" captured-key))
+      (should (equal "" captured-mods)))))
+
+(ert-deftest ghostel-test-send-next-key-c0-bytes ()
+  "Send-next-key maps raw C0 bytes to functional keys via the encoder.
+A TTY delivers Enter/Tab/ESC as 13/9/27; they must encode as the
+functional key, not as a ctrl chord, and the escape hatch must not
+inject raw bytes a kitty-protocol child cannot parse."
+  (dolist (case '((?\e "escape" "")
+                  (?\r "return" "")
+                  (?\t "tab" "")
+                  (127 "backspace" "")
+                  (?\C-c "c" "ctrl")))
+    (let (encoded raw)
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key mods &optional _utf8)
+                   (setq encoded (cons key mods))))
+                ((symbol-function 'ghostel--send-string)
+                 (lambda (str) (setq raw str))))
+        (let ((unread-command-events (list (car case))))
+          (ghostel-send-next-key))
+        (should (equal (cons (nth 1 case) (nth 2 case)) encoded))
+        (should-not raw)))))
+
+(ert-deftest ghostel-test-send-next-key-non-ascii-utf8 ()
+  "Send-next-key falls back to UTF-8 bytes for non-ASCII characters."
+  (let (encoded raw)
+    (cl-letf (((symbol-function 'ghostel--send-encoded)
+               (lambda (key mods &optional _utf8)
+                 (setq encoded (cons key mods))))
+              ((symbol-function 'ghostel--send-string)
+               (lambda (str) (setq raw str))))
+      (let ((unread-command-events (list ?ä)))
+        (ghostel-send-next-key))
+      (should-not encoded)
+      (should (equal (encode-coding-string "ä" 'utf-8) raw)))))
 
 (ert-deftest ghostel-test-send-next-key-meta-x ()
   "Send-next-key routes meta-x through the encoder with meta modifier."
@@ -1103,6 +1146,33 @@ External packages may still call the old internal name."
     (ghostel--define-terminal-keys map)
     (should-not (eq (lookup-key map (kbd "ESC ESC"))
                     #'ghostel--send-event))))
+
+(ert-deftest ghostel-test-event-key-spec ()
+  "`ghostel--event-key-spec' decodes events into encoder key/mod pairs."
+  ;; Raw C0 bytes for RET/TAB/ESC map to the functional key, ctrl dropped.
+  (should (equal '("return" . "") (ghostel--event-key-spec ?\r)))
+  (should (equal '("tab" . "") (ghostel--event-key-spec ?\t)))
+  (should (equal '("escape" . "") (ghostel--event-key-spec ?\e)))
+  ;; Other C0 chars demodify to ctrl+base.
+  (should (equal '("a" . "ctrl") (ghostel--event-key-spec ?\C-a)))
+  (should (equal '("@" . "ctrl") (ghostel--event-key-spec ?\C-@)))
+  ;; TTY backspace byte.
+  (should (equal '("backspace" . "") (ghostel--event-key-spec 127)))
+  ;; Plain and shifted ASCII.
+  (should (equal '("q" . "") (ghostel--event-key-spec ?q)))
+  (should (equal '(" " . "") (ghostel--event-key-spec ?\s)))
+  (should (equal '("A" . "shift")
+                 (ghostel--event-key-spec (event-convert-list '(shift ?a)))))
+  ;; Modified keys and function-key symbols.
+  (should (equal '("x" . "meta") (ghostel--event-key-spec ?\M-x)))
+  (should (equal '("a" . "ctrl,meta") (ghostel--event-key-spec ?\C-\M-a)))
+  (should (equal '("f5" . "") (ghostel--event-key-spec 'f5)))
+  (should (equal '("up" . "ctrl") (ghostel--event-key-spec 'C-up)))
+  ;; META adds meta for the TTY ESC-prefix delivery, without doubling.
+  (should (equal '("x" . "meta") (ghostel--event-key-spec ?x t)))
+  (should (equal '("x" . "meta") (ghostel--event-key-spec ?\M-x t)))
+  ;; Non-ASCII characters have no encoder representation.
+  (should-not (ghostel--event-key-spec ?ä)))
 
 (provide 'ghostel-keys-test)
 ;;; ghostel-keys-test.el ends here


### PR DESCRIPTION
## Summary

`ghostel-send-next-key` (`C-c C-q`) wrote C0 and printable-ASCII events to the PTY as raw bytes, bypassing the key encoder. A child that enabled the kitty keyboard protocol then received bytes outside the negotiated encoding — e.g. a bare `ESC` where the disambiguate flag promises `CSI 27u`.

## Changes

- Extract the event → (key-name . mod-string) decoding from `ghostel--send-event` into a shared `ghostel--event-key-spec` helper (C0 disambiguation for Enter/Tab/ESC, shift-case restore, function-key symbols).
- Route `ghostel-send-next-key` through it, so every key with an encoder representation goes through the terminal's negotiated encoding. Non-ASCII plain characters keep the UTF-8 fallback.
- Legacy children see byte-identical output for unmodified and ctrl-chord C0/ASCII input; ctrl+shift chords now encode CSI-u, consistent with what `ghostel--send-event` already did for bound keys.
- The rescue commands (`ghostel-send-C-c` and friends) intentionally keep sending raw bytes so the tty line discipline acts on them regardless of the child's protocol state.

## Testing

- New ERT tests: `ghostel--event-key-spec` decode contract, C0 bytes through the encoder, non-ASCII UTF-8 fallback; updated the three tests that pinned the old raw-byte behavior.
- `make -j8 all` green (build, elisp + native tests, lint).