### PR TITLE
Keep the logical path in symlinked directories and fix bookmark reuse

### DIFF
--- a/lisp/ghostel-bookmark.el
+++ b/lisp/ghostel-bookmark.el
@@ -7,9 +7,10 @@
 
 ;; Integrate ghostel buffers with Emacs's built-in bookmark facility
 ;; (`bookmark-set' / `bookmark-jump', i.e. `C-x r m' / `C-x r b').  A
-;; bookmark records the buffer's working directory and name; jumping to
-;; it reuses a live ghostel buffer of that name, or starts a fresh shell
-;; in the bookmarked directory when none exists.
+;; bookmark records the buffer's working directory, name, and identity
+;; (see `ghostel--buffer-identity'); jumping to it reuses a live ghostel
+;; buffer with that identity (or name, for records without one), or
+;; starts a fresh shell in the bookmarked directory when none exists.
 ;;
 ;; `ghostel-mode' wires up `bookmark-make-record-function' to point at
 ;; `ghostel--bookmark-make-record' (a quoted symbol, so ghostel.el needs
@@ -33,34 +34,47 @@ a `cd' to the bookmarked directory is typed into the shell."
 ;;;###autoload
 (defun ghostel--bookmark-make-record ()
   "Return a bookmark record for the current ghostel buffer.
-Notes the working directory and buffer name.
+Notes the working directory, buffer name, and buffer identity.
 See `ghostel--bookmark-handler' for how they are restored."
   `(nil
     (handler . ghostel--bookmark-handler)
     (location . ,default-directory)
     (buf-name . ,(buffer-name))
+    (identity . ,ghostel--buffer-identity)
     (defaults . nil)))
 
 ;;;###autoload
 (defun ghostel--bookmark-handler (bmk)
   "Restore the ghostel bookmark BMK.
-Reuse a live ghostel buffer of the bookmarked name, or create one with a shell
-started in the bookmarked directory.  When a reused buffer's directory differs
-and `ghostel-bookmark-check-dir' is non-nil, type a `cd' into the shell."
+Reuse a live ghostel buffer with the bookmarked identity (or name, for
+records without one; title tracking may have renamed the buffer since),
+or create one with a shell started in the bookmarked directory.
+When a reused buffer's directory differs and `ghostel-bookmark-check-dir'
+is non-nil, type a `cd' into the shell."
   (ghostel--load-module t)
   (let* ((dir (bookmark-prop-get bmk 'location))
          (buf-name (bookmark-prop-get bmk 'buf-name))
-         (buf (get-buffer buf-name))
-         (mode (and buf (buffer-local-value 'major-mode buf))))
+         (identity (bookmark-prop-get bmk 'identity))
+         (live-p (lambda (b)
+                   (let ((p (and b (buffer-local-value 'ghostel--process b))))
+                     (and p (process-live-p p) b))))
+         ;; Retained dead-shell buffers may share the identity; reuse only
+         ;; a live one.  The name lookup is for pre-identity records only.
+         (buf (if identity
+                  (ghostel--find-buffer-by-identity identity live-p)
+                (let ((b (get-buffer buf-name)))
+                  (and b
+                       (eq (buffer-local-value 'major-mode b) 'ghostel-mode)
+                       (funcall live-p b))))))
     ;; Create branch: the shell starts directly in DIR (no `cd').
-    (when (or (not buf) (not (eq mode 'ghostel-mode)))
+    (unless buf
       (let ((default-directory (if ghostel-bookmark-check-dir
                                    dir
                                  default-directory)))
         (setq buf (ghostel--create buf-name))
         (with-current-buffer buf
           (setq ghostel--managed-buffer-name (buffer-name)
-                ghostel--buffer-identity buf-name)
+                ghostel--buffer-identity (or identity buf-name))
           (ghostel--start-process)
           (ghostel--apply-initial-input-mode))))
     ;; Reuse branch: `cd' if the live buffer has wandered elsewhere.

--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -641,6 +641,7 @@ Returns the process."
                   (ghostel--terminal-env)
                   ;; Defeat pagers (git grep, etc.).
                   (list "PAGER=")
+                  (ghostel--logical-pwd-env remote-p)
                   (copy-sequence process-environment)))
          ;; See `ghostel--spawn-pty' for why these are set.
          (process-adaptive-read-buffering nil)

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -5292,14 +5292,17 @@ or quit, the partially created buffer is killed before re-signaling."
          (kill-buffer buffer))
        (signal (car err) (cdr err))))))
 
