### PR TITLE
Keep TRAMP from reconnecting during remote temp-file cleanup

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3832,11 +3832,15 @@ available or the push fails."
 (defun ghostel--cleanup-temp-paths (files dirs)
   "Delete temporary FILES and DIRS created for remote shell integration.
 Directories are removed recursively so any contents written into them,
-such as a per-session `.zshenv', are cleaned up as well."
-  (dolist (f files)
-    (ignore-errors (delete-file f)))
-  (dolist (d dirs)
-    (ignore-errors (delete-directory d t))))
+such as a per-session `.zshenv', are cleaned up as well.
+Binding `non-essential' keeps TRAMP from opening a new connection (and
+possibly prompting for a password) just to delete temp files; when the
+remote connection is already gone the paths are simply left behind."
+  (let ((non-essential t))
+    (dolist (f files)
+      (ignore-errors (delete-file f)))
+    (dolist (d dirs)
+      (ignore-errors (delete-directory d t)))))
 
 (defun ghostel--merge-integration-plists (base extra)
   "Merge EXTRA into BASE plist, appending list values for shared keys.

--- a/test/ghostel-tramp-test.el
+++ b/test/ghostel-tramp-test.el
@@ -179,5 +179,19 @@ matching on TRAMP-launched ghostel remotes — this canary catches it."
     (ghostel--update-directory "file://myhost/home/dan")
     (should (equal "/ssh:dan@myhost:/home/dan/" default-directory))))
 
+(ert-deftest ghostel-test-cleanup-temp-paths-non-essential ()
+  "Temp-path cleanup must not let TRAMP open a new connection.
+`non-essential' has to be bound around the deletions so TRAMP refuses
+to re-establish a dead connection — reconnecting would prompt for a
+password, e.g. right after `tramp-cleanup-all-connections'."
+  (let (seen)
+    (cl-letf (((symbol-function 'delete-file)
+               (lambda (&rest _) (push non-essential seen)))
+              ((symbol-function 'delete-directory)
+               (lambda (&rest _) (push non-essential seen))))
+      (ghostel--cleanup-temp-paths
+       '("/ssh:host:/tmp/ghostel-rc") '("/ssh:host:/tmp/ghostel-terminfo")))
+    (should (equal seen '(t t)))))
+
 (provide 'ghostel-tramp-test)
 ;;; ghostel-tramp-test.el ends here


### PR DESCRIPTION
## Problem

With `ghostel-tramp-shell-integration` enabled, running `tramp-cleanup-all-connections` (or any TRAMP cleanup) while a remote ghostel session exists triggers an SSH password prompt — especially painful during network drops, where TRAMP then blocks trying to reconnect.

Fixes #602.

## Cause

TRAMP cleanup flushes the password cache and kills the connection processes, which kills the remote ghostel session. Its sentinel kills the buffer (default `ghostel-kill-buffer-on-exit` t), and the buffer-local `kill-buffer-hook` then runs `ghostel--cleanup-temp-paths` on the remote temp paths (shell-integration rc file, pushed terminfo dir). `delete-file` on a remote path with no live connection forces TRAMP to establish a brand-new SSH connection — hence the password prompt.

## Fix

Bind `non-essential` around the deletions. TRAMP then refuses to open a new connection (`tramp-maybe-open-connection` throws `non-essential` and falls back to the real handler, which fails harmlessly under the existing `ignore-errors`). Cleanup on a live connection is unaffected; when the connection is already gone, the per-session temp files are simply left behind in the remote `/tmp`.

## Verification

- New regression test `ghostel-test-cleanup-temp-paths-non-essential`; full `make -j8 all` passes.
- Live-verified with TRAMP's mock method: with the old code, the cleanup hook silently opened a fresh connection after `tramp-cleanup-all-connections` and deleted the temp files; with the fix, zero new connection opens and no live connection process afterward.