### PR TITLE
Show the terminal title in the mode line instead of renaming buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Terminal buffers keep a stable name; the terminal title moves to the
+  mode line.  `ghostel-buffer-name-function` now defaults to nil, so
+  OSC 2 titles and OSC 7 `cd`s no longer rename the buffer — names like
+  `*ghostel*` stay valid for `switch-to-buffer` history,
+  `display-buffer-alist` rules, bookmarks, and desktop restore, and
+  buffer lists still disambiguate terminals by directory (buffer-menu,
+  ibuffer, and marginalia show each terminal's cwd).  The title is
+  instead shown in `mode-line-buffer-identification`, controlled by the
+  new `ghostel-buffer-identification-format` — a `format-spec` string
+  (default `"%b (%.30t)"`) with `%b` = buffer name, `%t` = title
+  (capped at 30 columns by default, full title in the tooltip), and
+  `%d` = abbreviated `default-directory`; when a format uses `%t` and
+  the terminal has no title, only the buffer name is shown, and nil
+  leaves the mode line untouched.  To restore the previous behavior:
+  `(setq ghostel-buffer-name-function #'ghostel-buffer-name-by-title)`.
 - `ghostel-compile` now honours `compilation-scroll-output` instead of
   always scrolling.  With the default nil, compilation-style runs keep
   the window at the top of the output like `M-x compile`; any non-nil

--- a/README.org
+++ b/README.org
@@ -821,8 +821,9 @@ TRAMP-aware =auth-source-pick-first-password= example.
   TRAMP-aware for remote hosts).
 - *OSC 133* - semantic prompt markers, enabling prompt-to-prompt navigation with
   =C-c M-n= / =C-c M-p=.
-- *OSC 2* - title tracking (the buffer is renamed from the terminal title; see
-  =ghostel-buffer-name-function=).
+- *OSC 2* - title tracking (the title is shown in the mode line; see
+  =ghostel-buffer-identification-format=.  Set =ghostel-buffer-name-function= to
+  rename the buffer from the title instead).
 - *OSC 52;e* - call whitelisted Emacs functions from shell scripts (see [[#calling-elisp-from-the-shell][Calling
   Elisp from the Shell]]).
 - *OSC 52* - clipboard support (opt-in, for remote sessions).
@@ -1304,23 +1305,24 @@ tables below group them by area; defaults shown are the out-of-the-box values.
 
 ** Process and environment
 
