### PR TITLE
Add ghostel-project-dwim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
   `desktop-read` starts a fresh shell in that directory under the
   saved buffer name, so restored window configurations find the
   buffer.
+- New command `ghostel-project-dwim`.  It creates a terminal when the
+  project has none, switches to it when there is exactly one, and
+  prompts via `read-buffer` when there are several.
 
 ### Changed
 - The bookmark functions are now public: `ghostel-bookmark-make-record`

--- a/README.org
+++ b/README.org
@@ -1824,6 +1824,7 @@ Enable it for any Emacs Lisp input method:
 |--------------------------------------+---------------------------------------------------------------------------|
 | =M-x ghostel=                          | Open a new terminal (create a new buffer with a prefix arg).              |
 | =M-x ghostel-project=                  | Open a terminal in the current project root (new buffer with prefix arg). |
+| =M-x ghostel-project-dwim=             | Project terminal: create if none, switch if one, pick if several.         |
 | =M-x ghostel-other=                    | Switch to the next terminal or create one.                                |
 | =M-x ghostel-next=                     | Cycle to the next ghostel buffer (sorted by name, wraps).                 |
 | =M-x ghostel-previous=                 | Cycle to the previous ghostel buffer.                                     |

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -38,6 +38,7 @@
 ;;
 ;;   M-x ghostel               Open a new terminal
 ;;   M-x ghostel-project       Open a terminal in the current project root
+;;   M-x ghostel-project-dwim  Project terminal: create, switch, or pick
 ;;   M-x ghostel-other         Switch to next terminal or create one
 ;;   M-x ghostel-next / ghostel-previous
 ;;                             Cycle through all ghostel buffers
