### PR TITLE
Clear the terminal title on an empty OSC 0/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,14 +31,21 @@ All notable changes to this project will be documented in this file.
   t.  Fixes [#599](https://github.com/dakra/ghostel/issues/599).
 
 ### Fixed
+- An empty OSC 0/2 title (e.g. `printf '\e]2;\a'`) now clears the
+  terminal title instead of being ignored, matching how Ghostty and
+  iTerm2 treat it (reset to as if no title was ever set): the mode
+  line falls back to the plain buffer name, and a buffer renamed by
+  title tracking reverts to its original name (manual renames are
+  still respected).
+  Fixes [#619](https://github.com/dakra/ghostel/issues/619).
 - evil-ghostel: typing the first key of an `evil-escape` chord (e.g.
   `jk`) no longer doubles the character in the shell, and completing
   the chord no longer leaks it.  evil-escape previews the first key
   with a speculative insert it reverts moments later; since terminal
   buffers became writable (0.47.0) that preview was forwarded to the
   PTY where it could not be reverted.  The preview is now skipped in
-  ghostel buffers — the chord itself keeps working.  Fixes
-  [#597](https://github.com/dakra/ghostel/issues/597).
+  ghostel buffers — the chord itself keeps working.
+  Fixes [#597](https://github.com/dakra/ghostel/issues/597).
 
 ## [0.49.0] — 2026-08-02
 
@@ -55,8 +62,8 @@ All notable changes to this project will be documented in this file.
   command with no trailing newline gets its link once the prompt
   returns.  Soft-wrap joining also restarts its row limit at every
   hard newline; regions holding more than 50 wrapped lines used to
-  stop joining at each 50th, losing that line's link.  Fixes
-  [#582](https://github.com/dakra/ghostel/issues/582).
+  stop joining at each 50th, losing that line's link.
+  Fixes [#582](https://github.com/dakra/ghostel/issues/582).
 - Redraws that rebuild the whole buffer — changing `ghostel-bold-color`,
   the foreign-insert repair, line-mode teardown — no longer strip
   detected file/URL links for good; they queue a rescan of what they

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -407,7 +407,9 @@ project:
 (defcustom ghostel-buffer-name-function nil
   "Function returning the ghostel buffer name, or nil to leave it unchanged.
 Called in the ghostel buffer with one argument, the terminal TITLE (the
-OSC 2 string; may be nil or empty), on both a title change and a `cd' \(OSC 7).
+OSC 2 string; nil when the terminal has no title), on both a title change
+and a `cd' \(OSC 7).  A title clear (empty OSC 0/2) reverts a
+title-derived name to the buffer's original name.
 Read `default-directory' for the current directory.
 Renames the buffer to the returned string, declining after a manual rename.
 The mode line shows the title independently of this variable;
@@ -1060,7 +1062,7 @@ local code should not assume it is signalable unless the process is local.")
   "Last known working directory from OSC 7, used for dedup.")
 
 (defvar-local ghostel--title nil
-  "Last terminal title reported by OSC 0/2.")
+  "Last terminal title reported by OSC 0/2; nil when unset or cleared.")
 
 (defvar-local ghostel--managed-buffer-name nil
   "Last buffer name managed by Ghostel title tracking.
@@ -3356,10 +3358,9 @@ PROGRESS is an integer 0-100 or nil."
                     (error-message-string err))))))))
 
 (defun ghostel-buffer-name-by-title (title)
-  "Return \"*ghostel: TITLE*\", or nil when TITLE is nil or empty.
+  "Return \"*ghostel: TITLE*\", or nil when TITLE is nil.
 A `ghostel-buffer-name-function' that names the buffer after the title."
-  (and title (not (string= "" title))
-       (format "*ghostel: %s*" title)))
+  (and title (format "*ghostel: %s*" title)))
 
 (defun ghostel-buffer-name-by-directory (_title)
   "Return \"*ghostel: DIR*\" from `default-directory', abbreviated.
@@ -3379,11 +3380,19 @@ Declines after a manual rename; a nil or unchanged NEW-NAME is a no-op."
 
 (defun ghostel--set-title (title)
   "Record a terminal TITLE report (OSC 0/2) and rename the buffer.
-Maps TITLE through `ghostel-buffer-name-function' and renames via
-`ghostel--rename-managed', which declines after a manual rename."
-  (setq ghostel--title title)
+A nil or empty TITLE clears the title and reverts a title-derived
+name to `ghostel--buffer-identity'.  Renames via
+`ghostel-buffer-name-function' and `ghostel--rename-managed', which
+declines after a manual rename."
+  (setq ghostel--title (and title (not (string= "" title)) title))
   (when ghostel-buffer-name-function
-    (ghostel--rename-managed (funcall ghostel-buffer-name-function title)))
+    (ghostel--rename-managed
+     (or (funcall ghostel-buffer-name-function ghostel--title)
+         ;; Revert only names title tracking has claimed; a clear must
+         ;; not rename a buffer it never touched.
+         (and (null ghostel--title)
+              ghostel--managed-buffer-name
+              ghostel--buffer-identity))))
   (ghostel--buffer-identification-update))
 
 (defun ghostel--buffer-identification (format)
@@ -3391,7 +3400,7 @@ Maps TITLE through `ghostel-buffer-name-function' and renames via
 See `ghostel-buffer-identification-format' for the specs.
 %b stays a live mode-line construct.
 A FORMAT with %t returns the plain buffer name while the terminal has no title."
-  (if (and (or (null ghostel--title) (string= "" ghostel--title))
+  (if (and (null ghostel--title)
            ;; Skip quoted percents so e.g. "50%%tests" is not read as a
            ;; title reference.
            (string-match-p "%[ 0<>^_-]*[0-9]*\\(?:\\.[0-9]+\\)?t"
@@ -5241,6 +5250,10 @@ spawn after initialization."
           ghostel--cursor-pos nil
           ghostel--cursor-char-pos nil
           ghostel--repainted-region nil)
+    ;; `ghostel-exec'-created buffers need an identity as the revert
+    ;; target for a title clear.
+    (unless ghostel--buffer-identity
+      (setq ghostel--buffer-identity (buffer-name)))
     ;; Reused buffers hold the previous session's title; drop it from
     ;; the mode line along with the buffer-local reset above.
     (ghostel--buffer-identification-update)

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -109,13 +109,12 @@ pub fn GhostelHandler(Context: type) type {
             };
         }
 
-        /// Called when the terminal title changes.
+        /// Called when the terminal title changes.  A cleared title (empty
+        /// OSC 0/2) reads back as null and is forwarded as "".
         fn titleChangedCallback(handler: *gt.TerminalStream.Handler) void {
             const self: *Self = @fieldParentPtr("inner", handler);
-            const title = handler.terminal.getTitle();
-            if (title) |t| {
-                self.context.effect("ghostel--set-title", .{t});
-            }
+            const title = handler.terminal.getTitle() orelse "";
+            self.context.effect("ghostel--set-title", .{title});
         }
 
         // ---------------------------------------------------------------------------

--- a/test/ghostel-buffer-name-test.el
+++ b/test/ghostel-buffer-name-test.el
@@ -15,13 +15,12 @@
 ;;; Pure formatters
 
 (ert-deftest ghostel-test-buffer-name-by-title-is-pure ()
-  "`ghostel-buffer-name-by-title' maps TITLE to a name; nil/empty give nil."
+  "`ghostel-buffer-name-by-title' maps TITLE to a name; nil gives nil."
   (with-temp-buffer
     (let ((name (buffer-name)))
       (should (equal "*ghostel: My Title*"
                      (ghostel-buffer-name-by-title "My Title")))
       (should (null (ghostel-buffer-name-by-title nil)))
-      (should (null (ghostel-buffer-name-by-title "")))
       ;; Pure: computing the name must not rename the current buffer.
       (should (equal name (buffer-name))))))
 
@@ -139,6 +138,91 @@
               (should (equal "*ghostel*" ghostel--managed-buffer-name)))))
       (when (buffer-live-p buf) (kill-buffer buf)))))
 
+(ert-deftest ghostel-test-set-title-clear-reverts-name ()
+  "An empty or nil title clears `ghostel--title' and reverts the name."
+  (let (buf)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--new)
+                   (lambda (&rest _args) 'fake-term))
+                  ((symbol-function 'ghostel--set-size) #'ignore)
+                  ((symbol-function 'ghostel--apply-palette)
+                   (lambda (&rest _args) nil))
+                  ((symbol-function 'ghostel--start-process)
+                   (lambda () nil)))
+          (let ((ghostel-buffer-name-function #'ghostel-buffer-name-by-title))
+            (ghostel)
+            (setq buf (current-buffer))
+            (with-current-buffer buf
+              (ghostel--set-title "Title A")
+              (should (equal "*ghostel: Title A*" (buffer-name)))
+              (ghostel--set-title "")
+              (should (null ghostel--title))
+              (should (equal ghostel--buffer-identity (buffer-name)))
+              (should (equal ghostel--buffer-identity
+                             ghostel--managed-buffer-name))
+              (ghostel--set-title "Title B")
+              (should (equal "*ghostel: Title B*" (buffer-name)))
+              (ghostel--set-title nil)
+              (should (null ghostel--title))
+              (should (equal ghostel--buffer-identity (buffer-name))))))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-set-title-clear-respects-manual ()
+  "A title clear declines to rename after a manual rename."
+  (let (buf)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--new)
+                   (lambda (&rest _args) 'fake-term))
+                  ((symbol-function 'ghostel--set-size) #'ignore)
+                  ((symbol-function 'ghostel--apply-palette)
+                   (lambda (&rest _args) nil))
+                  ((symbol-function 'ghostel--start-process)
+                   (lambda () nil)))
+          (let ((ghostel-buffer-name-function #'ghostel-buffer-name-by-title))
+            (ghostel)
+            (setq buf (current-buffer))
+            (with-current-buffer buf
+              (ghostel--set-title "Title A")
+              (rename-buffer "manual title" t)
+              (ghostel--set-title "")
+              (should (null ghostel--title))
+              (should (equal "manual title" (buffer-name))))))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
+(ert-deftest ghostel-test-set-title-clear-unclaimed-keeps-name ()
+  "A clear does not rename a buffer title tracking never renamed."
+  (with-temp-buffer
+    (setq-local ghostel--buffer-identity "*ghostel-orig*")
+    (let ((ghostel-buffer-name-function #'ghostel-buffer-name-by-title)
+          (name (buffer-name)))
+      (ghostel--set-title "")
+      (should (null ghostel--title))
+      (should (equal name (buffer-name))))))
+
+(ert-deftest ghostel-test-set-title-clear-by-directory-keeps-name ()
+  "A title clear leaves a by-directory name alone."
+  (let (buf)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--new)
+                   (lambda (&rest _args) 'fake-term))
+                  ((symbol-function 'ghostel--set-size) #'ignore)
+                  ((symbol-function 'ghostel--apply-palette)
+                   (lambda (&rest _args) nil))
+                  ((symbol-function 'ghostel--start-process)
+                   (lambda () nil)))
+          (let ((ghostel-buffer-name-function
+                 #'ghostel-buffer-name-by-directory))
+            (ghostel)
+            (setq buf (current-buffer))
+            (with-current-buffer buf
+              (let ((expected (ghostel-buffer-name-by-directory nil)))
+                (ghostel--set-title "ignored")
+                (should (equal expected (buffer-name)))
+                (ghostel--set-title "")
+                (should (null ghostel--title))
+                (should (equal expected (buffer-name)))))))
+      (when (buffer-live-p buf) (kill-buffer buf)))))
+
 ;;; Directory path (OSC 7) and combination -- native term
 
 (ert-deftest ghostel-test-directory-rename-by-directory ()
@@ -252,10 +336,9 @@ Guards against renaming to \"*ghostel: nil*\" before a title is set."
 (ert-deftest ghostel-test-buffer-identification-empty-title-fallback ()
   "A format referencing %t collapses to the buffer name without a title."
   (with-temp-buffer
-    (dolist (title '(nil ""))
-      (setq-local ghostel--title title)
-      (should (equal '("%b")
-                     (ghostel--buffer-identification "%b (%.30t)"))))))
+    (setq-local ghostel--title nil)
+    (should (equal '("%b")
+                   (ghostel--buffer-identification "%b (%.30t)")))))
 
 (ert-deftest ghostel-test-buffer-identification-no-title-spec-renders ()
   "A format without %t renders even when the terminal has no title."

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -61,6 +61,29 @@
           (should (equal title ghostel--title))
           (should (equal expected (buffer-name))))))))
 
+(ert-deftest ghostel-test-osc2-empty-title-clears ()
+  "An empty OSC 0/2 clears the title and reverts the tracked buffer name.
+Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
+  :tags '(native)
+  (let ((ghostel-buffer-name-function #'ghostel-buffer-name-by-title))
+    (ghostel-test--with-pty-matrix backend
+      (ghostel-test--with-raw-echo-buffer (buf proc)
+        (let ((identity ghostel--buffer-identity)
+              (round 0))
+          (dolist (clear '("\e]2;\e\\" "\e]2;\a" "\e]0;\a"))
+            (let ((title (format "Clear Me %S %d" backend
+                                 (setq round (1+ round)))))
+              (ghostel--write-pty ghostel--term (format "\e]2;%s\e\\" title))
+              (ghostel-test--wait-until
+               (lambda () (equal title ghostel--title)) proc 5)
+              (should (equal (format "*ghostel: %s*" title) (buffer-name)))
+              (ghostel--write-pty ghostel--term clear)
+              (ghostel-test--wait-until
+               (lambda () (null ghostel--title)) proc 5)
+              (should (null ghostel--title))
+              (should (equal identity (buffer-name)))
+              (should (equal identity ghostel--managed-buffer-name)))))))))
+
 (ert-deftest ghostel-test-osc9-notification ()
   "OSC 9 iTerm2-style notifications reach `ghostel-notification-function'."
   :tags '(native)

--- a/test/ghostel-project-test.el
+++ b/test/ghostel-project-test.el
@@ -291,7 +291,7 @@ same name must get separate buffers."
             (should (eq ghostel--term 'fake-term))
             (should-not ghostel--term-rows)
             (should-not ghostel--term-cols)
-            (should-not ghostel--buffer-identity)))
+            (should (equal (buffer-name) ghostel--buffer-identity))))
       (when (buffer-live-p buf)
         (kill-buffer buf)))))
 


### PR DESCRIPTION
An empty OSC 0/2 title (`printf '\e]2;\a'`, the standard way to reset a title) was silently dropped at the native title callback: libghostty stores a cleared title as *no title*, `getTitle` returns null for it, and the callback only forwarded non-null titles. The stale title stayed in the mode line and in a title-derived buffer name until the next title report.

## Changes

- **`src/handler.zig`** — `titleChangedCallback` forwards a cleared title as `""` instead of dropping it. libghostty delivers the clear correctly end to end (empty payload still parses as `change_window_title`, `title_changed` fires unconditionally); this guard was the only drop point.
- **`lisp/ghostel.el`** — `ghostel--set-title` treats an empty title as "as if no title was ever set", matching Ghostty and iTerm2: `ghostel--title` normalizes to nil (invariant is now nil-or-non-empty, so the mode line falls back to the plain buffer name), and a title-derived buffer name reverts to `ghostel--buffer-identity`. The revert only applies to names title tracking has claimed and still goes through the manual-rename guard.
- `ghostel--init-buffer` backfills a nil `ghostel--buffer-identity` with the creation name so buffers created outside the `ghostel` command (`ghostel-exec`, eshell visual commands) have a revert target.
- The now-dead empty-string handling in `ghostel--buffer-identification` and `ghostel-buffer-name-by-title` is removed; the `ghostel-buffer-name-function` contract is now "nil or non-empty string" (custom name functions see nil on a clear, never `""`).

## Tests

- New native PTY-matrix regression test: title set, then cleared via OSC 2+ST, OSC 2+BEL, and OSC 0+BEL — asserts nil `ghostel--title` and the reverted buffer name on both backends.
- New elisp unit tests: clear reverts a by-title name to the identity, declines after a manual rename, is a no-op for buffers title tracking never renamed, and leaves by-directory names alone.
- Verified live in a terminal Emacs session (bash `--norc`, shell integration off): OSC 0/2 set/clear round-trips update `ghostel--title`, the mode line (no empty-parens leftovers), and by-title renames/reverts, with manual renames respected.

Fixes #619