### PR TITLE
Honor compilation-scroll-output in ghostel-compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- `ghostel-compile` now honours `compilation-scroll-output` instead of
+  always scrolling.  With the default nil, compilation-style runs keep
+  the window at the top of the output like `M-x compile`; any non-nil
+  value follows the output as it arrives, and `first-error`
+  additionally leaves point on the first error message in the compile
+  buffer when the command finishes.  Interactive runs (`C-u
+  M-x ghostel-compile`) always follow the live cursor.  To keep the
+  previous always-scroll behavior, set `compilation-scroll-output` to
+  t.  Fixes [#599](https://github.com/dakra/ghostel/issues/599).
+
 ### Fixed
 - evil-ghostel: typing the first key of an `evil-escape` chord (e.g.
   `jk`) no longer doubles the character in the shell, and completing

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -192,8 +192,14 @@ alt-screen and when the native renderer defers synchronized output."
               (move-to-column saved-col)))
            ;; Don't drag point to the cursor while the user reads scrollback;
            ;; redisplay would yank the viewport back to the bottom each frame.
+           ;; A `ghostel-inhibit-anchor-functions' veto (e.g. a compile
+           ;; buffer with `compilation-scroll-output' nil) blocks the drag
+           ;; the same way it blocks the window anchor.
            ((and (memq evil-state '(insert emacs))
-                 (evil-ghostel--following-window-p))
+                 (evil-ghostel--following-window-p)
+                 (not (run-hook-with-args-until-success
+                       'ghostel-inhibit-anchor-functions
+                       (get-buffer-window (current-buffer) t) nil)))
             (evil-ghostel--reset-cursor-point)))
           (when visual-p
             (let ((pmax (point-max)))

--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -54,7 +54,8 @@
 ;;   `compilation-auto-jump-to-first-error'
 ;;   `compilation-finish-functions' (runs alongside
 ;;     `ghostel-compile-finish-functions')
-;;   `compilation-scroll-output' (effectively always on)
+;;   `compilation-scroll-output' (`first-error' follows the output
+;;     and jumps to the first error message when the command finishes)
 ;;
 ;; Keys in the finished buffer:
 ;;   g           — ghostel-recompile
@@ -220,6 +221,11 @@ the same keys work while the command is still executing."
   (add-hook 'eldoc-documentation-functions #'ghostel--eldoc-link nil t)
   ;; Expose cwd to buffer-menu/ibuffer
   (setq-local list-buffers-directory (expand-file-name default-directory)))
+
+(defun ghostel-compile--anchor-inhibit (_window force)
+  "Veto following live output while `compilation-scroll-output' is nil.
+Interactive runs always follow the output, as do FORCE anchors (e.g. paste)."
+  (not (or force ghostel-compile--interactive compilation-scroll-output)))
 
 (defun ghostel-compile--format-duration (seconds)
   "Format SECONDS (float) as a compilation-style duration string.
@@ -479,10 +485,33 @@ same as in any compilation buffer."
                   (error
                    (message "ghostel-compile: error scanning output: %s"
                             (error-message-string err)))))))
