### PR TITLE
Fix stale [Compiling] modeline and copy-mode trap in ghostel-compile

### DIFF
--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -562,29 +562,34 @@ destroys the grid, so commit it here or lose the output it holds."
 (defun ghostel-compile--sentinel (process _event)
   "Sentinel for the compile PROCESS: finalize the buffer on exit."
   (when (memq (process-status process) '(exit signal))
-    (let ((buffer (process-buffer process))
-          (exit (process-exit-status process)))
-      (when (buffer-live-p buffer)
-        (with-current-buffer buffer
-          (when ghostel-compile-debug
-            (message "ghostel-compile: sentinel exit=%S status=%S"
-                     exit (process-status process)))
-          ;; Cancel any scheduled redraw and commit the current terminal state
-          ;; to the buffer synchronously.  Without this, a short-lived
-          ;; command (`echo`, `false`, `exit 7`) finishes before the
-          ;; ~16 ms redraw timer fires and its output is lost when
-          ;; `--teardown-terminal' destroys the renderer.
-          (when ghostel--term
-            (when ghostel--redraw-timer
-              (cancel-timer ghostel--redraw-timer)
-              (setq ghostel--redraw-timer nil))
-            (ghostel--redraw-now buffer)
-            (ghostel-compile--commit-pending-frame buffer))
-          (setq compilation-in-progress
-                (delq process compilation-in-progress))
-          (when (fboundp 'compilation--update-in-progress-mode-line)
-            (compilation--update-in-progress-mode-line))
-          (ghostel-compile--finalize buffer exit (current-time)))))))
+    ;; The `compilation-in-progress' cleanup runs unconditionally: killing
+    ;; the buffer kills the process and fires this sentinel with a dead
+    ;; buffer, and the process must still leave the in-progress list or
+    ;; the global [Compiling] mode-line indicator sticks forever.
+    (unwind-protect
+        (let ((buffer (process-buffer process))
+              (exit (process-exit-status process)))
+          (when (buffer-live-p buffer)
+            (with-current-buffer buffer
+              (when ghostel-compile-debug
+                (message "ghostel-compile: sentinel exit=%S status=%S"
+                         exit (process-status process)))
+              ;; Cancel any scheduled redraw and commit the current terminal state
+              ;; to the buffer synchronously.  Without this, a short-lived
+              ;; command (`echo`, `false`, `exit 7`) finishes before the
+              ;; ~16 ms redraw timer fires and its output is lost when
+              ;; `--teardown-terminal' destroys the renderer.
+              (when ghostel--term
+                (when ghostel--redraw-timer
+                  (cancel-timer ghostel--redraw-timer)
+                  (setq ghostel--redraw-timer nil))
+                (ghostel--redraw-now buffer)
+                (ghostel-compile--commit-pending-frame buffer))
+              (ghostel-compile--finalize buffer exit (current-time)))))
+      (setq compilation-in-progress
+            (delq process compilation-in-progress))
+      (when (fboundp 'compilation--update-in-progress-mode-line)
+        (compilation--update-in-progress-mode-line)))))
 
 (defconst ghostel-compile--stty-flags
   (concat ghostel--default-stty " -echo")

--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -765,7 +765,7 @@ the rendered buffer remains read-only in both cases."
         (use-local-map ghostel-compile-view-mode-map)
         (setq buffer-read-only t)
         ;; Compilation-style buffers keep the plain read-only barrier.
-        (setq ghostel--inhibit-insert-forwarding t))
+        (ghostel-compile--set-compilation-style-input t))
       ;; Enable the live toggle (`C-c C-j' / `C-c C-e') in compile
       ;; buffers, regardless of which run mode they're in.  The
       ;; minor-mode keymap takes precedence over the major-mode map
@@ -1046,6 +1046,31 @@ case \"$s\" in *-icanon*) ;; *) stty echo < %s 2>/dev/null ;; esac"
          (format "stty -echo < %s 2>/dev/null"
                  (shell-quote-argument tty)))))))
 
+(defun ghostel-compile--set-compilation-style-input (enable)
+  "Install (non-nil ENABLE) or clear the compilation-style input barrier.
+Sets `ghostel--inhibit-insert-forwarding' and `ghostel--readonly-exit-function'
+as a pair: the flag alone would leave copy-mode exits restoring the semi-char
+keymap over the view map."
+  (setq ghostel--inhibit-insert-forwarding (and enable t))
+  (setq ghostel--readonly-exit-function
+        (and enable #'ghostel-compile--restore-compilation-style)))
+
+(defun ghostel-compile--restore-compilation-style ()
+  "Restore compilation-style state after exiting copy or Emacs mode.
+Installed as `ghostel--readonly-exit-function' so leaving a
+read-only mode reinstates the view keymap and read-only barrier
+instead of a terminal input mode.  Point stays where the user left it."
+  (ghostel--leave-readonly-state)
+  (setq ghostel--input-mode 'semi-char)
+  (use-local-map ghostel-compile-view-mode-map)
+  (ghostel--sync-read-only)
+  (setq ghostel--mode-line-tag nil)
+  (ghostel--mode-line-refresh)
+  (when (process-live-p ghostel--process)
+    (ghostel-compile--set-mode-line-running)
+    (setq ghostel--force-next-redraw t)
+    (ghostel--invalidate)))
+
 (defun ghostel-compile-switch-to-interactive ()
   "Switch the current `ghostel-compile' run to interactive mode.
 `ghostel-semi-char-mode-map' is restored so keystrokes reach the running
@@ -1063,7 +1088,7 @@ Bound to \\[ghostel-compile-switch-to-interactive] in
       (message "ghostel-compile: already interactive")
     (setq ghostel-compile--interactive t)
     (use-local-map ghostel-semi-char-mode-map)
-    (setq ghostel--inhibit-insert-forwarding nil)
+    (ghostel-compile--set-compilation-style-input nil)
     (ghostel--sync-read-only)
     ;; Turn on PTY echo so input typed at a read prompt is visible.
     ;; Skipped when the cursor row looks like a password prompt: the
@@ -1102,7 +1127,7 @@ Bound to \\[ghostel-compile-switch-to-compilation-style] in
       (message "ghostel-compile: already compilation-style")
     (setq ghostel-compile--interactive nil)
     (use-local-map ghostel-compile-view-mode-map)
-    (setq ghostel--inhibit-insert-forwarding t)
+    (ghostel-compile--set-compilation-style-input t)
     (ghostel--sync-read-only)
     (ghostel-compile--set-pty-echo nil)
     (ghostel-compile--set-mode-line-running)

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2489,6 +2489,12 @@ Tracks the mode the user was in immediately before the most
 recent read-only entry, so Emacs → copy → exit returns to Emacs
 mode and copy → Emacs → exit returns to copy.")
 
+(defvar-local ghostel--readonly-exit-function nil
+  "When non-nil, `ghostel-readonly-exit' calls this instead of the default restore.
+The function is responsible for the full post-exit state (input mode, keymap,
+read-only flag, mode line, redraw).  Set in compilation-style compile buffers,
+whose exit must restore the view keymap rather than a terminal input mode.")
+
 (defun ghostel--readonly-keymap ()
   "Return the keymap to use for the current read-only mode."
   (if ghostel-readonly-fast-exit
@@ -2626,16 +2632,18 @@ Add it to other jump commands as a hook or `:after' advice (see the README)."
   (when (memq ghostel--input-mode '(copy emacs))
     (let ((target (or ghostel--pre-readonly-mode 'semi-char)))
       (setq ghostel--pre-readonly-mode nil)
-      ;; Return to the live viewport before reenabling terminal input.
-      (goto-char (point-max))
-      (setq ghostel--force-next-redraw t)
-      (pcase target
-        ('char  (ghostel-char-mode))
-        ('emacs (ghostel-emacs-mode))
-        (_      (ghostel-semi-char-mode)))
-      (ghostel--adjust-size (selected-window) t)
-      (ghostel--anchor-window nil t)
-      (ghostel-force-redraw))
+      (if ghostel--readonly-exit-function
+          (funcall ghostel--readonly-exit-function)
+        ;; Return to the live viewport before reenabling terminal input.
+        (goto-char (point-max))
+        (setq ghostel--force-next-redraw t)
+        (pcase target
+          ('char  (ghostel-char-mode))
+          ('emacs (ghostel-emacs-mode))
+          (_      (ghostel-semi-char-mode)))
+        (ghostel--adjust-size (selected-window) t)
+        (ghostel--anchor-window nil t)
+        (ghostel-force-redraw)))
     (message "Read-only mode exited")))
 
 (defun ghostel-readonly-exit-and-clear ()
@@ -2649,9 +2657,11 @@ Add it to other jump commands as a hook or `:after' advice (see the README)."
 Only forwards the key when the mode we are returning to actually
 accepts terminal input (semi-char or char)."
   (interactive)
-  (let ((target (or ghostel--pre-readonly-mode 'semi-char)))
+  (let ((target (or ghostel--pre-readonly-mode 'semi-char))
+        (custom-exit ghostel--readonly-exit-function))
     (ghostel-readonly-exit)
-    (when (and ghostel--term (memq target '(semi-char char)))
+    (when (and ghostel--term (not custom-exit)
+               (memq target '(semi-char char)))
       (ghostel--self-insert))))
 
 (defun ghostel-readonly-RET-or-exit-and-send ()
@@ -2668,9 +2678,11 @@ press anywhere else exits and forwards a CR to the terminal."
       (progn
         (ghostel-readonly-exit)
         (ghostel--open-link url))
-    (let ((target (or ghostel--pre-readonly-mode 'semi-char)))
+    (let ((target (or ghostel--pre-readonly-mode 'semi-char))
+          (custom-exit ghostel--readonly-exit-function))
       (ghostel-readonly-exit)
-      (when (and ghostel--term (memq target '(semi-char char)))
+      (when (and ghostel--term (not custom-exit)
+                 (memq target '(semi-char char)))
         (ghostel--send-encoded "return" "")))))
 
 (defun ghostel--filter-soft-wraps (text)

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1671,7 +1671,8 @@ Detect that case via `this-command-keys-vector' and re-inject meta."
 ;;; Programmatic insert forwarding
 
 (defvar-local ghostel--inhibit-insert-forwarding nil
-  "Non-nil disables insert forwarding (e.g. compilation-style runs).")
+  "Non-nil disables insert forwarding (e.g. compilation-style runs).
+Also suppresses automatic input-mode switching (point-leave, mark-activation).")
 
 (defsubst ghostel--insert-forwarding-live-p ()
   "Non-nil in a terminal-input mode with a live process and forwarding on."
@@ -2599,7 +2600,8 @@ command set the region, so the selection survives the switch."
   (when (and (not (memq this-command '(ghostel-mouse-press-or-copy-mode
                                        ghostel-mouse-release-or-set-point
                                        ghostel-mouse-drag-or-set-region)))
-             (eq ghostel--input-mode 'semi-char))
+             (eq ghostel--input-mode 'semi-char)
+             (not ghostel--inhibit-insert-forwarding))
     (ghostel--enter-readonly-input-mode ghostel-mark-activation-input-mode)))
 
 (defun ghostel-maybe-leave-input (&rest _)
@@ -2610,6 +2612,7 @@ Add it to other jump commands as a hook or `:after' advice (see the README)."
   (interactive)
   (when (and ghostel-point-leave-input-mode
              (eq ghostel--input-mode 'semi-char)
+             (not ghostel--inhibit-insert-forwarding)
              ghostel--term
              ghostel--cursor-char-pos
              (not executing-kbd-macro)

--- a/test/ghostel-compile-test.el
+++ b/test/ghostel-compile-test.el
@@ -2355,6 +2355,41 @@ mode-line indicator sticks forever."
     ;; the list itself is the testable state).
     (should-not compilation-in-progress)))
 
+(ert-deftest ghostel-test-compile-point-leave-suppressed ()
+  "Point-leave must not enter copy mode in a compilation-style buffer."
+  (ghostel-test--with-compile-buffer buf
+    (ghostel-test--insert-rendered "output")
+    (setq-local ghostel--term 'fake)
+    (setq-local ghostel--cursor-char-pos (point-max))
+    (setq ghostel--inhibit-insert-forwarding t)
+    (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+              ((symbol-function 'ghostel--anchor-window) #'ignore))
+      (let ((ghostel-point-leave-input-mode 'copy))
+        (goto-char (point-min))
+        (ghostel-maybe-leave-input)
+        (should (eq ghostel--input-mode 'semi-char))
+        ;; Control: with the flag off the same state enters copy mode.
+        (setq ghostel--inhibit-insert-forwarding nil)
+        (ghostel-maybe-leave-input)
+        (should (eq ghostel--input-mode 'copy))))))
+
+(ert-deftest ghostel-test-compile-mark-activation-suppressed ()
+  "Mark activation must not enter copy mode in a compilation-style buffer."
+  (ghostel-test--with-compile-buffer buf
+    (ghostel-test--insert-rendered "output")
+    (setq-local ghostel--term 'fake)
+    (setq ghostel--inhibit-insert-forwarding t)
+    (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+              ((symbol-function 'ghostel--anchor-window) #'ignore))
+      (let ((ghostel-mark-activation-input-mode 'copy)
+            (this-command 'set-mark-command))
+        (ghostel--mark-activated)
+        (should (eq ghostel--input-mode 'semi-char))
+        ;; Control: with the flag off the same activation enters copy mode.
+        (setq ghostel--inhibit-insert-forwarding nil)
+        (ghostel--mark-activated)
+        (should (eq ghostel--input-mode 'copy))))))
+
 (ert-deftest ghostel-test-compile-kill-buffer-clears-in-progress ()
   "End-to-end: killing a live compile buffer clears the [Compiling] indicator."
   :tags '(native)

--- a/test/ghostel-compile-test.el
+++ b/test/ghostel-compile-test.el
@@ -2390,6 +2390,102 @@ mode-line indicator sticks forever."
         (ghostel--mark-activated)
         (should (eq ghostel--input-mode 'copy))))))
 
+(ert-deftest ghostel-test-compile-readonly-exit-restores-view-state ()
+  "Exiting copy mode in a compilation-style buffer restores the view state.
+The default exit installs `ghostel-semi-char-mode-map' and drops the
+read-only barrier; a compilation-style buffer must get its view
+keymap and read-only flag back instead."
+  (ghostel-test--with-compile-buffer buf
+    (ghostel-test--insert-rendered "output")
+    (setq-local ghostel--term 'fake)
+    (use-local-map ghostel-compile-view-mode-map)
+    (setq ghostel--inhibit-insert-forwarding t)
+    (setq ghostel--readonly-exit-function
+          #'ghostel-compile--restore-compilation-style)
+    (ghostel--sync-read-only)
+    (cl-letf (((symbol-function 'ghostel--invalidate) #'ignore)
+              ((symbol-function 'ghostel--anchor-window) #'ignore))
+      (let ((inhibit-message t))
+        (ghostel-copy-mode)
+        (should (eq ghostel--input-mode 'copy))
+        (ghostel-readonly-exit)
+        (should (eq ghostel--input-mode 'semi-char))
+        (should (eq (current-local-map) ghostel-compile-view-mode-map))
+        (should buffer-read-only)))))
+
+(ert-deftest ghostel-test-compile-readonly-exit-and-send-sends-nothing ()
+  "The exiting keypress must not reach the PTY in a compilation-style buffer."
+  (ghostel-test--with-compile-buffer buf
+    (ghostel-test--insert-rendered "output")
+    (setq-local ghostel--term 'fake)
+    (use-local-map ghostel-compile-view-mode-map)
+    (setq ghostel--inhibit-insert-forwarding t)
+    (setq ghostel--readonly-exit-function
+          #'ghostel-compile--restore-compilation-style)
+    (ghostel--sync-read-only)
+    (cl-letf* ((sent nil)
+               ((symbol-function 'ghostel--invalidate) #'ignore)
+               ((symbol-function 'ghostel--anchor-window) #'ignore)
+               ((symbol-function 'ghostel--self-insert)
+                (lambda (&rest _) (setq sent 'self-insert)))
+               ((symbol-function 'ghostel--send-encoded)
+                (lambda (&rest _) (setq sent 'encoded))))
+      (let ((inhibit-message t))
+        (ghostel-copy-mode)
+        (ghostel-readonly-exit-and-send)
+        (should-not sent)
+        (should (eq (current-local-map) ghostel-compile-view-mode-map))
+        (ghostel-copy-mode)
+        (ghostel-readonly-RET-or-exit-and-send)
+        (should-not sent)
+        (should (eq (current-local-map) ghostel-compile-view-mode-map))))))
+
+(ert-deftest ghostel-test-compile-copy-mode-exit-integration ()
+  "End-to-end: copy mode in a real compile run exits back to the view state.
+Goes through `ghostel-compile--start' so the production wiring (the
+inhibit flag and exit function installed by `--prepare-buffer') is
+what the exit exercises, not test-installed state."
+  :tags '(native)
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let ((buf-name "*ghostel-test-copy-exit-integration*")
+        (compilation-in-progress nil)
+        (inhibit-message t)
+        (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil))
+        (kill-buffer buf-name)))
+    (unwind-protect
+        (let ((buf (ghostel-compile--start "sleep 30" buf-name
+                                           default-directory)))
+          (with-current-buffer buf
+            (ghostel-test--wait-for
+             ghostel--process
+             (lambda () (eq 'run (process-status ghostel--process))))
+            ;; Wiring installed by `--prepare-buffer'.
+            (should ghostel--inhibit-insert-forwarding)
+            (should (eq ghostel--readonly-exit-function
+                        #'ghostel-compile--restore-compilation-style))
+            (ghostel-copy-mode)
+            (should (eq ghostel--input-mode 'copy))
+            (ghostel-readonly-exit)
+            (should (eq ghostel--input-mode 'semi-char))
+            (should (eq (current-local-map) ghostel-compile-view-mode-map))
+            (should buffer-read-only)
+            ;; The ":run" indicator is back (batch `format-mode-line'
+            ;; renders "", so check the construct itself).
+            (should (member ":run" (flatten-tree mode-line-process)))
+            ;; Kill the sleep process so the test doesn't leak.
+            (let ((p ghostel--process))
+              (when (process-live-p p)
+                (set-process-sentinel p #'ignore)
+                (set-process-filter p #'ignore)
+                (setq compilation-in-progress
+                      (delq p compilation-in-progress))
+                (delete-process p)))))
+      (when (get-buffer buf-name)
+        (let ((kill-buffer-query-functions nil))
+          (kill-buffer buf-name))))))
+
 (ert-deftest ghostel-test-compile-kill-buffer-clears-in-progress ()
   "End-to-end: killing a live compile buffer clears the [Compiling] indicator."
   :tags '(native)

--- a/test/ghostel-compile-test.el
+++ b/test/ghostel-compile-test.el
@@ -2329,5 +2329,55 @@ ever, so that row would keep its link forever otherwise."
           (should (equal uri (get-text-property (1- (match-end 0))
                                                 'help-echo))))))))
 
+;;; Kill-buffer sentinel cleanup and copy-mode suppression
+
+(ert-deftest ghostel-test-compile-sentinel-cleans-up-dead-buffer ()
+  "Killing the compile buffer mid-run still drains `compilation-in-progress'.
+The buffer kill deletes the process and fires the sentinel with a
+dead buffer; the cleanup must run anyway or the global [Compiling]
+mode-line indicator sticks forever."
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((compilation-in-progress nil)
+         (buf (generate-new-buffer " *ghostel-test-sentinel-cleanup*"))
+         (proc (make-process :name "ghostel-test-sentinel-cleanup"
+                             :buffer buf
+                             :command '("/bin/sh" "-c" "sleep 5")
+                             :sentinel #'ghostel-compile--sentinel)))
+    (push proc compilation-in-progress)
+    (when (fboundp 'compilation--update-in-progress-mode-line)
+      (compilation--update-in-progress-mode-line))
+    (let ((kill-buffer-query-functions nil))
+      (kill-buffer buf))
+    (ghostel-test--wait-for
+     proc (lambda () (not (memq proc compilation-in-progress))))
+    ;; The [Compiling] indicator is a mode-line construct conditional on
+    ;; `compilation-in-progress' (batch `format-mode-line' renders "" so
+    ;; the list itself is the testable state).
+    (should-not compilation-in-progress)))
+
+(ert-deftest ghostel-test-compile-kill-buffer-clears-in-progress ()
+  "End-to-end: killing a live compile buffer clears the [Compiling] indicator."
+  :tags '(native)
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let ((buf-name "*ghostel-test-kill-in-progress*")
+        (compilation-in-progress nil)
+        (inhibit-message t)
+        (ghostel-compile-finished-major-mode nil))
+    (when (get-buffer buf-name)
+      (let ((kill-buffer-query-functions nil))
+        (kill-buffer buf-name)))
+    (let* ((buf (ghostel-compile--start "sleep 30" buf-name
+                                        default-directory))
+           (proc (buffer-local-value 'ghostel--process buf)))
+      (ghostel-test--wait-for
+       proc (lambda () (eq 'run (process-status proc))))
+      (should (memq proc compilation-in-progress))
+      (let ((kill-buffer-query-functions nil))
+        (kill-buffer buf))
+      (ghostel-test--wait-for
+       proc (lambda () (not (memq proc compilation-in-progress))))
+      ;; The [Compiling] indicator is conditional on this list.
+      (should-not compilation-in-progress))))
+
 (provide 'ghostel-compile-test)
 ;;; ghostel-compile-test.el ends here


### PR DESCRIPTION
Fixes #605.

Two bugs in compilation-style `ghostel-compile` buffers:

1. **Stale `[Compiling]` modeline**: killing a compile buffer mid-run fired the sentinel with a dead buffer, which skipped the `compilation-in-progress` cleanup — the dead process stayed in the list and the global `[Compiling]` indicator stuck forever.
2. **Copy-mode trap under popper**: the deferred point-leave check after the `M-x ghostel-compile` minibuffer exit fired in the popper-selected popup window and auto-entered copy mode (frozen terminal, no output). Exiting copy mode then restored `ghostel-semi-char-mode-map`, clobbering `ghostel-compile-view-mode-map` so `C-p`/`C-n`/`RET` were sent to the PTY until finalize.

One commit per fix:

- **Drain `compilation-in-progress` when the compile buffer dies mid-run**: the sentinel now runs the cleanup in an `unwind-protect` cleanup form, mirroring stock `compilation-sentinel` (including its ordering: finalize before the `delq`, so finish hooks observe stock-compatible state).
- **Suppress automatic copy-mode entry in compilation-style buffers**: the point-leave check and mark activation are gated on `ghostel--inhibit-insert-forwarding`, the existing compilation-style marker. Interactive compile runs (flag nil) keep auto-switching.
- **Restore compilation-style state when exiting copy or Emacs mode**: new buffer-local `ghostel--readonly-exit-function`; when set, `ghostel-readonly-exit` delegates the post-exit restore to it and the `*-and-send` exits don't forward the triggering key. Compile buffers install `ghostel-compile--restore-compilation-style` (view keymap, read-only barrier, `:run` indicator, redraw-timer restart), set/cleared in lockstep with the inhibit flag through a shared setter. This also covers the remaining paths into copy mode there (explicit `M-x ghostel-copy-mode`, link follow).

Tests: 8 new (6 elisp, 2 native), including an end-to-end kill-mid-run test and an integration test that goes through `ghostel-compile--start` → `ghostel-copy-mode` → exit against the production wiring.

Verified live (Emacs 31, real popper 0.4.8): kill mid-run leaves no `[Compiling]`; with popper the compile popup opens in semi-char with output streaming and view keys bound; copy-mode exit restores the view state with no byte sent to the PTY.