### PR TITLE
Show ghostel bookmarks properly in the bookmark list

### DIFF
--- a/lisp/ghostel-bookmark.el
+++ b/lisp/ghostel-bookmark.el
@@ -37,7 +37,7 @@ Notes the working directory and buffer name.
 See `ghostel--bookmark-handler' for how they are restored."
   `(nil
     (handler . ghostel--bookmark-handler)
-    (thisdir . ,default-directory)
+    (location . ,default-directory)
     (buf-name . ,(buffer-name))
     (defaults . nil)))
 
@@ -48,14 +48,14 @@ Reuse a live ghostel buffer of the bookmarked name, or create one with a shell
 started in the bookmarked directory.  When a reused buffer's directory differs
 and `ghostel-bookmark-check-dir' is non-nil, type a `cd' into the shell."
   (ghostel--load-module t)
-  (let* ((thisdir (bookmark-prop-get bmk 'thisdir))
+  (let* ((dir (bookmark-prop-get bmk 'location))
          (buf-name (bookmark-prop-get bmk 'buf-name))
          (buf (get-buffer buf-name))
          (mode (and buf (buffer-local-value 'major-mode buf))))
-    ;; Create branch: the shell starts directly in THISDIR (no `cd').
+    ;; Create branch: the shell starts directly in DIR (no `cd').
     (when (or (not buf) (not (eq mode 'ghostel-mode)))
       (let ((default-directory (if ghostel-bookmark-check-dir
-                                   thisdir
+                                   dir
                                  default-directory)))
         (setq buf (ghostel--create buf-name))
         (with-current-buffer buf
@@ -67,15 +67,18 @@ and `ghostel-bookmark-check-dir' is non-nil, type a `cd' into the shell."
     (with-current-buffer buf
       (when (and ghostel-bookmark-check-dir
                  ghostel--term
-                 (not (string-equal default-directory thisdir)))
+                 (not (string-equal default-directory dir)))
         (when (memq ghostel--input-mode '(copy emacs))
           (ghostel-readonly-exit))
         ;; Ghostel records remote dirs as TRAMP paths, so strip the TRAMP prefix
         ;; with `file-local-name', and quote so paths with spaces survive.
         (ghostel-send-string
-         (concat "cd " (shell-quote-argument (file-local-name thisdir))))
+         (concat "cd " (shell-quote-argument (file-local-name dir))))
         (ghostel-send-key "return")))
     (set-buffer buf)))
+
+;; Fills the Type column of `bookmark-bmenu-list' (Emacs 29+).
+(put 'ghostel--bookmark-handler 'bookmark-handler-type "Ghostel")
 
 (provide 'ghostel-bookmark)
 ;;; ghostel-bookmark.el ends here

--- a/test/ghostel-bookmark-test.el
+++ b/test/ghostel-bookmark-test.el
@@ -14,15 +14,27 @@
 (require 'ghostel-bookmark)
 
 (ert-deftest ghostel-test-bookmark-make-record ()
-  "`ghostel--bookmark-make-record' captures handler, dir, and buffer name."
+  "`ghostel--bookmark-make-record' captures handler, dir, and buffer name.
+The directory goes under `location' so `bookmark-bmenu-list' shows it
+instead of \"-- Unknown location --\"."
   (ghostel-test--with-compile-buffer buf
     (let* ((default-directory "/tmp/ghostel-bookmark-make-record/")
            (record (ghostel--bookmark-make-record)))
       (should (eq (bookmark-prop-get record 'handler)
                   'ghostel--bookmark-handler))
-      (should (equal (bookmark-prop-get record 'thisdir)
+      (should (equal (bookmark-prop-get record 'location)
                      "/tmp/ghostel-bookmark-make-record/"))
+      ;; `bookmark-location' is what the bmenu File column shows.  Point
+      ;; `bookmark-default-file' at nothing so it cannot load the user's.
+      (let ((bookmark-default-file "/nonexistent/ghostel-test-bookmarks"))
+        (should (equal (bookmark-location record)
+                       "/tmp/ghostel-bookmark-make-record/")))
       (should (equal (bookmark-prop-get record 'buf-name) (buffer-name))))))
+
+(ert-deftest ghostel-test-bookmark-handler-type ()
+  "The handler carries a `bookmark-handler-type' for the bmenu Type column."
+  (should (equal (get 'ghostel--bookmark-handler 'bookmark-handler-type)
+                 "Ghostel")))
 
 (ert-deftest ghostel-test-bookmark-mode-wires-record-function ()
   "`ghostel-mode' wires `bookmark-make-record-function'; the record round-trips.
@@ -35,11 +47,11 @@
                   'ghostel--bookmark-handler))
       (should (equal (bookmark-prop-get record 'buf-name) (buffer-name))))))
 
-(defun ghostel-test--bookmark-record (buf-name thisdir)
-  "Return a ghostel bookmark record for BUF-NAME pointing at THISDIR."
+(defun ghostel-test--bookmark-record (buf-name dir)
+  "Return a ghostel bookmark record for BUF-NAME pointing at DIR."
   `(,buf-name
     (handler . ghostel--bookmark-handler)
-    (thisdir . ,thisdir)
+    (location . ,dir)
     (buf-name . ,buf-name)
     (defaults . nil)))
 


### PR DESCRIPTION
Fixes #613.

`bookmark-bmenu-list` (`C-x r l`) showed ghostel bookmarks with a blank
Type column and `-- Unknown location --` in the File column.

Two causes:

- The record stored the working directory under a private `thisdir` key
  inherited from vterm. `bookmark-location` reads `location` (or
  `filename`), so it fell through to its unknown-location fallback.
- `ghostel--bookmark-handler` carried no `bookmark-handler-type` symbol
  property, which is what `bookmark-type-from-full-record` reads to fill
  the Type column.

Both fixed as suggested in the issue: the directory moves to `location`,
and the handler gets `(put 'ghostel--bookmark-handler
'bookmark-handler-type "Ghostel")` — matching how `shell.el`,
`esh-mode.el`, and the rest of Emacs core do it.

### Compatibility

Bookmarks saved by an earlier ghostel keep their `thisdir` key and will
no longer restore; the handler reads `location` exclusively. Bookmark
support only landed a few weeks ago, so this is deliberate rather than
carrying a fallback forever.

The `put` is inert before Emacs 29, which introduced the Type column.
`location` is read by every supported version, so nothing needs a
version guard or a compat shim.

### Verification

`make -j8 all` is green. The maker test now asserts `bookmark-location`
— the value the File column actually renders — rather than just the raw
property, plus a new test for the handler type. Rendering the real
`bookmark-bmenu-list` over a ghostel record now gives:

```
    ghostel: proj                  Ghostel  /Users/daniel/.emacs.d/lib/ghostel/
```