-          (goto-char (point-max))
-          (dolist (win (get-buffer-window-list buffer nil t))
-            (set-window-point win (point-max))
-            (with-selected-window win (recenter -1))))
+          ;; Final point position per `compilation-scroll-output':
+          ;; non-nil tails past the footer, `first-error' lands on the first
+          ;; error message (tail when the run had none), nil leaves point where
+          ;; the user (or the initial top-of-buffer placement) left it.
+          (cond
+           ((or ghostel-compile--interactive  ; Interactive runs always tail.
+                (and compilation-scroll-output
+                     (not (eq compilation-scroll-output 'first-error))))
+            (goto-char (point-max))
+            (dolist (win (get-buffer-window-list buffer nil t))
+              (set-window-point win (point-max))
+              (with-selected-window win (recenter -1))))
+           ((eq compilation-scroll-output 'first-error)
+            ;; One char before the scan start: `compilation-next-error'
+            ;; skips a message point is already on, and the command's
+            ;; first output line may itself be one.
+            (goto-char (max (point-min) (1- (or start (point-min)))))
+            (condition-case nil
+                (compilation-next-error 1)
+              (error (goto-char (point-max))))
+            ;; Also establish the window start: the sentinel's last
+            ;; render anchored the window to the tail, and that forced
+            ;; start would win at the next redisplay, clamping a bare
+            ;; `set-window-point' back into the tail view.
+            (dolist (win (get-buffer-window-list buffer nil t))
+              (set-window-point win (point))
+              (with-selected-window win (recenter))))))
         (ghostel-compile--set-mode-line-exit exit)
         (setq next-error-last-buffer buffer)
         (run-hook-with-args 'compilation-finish-functions
@@ -703,6 +732,10 @@ the rendered buffer remains read-only in both cases."
       ;; Wire up `next-error' so `\\[next-error]' / `M-g n' work as soon
       ;; as errors land, including in the interactive variant.
       (setq-local next-error-function #'compilation-next-error-function)
+      ;; Honour `compilation-scroll-output': when nil, windows on a
+      ;; compilation-style run must not follow the output.
+      (add-hook 'ghostel-inhibit-anchor-functions
+                #'ghostel-compile--anchor-inhibit nil t)
 
       ;; In compilation-style mode, swap only the local keymap.  Major mode stays
       ;; `ghostel-mode'
@@ -834,6 +867,15 @@ any other code that walks `compilation-arguments') re-runs via
               (forward-line (cdr ghostel--cursor-pos))
               (copy-marker (point))))
       (ghostel-compile--set-mode-line-running)
+      ;; With `compilation-scroll-output' nil the window stays at the
+      ;; top of the buffer while output flows
+      ;; (`ghostel-compile--anchor-inhibit' vetoes output-following);
+      ;; park point there like `compilation-start' does.
+      (unless (or interactive compilation-scroll-output)
+        (goto-char (point-min))
+        (when (window-live-p outwin)
+          (set-window-start outwin (point-min))
+          (set-window-point outwin (point-min))))
       ;; Match the VT size computed above (or fall back to the selected
       ;; window's own dimensions when `display-buffer' didn't surface a
       ;; window, e.g. `allow-no-window').  Use `window-max-chars-per-line'
@@ -883,11 +925,12 @@ Interactively, prompts for the command if option
 `compilation-read-command' is non-nil, otherwise uses
 `compile-command'.  With prefix arg, always prompts.
 
-Output always scrolls as it arrives (equivalent to
-`compilation-scroll-output' being non-nil).  `compilation-ask-about-save'
-and `compilation-auto-jump-to-first-error' are honoured.  The command
-default and history are shared with \\[compile] via `compile-command'
-and `compile-history'."
+`compilation-scroll-output', `compilation-ask-about-save' and
+`compilation-auto-jump-to-first-error' are honoured.  The value
+`first-error' of `compilation-scroll-output' follows the output during
+the run and leaves point on the first error message in the compile
+buffer when the command finishes.  The command default and history are
+shared with \\[compile] via `compile-command' and `compile-history'."
   (interactive
    (list
     (let ((default (eval compile-command t)))
@@ -1016,6 +1059,9 @@ Bound to \\[ghostel-compile-switch-to-interactive] in
         (goto-char (point-min))
         (forward-line (cdr rc))
         (move-to-column (car rc))))
+    ;; Bottom-align the window on the live output; a nil-scroll run
+    ;; has it parked at the top of the buffer.
+    (ghostel--anchor-window nil t)
     (ghostel-compile--set-mode-line-running)
     (when ghostel-compile-debug
       (message "ghostel-compile: switched to interactive"))))

--- a/test/ghostel-compile-test.el
+++ b/test/ghostel-compile-test.el
@@ -309,7 +309,7 @@ another window.  RET/`compile-goto-error' is for opening."
         (should-not opened)))))                              ; no file opened
 
 (ert-deftest ghostel-test-compile-finalize-leaves-point-at-end ()
-  "Regression: finalize must put point at `point-max', past the footer.
+  "Regression: with scrolling on, finalize puts point at `point-max'.
 The \"Compilation finished at ..., duration ...\" line must be visible
 when the window recenters to the bottom.  Point at the start of the
 footer (or at the end of output before the footer) leaves the footer
@@ -321,7 +321,8 @@ scrolled below the window."
       (setq ghostel-compile--command "true"
             ghostel-compile--start-time (current-time)
             ghostel-compile--scan-marker (copy-marker (point-min))))
-    (ghostel-compile--finalize buf 0 (current-time))
+    (let ((compilation-scroll-output t))
+      (ghostel-compile--finalize buf 0 (current-time)))
     (should (= (point) (point-max)))                           ; past footer
     ;; And the footer text really is the last thing in the buffer.
     (should (string-match-p
@@ -329,6 +330,137 @@ scrolled below the window."
              (buffer-substring-no-properties
               (max (point-min) (- (point-max) 200))
               (point-max))))))
+
+(ert-deftest ghostel-test-compile-finalize-scroll-output-nil-keeps-point ()
+  "With `compilation-scroll-output' nil, finalize leaves point alone."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (insert "line A\nline B\nline C\n")
+      (setq ghostel-compile--command "true"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--scan-marker (copy-marker (point-min))))
+    (goto-char (point-min))
+    (let ((compilation-scroll-output nil))
+      (ghostel-compile--finalize buf 0 (current-time)))
+    (should (= (point) (point-min)))))
+
+(ert-deftest ghostel-test-compile-finalize-scroll-output-nil-interactive-tails ()
+  "An interactive run tails at finalize even with scrolling off."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (insert "line A\n")
+      (setq ghostel-compile--command "true"
+            ghostel-compile--interactive t
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--scan-marker (copy-marker (point-min))))
+    (goto-char (point-min))
+    (let ((compilation-scroll-output nil))
+      (ghostel-compile--finalize buf 0 (current-time)))
+    (should (= (point) (point-max)))))
+
+(ert-deftest ghostel-test-compile-finalize-scroll-first-error-lands-on-error ()
+  "With `compilation-scroll-output' `first-error', point ends on the error."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (insert "building\n")
+      (setq ghostel-compile--command "make"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--scan-marker (copy-marker (point)))
+      (insert "more output\n/tmp/foo.c:10:5: error: bad thing\ntail\n")
+      (goto-char (point-max)))
+    (let ((compilation-scroll-output 'first-error))
+      (ghostel-compile--finalize buf 1 (current-time)))
+    (should (save-excursion (beginning-of-line)
+                            (looking-at "/tmp/foo\\.c")))))
+
+(ert-deftest ghostel-test-compile-finalize-scroll-first-error-without-errors-tails ()
+  "`first-error' falls back to the tail when the run produced no errors."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (insert "clean output\nall good\n")
+      (setq ghostel-compile--command "true"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--scan-marker (copy-marker (point-min))))
+    (goto-char (point-min))
+    (let ((compilation-scroll-output 'first-error))
+      (ghostel-compile--finalize buf 0 (current-time)))
+    (should (= (point) (point-max)))))
+
+(ert-deftest ghostel-test-compile-finalize-scroll-first-error-at-scan-start ()
+  "`first-error' finds a message starting exactly at the scan marker."
+  (ghostel-test--with-compile-buffer buf
+    (let ((inhibit-read-only t))
+      (insert "header\n")
+      (setq ghostel-compile--command "make"
+            ghostel-compile--start-time (current-time)
+            ghostel-compile--scan-marker (copy-marker (point)))
+      (insert "/tmp/first.c:1:1: error: first line\ntail\n")
+      (goto-char (point-max)))
+    (let ((compilation-scroll-output 'first-error))
+      (ghostel-compile--finalize buf 1 (current-time)))
+    (should (save-excursion (beginning-of-line)
+                            (looking-at "/tmp/first\\.c")))))
+
+(ert-deftest ghostel-test-compile-prepare-buffer-installs-anchor-veto ()
+  "`ghostel-compile--prepare-buffer' adds the scroll veto buffer-locally.
+The `(ghostel-mode)' reset kills local hooks, so the veto must be
+added after it — including on the recompile reuse path (second
+iteration)."
+  :tags '(native)
+  (let ((buf-name "*ghostel-test-anchor-veto*")
+        (inhibit-message t))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name)))
+    (unwind-protect
+        (dotimes (_ 2)
+          (let ((buf (ghostel-compile--prepare-buffer
+                      buf-name default-directory)))
+            (with-current-buffer buf
+              (should (local-variable-p 'ghostel-inhibit-anchor-functions))
+              (should (memq #'ghostel-compile--anchor-inhibit
+                            ghostel-inhibit-anchor-functions)))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name))))))
+
+(ert-deftest ghostel-test-compile-scroll-output-nil-run-keeps-point-at-top ()
+  "A nil-scroll run parks point at the top and finalize leaves it there."
+  :tags '(native)
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((buf-name "*ghostel-test-noscroll-run*")
+         (inhibit-message t)
+         (compilation-scroll-output nil)
+         (shell-file-name "/bin/sh")
+         (save-some-buffers-default-predicate (lambda () nil)))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name)))
+    (unwind-protect
+        (let ((buf (ghostel-compile--start "seq 1 200" buf-name
+                                           default-directory)))
+          (with-current-buffer buf
+            (should (= (point) (point-min)))            ; parked at top
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () ghostel-compile--finalized) 10)
+            (should (= (point) (point-min)))            ; still at top
+            (should (string-match-p "Compilation finished"
+                                    (buffer-string)))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil)) (kill-buffer buf-name))))))
+
+(ert-deftest ghostel-test-compile-anchor-inhibit-honours-scroll-output ()
+  "`ghostel-compile--anchor-inhibit' vetoes only nil-scroll read-only runs."
+  (ghostel-test--with-compile-buffer buf
+    (setq ghostel-compile--interactive nil)
+    (let ((compilation-scroll-output nil))
+      (should (ghostel-compile--anchor-inhibit nil nil))
+      (should-not (ghostel-compile--anchor-inhibit nil t)))    ; FORCE wins
+    (let ((compilation-scroll-output t))
+      (should-not (ghostel-compile--anchor-inhibit nil nil)))
+    (let ((compilation-scroll-output 'first-error))
+      (should-not (ghostel-compile--anchor-inhibit nil nil)))
+    (setq ghostel-compile--interactive t)
+    (let ((compilation-scroll-output nil))
+      (should-not (ghostel-compile--anchor-inhibit nil nil)))))
 
 (ert-deftest ghostel-test-compile-finalize-switches-major-mode ()
   "With the default option, finalize switches to `ghostel-compile-view-mode'."

--- a/test/ghostel-test-helpers.el
+++ b/test/ghostel-test-helpers.el
@@ -191,6 +191,14 @@ succeeds.  TIMEOUT is scaled by `ghostel-test--timeout-scale'."
                 (< (float-time) deadline)
                 (process-live-p proc))
       (accept-process-output proc 0.05))
+    ;; The child's exit is visible via `process-live-p' before its
+    ;; sentinel has run; drain events briefly so sentinel-driven
+    ;; predicates get their chance before this fails.
+    (unless (or result (process-live-p proc))
+      (let ((grace (+ (float-time) 1.0)))
+        (while (and (not (setq result (funcall pred)))
+                    (< (float-time) grace))
+          (accept-process-output nil 0.05))))
     (unless result
       (ert-fail
        (if (process-live-p proc)


### PR DESCRIPTION
Fixes #599.

`ghostel-compile` buffers always followed the live output — the buffer stays in `ghostel-mode` during the run and its windows are re-anchored to the tail on every redraw. `compilation-scroll-output` now controls this for compilation-style runs, making `ghostel-compile` a drop-in for `M-x compile` here too (as suggested by @emil-e in the issue):

- **nil** (default): the window stays at the top of the output — a buffer-local `ghostel-compile--anchor-inhibit` entry on `ghostel-inhibit-anchor-functions` vetoes output-following, point and `window-start` are parked at the top like `compilation-start` does, and finalize leaves point alone. Note this changes the previous always-scroll default; set `compilation-scroll-output` to `t` to keep the old behavior.
- **`first-error`**: follows the output during the run; at finalize point lands on the first error message in the compile buffer and the window recenters on it (tail when the run had no errors). The finalize branch also re-establishes the window start — the sentinel-time tail anchor leaves a forced `window-start` pending, and the next redisplay would otherwise clamp a bare `set-window-point` back into the tail view. The error search starts one char before the scan marker because `compilation-next-error` skips a message point is already on.
- **other non-nil**: unchanged — follow during the run, tail past the footer at finalize.

Interactive runs (`C-u M-x ghostel-compile`, `MODE=t` under the global mode) always follow the live cursor, and `C-c C-j` now bottom-anchors the window when toggling to interactive mid-run.

evil-ghostel's insert/emacs-state cursor drag (`evil-ghostel--around-redraw`) is gated on the same veto hook, so it no longer pulls point to the terminal cursor in a nil-scroll compile buffer; its own veto entry returns nil in insert state, so plain terminals are unaffected.

Tests: finalize matrix for all three values (plus interactive-tails and error-at-scan-start edge cases), veto installation across the recompile reuse path, and an end-to-end nil-scroll run keeping point at the top. Also verified live (terminal Emacs, non-selected compile window): nil / t / first-error / interactive, and the evil-ghostel scenarios including normal-state roaming regression guards.