-| Variable                         | Default                                       | Description                                                                                                   |
-|----------------------------------+-----------------------------------------------+---------------------------------------------------------------------------------------------------------------|
-| =ghostel-shell=                    | =$SHELL= (else =/bin/sh=)                         | Shell program to run.  A string, or a list of executable + args.                                              |
-| =ghostel-use-native-pty=           | =t=                                             | Use the native PTY reader for local buffers.  Remote TRAMP buffers always use Emacs processes.                |
-| =ghostel-term=                     | ="xterm-ghostty"=                               | Value of =TERM=.  Advertises the bundled terminfo's full capability set.  Set to ="xterm-256color"= to fall back. |
-| =ghostel-environment=              | =nil=                                           | Extra env vars (list of ="KEY=VALUE"= strings; bare ="KEY"= unsets).  Honored via dir-locals.                     |
-| =ghostel-macos-login-shell=        | =t= on macOS                                    | Wrap the shell via =login(1)= so it starts as a login shell (matches Terminal.app / Ghostty).                   |
-| =ghostel-pre-spawn-hook=           | =nil=                                           | Hook run just before =make-process=; =process-environment= is bound for last-minute env tweaks.                   |
-| =ghostel-buffer-name=              | ="*ghostel*"=                                     | Default buffer name.                                                                                          |
-| =ghostel-project-buffer-scope=     | =both=                                          | How project commands scope buffers: =default-directory=, =identity=, or =both=.                                     |
-| =ghostel-buffer-name-function=     | =ghostel-buffer-name-by-title=                  | Maps OSC 2 title + =default-directory= to a buffer name (nil return keeps it); nil disables.                    |
-| =ghostel-kill-buffer-on-exit=      | =t=                                             | Kill the buffer when the shell process exits.                                                                 |
-| =ghostel-query-before-killing=     | =auto=                                          | Confirm before killing a live buffer / exiting Emacs: =t=, =nil=, or =auto= (only while a command runs).            |
-| =ghostel-exit-functions=           | =nil=                                           | Hook run with =(BUFFER EVENT)= when the terminal process exits.                                                 |
-| =ghostel-command-start-functions=  | =(ghostel--query-before-killing-on-cmd-start)=  | Hook run with =(BUFFER)= on OSC 133 C (command start).                                                          |
-| =ghostel-command-finish-functions= | =(ghostel--query-before-killing-on-cmd-finish)= | Hook run with =(BUFFER EXIT-STATUS)= on OSC 133 D (command finish).                                             |
-| =ghostel-bookmark-check-dir=       | =t=                                             | Restore the working directory when jumping to a ghostel [[#bookmarks][bookmark]] (=cd= into a reused buffer that moved).      |
+| Variable                             | Default                                       | Description                                                                                                                                                                                              |
+|--------------------------------------+-----------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| =ghostel-shell=                        | =$SHELL= (else =/bin/sh=)                         | Shell program to run.  A string, or a list of executable + args.                                                                                                                                         |
+| =ghostel-use-native-pty=               | =t=                                             | Use the native PTY reader for local buffers.  Remote TRAMP buffers always use Emacs processes.                                                                                                           |
+| =ghostel-term=                         | ="xterm-ghostty"=                               | Value of =TERM=.  Advertises the bundled terminfo's full capability set.  Set to ="xterm-256color"= to fall back.                                                                                            |
+| =ghostel-environment=                  | =nil=                                           | Extra env vars (list of ="KEY=VALUE"= strings; bare ="KEY"= unsets).  Honored via dir-locals.                                                                                                                |
+| =ghostel-macos-login-shell=            | =t= on macOS                                    | Wrap the shell via =login(1)= so it starts as a login shell (matches Terminal.app / Ghostty).                                                                                                              |
+| =ghostel-pre-spawn-hook=               | =nil=                                           | Hook run just before =make-process=; =process-environment= is bound for last-minute env tweaks.                                                                                                              |
+| =ghostel-buffer-name=                  | ="*ghostel*"=                                     | Default buffer name.                                                                                                                                                                                     |
+| =ghostel-project-buffer-scope=         | =both=                                          | How project commands scope buffers: =default-directory=, =identity=, or =both=.                                                                                                                                |
+| =ghostel-buffer-name-function=         | =nil=                                           | Maps OSC 2 title + =default-directory= to a buffer name (nil return keeps it); nil (default) disables renaming.  =ghostel-buffer-name-by-title= and =ghostel-buffer-name-by-directory= are ready-made choices. |
+| =ghostel-buffer-identification-format= | ="%b (%.30t)"=                                  | =format-spec= string for =mode-line-buffer-identification=: =%b= buffer name, =%t= terminal title, =%d= abbreviated =default-directory=.  nil leaves the mode line alone.                                            |
+| =ghostel-kill-buffer-on-exit=          | =t=                                             | Kill the buffer when the shell process exits.                                                                                                                                                            |
+| =ghostel-query-before-killing=         | =auto=                                          | Confirm before killing a live buffer / exiting Emacs: =t=, =nil=, or =auto= (only while a command runs).                                                                                                       |
+| =ghostel-exit-functions=               | =nil=                                           | Hook run with =(BUFFER EVENT)= when the terminal process exits.                                                                                                                                            |
+| =ghostel-command-start-functions=      | =(ghostel--query-before-killing-on-cmd-start)=  | Hook run with =(BUFFER)= on OSC 133 C (command start).                                                                                                                                                     |
+| =ghostel-command-finish-functions=     | =(ghostel--query-before-killing-on-cmd-finish)= | Hook run with =(BUFFER EXIT-STATUS)= on OSC 133 D (command finish).                                                                                                                                        |
+| =ghostel-bookmark-check-dir=           | =t=                                             | Restore the working directory when jumping to a ghostel [[#bookmarks][bookmark]] (=cd= into a reused buffer that moved).                                                                                                   |
 
 ** Native module
 

--- a/lisp/ghostel-eshell.el
+++ b/lisp/ghostel-eshell.el
@@ -42,8 +42,7 @@
   "Whether to let visual-command buffers rename themselves via OSC titles.
 When nil (the default), the visual-command buffer keeps its initial
 name (e.g. \"*vim*\") for the duration of the program.  When non-nil,
-the terminal program may rename the buffer via OSC 0/2 title escapes
-the same way a regular ghostel terminal does."
+OSC 0/2 title escapes rename the buffer via `ghostel-buffer-name-by-title'."
   :type 'boolean
   :group 'ghostel)
 
@@ -89,8 +88,9 @@ eshell."
       (with-current-buffer buf
         (setq-local ghostel-kill-buffer-on-exit
                     (bound-and-true-p eshell-destroy-buffer-when-process-dies))
-        (unless ghostel-eshell-track-title
-          (setq-local ghostel-buffer-name-function nil))
+        (setq-local ghostel-buffer-name-function
+                    (and ghostel-eshell-track-title
+                         #'ghostel-buffer-name-by-title))
         (add-hook 'ghostel-exit-functions
                   #'ghostel-eshell--visual-exit nil t))
       nil)))

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -89,6 +89,7 @@
 (require 'cl-lib)
 (require 'comint)
 (require 'compat)
+(require 'format-spec)
 (require 'project)
 (require 'shell)
 (require 'text-property-search)
@@ -403,19 +404,34 @@ project:
 (define-obsolete-variable-alias 'ghostel-set-title-function
   'ghostel-buffer-name-function "0.32.0")
 
-(defcustom ghostel-buffer-name-function #'ghostel-buffer-name-by-title
+(defcustom ghostel-buffer-name-function nil
   "Function returning the ghostel buffer name, or nil to leave it unchanged.
 Called in the ghostel buffer with one argument, the terminal TITLE (the
 OSC 2 string; may be nil or empty), on both a title change and a `cd' \(OSC 7).
 Read `default-directory' for the current directory.
 Renames the buffer to the returned string, declining after a manual rename.
-Set to nil to disable renaming entirely."
+The mode line shows the title independently of this variable;
+see `ghostel-buffer-identification-format'."
   :type '(choice (const :tag "Disabled" nil)
                  (function-item :tag "By title — *ghostel: TITLE*"
                                 ghostel-buffer-name-by-title)
                  (function-item :tag "By directory — *ghostel: DIR*"
                                 ghostel-buffer-name-by-directory)
                  (function :tag "Custom function")))
+
+(defcustom ghostel-buffer-identification-format "%b (%.30t)"
+  "Format for `mode-line-buffer-identification' in ghostel buffers.
+A `format-spec' string with these specs:
+  %b  buffer name (stays live across renames)
+  %t  terminal title (OSC 0/2)
+  %d  abbreviated `default-directory'
+`format-spec' width and truncation modifiers apply to %t and %d (the
+default caps the title at 30 columns) but are ignored on %b.
+When the format references %t and the terminal has no title,
+only the buffer name is shown.
+Set to nil to leave `mode-line-buffer-identification' alone."
+  :type '(choice (const :tag "Leave the mode line alone" nil)
+                 (string :tag "Format string")))
 
 (defcustom ghostel-kill-buffer-on-exit t
   "Kill the buffer when the terminal process exits."
@@ -3367,7 +3383,51 @@ Maps TITLE through `ghostel-buffer-name-function' and renames via
 `ghostel--rename-managed', which declines after a manual rename."
   (setq ghostel--title title)
   (when ghostel-buffer-name-function
-    (ghostel--rename-managed (funcall ghostel-buffer-name-function title))))
+    (ghostel--rename-managed (funcall ghostel-buffer-name-function title)))
+  (ghostel--buffer-identification-update))
+
+(defun ghostel--buffer-identification (format)
+  "Return a `mode-line-buffer-identification' value built from FORMAT.
+See `ghostel-buffer-identification-format' for the specs.
+%b stays a live mode-line construct.
+A FORMAT with %t returns the plain buffer name while the terminal has no title."
+  (if (and (or (null ghostel--title) (string= "" ghostel--title))
+           ;; Skip quoted percents so e.g. "50%%tests" is not read as a
+           ;; title reference.
+           (string-match-p "%[ 0<>^_-]*[0-9]*\\(?:\\.[0-9]+\\)?t"
+                           (string-replace "%%" "" format)))
+      (propertized-buffer-identification "%b")
+    (let* ((expanded
+            ;; %b is passed through to the mode line, where `format-spec'
+            ;; modifiers have no meaning; drop them so they cannot pad or
+            ;; truncate the placeholder instead of the buffer name.
+            (format-spec (replace-regexp-in-string
+                          "%[ 0<>^_-]*[0-9]*\\(?:\\.[0-9]+\\)?b" "%b" format)
+                         `((?b . "\0")
+                           (?t . ,(propertize (or ghostel--title "")
+                                              'help-echo ghostel--title))
+                           (?d . ,(abbreviate-file-name
+                                   (directory-file-name default-directory))))
+                         'ignore))
+           (name (propertized-buffer-identification "%b"))
+           (parts (split-string expanded "\0"))
+           (construct (list (string-replace "%" "%%" (car parts)))))
+      (dolist (part (cdr parts))
+        (push name construct)
+        (push (string-replace "%" "%%" part) construct))
+      (nreverse construct))))
+
+(defun ghostel--buffer-identification-update ()
+  "Recompute `mode-line-buffer-identification' from the configured format.
+No-op when `ghostel-buffer-identification-format' is nil."
+  (when ghostel-buffer-identification-format
+    (let ((new (ghostel--buffer-identification
+                ghostel-buffer-identification-format)))
+      ;; Property-aware comparison: a truncated %t can render identically
+      ;; for different titles while the help-echo differs.
+      (unless (equal-including-properties new mode-line-buffer-identification)
+        (setq-local mode-line-buffer-identification new)
+        (force-mode-line-update)))))
 
 (defun ghostel--cursor-blink-stop ()
   "Cancel the blink timer, restore the cursor, and remove the blink hooks.
@@ -3481,7 +3541,8 @@ file:// URL does not match the local machine, construct a TRAMP path."
                   list-buffers-directory default-directory))))
       (when ghostel-buffer-name-function
         (ghostel--rename-managed
-         (funcall ghostel-buffer-name-function ghostel--title))))))
+         (funcall ghostel-buffer-name-function ghostel--title)))
+      (ghostel--buffer-identification-update))))
 
 
 ;;; Palette
@@ -5046,6 +5107,7 @@ may change freely (`ghostel-compile' finalize relies on this)."
   (setq-local filter-buffer-substring-function #'ghostel--filter-buffer-substring)
   ;; expose cwd to buffer-menu/ibuffer
   (setq-local list-buffers-directory (expand-file-name default-directory))
+  (ghostel--buffer-identification-update)
   ;; bookmark this buffer's cwd (loads ghostel-bookmark.el lazily on use)
   (setq-local bookmark-make-record-function #'ghostel--bookmark-make-record)
   (setq ghostel--input-mode 'semi-char)
@@ -5168,6 +5230,9 @@ spawn after initialization."
           ghostel--cursor-pos nil
           ghostel--cursor-char-pos nil
           ghostel--repainted-region nil)
+    ;; Reused buffers hold the previous session's title; drop it from
+    ;; the mode line along with the buffer-local reset above.
+    (ghostel--buffer-identification-update)
     (let* ((w (or (get-buffer-window buffer t) (selected-window)))
            (height (max 1 (or rows
                               (if (window-live-p w)

--- a/test/ghostel-buffer-name-test.el
+++ b/test/ghostel-buffer-name-test.el
@@ -46,7 +46,7 @@
 ;;; Title path (OSC 2) -- pure elisp
 
 (ert-deftest ghostel-test-set-title-renames-and-respects-manual ()
-  "An OSC 2 title renames via the default function; a manual rename wins."
+  "An OSC 2 title renames via the by-title function; a manual rename wins."
   (let (buf)
     (unwind-protect
         (cl-letf (((symbol-function 'ghostel--new)
@@ -56,21 +56,22 @@
                    (lambda (&rest _args) nil))
                   ((symbol-function 'ghostel--start-process)
                    (lambda () nil)))
-          (ghostel)
-          (setq buf (current-buffer))
-          (with-current-buffer buf
-            (should (equal "*ghostel*" (buffer-name)))
-            (should (equal "*ghostel*" ghostel--managed-buffer-name))
-            (ghostel--set-title "Title A")
-            (should (equal "Title A" ghostel--title))
-            (should (equal "*ghostel: Title A*" (buffer-name)))
-            (should (equal "*ghostel: Title A*" ghostel--managed-buffer-name))
-            (ghostel--set-title "Title A2")
-            (should (equal "*ghostel: Title A2*" (buffer-name)))
-            (rename-buffer "manual title" t)
-            (ghostel--set-title "Title B")
-            (should (equal "manual title" (buffer-name)))
-            (should (equal "*ghostel: Title A2*" ghostel--managed-buffer-name))))
+          (let ((ghostel-buffer-name-function #'ghostel-buffer-name-by-title))
+            (ghostel)
+            (setq buf (current-buffer))
+            (with-current-buffer buf
+              (should (equal "*ghostel*" (buffer-name)))
+              (should (equal "*ghostel*" ghostel--managed-buffer-name))
+              (ghostel--set-title "Title A")
+              (should (equal "Title A" ghostel--title))
+              (should (equal "*ghostel: Title A*" (buffer-name)))
+              (should (equal "*ghostel: Title A*" ghostel--managed-buffer-name))
+              (ghostel--set-title "Title A2")
+              (should (equal "*ghostel: Title A2*" (buffer-name)))
+              (rename-buffer "manual title" t)
+              (ghostel--set-title "Title B")
+              (should (equal "manual title" (buffer-name)))
+              (should (equal "*ghostel: Title A2*" ghostel--managed-buffer-name)))))
       (when (buffer-live-p buf) (kill-buffer buf)))))
 
 (ert-deftest ghostel-test-buffer-name-disabled ()
@@ -214,6 +215,164 @@ Guards against renaming to \"*ghostel: nil*\" before a title is set."
             (ghostel--update-directory dir)
             (should (equal before (buffer-name)))
             (should (equal dir default-directory))))
+      (delete-directory dir))))
+
+;;; Mode-line buffer identification
+
+(ert-deftest ghostel-test-buffer-name-function-default-nil ()
+  "Renaming is off by default; the title lives in the mode line instead."
+  (should (null (default-value 'ghostel-buffer-name-function))))
+
+;; `format-mode-line' renders as "" in batch Emacs, so these tests
+;; assert on the mode-line construct itself.  `equal' ignores text
+;; properties: ("%b") is the live buffer-name construct returned by
+;; `propertized-buffer-identification'.
+
+(ert-deftest ghostel-test-buffer-identification-title-and-dir ()
+  "%t and %d substitute; %b stays a live mode-line construct."
+  (with-temp-buffer
+    (setq-local ghostel--title "vim main.c")
+    (let ((default-directory "/tmp/some/dir/"))
+      (should (equal `("" ("%b") ,(format " (vim main.c) [%s]"
+                                          (abbreviate-file-name
+                                           "/tmp/some/dir")))
+                     (ghostel--buffer-identification "%b (%t) [%d]"))))))
+
+(ert-deftest ghostel-test-buffer-identification-truncates-title ()
+  "A precision modifier caps the title; `help-echo' keeps the full title."
+  (with-temp-buffer
+    (setq-local ghostel--title "abcdefgh")
+    (let* ((construct (ghostel--buffer-identification "%b %.5t"))
+           (seg (car (last construct))))
+      (should (equal '("" ("%b") " abcde") construct))
+      (should (equal "abcdefgh"
+                     (get-text-property (string-search "abcde" seg) 'help-echo
+                                        seg))))))
+
+(ert-deftest ghostel-test-buffer-identification-empty-title-fallback ()
+  "A format referencing %t collapses to the buffer name without a title."
+  (with-temp-buffer
+    (dolist (title '(nil ""))
+      (setq-local ghostel--title title)
+      (should (equal '("%b")
+                     (ghostel--buffer-identification "%b (%.30t)"))))))
+
+(ert-deftest ghostel-test-buffer-identification-no-title-spec-renders ()
+  "A format without %t renders even when the terminal has no title."
+  (with-temp-buffer
+    (setq-local ghostel--title nil)
+    (let ((default-directory "/tmp/some/dir/"))
+      (should (equal `("" ("%b") ,(format " [%s]"
+                                          (abbreviate-file-name
+                                           "/tmp/some/dir")))
+                     (ghostel--buffer-identification "%b [%d]"))))))
+
+(ert-deftest ghostel-test-buffer-identification-escapes-percent ()
+  "A % in the title is escaped instead of parsed as a mode-line construct."
+  (with-temp-buffer
+    (setq-local ghostel--title "100% done")
+    (should (equal '("" ("%b") " (100%% done)")
+                   (ghostel--buffer-identification "%b (%t)")))))
+
+(ert-deftest ghostel-test-buffer-identification-b-ignores-modifiers ()
+  "Width/precision modifiers on %b are dropped, not applied to the placeholder."
+  (with-temp-buffer
+    (setq-local ghostel--title "title")
+    (dolist (fmt '("%-10b (%t)" "%12b (%t)" "%.0b (%t)"))
+      (should (equal '("" ("%b") " (title)")
+                     (ghostel--buffer-identification fmt))))))
+
+(ert-deftest ghostel-test-buffer-identification-quoted-percent-not-title ()
+  "A quoted %% before t is not read as a %t reference."
+  (with-temp-buffer
+    (setq-local ghostel--title nil)
+    ;; No fallback: the format does not reference the title.
+    (should (equal '("" ("%b") " 50%%tests")
+                   (ghostel--buffer-identification "%b 50%%tests")))))
+
+(ert-deftest ghostel-test-buffer-identification-help-echo-tracks-title ()
+  "Titles sharing a truncated prefix still refresh the `help-echo'."
+  (with-temp-buffer
+    (let ((ghostel-buffer-identification-format "%b %.5t"))
+      (setq-local ghostel--title "abcdeXX")
+      (ghostel--buffer-identification-update)
+      (setq-local ghostel--title "abcdeYY")
+      (ghostel--buffer-identification-update)
+      (let ((seg (car (last mode-line-buffer-identification))))
+        (should (equal "abcdeYY"
+                       (get-text-property (string-search "abcde" seg)
+                                          'help-echo seg)))))))
+
+(ert-deftest ghostel-test-buffer-identification-b-stays-live ()
+  "%b expands to the live construct, never a frozen buffer name."
+  (with-temp-buffer
+    (setq-local ghostel--title "title")
+    (let ((construct (ghostel--buffer-identification "%b (%t)")))
+      (should (equal '("%b") (nth 1 construct)))
+      ;; No segment carries a snapshot of the current buffer name.
+      (dolist (part construct)
+        (when (stringp part)
+          (should-not (string-search (buffer-name) part)))))))
+
+(ert-deftest ghostel-test-buffer-identification-nil-format-leaves-mode-line ()
+  "A nil `ghostel-buffer-identification-format' leaves the mode line alone."
+  (with-temp-buffer
+    (setq-local ghostel--title "title")
+    (let ((before mode-line-buffer-identification)
+          (ghostel-buffer-identification-format nil))
+      (ghostel--buffer-identification-update)
+      (should (eq before mode-line-buffer-identification)))))
+
+(ert-deftest ghostel-test-set-title-updates-identification ()
+  "An OSC 2 title lands in the mode line; the buffer name stays put."
+  (let (buf)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--new)
+                   (lambda (&rest _args) 'fake-term))
+                  ((symbol-function 'ghostel--set-size) #'ignore)
+                  ((symbol-function 'ghostel--apply-palette)
+                   (lambda (&rest _args) nil))
+                  ((symbol-function 'ghostel--start-process)
+                   (lambda () nil)))
+          (ghostel)
+          (setq buf (current-buffer))
+          (with-current-buffer buf
+            ;; No title yet: identification is the plain buffer name.
+            (should (equal '("%b") mode-line-buffer-identification))
+            (ghostel--set-title "Hello")
+            ;; Default `ghostel-buffer-name-function' nil: no rename.
+            (should (equal "*ghostel*" (buffer-name)))
+            (should (equal '("" ("%b") " (Hello)")
+                           mode-line-buffer-identification))
+            ;; Reinitializing a reused buffer drops the stale title.
+            (ghostel--init-buffer buf)
+            (should (null ghostel--title))
+            (should (equal '("%b") mode-line-buffer-identification))))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-update-directory-updates-identification ()
+  "An OSC 7 `cd' recomputes a %d identification."
+  (let ((dir (file-name-as-directory (make-temp-file "ghostel-cd" t)))
+        (ghostel-buffer-identification-format "%b [%d]")
+        buf)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--new)
+                   (lambda (&rest _args) 'fake-term))
+                  ((symbol-function 'ghostel--set-size) #'ignore)
+                  ((symbol-function 'ghostel--apply-palette)
+                   (lambda (&rest _args) nil))
+                  ((symbol-function 'ghostel--start-process)
+                   (lambda () nil)))
+          (ghostel)
+          (setq buf (current-buffer))
+          (with-current-buffer buf
+            (ghostel--update-directory dir)
+            (should (equal dir default-directory))
+            (should (equal `("" ("%b") ,(format " [%s]"
+                                                (abbreviate-file-name
+                                                 (directory-file-name dir))))
+                           mode-line-buffer-identification))))
+      (when (buffer-live-p buf) (kill-buffer buf))
       (delete-directory dir))))
 
 (provide 'ghostel-buffer-name-test)


### PR DESCRIPTION
## Summary

- `ghostel-buffer-name-function` now defaults to nil: OSC 2 titles and OSC 7 `cd`s no longer rename terminal buffers. Names stay stable for `switch-to-buffer` history, `display-buffer-alist` rules, bookmarks, and desktop restore; buffer lists still tell terminals apart by directory (buffer-menu, ibuffer, and marginalia show each terminal's cwd via `list-buffers-directory` / the process annotation).
- The title moves to `mode-line-buffer-identification`, driven by the new `ghostel-buffer-identification-format` — a `format-spec` string (default `"%b (%.30t)"`):
  - `%b` buffer name, passed through as a live mode-line construct (manual renames show without a recompute; `format-spec` modifiers are ignored on it)
  - `%t` terminal title, truncatable (e.g. `%.30t`), full title as `help-echo` on the truncated text
  - `%d` abbreviated `default-directory`
  - a format referencing `%t` collapses to the plain buffer name while no title is set; nil leaves the mode line alone
- Recomputed at the OSC 2 / OSC 7 choke points and on buffer (re)init; title/directory text is %-escaped after truncation so a literal `%` can't be parsed as a mode-line construct.
- `ghostel-eshell-track-title` now installs `ghostel-buffer-name-by-title` buffer-locally instead of relying on the old global default.

To restore the previous behavior:
```elisp
(setq ghostel-buffer-name-function #'ghostel-buffer-name-by-title)
```

## Testing

- `make -j8 all` (byte-compile, elisp + native tests, package-lint, checkdoc) passes
- 13 new ERT tests in `test/ghostel-buffer-name-test.el` covering spec expansion, truncation + `help-echo`, empty-title fallback, `%%` quoting, `%b` modifier handling, nil format, both choke points, and the reinit path (construct-structural, since `format-mode-line` renders empty in batch)
- Live TTY render verified in a real Emacs frame: title display, no-rename default, literal `%`, 30-column cap, live `%b` after manual rename, `%d` tracking OSC 7