### PR TITLE
Skip evil-escape's speculative first-key insert in ghostel buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- evil-ghostel: typing the first key of an `evil-escape` chord (e.g.
+  `jk`) no longer doubles the character in the shell, and completing
+  the chord no longer leaks it.  evil-escape previews the first key
+  with a speculative insert it reverts moments later; since terminal
+  buffers became writable (0.47.0) that preview was forwarded to the
+  PTY where it could not be reverted.  The preview is now skipped in
+  ghostel buffers — the chord itself keeps working.  Fixes
+  [#597](https://github.com/dakra/ghostel/issues/597).
+
 ## [0.49.0] — 2026-08-02
 
 ### Fixed

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -884,6 +884,19 @@ the default."
             #'evil-force-normal-state)
 
 
+;; evil-escape
+
+(defun evil-ghostel--evil-escape-skip-insert ()
+  "Return nil in ghostel buffers, gating `evil-escape--insert'.
+Its speculative first-key preview would be forwarded to the PTY by the
+foreign-edit interceptor before evil-escape can revert it, leaking the key
+to the shell; without the preview the chord still works via `read-event'."
+  (not (derived-mode-p 'ghostel-mode)))
+
+(advice-add 'evil-escape--insert :before-while
+            #'evil-ghostel--evil-escape-skip-insert)
+
+
 ;; Minor mode
 
 (defun evil-ghostel--any-active-elsewhere-p (except-buffer)

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -2617,6 +2617,21 @@ character, so it must not consume a backspace or a replacement char."
 `cw' / `cW' behave like `ce' / `cE' (stop at the word end)."
   (should (memq 'evil-ghostel-change evil-change-commands)))
 
+(ert-deftest evil-ghostel-test-evil-escape-insert-skipped ()
+  "evil-escape's speculative first-key insert is a no-op in ghostel buffers.
+Defines a stub `evil-escape--insert'; evil-ghostel's pending advice
+attaches to it and gates it by major mode."
+  (defun evil-escape--insert () (insert "x") t)
+  (should (advice-member-p #'evil-ghostel--evil-escape-skip-insert
+                           'evil-escape--insert))
+  (with-temp-buffer
+    (setq major-mode 'ghostel-mode)
+    (should-not (evil-escape--insert))
+    (should (string-empty-p (buffer-string))))
+  (with-temp-buffer
+    (should (evil-escape--insert))
+    (should (equal "x" (buffer-string)))))
+
 (defun evil-ghostel-test-run ()
   "Run all evil-ghostel tests.
 Most tests mock the native module; the few that drive a real terminal


### PR DESCRIPTION
evil-escape previews the first key of its chord (e.g. `jk`) with a speculative `self-insert-command` it reverts moments later, guarded by `buffer-read-only`. Since live terminal buffers became writable for the foreign-edit interceptor (0.47.0), that preview was captured and forwarded to the PTY where it cannot be reverted: a lone first key reached the shell twice (`jj`), and a completed chord leaked it once before entering normal state.

evil-ghostel now gates `evil-escape--insert` with `:before-while` advice returning nil in ghostel buffers, so the preview is skipped and the chord works through `read-event` alone, exactly as it did while the buffer was read-only. The advice is installed at top level; nadvice keeps it pending until evil-escape defines the function, covering either load order. Users without evil-escape are unaffected (the advice stays inert on the undefined symbol).

Verified end-to-end in live sandboxed Emacs sessions (evil + evil-escape `"jk"` + evil-ghostel, raw TTY key injection through the real command loop), in both load orders: a lone `j` is sent to the PTY exactly once and stays in insert state; `jk` sends nothing, enters normal state, and leaves the prompt line clean. Includes a regression test covering the advice gating.

Fixes #597