### PR TITLE
Annotate buffer picker candidates with the terminal title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
   `desktop-read` starts a fresh shell in that directory under the
   saved buffer name, so restored window configurations find the
   buffer.
+- The buffer pickers (`ghostel-list-buffers`, etc.) annotate each
+  candidate with its terminal title, so completion shows what every
+  terminal is running even though the stable buffer names no longer
+  carry it.  The title is capped at `ghostel-annotation-title-width`
+  columns (default 30, nil for the full title).  Marginalia users need
+  a small wrapper around `ghostel-annotate-buffer`, see the README.
 
 ### Changed
 - The bookmark functions are now public: `ghostel-bookmark-make-record`

--- a/README.org
+++ b/README.org
@@ -1338,6 +1338,7 @@ tables below group them by area; defaults shown are the out-of-the-box values.
 | =ghostel-project-buffer-scope=         | =both=                                          | How project commands scope buffers: =default-directory=, =identity=, or =both=.                                                                                                                                |
 | =ghostel-buffer-name-function=         | =nil=                                           | Maps OSC 2 title + =default-directory= to a buffer name (nil return keeps it); nil (default) disables renaming.  =ghostel-buffer-name-by-title= and =ghostel-buffer-name-by-directory= are ready-made choices. |
 | =ghostel-buffer-identification-format= | ="%b (%.30t)"=                                  | =format-spec= string for =mode-line-buffer-identification=: =%b= buffer name, =%t= terminal title, =%d= abbreviated =default-directory=.  nil leaves the mode line alone.                                            |
+| =ghostel-annotation-title-width=       | =30=                                            | Column cap for the title in the buffer pickers' completion annotations; nil shows the full title.  See [[#picker-annotations][Picker annotations]].                                                                            |
 | =ghostel-kill-buffer-on-exit=          | =t=                                             | Kill the buffer when the shell process exits.                                                                                                                                                            |
 | =ghostel-query-before-killing=         | =auto=                                          | Confirm before killing a live buffer / exiting Emacs: =t=, =nil=, or =auto= (only while a command runs).                                                                                                       |
 | =ghostel-exit-functions=               | =nil=                                           | Hook run with =(BUFFER EVENT)= when the terminal process exits.                                                                                                                                            |
@@ -1827,7 +1828,7 @@ Enable it for any Emacs Lisp input method:
 | =M-x ghostel-other=                    | Switch to the next terminal or create one.                                |
 | =M-x ghostel-next=                     | Cycle to the next ghostel buffer (sorted by name, wraps).                 |
 | =M-x ghostel-previous=                 | Cycle to the previous ghostel buffer.                                     |
-| =M-x ghostel-list-buffers=             | Pick a ghostel buffer via =read-buffer=.                                    |
+| =M-x ghostel-list-buffers=             | Pick a ghostel buffer via =read-buffer= (candidates show the title).        |
 | =M-x ghostel-project-next=             | Cycle to the next ghostel buffer in the current project.                  |
 | =M-x ghostel-project-previous=         | Cycle to the previous ghostel buffer in the current project.              |
 | =M-x ghostel-project-list-buffers=     | Pick a project-scoped ghostel buffer.                                     |
@@ -1852,6 +1853,36 @@ Enable it for any Emacs Lisp input method:
 | =M-x ghostel-ssh-clear-terminfo-cache= | Clear the outbound-ssh terminfo install cache (force re-probe).           |
 | =M-x ghostel-download-module=          | Download the pre-built native module.                                     |
 | =M-x ghostel-module-compile=           | Compile the native module from source.                                    |