-(defun ghostel--find-buffer-by-identity (identity)
-  "Return the live ghostel buffer whose identity equals IDENTITY, or nil.
+(defun ghostel--find-buffer-by-identity (identity &optional predicate)
+  "Return the first live ghostel buffer whose identity equals IDENTITY, or nil.
 Identity is the `ghostel-buffer-name' (or numbered variant) recorded at
-buffer creation time — see `ghostel--buffer-identity'."
+buffer creation time.  See `ghostel--buffer-identity'.
+Non-nil PREDICATE further filters candidates (called with the buffer),
+so several buffers sharing IDENTITY cannot shadow one the caller wants."
   (seq-find (lambda (b)
               (and (buffer-live-p b)
                    (equal (buffer-local-value 'ghostel--buffer-identity b)
-                          identity)))
+                          identity)
+                   (if predicate (funcall predicate b) t)))
             (buffer-list)))
 
 (defun ghostel--apply-initial-input-mode ()

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -162,7 +162,7 @@ A list of \"KEY=VALUE\" strings, prepended to `process-environment'
 before spawning the shell.  A bare \"KEY\" (no `=') unsets the variable.
 
 For local spawns, entries here take precedence over ghostel's own
-variables (TERM, INSIDE_EMACS, EMACS_GHOSTEL_PATH,
+variables (TERM, INSIDE_EMACS, PWD, EMACS_GHOSTEL_PATH,
 shell-integration vars), so a user who sets TERM here wins — which
 will also disable ghostel's shell integration if the chosen TERM
 breaks its assumptions.
@@ -4185,6 +4185,16 @@ verbatim.  `COLORTERM=truecolor' is exported unconditionally."
     (concat "TERM=" (shell-quote-argument ghostel-term)
             "; COLORTERM=truecolor; export TERM COLORTERM; "))))
 
+(defun ghostel--logical-pwd-env (remote-p)
+  "Return a PWD env entry naming the logical `default-directory', as a list.
+Nil when REMOTE-P.  Shells keep an inherited PWD that names the cwd
+\(same inode) and otherwise reset it from getcwd(), which resolves symlinks.
+Without this entry a shell started in a symlinked directory shows the
+physical path in its prompt and OSC 7."
+  (unless remote-p
+    (list (format "PWD=%s"
+                  (directory-file-name (expand-file-name default-directory))))))
+
 (defun ghostel--spawn-pty (program program-args extra-env &optional remote-p)
   "Spawn PROGRAM with PROGRAM-ARGS as a PTY-backed process in the current buffer.
 
@@ -4209,6 +4219,7 @@ for the native child process."
                  ;; terminfo(5)) makes ncurses ignore system entries.
                  (if remote-p '() (ghostel--terminal-env)))
            extra-env
+           (ghostel--logical-pwd-env remote-p)
            process-environment))
          ;; Large TUI redraws (Claude Code, pi on resize) can emit
          ;; hundreds of KB in one write.  Before Emacs 31,

--- a/test/ghostel-bookmark-test.el
+++ b/test/ghostel-bookmark-test.el
@@ -3,10 +3,10 @@
 ;;; Commentary:
 
 ;; Emacs bookmark integration: the `bookmark-make-record-function' maker and
-;; the jump handler.  The maker tests are pure elisp (a `ghostel-mode' buffer
-;; spawns no process).  The handler tests need the native module: they spawn a
-;; real shell and observe OSC 7 directory tracking, so they are tagged
-;; `native'.
+;; the jump handler.  The maker tests and the stub-driven handler tests are
+;; pure elisp (a `ghostel-mode' buffer spawns no process; reuse tests attach
+;; a dummy pipe process so the handler's live-shell check passes).  Handler
+;; tests that spawn a real shell are tagged `native'.
 
 ;;; Code:
 
@@ -14,12 +14,15 @@
 (require 'ghostel-bookmark)
 
 (ert-deftest ghostel-test-bookmark-make-record ()
-  "`ghostel--bookmark-make-record' captures handler, dir, and buffer name.
+  "`ghostel--bookmark-make-record' captures handler, dir, name, and identity.
 The directory goes under `location' so `bookmark-bmenu-list' shows it
 instead of \"-- Unknown location --\"."
   (ghostel-test--with-compile-buffer buf
+    (setq ghostel--buffer-identity "bm-make-record-identity")
     (let* ((default-directory "/tmp/ghostel-bookmark-make-record/")
            (record (ghostel--bookmark-make-record)))
+      (should (equal (bookmark-prop-get record 'identity)
+                     "bm-make-record-identity"))
       (should (eq (bookmark-prop-get record 'handler)
                   'ghostel--bookmark-handler))
       (should (equal (bookmark-prop-get record 'location)
@@ -47,13 +50,182 @@ instead of \"-- Unknown location --\"."
                   'ghostel--bookmark-handler))
       (should (equal (bookmark-prop-get record 'buf-name) (buffer-name))))))
 
-(defun ghostel-test--bookmark-record (buf-name dir)
-  "Return a ghostel bookmark record for BUF-NAME pointing at DIR."
+(defun ghostel-test--bookmark-record (buf-name dir &optional identity)
+  "Return a ghostel bookmark record for BUF-NAME pointing at DIR.
+Non-nil IDENTITY adds an `identity' property; omitting it mimics a
+record saved before identities were recorded."
   `(,buf-name
     (handler . ghostel--bookmark-handler)
     (location . ,dir)
     (buf-name . ,buf-name)
+    ,@(and identity `((identity . ,identity)))
     (defaults . nil)))
+
+(ert-deftest ghostel-test-bookmark-handler-reuses-by-identity ()
+  "A renamed buffer is still reused when the record carries its identity.
+The default `ghostel-buffer-name-function' renames buffers from the
+terminal title, so the name recorded at `bookmark-set' time is usually
+stale by jump time; the rename-stable identity must find the buffer."
+  (ghostel-test--with-compile-buffer buf
+    (setq ghostel--buffer-identity "bm-reuse-identity"
+          default-directory "/tmp/ghostel-bm-reuse/")
+    (setq-local ghostel--process (ghostel-test--dummy-process "bm-reuse" nil))
+    (rename-buffer (generate-new-buffer-name " *ghostel-bm-renamed*"))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                  ((symbol-function 'ghostel--create)
+                   (lambda (&rest _)
+                     (ert-fail "Created a new buffer instead of reusing"))))
+          (with-temp-buffer
+            (ghostel--bookmark-handler
+             (ghostel-test--bookmark-record " *ghostel-bm-stale-name*"
+                                            "/tmp/ghostel-bm-reuse/"
+                                            "bm-reuse-identity"))
+            (should (eq (current-buffer) buf))))
+      (delete-process ghostel--process))))
+
+(ert-deftest ghostel-test-bookmark-handler-reuses-by-name-fallback ()
+  "A record without identity (saved before identities) reuses by name."
+  (ghostel-test--with-compile-buffer buf
+    (setq default-directory "/tmp/ghostel-bm-name/")
+    (setq-local ghostel--process (ghostel-test--dummy-process "bm-name" nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                  ((symbol-function 'ghostel--create)
+                   (lambda (&rest _)
+                     (ert-fail "Created a new buffer instead of reusing"))))
+          (with-temp-buffer
+            (ghostel--bookmark-handler
+             (ghostel-test--bookmark-record (buffer-name buf)
+                                            "/tmp/ghostel-bm-name/"))
+            (should (eq (current-buffer) buf))))
+      (delete-process ghostel--process))))
+
+(ert-deftest ghostel-test-bookmark-handler-skips-dead-identity-holder ()
+  "A dead buffer sharing the identity must not shadow a live one.
+After a dead-shell fall-through both the retained buffer and its
+replacement carry the bookmarked identity; when the dead one ranks
+higher in `buffer-list' the handler must still reuse the live one."
+  (ghostel-test--with-compile-buffer dead
+    (setq ghostel--buffer-identity "bm-shadow-identity")
+    (let ((live (generate-new-buffer " *ghostel-bm-shadow-live*")))
+      (unwind-protect
+          (progn
+            (with-current-buffer live
+              (ghostel-mode)
+              (setq ghostel--buffer-identity "bm-shadow-identity"
+                    default-directory "/tmp/ghostel-bm-shadow/")
+              (setq-local ghostel--process
+                          (ghostel-test--dummy-process "bm-shadow" nil)))
+            (bury-buffer live)
+            ;; Precondition: the dead buffer outranks the live one.
+            (should (eq (ghostel--find-buffer-by-identity
+                         "bm-shadow-identity")
+                        dead))
+            (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                      ((symbol-function 'ghostel--create)
+                       (lambda (&rest _)
+                         (ert-fail "Created a new buffer instead of reusing"))))
+              (with-temp-buffer
+                (ghostel--bookmark-handler
+                 (ghostel-test--bookmark-record " *ghostel-bm-shadow-stale*"
+                                                "/tmp/ghostel-bm-shadow/"
+                                                "bm-shadow-identity"))
+                (should (eq (current-buffer) live)))))
+        (let ((p (buffer-local-value 'ghostel--process live)))
+          (when (processp p) (delete-process p)))
+        (kill-buffer live)))))
+
+(ert-deftest ghostel-test-bookmark-handler-identity-record-skips-name ()
+  "An identity-bearing record must not reuse an unrelated name match.
+When the identity's buffer is gone, a live shell that merely holds the
+recorded (often generic) name must be left alone; the jump creates a
+fresh buffer instead of typing a `cd' into the unrelated one."
+  (ghostel-test--with-compile-buffer buf
+    (setq ghostel--buffer-identity "bm-other-identity")
+    (setq-local ghostel--process (ghostel-test--dummy-process "bm-other" nil))
+    (let ((created nil))
+      (unwind-protect
+          (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                    ((symbol-function 'ghostel--create)
+                     (lambda (name &rest _)
+                       (let ((b (generate-new-buffer name)))
+                         (with-current-buffer b (ghostel-mode))
+                         (setq created b)
+                         b)))
+                    ((symbol-function 'ghostel--start-process) #'ignore)
+                    ((symbol-function 'ghostel--apply-initial-input-mode)
+                     #'ignore))
+            (with-temp-buffer
+              (ghostel--bookmark-handler
+               (ghostel-test--bookmark-record (buffer-name buf)
+                                              "/tmp/ghostel-bm-other/"
+                                              "bm-vanished-identity"))
+              (should created)
+              (should (eq (current-buffer) created))))
+        (delete-process ghostel--process)
+        (when (buffer-live-p created) (kill-buffer created))))))
+
+(ert-deftest ghostel-test-bookmark-handler-dead-shell-creates-fresh ()
+  "A matched buffer whose shell has exited is not reused.
+With `ghostel-kill-buffer-on-exit' nil the buffer outlives its shell;
+typing a `cd' into the dead PTY would error mid-jump, so the handler
+must fall through to the create branch instead."
+  (ghostel-test--with-compile-buffer buf
+    (setq ghostel--buffer-identity "bm-dead-identity")
+    (let ((created nil))
+      (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                ((symbol-function 'ghostel--create)
+                 (lambda (name &rest _)
+                   (let ((b (generate-new-buffer name)))
+                     (with-current-buffer b (ghostel-mode))
+                     (setq created b)
+                     b)))
+                ((symbol-function 'ghostel--start-process) #'ignore)
+                ((symbol-function 'ghostel--apply-initial-input-mode)
+                 #'ignore))
+        (unwind-protect
+            (with-temp-buffer
+              (ghostel--bookmark-handler
+               (ghostel-test--bookmark-record (buffer-name buf)
+                                              "/tmp/ghostel-bm-dead/"
+                                              "bm-dead-identity"))
+              (should created)
+              (should (eq (current-buffer) created)))
+          (when (buffer-live-p created)
+            (kill-buffer created)))))))
+
+(ert-deftest ghostel-test-bookmark-handler-create-stamps-identity ()
+  "The create branch stamps the recorded identity, buffer name as fallback."
+  (let ((made nil))
+    (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+              ((symbol-function 'ghostel--create)
+               (lambda (name &rest _)
+                 (let ((b (generate-new-buffer name)))
+                   (with-current-buffer b (ghostel-mode))
+                   (push b made)
+                   b)))
+              ((symbol-function 'ghostel--start-process) #'ignore)
+              ((symbol-function 'ghostel--apply-initial-input-mode) #'ignore))
+      (unwind-protect
+          (progn
+            (with-temp-buffer
+              (ghostel--bookmark-handler
+               (ghostel-test--bookmark-record " *ghostel-bm-new*"
+                                              "/tmp/ghostel-bm-create/"
+                                              "bm-create-identity")))
+            (should (equal (buffer-local-value 'ghostel--buffer-identity
+                                               (car made))
+                           "bm-create-identity"))
+            (with-temp-buffer
+              (ghostel--bookmark-handler
+               (ghostel-test--bookmark-record " *ghostel-bm-old*"
+                                              "/tmp/ghostel-bm-create/")))
+            (should (equal (buffer-local-value 'ghostel--buffer-identity
+                                               (car made))
+                           " *ghostel-bm-old*")))
+        (dolist (b made)
+          (when (buffer-live-p b) (kill-buffer b)))))))
 
 (ert-deftest ghostel-test-bookmark-handler-creates-buffer ()
   "Jumping to a bookmark with no live buffer starts a fresh shell in its dir."
@@ -85,8 +257,10 @@ too timing-sensitive to drive a real shell through here).  With
 `ghostel-bookmark-check-dir' nil, nothing is typed."
   :tags '(native)
   ;; `ghostel-test--with-terminal-buffer' gives a live `ghostel--term' (so the
-  ;; reuse-branch guard passes) without a process; we stub the send functions.
+  ;; reuse-branch guard passes); a dummy pipe process satisfies the handler's
+  ;; live-shell check, and the send functions are stubbed.
   (ghostel-test--with-terminal-buffer (buf term 24 80 1000)
+    (setq-local ghostel--process (ghostel-test--dummy-process "bm-cd" nil))
     (let ((sent nil)
           (default-directory "/tmp/ghostel-bm-here/")
           ;; A remote dir with a space exercises both departures from vterm:

--- a/test/ghostel-environment-test.el
+++ b/test/ghostel-environment-test.el
@@ -127,6 +127,102 @@ returns the first match) resolves to the user's value."
       (should-not (ghostel-test--terminal-text-line-p
                    "TERM=xterm-ghostty" text)))))
 
+(ert-deftest ghostel-test-spawn-env-injects-logical-pwd ()
+  "Local spawns carry a PWD entry naming the logical `default-directory'.
+Shells keep an inherited PWD that names the cwd (same inode) and
+otherwise reset it from getcwd(), which resolves symlinks — with a
+stale or missing PWD, a shell started in a symlinked directory shows
+the physical path in its prompt and OSC 7.  The injected entry must
+override a stale inherited PWD, while a user PWD in
+`ghostel-environment' must win over the injected one."
+  (let* ((captured nil)
+         (ghostel-shell "/bin/sh")
+         (ghostel-shell-integration nil)
+         (ghostel-macos-login-shell nil)
+         (default-directory (ghostel-test--temp-directory))
+         (process-environment (cons "PWD=/ghostel/stale"
+                                    process-environment))
+         (ghostel-pre-spawn-hook
+          (list (lambda () (setq captured (getenv "PWD"))))))
+    (cl-letf (((symbol-function 'ghostel--spawn-process)
+               (lambda (&rest _) nil)))
+      (ghostel--start-process)
+      (should (equal captured
+                     (directory-file-name
+                      (expand-file-name default-directory))))
+      (let ((ghostel-environment '("PWD=/ghostel/user-override")))
+        (ghostel--start-process))
+      (should (equal captured "/ghostel/user-override")))))
+
+(ert-deftest ghostel-test-spawn-symlinked-dir-child-sees-logical-pwd ()
+  "A child spawned in a symlinked directory sees the logical path in PWD.
+End-to-end over both PTY backends: the injected PWD overrides a stale
+inherited one, survives the spawn and the shell's same-inode
+validation, and an OSC 7 report built from the child's $PWD keeps
+`default-directory' on the logical path instead of the
+getcwd()-resolved physical one."
+  :tags '(native posix)
+  (ghostel-test--with-pty-matrix backend
+    (let* ((target (make-temp-file "ghostel-pwd-target" t))
+           (link (make-temp-name
+                  (expand-file-name "ghostel-pwd-link"
+                                    (ghostel-test--temp-directory)))))
+      (unwind-protect
+          (progn
+            (make-symbolic-link target link)
+            (let* ((process-environment
+                    (cons "PWD=/ghostel/stale-physical"
+                          (ghostel-test--base-process-environment)))
+                   (ghostel-shell
+                    '("/bin/sh" "-c"
+                      "printf '\\033]7;file://%s\\033\\\\' \"$PWD\"; \
+env; printf GHOSTEL_ENV_DONE"))
+                   (ghostel-shell-integration nil)
+                   (ghostel-macos-login-shell nil)
+                   (ghostel-kill-buffer-on-exit nil)
+                   (default-directory (file-name-as-directory link)))
+              (ghostel-test--with-terminal-buffer (buf _term 25 200 1000)
+                (let ((proc (ghostel--start-process)))
+                  ;; Sentinel: the buffer inherits the link path at
+                  ;; creation, so the OSC 7 wait below would otherwise be
+                  ;; satisfied before any report arrives.  Safe to set
+                  ;; here — filters only run inside
+                  ;; `accept-process-output', so no output has been
+                  ;; processed yet.
+                  (setq default-directory "/")
+                  (ghostel-test--wait-for-text "GHOSTEL_ENV_DONE" proc 5)
+                  (should (ghostel-test--terminal-text-line-p
+                           (format "PWD=%s" link)))
+                  ;; OSC events can trail the text on the native backend.
+                  (ghostel-test--wait-until
+                   (lambda () (equal default-directory
+                                     (file-name-as-directory link)))
+                   proc 5)))))
+        (ignore-errors (delete-file link))
+        (ignore-errors (delete-directory target t))))))
+
+(ert-deftest ghostel-test-compile-spawn-env-injects-logical-pwd ()
+  "`ghostel-compile--spawn' children also get the logical PWD entry."
+  (let ((captured 'unset)
+        (buf (generate-new-buffer " *ghostel-compile-pwd*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let ((default-directory (ghostel-test--temp-directory))
+                (process-environment (cons "PWD=/ghostel/stale"
+                                           process-environment)))
+            (cl-letf (((symbol-function 'make-process)
+                       (lambda (&rest _)
+                         (setq captured (getenv "PWD"))
+                         (ghostel-test--dummy-process "compile-pwd" nil)))
+                      ((symbol-function 'set-process-window-size) #'ignore))
+              (ghostel-compile--spawn "true" buf 24 80))
+            (should (equal captured
+                           (directory-file-name
+                            (expand-file-name default-directory))))))
+      (let ((proc (buffer-local-value 'ghostel--process buf)))
+        (when (processp proc) (delete-process proc)))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-environment-honors-dir-locals ()
   "End-to-end: a real `.dir-locals.el' populates `ghostel-environment'.
 Covers the whole pipeline (`hack-dir-local-variables' reading the


### PR DESCRIPTION
Closes #618

Two fixes for the symptoms reported there:

## Logical `PWD` for local children

POSIX shells keep an inherited `PWD` only when it names the current directory (same inode); otherwise they reset it from `getcwd()`, which resolves symlinks. Ghostel spawned children with the correct logical cwd but an absent (GUI-launched macOS Emacs) or stale inherited `PWD`, so a shell started in a symlinked directory showed the physical path in its prompt, title, and OSC 7 report — which then flowed back into `default-directory` and the buffer identification. Emacs core's own `PWD` correction in `make_environment_block` only fires when `PWD` is already present in the environment, and the native spawn path bypasses core entirely.

Local spawns now inject `PWD=<logical default-directory>` (new `ghostel--logical-pwd-env`, used by `ghostel--spawn-pty` — covering shell and `ghostel-exec` buffers — and `ghostel-compile--spawn`). Precedence: the entry overrides an inherited stale `PWD`, while `ghostel-environment` and `ghostel-pre-spawn-hook` still win over it. Remote spawns are unchanged. The `ghostel-pre-spawn-hook` workaround from the issue keeps working and becomes a no-op.

## Bookmark reuse by identity

Jumping to a ghostel bookmark looked the buffer up by the name recorded at `bookmark-set` time, so any rename in between broke reuse and every jump spawned another shell in a fresh buffer. Records now carry the rename-stable `ghostel--buffer-identity`; the handler reuses by identity, falls back to the recorded name for older records, and only reuses buffers whose shell process is still live — a retained buffer with an exited shell (`ghostel-kill-buffer-on-exit` nil) gets a fresh one instead of a `cd` typed into a dead PTY.

## Testing

- Elisp tests: injected `PWD` value and `ghostel-environment` precedence, compile-spawn coverage, bookmark identity recording, reuse-by-identity after a rename, name fallback for old records, dead-shell fall-through, create-branch identity stamping.
- Native test: real `/bin/sh` spawned through a symlinked directory on both PTY backends, asserting the child's `$PWD` stays logical (overriding a stale inherited value through the native env path) and that an OSC 7 report built from it keeps `default-directory` on the logical path.
- Live-verified in a real session (zsh, shell integration, default macOS `login -flp` wrapper active, `PWD` stripped from the environment to simulate a GUI launch): prompt/`$PWD`/buffer state keep the logical path; bookmark jumps reuse across renames and across kill/recreate.