@@ -5743,6 +5744,26 @@ Project membership is determined by `ghostel-project-buffer-scope'."
                                        (ghostel--project-buffers))
                  (append display-buffer--same-window-action
                          '((category . comint)))))
+
+;;;###autoload
+(defun ghostel-project-dwim (&optional arg)
+  "Switch to the current project's Ghostel terminal, creating or picking one.
+With no project terminal open, create one via `ghostel-project'.
+With exactly one open, switch to it.  With several open, pick one
+via `read-buffer'.  Membership is determined by
+`ghostel-project-buffer-scope'.  With prefix ARG, skip the
+selection and call `ghostel-project' with the prefix, so
+\\[universal-argument] still forces a new terminal.  Returns the buffer."
+  (interactive "P")
+  (let ((bufs (unless arg (ghostel--project-buffers))))
+    (if (or arg (null bufs))
+        (ghostel-project arg)
+      (let ((buffer (if (cdr bufs)
+                        (ghostel--read-buffer "Project ghostel buffer: " bufs)
+                      (car bufs))))
+        (pop-to-buffer buffer (append display-buffer--same-window-action
+                                      '((category . comint))))
+        buffer))))
 
 (provide 'ghostel)
 

--- a/test/ghostel-buffers-test.el
+++ b/test/ghostel-buffers-test.el
@@ -434,5 +434,56 @@ project's terminal because both rendered the same buffer name."
                (when maybe-prompt (user-error "No project")))))
     (should-error (ghostel-project-next) :type 'user-error)))
 
+;;; ghostel-project-dwim
+
+(ert-deftest ghostel-test-project-dwim-no-buffers-creates ()
+  "With no project terminal, `ghostel-project-dwim' calls `ghostel-project'."
+  (let ((captured 'not-called))
+    (cl-letf (((symbol-function 'ghostel--project-buffers) #'ignore)
+              ((symbol-function 'ghostel-project)
+               (lambda (&optional arg) (setq captured arg))))
+      (ghostel-project-dwim))
+    (should-not captured)
+    (should-not (eq captured 'not-called))))
+
+(ert-deftest ghostel-test-project-dwim-single-buffer-switches ()
+  "With one project terminal, `ghostel-project-dwim' pops to it, no prompt."
+  (ghostel-buffers-test--with-bufs ((a "*ghostel-a*"))
+    (let (popped)
+      (cl-letf (((symbol-function 'ghostel--project-buffers)
+                 (lambda () (list a)))
+                ((symbol-function 'ghostel-project)
+                 (lambda (&optional _) (error "Should not create")))
+                ((symbol-function 'read-buffer)
+                 (lambda (&rest _) (error "Should not prompt")))
+                ((symbol-function 'pop-to-buffer)
+                 (lambda (buf &rest _) (setq popped buf))))
+        (should (eq (ghostel-project-dwim) a))
+        (should (eq popped a))))))
+
+(ert-deftest ghostel-test-project-dwim-multiple-buffers-prompts ()
+  "With several project terminals, `ghostel-project-dwim' picks via prompt."
+  (ghostel-buffers-test--with-bufs ((a "*ghostel-a*")
+                                    (b "*ghostel-b*"))
+    (let (popped)
+      (cl-letf (((symbol-function 'ghostel--project-buffers)
+                 (lambda () (list a b)))
+                ((symbol-function 'read-buffer)
+                 (lambda (&rest _) (buffer-name b)))
+                ((symbol-function 'pop-to-buffer)
+                 (lambda (buf &rest _) (setq popped buf))))
+        (should (eq (ghostel-project-dwim) b))
+        (should (eq popped b))))))
+
+(ert-deftest ghostel-test-project-dwim-prefix-arg-passes-through ()
+  "A prefix arg makes `ghostel-project-dwim' defer to `ghostel-project'."
+  (let ((captured 'not-called))
+    (cl-letf (((symbol-function 'ghostel--project-buffers)
+               (lambda () (error "Should not scan buffers")))
+              ((symbol-function 'ghostel-project)
+               (lambda (&optional arg) (setq captured arg))))
+      (ghostel-project-dwim '(4)))
+    (should (equal captured '(4)))))
+
 (provide 'ghostel-buffers-test)
 ;;; ghostel-buffers-test.el ends here


### PR DESCRIPTION
## Problem

Working with more than one terminal per project is awkward, because no single command is safe to bind as "take me to a project terminal":

- `ghostel-project` keys its reuse check on the unnumbered project identity. Once only numbered or renamed instances remain (e.g. open two project terminals, kill the first), it creates yet another terminal instead of switching to the surviving one.
- Reaching a specific one of several project terminals means `ghostel-project-next` cycling or `ghostel-project-list-buffers`, and both signal an error when the project has no terminal yet.

(Related: #133 asked for support for multiple terminals per project. The cycle and list commands have since been added to ghostel, but without a tidy way to make everything work together in a single command.)

## Fix

A new command, `ghostel-project-dwim`, that does the expected thing at every amount of project terminals:

- with no project terminal it creates one via `ghostel-project`
- with exactly one it switches to it, whatever it is named
- with several  it prompts via `read-buffer`, defaulting to the forward-cycle buffer like `ghostel-project-list-buffers` does. Membership uses the existing `ghostel-project-buffer-scope` machinery.
- A prefix argument passes through to `ghostel-project`, so `C-u` still forces a new terminal and numeric session arguments keep their meaning.

For what it's worth, I surveyed how comparable packages (project.el's `project-shell`/`project-eshell`, eat, vterm, multi-vterm, mistty, vterm-toggle, shell-pop) handle several-terminals-per-project. All of them provide numeric prefix indices or blind cycling, consistent with ghostel, but none supports a picker. As far as I could tell, **this would be a novel feature unique to ghostel**. 🚀

Since ghostel already ships a `read-buffer` picker, extending it into a dwim entry point seemed like the natural ghostel-native answer.

## Other info

Four new tests in test/ghostel-buffers-test.el cover the three branches and the prefix pass-through.

README command table and CHANGELOG entries included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