+
+** Picker annotations
+:properties:
+:custom_id: picker-annotations
+:end:
+#+findex: ghostel-annotate-buffer
+
+The buffer pickers (=ghostel-list-buffers= etc.) annotate each candidate with
+the terminal title, i.e. whatever the shell or a program set via OSC 2
+(typically the current command or working directory).  This makes same-named
+terminals like =*ghostel*= and =*ghostel*<2>= easy to tell apart.
+=ghostel-annotation-title-width= caps the title at 30 columns; set it to nil
+for the full title.
+
+[[https://github.com/minad/marginalia][Marginalia]] replaces annotations for the whole =buffer= category with its own,
+which hides the title.  You can prepend the title to marginalia's annotator to
+show it in every buffer prompt (=C-x b=, =consult-buffer=, and ghostel's own):
+
+#+begin_src emacs-lisp
+(with-eval-after-load 'marginalia
+  (defun ghostel-marginalia-annotate-buffer (cand)
+    "`marginalia-annotate-buffer', prefixed with the ghostel terminal title."
+    (concat (when-let* ((annotation (and (fboundp 'ghostel-annotate-buffer)
+                                         (ghostel-annotate-buffer cand))))
+              (propertize annotation 'face 'marginalia-value))
+            (marginalia-annotate-buffer cand)))
+  (dolist (category '(buffer project-buffer))
+    (cl-pushnew #'ghostel-marginalia-annotate-buffer
+                (alist-get category marginalia-annotators))))
+#+end_src
 
 ** Sending input from Lisp
 :properties:

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -440,6 +440,11 @@ Set to nil to leave `mode-line-buffer-identification' alone."
   :type '(choice (const :tag "Leave the mode line alone" nil)
                  (string :tag "Format string")))
 
+(defcustom ghostel-annotation-title-width 30
+  "Column cap for the title in the buffer pickers' completion annotations.
+nil annotates with the full title."
+  :type '(choice (natnum :tag "Columns") (const :tag "Full title" nil)))
+
 (defcustom ghostel-kill-buffer-on-exit t
   "Kill the buffer when the terminal process exits."
   :type 'boolean)
@@ -5725,6 +5730,17 @@ Project membership is determined by `ghostel-project-buffer-scope'."
                   "No ghostel buffers in this project"
                   "Only one ghostel buffer in this project"))
 
+(defun ghostel-annotate-buffer (name)
+  "Return a completion annotation for the ghostel buffer named NAME, or nil.
+The annotation is the terminal title, capped at
+`ghostel-annotation-title-width' columns."
+  (when-let* ((buffer (get-buffer name))
+              (title (buffer-local-value 'ghostel--title buffer)))
+    (concat "  " (if ghostel-annotation-title-width
+                     (truncate-string-to-width
+                      title ghostel-annotation-title-width nil nil t)
+                   title))))
+
 (defun ghostel--read-buffer (prompt bufs)
   "Prompt with PROMPT for one of BUFS via `read-buffer'.
 Default candidate is the buffer `ghostel-next' would land on, so RET
@@ -5738,6 +5754,8 @@ signals `user-error' if BUFS is empty."
          (default (cond
                    ((null idx) (car names))
                    (t (nth (mod (1+ idx) (length bufs)) names))))
+         (completion-extra-properties
+          (list :annotation-function #'ghostel-annotate-buffer))
          (chosen (read-buffer prompt default t
                               (lambda (cand)
                                 (let ((name (if (consp cand) (car cand) cand)))

--- a/test/ghostel-buffers-test.el
+++ b/test/ghostel-buffers-test.el
@@ -198,6 +198,40 @@ Each BINDING is (VAR NAME [DIR [IDENTITY]])."
   "`ghostel-list-buffers' signals `user-error' when none exist."
   (should-error (ghostel-list-buffers) :type 'user-error))
 
+;;; Completion annotations
+
+(ert-deftest ghostel-test-annotate-buffer-title ()
+  "`ghostel-annotate-buffer' caps the title at `ghostel-annotation-title-width'."
+  (ghostel-buffers-test--with-bufs ((a "*ghostel-a*"))
+    (with-current-buffer a (setq-local ghostel--title "make test"))
+    (should (equal "  make test" (ghostel-annotate-buffer (buffer-name a))))
+    (with-current-buffer a (setq-local ghostel--title (make-string 60 ?x)))
+    (let* ((ghostel-annotation-title-width 30)
+           (annotation (ghostel-annotate-buffer (buffer-name a))))
+      (should (<= (string-width annotation) 32))
+      (should (string-suffix-p (truncate-string-ellipsis) annotation)))
+    (let* ((ghostel-annotation-title-width nil)
+           (annotation (ghostel-annotate-buffer (buffer-name a))))
+      (should (equal (concat "  " (make-string 60 ?x)) annotation)))))
+
+(ert-deftest ghostel-test-annotate-buffer-no-title ()
+  "`ghostel-annotate-buffer' returns nil without a title or buffer."
+  (ghostel-buffers-test--with-bufs ((a "*ghostel-a*"))
+    (should-not (ghostel-annotate-buffer (buffer-name a))))
+  (should-not (ghostel-annotate-buffer "*ghostel-no-such-buffer*")))
+
+(ert-deftest ghostel-test-read-buffer-annotates ()
+  "`ghostel--read-buffer' exposes `ghostel-annotate-buffer' to completion."
+  (ghostel-buffers-test--with-bufs ((a "*ghostel-a*"))
+    (let (captured)
+      (cl-letf (((symbol-function 'read-buffer)
+                 (lambda (_prompt default &rest _)
+                   (setq captured (plist-get completion-extra-properties
+                                             :annotation-function))
+                   default)))
+        (ghostel--read-buffer "Ghostel buffer: " (list a))
+        (should (eq captured #'ghostel-annotate-buffer))))))
+
 ;;; Project-scope helpers
 
 (defun ghostel-buffers-test--proj-stub (root)


### PR DESCRIPTION
## Problem

Since the stable-names change (#568), buffer names no longer carry the terminal title. This is right for name stability, but it left the pickers blind.

With several terminals in one project, `ghostel-list-buffers` and `ghostel-project-list-buffers` complete over names like `*ghostel*` and `*ghostel*<2>` with nothing to say what each terminal is running. The mode line (`ghostel-buffer-identification-format`) only shows the title of the buffer you are already visiting, so it cannot help at pick time.

## Fix

`ghostel--read-buffer` now provides an annotation function through `completion-extra-properties`. Each candidate is annotated with its terminal title, capped at `ghostel-annotation-title-width` columns (a new defcustom, default 30 to match the `%.30t` in `ghostel-buffer-identification-format`). nil annotates with the full title. Terminals with no title (at a quiet prompt) simply get no annotation.

The annotation function, `ghostel-annotate-buffer`, is public so other completion frontends can reuse it. As a marginalia user, I found that marginalia replaces annotations for the whole `buffer` category with its own, which would hide these.

The README documents a small wrapper that prepends the title to `marginalia-annotate-buffer`. Documenting this seemed better than shipping code that rewrites marginalia's registry behind the user's back.

## Other info

Three new pure-elisp tests. README and CHANGELOG entries included.

On the default width: 30 matches the mode-line convention, but the picker has a whole line per candidate, so happy to bump the default if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
