### PR TITLE
Don't conflate equally named projects in project buffer matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ All notable changes to this project will be documented in this file.
   t.  Fixes [#599](https://github.com/dakra/ghostel/issues/599).
 
 ### Fixed
+- `ghostel-project` and the project-scoped cycling commands no longer
+  conflate projects that share a directory name.  The identity used
+  for buffer reuse and for `identity`-scope matching was the
+  project-prefixed buffer name alone, so two projects both named e.g.
+  `website` shared buffers.  Buffers now record their project root at
+  creation (mirroring how magit keys buffers on the repository
+  toplevel rather than the buffer name).  Buffers from older sessions
+  (no recorded root) keep matching by name alone.
 - evil-ghostel: typing the first key of an `evil-escape` chord (e.g.
   `jk`) no longer doubles the character in the shell, and completing
   the chord no longer leaks it.  evil-escape previews the first key

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -389,10 +389,12 @@ project:
   against the current project root.  Follows shell `cd'.
   A terminal that walked out of the project is excluded; a plain
   `ghostel' buffer that cd'd into the project is included.
-- `identity': match each buffer's `ghostel--buffer-identity'
-  against the name `ghostel-project' would use for the current project.
-  Stable across `cd', but only finds buffers originally
-  created via `ghostel-project'.
+- `identity': match buffers created via `ghostel-project' for this
+  project by their recorded project root, so equally named projects
+  stay separate and numbered instances are found.  Buffers without a
+  recorded root (older sessions) fall back to comparing
+  `ghostel--buffer-identity' against the project-prefixed name.
+  Stable across `cd'.
 - `both' (default): union of the two - `default-directory' first,
   then identity-matched buffers not already covered."
   :type '(choice (const :tag "Match by buffer default-directory" default-directory)
@@ -1072,6 +1074,13 @@ variable re-enables automatic renaming for the next title update.")
 Set at buffer creation to the value of `ghostel-buffer-name' (or its numbered
 variant) before any title-tracking renames.  Used so that `ghostel' can reuse
 an existing buffer even after `ghostel--set-title' has renamed it.")
+
+(defvar-local ghostel--buffer-project-root nil
+  "Project root recorded when this buffer was created via `ghostel-project'.
+Nil for buffers created outside a project context, or by versions that
+did not track the root.  Qualifies `ghostel--buffer-identity' matches so
+two projects that share a directory name, and hence a buffer name, are
+not conflated.")
 
 (defvar-local ghostel--prompt-positions nil
   "List of prompt positions as (buffer-line . exit-status) pairs.
@@ -5292,16 +5301,29 @@ or quit, the partially created buffer is killed before re-signaling."
          (kill-buffer buffer))
        (signal (car err) (cdr err))))))
 
+(defvar ghostel--project-root nil
+  "Project root for the `ghostel' call in flight, or nil.
+Bound by `ghostel-project' so buffer creation records the root in
+`ghostel--buffer-project-root' and buffer reuse requires it to match.")
+
 (defun ghostel--find-buffer-by-identity (identity &optional predicate)
   "Return the first live ghostel buffer whose identity equals IDENTITY, or nil.
 Identity is the `ghostel-buffer-name' (or numbered variant) recorded at
-buffer creation time.  See `ghostel--buffer-identity'.
+buffer creation time.  See `ghostel--buffer-identity'.  When both
+`ghostel--project-root' and the buffer's recorded project root are
+non-nil they must also match, so equally named projects do not share
+buffers; a nil on either side matches anything, preserving buffers
+created before the root was tracked.
 Non-nil PREDICATE further filters candidates (called with the buffer),
 so several buffers sharing IDENTITY cannot shadow one the caller wants."
   (seq-find (lambda (b)
               (and (buffer-live-p b)
                    (equal (buffer-local-value 'ghostel--buffer-identity b)
                           identity)
+                   (let ((root (buffer-local-value
+                                'ghostel--buffer-project-root b)))
+                     (or (null root) (null ghostel--project-root)
+                         (equal root ghostel--project-root)))
                    (if predicate (funcall predicate b) t)))
             (buffer-list)))
 
@@ -5344,6 +5366,7 @@ Returns the buffer."
       (with-current-buffer buffer
         (setq ghostel--managed-buffer-name (buffer-name))
         (setq ghostel--buffer-identity (or identity (buffer-name)))
+        (setq ghostel--buffer-project-root ghostel--project-root)
         (ghostel--start-process)
         (ghostel--apply-initial-input-mode)))
     buffer))
@@ -5403,8 +5426,10 @@ To add this to `project-switch-commands':
   (add-to-list \\='project-switch-commands \\='(ghostel-project \"Ghostel\") t)
 Returns the buffer."
   (interactive "P")
-  (let* ((default-directory (project-root (project-current t)))
-         (ghostel-buffer-name (ghostel--project-buffer-name default-directory)))
+  (let* ((root (project-root (project-current t)))
+         (default-directory root)
+         (ghostel-buffer-name (ghostel--project-buffer-name root))
+         (ghostel--project-root root))
     (ghostel arg)))
 
 (defun ghostel-other ()
@@ -5460,8 +5485,17 @@ synchronously on every cycle."
           (and (memq scope '(identity both))
                (cl-remove-if-not
                 (lambda (b)
-                  (equal (buffer-local-value 'ghostel--buffer-identity b)
-                         identity-prefix))
+                  ;; Use recorded project root to distinguish equally named
+                  ;; projects and match numbered instances ("*NAME-ghostel*<2>")
+                  ;; whose identity differs from the un-numbered prefix.
+                  (let ((broot (buffer-local-value
+                                'ghostel--buffer-project-root b)))
+                    (if broot
+                        (equal broot root)
+                      ;; Buffers without a recorded root (older sessions) fall
+                      ;; back to comparing identity by name.
+                      (equal (buffer-local-value 'ghostel--buffer-identity b)
+                             identity-prefix))))
                 all))))
     (sort (cl-delete-duplicates (append by-dir by-id) :test #'eq)
           (lambda (a b) (string< (buffer-name a) (buffer-name b))))))

--- a/test/ghostel-buffers-test.el
+++ b/test/ghostel-buffers-test.el
@@ -9,17 +9,19 @@
 
 (require 'ghostel-test-helpers)
 
-(defun ghostel-buffers-test--make (name &optional dir identity)
+(defun ghostel-buffers-test--make (name &optional dir identity root)
   "Create a fake ghostel-mode buffer for tests.
-NAME is the buffer name.  Optional DIR sets `default-directory'
-and IDENTITY sets `ghostel--buffer-identity'.  The buffer claims
-`ghostel-mode' via `major-mode' without invoking the mode
-function (which would require the native module)."
+NAME is the buffer name.  Optional DIR sets `default-directory',
+IDENTITY sets `ghostel--buffer-identity', and ROOT sets
+`ghostel--buffer-project-root'.  The buffer claims `ghostel-mode' via
+`major-mode' without invoking the mode function (which would require
+the native module)."
   (let ((buf (generate-new-buffer name)))
     (with-current-buffer buf
       (setq major-mode 'ghostel-mode)
       (when dir (setq default-directory dir))
-      (when identity (setq-local ghostel--buffer-identity identity)))
+      (when identity (setq-local ghostel--buffer-identity identity))
+      (when root (setq-local ghostel--buffer-project-root root)))
     buf))
 
 (defmacro ghostel-buffers-test--with-bufs (bindings &rest body)
@@ -249,6 +251,71 @@ Each BINDING is (VAR NAME [DIR [IDENTITY]])."
           (let ((bufs (ghostel--project-buffers)))
             (should (memq tagged bufs))
             (should-not (memq untagged bufs))))))))
+
+(ert-deftest ghostel-test-project-buffers-identity-same-name-projects ()
+  "Scope `identity' separates equally named projects by recorded root.
+Buffers without a recorded root (older sessions) still match by
+identity alone."
+  (let* ((root (file-name-as-directory (make-temp-file "ghostel-myproj" t)))
+         (other-root (file-name-as-directory
+                      (make-temp-file "ghostel-twin" t)))
+         (ghostel-buffer-name "*ghostel*"))
+    (ghostel-buffers-test--with-bufs
+        ((ours "*ghostel-ours*" other-root "*myproj-ghostel*" root)
+         (twin "*ghostel-twin*" other-root "*myproj-ghostel*" other-root)
+         (legacy "*ghostel-legacy*" other-root "*myproj-ghostel*"))
+      (cl-letf (((symbol-function 'project-current)
+                 (ghostel-buffers-test--proj-stub root))
+                ((symbol-function 'project-root) (lambda (p) (cdr p)))
+                ((symbol-function 'project-prefixed-buffer-name)
+                 (lambda (name) (format "*myproj-%s*" name))))
+        (let ((default-directory root)
+              (ghostel-project-buffer-scope 'identity))
+          (let ((bufs (ghostel--project-buffers)))
+            (should (memq ours bufs))
+            (should-not (memq twin bufs))
+            (should (memq legacy bufs))))))))
+
+(ert-deftest ghostel-test-project-buffers-identity-root-primary ()
+  "Identity scope keys on the recorded root, not the buffer name.
+A numbered instance (\"*myproj-ghostel*<2>\") that cd'd out of the
+project is still found via its recorded root; a root-less buffer whose
+identity is not the project-prefixed name stays excluded."
+  (let* ((root (file-name-as-directory (make-temp-file "ghostel-myproj" t)))
+         (other-root (file-name-as-directory
+                      (make-temp-file "ghostel-other" t)))
+         (ghostel-buffer-name "*ghostel*"))
+    (ghostel-buffers-test--with-bufs
+        ((numbered "*ghostel-numbered*" other-root "*myproj-ghostel*<2>" root)
+         (plain "*ghostel-plain*" other-root "*ghostel*"))
+      (cl-letf (((symbol-function 'project-current)
+                 (ghostel-buffers-test--proj-stub root))
+                ((symbol-function 'project-root) (lambda (p) (cdr p)))
+                ((symbol-function 'project-prefixed-buffer-name)
+                 (lambda (name) (format "*myproj-%s*" name))))
+        (let ((default-directory root)
+              (ghostel-project-buffer-scope 'identity))
+          (let ((bufs (ghostel--project-buffers)))
+            (should (memq numbered bufs))
+            (should-not (memq plain bufs))))))))
+
+(ert-deftest ghostel-test-find-buffer-by-identity-root ()
+  "`ghostel--find-buffer-by-identity' honours `ghostel--project-root'.
+A bound root skips buffers recording a different root but accepts
+buffers with no recorded root; an unbound (nil) root matches any."
+  (ghostel-buffers-test--with-bufs
+      ((twin "*ghostel-twin*" nil "*myproj-ghostel*" "/tmp/b/myproj/"))
+    (let ((ghostel--project-root "/tmp/a/myproj/"))
+      (should-not (ghostel--find-buffer-by-identity "*myproj-ghostel*")))
+    (let ((ghostel--project-root "/tmp/b/myproj/"))
+      (should (eq twin (ghostel--find-buffer-by-identity "*myproj-ghostel*"))))
+    (let ((ghostel--project-root nil))
+      (should (eq twin (ghostel--find-buffer-by-identity "*myproj-ghostel*")))))
+  (ghostel-buffers-test--with-bufs
+      ((legacy "*ghostel-legacy*" nil "*myproj-ghostel*"))
+    (let ((ghostel--project-root "/tmp/a/myproj/"))
+      (should (eq legacy
+                  (ghostel--find-buffer-by-identity "*myproj-ghostel*"))))))
 
 (ert-deftest ghostel-test-project-buffers-both ()
   "Scope `both' unions `default-directory' and identity matches; no duplicates."

--- a/test/ghostel-project-test.el
+++ b/test/ghostel-project-test.el
@@ -27,6 +27,24 @@
       (should (string-match-p "ghostel" (cdr result)))
       (should-not (string-match-p "\\*\\*" (cdr result))))))
 
+(ert-deftest ghostel-test-project-binds-root ()
+  "`ghostel-project' binds `ghostel--project-root' around the `ghostel' call.
+The root is what creation records in `ghostel--buffer-project-root' and
+what reuse lookups match against."
+  (require 'project)
+  (let ((ghostel-buffer-name "*ghostel*")
+        captured)
+    (cl-letf (((symbol-function 'project-current)
+               (lambda (_maybe-prompt) '(transient . "/tmp/myproj/")))
+              ((symbol-function 'project-root)
+               (lambda (proj) (cdr proj)))
+              ((symbol-function 'project-prefixed-buffer-name)
+               (lambda (name) (format "*myproj-%s*" name)))
+              ((symbol-function 'ghostel)
+               (lambda (&optional _) (setq captured ghostel--project-root))))
+      (ghostel-project)
+      (should (equal "/tmp/myproj/" captured)))))
+
 (ert-deftest ghostel-test-project-universal-arg ()
   "`ghostel-project' forwards the prefix arg and binds `ghostel-buffer-name'."
   (require 'project)


### PR DESCRIPTION

Fixes #432.  (The issue was closed without a linked fix. The local same-name case it describes still reproduces on `main`.)

## Problem

`ghostel-project` and the project-scoped buffer commands identify a project's buffers by `ghostel--buffer-identity`, which is the project-prefixed buffer name, e.g. `*<root-dirname>-ghostel*`.

The name alone is ambiguous: two projects that share a directory name (say `~/work/website` and `~/oss/website`) produce the identical identity `*website-ghostel*`, so `ghostel-project` in project A switches to project B's terminal instead of creating one for A. The `identity` (and default `both`) scope of `ghostel--project-buffers` lists and cycles B's buffers while you are in A.

#499 fixed the sibling collision, a local and a remote root with the same path, by folding the TRAMP host into the name, but two local (or two same-host) projects with the same directory name still collide.

## Fix

Record the project root at creation and key identity matching on it.  **This mirrors how magit keys its per-repository buffers**: reuse compares `(major-mode, magit--default-directory, lock value)`, a toplevel recorded at creation, and never the buffer name, which stays purely cosmetic.

- New buffer-local `ghostel--buffer-project-root`, set at creation from the new dynamic variable `ghostel--project-root`, which `ghostel-project` binds around its `ghostel` call.  Plain `ghostel` buffers record nil.
- Identity-scope matching in `ghostel--project-buffers` keys on the recorded root, regardless of name.  **This also closes a pre-existing gap**: numbered instances (`*website-ghostel*<2>` from a numeric-arg `ghostel-project`) never matched the `equal` comparison against the un-numbered prefix, so identity scope missed them once their shell cd'd out of the project.
- Buffer reuse (`ghostel--find-buffer-by-identity`) additionally requires the roots to agree when both sides are non-nil. The name still distinguishes numbered instances within one project, so `C-5 M-x ghostel-project` finds instance 5 specifically.
- A nil recorded root (buffers from older sessions, `ghostel-bookmark` restores, or manual `ghostel-buffer-name` binders) keeps matching by name alone, so existing sessions and workflows are unaffected.

The displayed buffer name is intentionally unchanged. This fixes the matching key only.  (Uniquifying the visible name on conflict, e.g.  `*website-ghostel*` vs `*website<oss>-ghostel*`, would be a separate, purely cosmetic follow-up.)

## Other notes

Four new tests across `test/ghostel-buffers-test.el` and `test/ghostel-project-test.el`.

CHANGELOG.md updated under [Unreleased].

🤖 Generated with [Claude Code](https://claude.com/claude-code)
