### PR TITLE
Key buffer reuse on structured identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,14 @@ All notable changes to this project will be documented in this file.
   identity; bookmarks saved by older versions still restore but spawn
   a fresh terminal instead of reusing a live one.  A numeric prefix
   of 1 now selects the default terminal (formerly a separate
-  `*ghostel*<1>` buffer).
+  `*ghostel*<1>` buffer).  `ghostel-exec` and eshell visual-command
+  buffers record their program and arguments in the identity's
+  `command` key; jumping to their bookmark reattaches to a live
+  buffer running the recorded command, or respawns it instead of a
+  plain shell.  Restored buffers are plain `ghostel-exec` buffers
+  without kind-specific wiring (such as eshell's visual exit
+  behavior), and the argv is saved to the bookmark file in
+  plaintext.
 
 ### Changed
 - Terminal buffers keep a stable name; the terminal title moves to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- `ghostel-project` no longer conflates same-named projects in
+  different directories.  Buffers now carry a structured identity (the
+  new buffer-local `ghostel-identity` alist: a mandatory `kind` plus
+  scope keys like `project-root` and an `instance` number for reusable
+  slots) instead of being matched by buffer name, so two projects that
+  share a directory basename get separate terminals, and the
+  `identity` scope of `ghostel-project-next`/`-previous`/
+  `-list-buffers` includes numbered instances and excludes
+  non-terminal buffers (e.g. a running `ghostel-compile`).  Third
+  parties can tag their own buffers (e.g. `(kind . my-repl)`) via the
+  new optional IDENTITY argument of `ghostel-exec` and filter them
+  with `ghostel-identity-match-p`.  Bookmarks store the structured
+  identity; bookmarks saved by older versions still restore but spawn
+  a fresh terminal instead of reusing a live one.  A numeric prefix
+  of 1 now selects the default terminal (formerly a separate
+  `*ghostel*<1>` buffer).
+
 ### Changed
 - Terminal buffers keep a stable name; the terminal title moves to the
   mode line.  `ghostel-buffer-name-function` now defaults to nil, so

--- a/lisp/ghostel-bookmark.el
+++ b/lisp/ghostel-bookmark.el
@@ -35,6 +35,8 @@ a `cd' to the bookmarked directory is typed into the shell."
 (defun ghostel--bookmark-make-record ()
   "Return a bookmark record for the current ghostel buffer.
 Notes the working directory, buffer name, and buffer identity.
+An identity `command' key (an exec'd program and its arguments) is
+saved to the bookmark file in plaintext.
 See `ghostel--bookmark-handler' for how they are restored."
   `(nil
     (handler . ghostel--bookmark-handler)
@@ -46,48 +48,82 @@ See `ghostel--bookmark-handler' for how they are restored."
 ;;;###autoload
 (defun ghostel--bookmark-handler (bmk)
   "Restore the ghostel bookmark BMK.
-Reuse a live ghostel buffer with the bookmarked slot identity (or
-name, for records without one; title tracking may have renamed the
-buffer since), or create one with a shell started in the bookmarked
-directory.
-When a reused buffer's directory differs and `ghostel-bookmark-check-dir'
-is non-nil, type a `cd' into the shell."
+Reuse a live ghostel buffer: slot identities match whole, command
+records match a live buffer running the recorded command, other
+records match by name (title tracking may have renamed the buffer).
+Otherwise create one in the bookmarked directory, respawning the
+recorded `command' or starting a shell.  Respawned buffers are plain
+`ghostel-exec' buffers; kind-specific setup (e.g. eshell's
+visual-command exit behavior) is not restored.
+When a reused shell's directory differs and `ghostel-bookmark-check-dir'
+is non-nil, a `cd' is typed into it; command buffers are left alone."
   (ghostel--load-module t)
   (let* ((dir (bookmark-prop-get bmk 'location))
          (buf-name (bookmark-prop-get bmk 'buf-name))
-         ;; Pre-structured records hold a name string; treat as identity-less.
+         ;; Bookmark files are external data; treat a non-alist identity
+         ;; as absent.
          (identity (let ((id (bookmark-prop-get bmk 'identity)))
                      (and (consp id) id)))
+         (command (alist-get 'command identity))
          (live-p (lambda (b)
                    (let ((p (and b (buffer-local-value 'ghostel--process b))))
                      (and p (process-live-p p) b))))
          ;; Retained dead-shell buffers may share the identity; reuse only
-         ;; a live one.  Kind-only identities (no `instance') are not
-         ;; unique, so those records reuse by name.
-         (buf (if (alist-get 'instance identity)
-                  (ghostel--find-buffer-by-identity identity live-p)
+         ;; a live one.  Slot identities (with an `instance') are unique;
+         ;; command records reattach to a live buffer running the same
+         ;; command (its name may have been uniquified); the rest reuse
+         ;; by name.
+         (buf (cond
+               ((alist-get 'instance identity)
+                (ghostel--find-buffer-by-identity identity live-p))
+               (command
+                (let ((match-p
+                       (lambda (b)
+                         (and (with-current-buffer b
+                                (and (derived-mode-p 'ghostel-mode)
+                                     (ghostel-identity-match-p
+                                      `((command . ,command))
+                                      ghostel-identity)))
+                              (funcall live-p b)))))
+                  ;; Prefer the recorded name so several buffers running
+                  ;; the same command each reattach to their own bookmark.
+                  (or (when-let* ((b (get-buffer buf-name)))
+                        (funcall match-p b))
+                      (seq-find match-p (buffer-list)))))
+               (t
                 (let ((b (get-buffer buf-name)))
                   (and b
                        (eq (buffer-local-value 'major-mode b) 'ghostel-mode)
-                       (funcall live-p b))))))
-    ;; Create branch: the shell starts directly in DIR (no `cd').
+                       (funcall live-p b)))))))
+    ;; Create branch: the program starts directly in DIR (no `cd').  A
+    ;; failed spawn kills the partially created buffer and re-signals.
     (unless buf
       (let ((default-directory (if ghostel-bookmark-check-dir
                                    dir
                                  default-directory)))
-        (setq buf (ghostel--create buf-name))
-        (with-current-buffer buf
-          ;; Legacy records stay identity-less; a fabricated slot would
-          ;; let plain `ghostel' claim this buffer.
-          (setq ghostel--managed-buffer-name (buffer-name)
-                ghostel--initial-name (buffer-name)
-                ghostel-identity identity)
-          (ghostel--start-process)
-          (ghostel--apply-initial-input-mode))))
-    ;; Reuse branch: `cd' if the live buffer has wandered elsewhere.
+        (condition-case err
+            (if command
+                (progn
+                  (setq buf (generate-new-buffer buf-name))
+                  (ghostel-exec buf (car command) (cdr command) identity))
+              (setq buf (ghostel--create buf-name))
+              (with-current-buffer buf
+                ;; A nil identity stays nil: a fabricated slot would let
+                ;; plain `ghostel' claim this buffer.
+                (setq ghostel--managed-buffer-name (buffer-name)
+                      ghostel--initial-name (buffer-name)
+                      ghostel-identity identity)
+                (ghostel--start-process)
+                (ghostel--apply-initial-input-mode)))
+          ((error quit)
+           (when (buffer-live-p buf) (kill-buffer buf))
+           (signal (car err) (cdr err))))))
+    ;; Reuse branch: `cd' if the live shell has wandered elsewhere.  A
+    ;; typed `cd' only makes sense in a shell, not in a command buffer.
     (with-current-buffer buf
       (when (and ghostel-bookmark-check-dir
                  ghostel--term
+                 (not (alist-get 'command ghostel-identity))
                  (not (string-equal default-directory dir)))
         (when (memq ghostel--input-mode '(copy emacs))
           (ghostel-readonly-exit))

--- a/lisp/ghostel-bookmark.el
+++ b/lisp/ghostel-bookmark.el
@@ -8,7 +8,7 @@
 ;; Integrate ghostel buffers with Emacs's built-in bookmark facility
 ;; (`bookmark-set' / `bookmark-jump', i.e. `C-x r m' / `C-x r b').  A
 ;; bookmark records the buffer's working directory, name, and identity
-;; (see `ghostel--buffer-identity'); jumping to it reuses a live ghostel
+;; (see `ghostel-identity'); jumping to it reuses a live ghostel
 ;; buffer with that identity (or name, for records without one), or
 ;; starts a fresh shell in the bookmarked directory when none exists.
 ;;
@@ -40,27 +40,31 @@ See `ghostel--bookmark-handler' for how they are restored."
     (handler . ghostel--bookmark-handler)
     (location . ,default-directory)
     (buf-name . ,(buffer-name))
-    (identity . ,ghostel--buffer-identity)
+    (identity . ,ghostel-identity)
     (defaults . nil)))
 
 ;;;###autoload
 (defun ghostel--bookmark-handler (bmk)
   "Restore the ghostel bookmark BMK.
-Reuse a live ghostel buffer with the bookmarked identity (or name, for
-records without one; title tracking may have renamed the buffer since),
-or create one with a shell started in the bookmarked directory.
+Reuse a live ghostel buffer with the bookmarked slot identity (or
+name, for records without one; title tracking may have renamed the
+buffer since), or create one with a shell started in the bookmarked
+directory.
 When a reused buffer's directory differs and `ghostel-bookmark-check-dir'
 is non-nil, type a `cd' into the shell."
   (ghostel--load-module t)
   (let* ((dir (bookmark-prop-get bmk 'location))
          (buf-name (bookmark-prop-get bmk 'buf-name))
-         (identity (bookmark-prop-get bmk 'identity))
+         ;; Pre-structured records hold a name string; treat as identity-less.
+         (identity (let ((id (bookmark-prop-get bmk 'identity)))
+                     (and (consp id) id)))
          (live-p (lambda (b)
                    (let ((p (and b (buffer-local-value 'ghostel--process b))))
                      (and p (process-live-p p) b))))
          ;; Retained dead-shell buffers may share the identity; reuse only
-         ;; a live one.  The name lookup is for pre-identity records only.
-         (buf (if identity
+         ;; a live one.  Kind-only identities (no `instance') are not
+         ;; unique, so those records reuse by name.
+         (buf (if (alist-get 'instance identity)
                   (ghostel--find-buffer-by-identity identity live-p)
                 (let ((b (get-buffer buf-name)))
                   (and b
@@ -73,8 +77,11 @@ is non-nil, type a `cd' into the shell."
                                  default-directory)))
         (setq buf (ghostel--create buf-name))
         (with-current-buffer buf
+          ;; Legacy records stay identity-less; a fabricated slot would
+          ;; let plain `ghostel' claim this buffer.
           (setq ghostel--managed-buffer-name (buffer-name)
-                ghostel--buffer-identity (or identity buf-name))
+                ghostel--initial-name (buffer-name)
+                ghostel-identity identity)
           (ghostel--start-process)
           (ghostel--apply-initial-input-mode))))
     ;; Reuse branch: `cd' if the live buffer has wandered elsewhere.

--- a/lisp/ghostel-compile.el
+++ b/lisp/ghostel-compile.el
@@ -750,6 +750,13 @@ the rendered buffer remains read-only in both cases."
       ;; also fired, but also made state-reset implicit; make it
       ;; explicit here so this helper doesn't have two code paths.
       (ghostel-mode)
+      (setq ghostel-identity
+            (if-let* ((proj (and (not (file-remote-p dir))
+                                 (project-current nil))))
+                `((kind . compile)
+                  (project-root . ,(ghostel--normalize-root
+                                    (project-root proj))))
+              '((kind . compile))))
       ;; Wire up `next-error' so `\\[next-error]' / `M-g n' work as soon
       ;; as errors land, including in the interactive variant.
       (setq-local next-error-function #'compilation-next-error-function)

--- a/lisp/ghostel-eshell.el
+++ b/lisp/ghostel-eshell.el
@@ -84,7 +84,8 @@ eshell."
            (buf (generate-new-buffer
                  (concat "*" (file-name-nondirectory program) "*"))))
       (switch-to-buffer buf)
-      (ghostel-exec buf program prog-args '((kind . eshell)))
+      (ghostel-exec buf program prog-args
+                    `((kind . eshell) (command . (,program . ,prog-args))))
       (with-current-buffer buf
         (setq-local ghostel-kill-buffer-on-exit
                     (bound-and-true-p eshell-destroy-buffer-when-process-dies))

--- a/lisp/ghostel-eshell.el
+++ b/lisp/ghostel-eshell.el
@@ -84,7 +84,7 @@ eshell."
            (buf (generate-new-buffer
                  (concat "*" (file-name-nondirectory program) "*"))))
       (switch-to-buffer buf)
-      (ghostel-exec buf program prog-args)
+      (ghostel-exec buf program prog-args '((kind . eshell)))
       (with-current-buffer buf
         (setq-local ghostel-kill-buffer-on-exit
                     (bound-and-true-p eshell-destroy-buffer-when-process-dies))

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1077,7 +1077,8 @@ variable re-enables automatic renaming for the next title update.")
 `kind' (mandatory) says what created the buffer: `term', `compile',
 `exec', `eshell', or a third-party symbol.  Scope keys like
 `project-root' or the plain-terminal `name' attach it to a context
-and may be combined; `instance' (an integer) marks a reusable slot.
+and may be combined; `command' records an exec'd (PROGRAM . ARGS);
+`instance' (an integer) marks a reusable slot.
 Slot reuse compares whole identities, so cosmetic keys must stay off slots;
 scoped listings match subsets with `ghostel-identity-match-p'.")
 (put 'ghostel-identity 'permanent-local t)
@@ -5422,11 +5423,12 @@ window, or 80x24 if BUFFER is not displayed.  PROGRAM and ARGS are
 passed as distinct argv entries, so shell metacharacters are not
 interpreted.  Shell integration is not applied.
 
-IDENTITY, when non-nil, is stored as the buffer's `ghostel-identity';
-it defaults to ((kind . exec)).
+IDENTITY, when non-nil, is stored verbatim as the buffer's
+`ghostel-identity'; include a `command' key to make bookmarks respawn the
+program.  It defaults to \((kind . exec) (command . (PROGRAM . ARGS))).
 
-Returns the lifecycle process object.  Signals `user-error' if BUFFER
-already has a live ghostel process."
+Returns the lifecycle process object.
+Signals `user-error' if BUFFER already has a live ghostel process."
   (ghostel--load-module t)
   (when (with-current-buffer buffer
           (process-live-p ghostel--process))
@@ -5446,7 +5448,11 @@ already has a live ghostel process."
     (with-current-buffer buffer
       (ghostel--init-buffer buffer height width)
       (setq ghostel--initial-name (buffer-name)
-            ghostel-identity (or identity '((kind . exec))))
+            ghostel-identity
+            (or identity
+                ;; Copy ARGS so a caller reusing its list cannot mutate
+                ;; the identity in place.
+                `((kind . exec) (command . (,program . ,(copy-sequence args))))))
       (let ((remote-p (file-remote-p default-directory)))
         (ghostel--spawn-pty program args nil remote-p)))))
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -389,8 +389,8 @@ project:
   against the current project root.  Follows shell `cd'.
   A terminal that walked out of the project is excluded; a plain
   `ghostel' buffer that cd'd into the project is included.
-- `identity': match each buffer's `ghostel--buffer-identity'
-  against the name `ghostel-project' would use for the current project.
+- `identity': match each buffer's `ghostel-identity' against the
+  current project root, for interactive terminals only.
   Stable across `cd', but only finds buffers originally
   created via `ghostel-project'.
 - `both' (default): union of the two - `default-directory' first,
@@ -1069,11 +1069,18 @@ local code should not assume it is signalable unless the process is local.")
 Nil means title tracking has not claimed the buffer yet.  Clearing this
 variable re-enables automatic renaming for the next title update.")
 
-(defvar-local ghostel--buffer-identity nil
-  "Canonical buffer name used to find this buffer on subsequent `ghostel' calls.
-Set at buffer creation to the value of `ghostel-buffer-name' (or its numbered
-variant) before any title-tracking renames.  Used so that `ghostel' can reuse
-an existing buffer even after `ghostel--set-title' has renamed it.")
+(defvar-local ghostel--initial-name nil
+  "Buffer name at creation time; the revert target when a title clears.")
+
+(defvar-local ghostel-identity nil
+  "Structured identity of this ghostel buffer, as an alist.
+`kind' (mandatory) says what created the buffer: `term', `compile',
+`exec', `eshell', or a third-party symbol.  Scope keys like
+`project-root' or the plain-terminal `name' attach it to a context
+and may be combined; `instance' (an integer) marks a reusable slot.
+Slot reuse compares whole identities, so cosmetic keys must stay off slots;
+scoped listings match subsets with `ghostel-identity-match-p'.")
+(put 'ghostel-identity 'permanent-local t)
 
 (defvar-local ghostel--prompt-positions nil
   "List of prompt positions as (buffer-line . exit-status) pairs.
@@ -3381,7 +3388,7 @@ Declines after a manual rename; a nil or unchanged NEW-NAME is a no-op."
 (defun ghostel--set-title (title)
   "Record a terminal TITLE report (OSC 0/2) and rename the buffer.
 A nil or empty TITLE clears the title and reverts a title-derived
-name to `ghostel--buffer-identity'.  Renames via
+name to the slot's creation-style name.  Renames via
 `ghostel-buffer-name-function' and `ghostel--rename-managed', which
 declines after a manual rename."
   (setq ghostel--title (and title (not (string= "" title)) title))
@@ -3392,7 +3399,7 @@ declines after a manual rename."
          ;; not rename a buffer it never touched.
          (and (null ghostel--title)
               ghostel--managed-buffer-name
-              ghostel--buffer-identity))))
+              ghostel--initial-name))))
   (ghostel--buffer-identification-update))
 
 (defun ghostel--buffer-identification (format)
@@ -5250,10 +5257,6 @@ spawn after initialization."
           ghostel--cursor-pos nil
           ghostel--cursor-char-pos nil
           ghostel--repainted-region nil)
-    ;; `ghostel-exec'-created buffers need an identity as the revert
-    ;; target for a title clear.
-    (unless ghostel--buffer-identity
-      (setq ghostel--buffer-identity (buffer-name)))
     ;; Reused buffers hold the previous session's title; drop it from
     ;; the mode line along with the buffer-local reset above.
     (ghostel--buffer-identification-update)
@@ -5305,16 +5308,54 @@ or quit, the partially created buffer is killed before re-signaling."
          (kill-buffer buffer))
        (signal (car err) (cdr err))))))
 
+(defun ghostel--identity-normalize (identity)
+  "Return a copy of IDENTITY with its pairs sorted by key name."
+  (sort (copy-sequence identity)
+        (lambda (a b) (string< (symbol-name (car a)) (symbol-name (car b))))))
+
+(defun ghostel--identity-equal (a b)
+  "Return non-nil when identities A and B contain the same pairs."
+  (equal (ghostel--identity-normalize a) (ghostel--identity-normalize b)))
+
+(defun ghostel-identity-match-p (pattern identity)
+  "Return non-nil when every (KEY . VALUE) pair of PATTERN is in IDENTITY.
+PATTERN and IDENTITY are `ghostel-identity' alists."
+  (seq-every-p (lambda (pair)
+                 (equal (alist-get (car pair) identity) (cdr pair)))
+               pattern))
+
+(defun ghostel--normalize-root (root)
+  "Return ROOT as a normalized directory path for `project-root' keys.
+Remote ROOTs are used as-is; TRAMP expansion and abbreviation
+depend on connection state and would make the key unstable."
+  (if (file-remote-p root)
+      (file-name-as-directory root)
+    (abbreviate-file-name (file-name-as-directory (expand-file-name root)))))
+
+(defun ghostel--next-instance (context)
+  "Return 1 + the highest slot instance in use for CONTEXT.
+CONTEXT is an identity alist without its `instance' pair."
+  (let ((max 0))
+    (dolist (b (buffer-list))
+      (let ((id (buffer-local-value 'ghostel-identity b)))
+        (when (and id
+                   (ghostel--identity-equal
+                    context (assq-delete-all 'instance (copy-alist id))))
+          (setq max (max max (or (alist-get 'instance id) 0))))))
+    (1+ max)))
+
 (defun ghostel--find-buffer-by-identity (identity &optional predicate)
   "Return the first live ghostel buffer whose identity equals IDENTITY, or nil.
-Identity is the `ghostel-buffer-name' (or numbered variant) recorded at
-buffer creation time.  See `ghostel--buffer-identity'.
+Only `ghostel-mode' buffers are considered: the permanent-local
+identity outlives a major-mode change, but the slot claim must not.
 Non-nil PREDICATE further filters candidates (called with the buffer),
 so several buffers sharing IDENTITY cannot shadow one the caller wants."
   (seq-find (lambda (b)
               (and (buffer-live-p b)
-                   (equal (buffer-local-value 'ghostel--buffer-identity b)
-                          identity)
+                   (with-current-buffer b
+                     (and (derived-mode-p 'ghostel-mode)
+                          (ghostel--identity-equal ghostel-identity
+                                                   identity)))
                    (if predicate (funcall predicate b) t)))
             (buffer-list)))
 
@@ -5326,6 +5367,39 @@ so several buffers sharing IDENTITY cannot shadow one the caller wants."
     ('char (ghostel-char-mode))
     ('line (setq ghostel--pending-initial-line-mode t))))
 
+(defun ghostel--start (context name &optional arg)
+  "Find or create the ghostel slot for CONTEXT and pop to it.
+CONTEXT is an identity alist without its `instance' pair; NAME is
+the buffer name for a new instance-1 buffer.  ARG follows
+`ghostel''s prefix conventions: a number selects that instance, any
+other non-nil value creates the next free instance.  Returns the
+buffer."
+  (ghostel--load-module t)
+  (let* ((fresh (and arg (not (numberp arg))))
+         (instance (cond ((numberp arg) arg)
+                         (fresh (ghostel--next-instance context))
+                         (t 1)))
+         (identity (append context `((instance . ,instance))))
+         (buf-name (if (> instance 1) (format "%s<%d>" name instance) name))
+         (display-action (append display-buffer--same-window-action
+                                 '((category . comint))))
+         (existing (and (not fresh)
+                        (ghostel--find-buffer-by-identity identity)))
+         (buffer (or existing (ghostel--create buf-name display-action))))
+    (if existing
+        (progn
+          (unless (buffer-local-value 'ghostel--term existing)
+            (user-error "Ghostel buffer %s has no terminal"
+                        (buffer-name existing)))
+          (pop-to-buffer existing display-action))
+      (with-current-buffer buffer
+        (setq ghostel--managed-buffer-name (buffer-name)
+              ghostel--initial-name (buffer-name)
+              ghostel-identity identity)
+        (ghostel--start-process)
+        (ghostel--apply-initial-input-mode)))
+    buffer))
+
 ;;;###autoload
 (defun ghostel (&optional arg)
   "Start a new Ghostel terminal.  If the buffer already exists, switch to it.
@@ -5335,39 +5409,21 @@ create it if it doesn't exist yet.
 The name of the buffer is determined by the value of `ghostel-buffer-name'.
 Returns the buffer."
   (interactive "P")
-  (ghostel--load-module t)
-  (let* ((fresh (and arg (not (numberp arg))))
-         (identity (cond (fresh nil)
-                         ((numberp arg)
-                          (format "%s<%d>" ghostel-buffer-name arg))
-                         (t ghostel-buffer-name)))
-         (display-action (append display-buffer--same-window-action
-                                 '((category . comint))))
-         (existing (and (not fresh)
-                        (ghostel--find-buffer-by-identity identity)))
-         (buffer (or existing
-                     (ghostel--create (or identity ghostel-buffer-name)
-                                      display-action))))
-    (if existing
-        (progn
-          (unless (buffer-local-value 'ghostel--term existing)
-            (user-error "Ghostel buffer %s has no terminal"
-                        (buffer-name existing)))
-          (pop-to-buffer existing display-action))
-      (with-current-buffer buffer
-        (setq ghostel--managed-buffer-name (buffer-name))
-        (setq ghostel--buffer-identity (or identity (buffer-name)))
-        (ghostel--start-process)
-        (ghostel--apply-initial-input-mode)))
-    buffer))
+  ;; The configured name is part of the plain-terminal slot key, so
+  ;; wrappers that let-bind `ghostel-buffer-name' get their own slots.
+  (ghostel--start `((kind . term) (name . ,ghostel-buffer-name))
+                  ghostel-buffer-name arg))
 
-(defun ghostel-exec (buffer program &optional args)
+(defun ghostel-exec (buffer program &optional args identity)
   "Run PROGRAM with ARGS as a ghostel terminal in BUFFER.
 
 BUFFER is switched into `ghostel-mode' and sized to its displayed
 window, or 80x24 if BUFFER is not displayed.  PROGRAM and ARGS are
 passed as distinct argv entries, so shell metacharacters are not
 interpreted.  Shell integration is not applied.
+
+IDENTITY, when non-nil, is stored as the buffer's `ghostel-identity';
+it defaults to ((kind . exec)).
 
 Returns the lifecycle process object.  Signals `user-error' if BUFFER
 already has a live ghostel process."
@@ -5389,6 +5445,8 @@ already has a live ghostel process."
                   80)))
     (with-current-buffer buffer
       (ghostel--init-buffer buffer height width)
+      (setq ghostel--initial-name (buffer-name)
+            ghostel-identity (or identity '((kind . exec))))
       (let ((remote-p (file-remote-p default-directory)))
         (ghostel--spawn-pty program args nil remote-p)))))
 
@@ -5416,9 +5474,12 @@ To add this to `project-switch-commands':
   (add-to-list \\='project-switch-commands \\='(ghostel-project \"Ghostel\") t)
 Returns the buffer."
   (interactive "P")
-  (let* ((default-directory (project-root (project-current t)))
-         (ghostel-buffer-name (ghostel--project-buffer-name default-directory)))
-    (ghostel arg)))
+  (let ((default-directory (project-root (project-current t))))
+    (ghostel--start `((kind . term)
+                      (project-root . ,(ghostel--normalize-root
+                                        default-directory)))
+                    (ghostel--project-buffer-name default-directory)
+                    arg)))
 
 (defun ghostel-other ()
   "Switch to the next ghostel terminal buffer, or create one."
@@ -5455,7 +5516,6 @@ against a TRAMP path would walk the remote filesystem
 synchronously on every cycle."
   (let* ((proj (project-current t))
          (root (project-root proj))
-         (identity-prefix (ghostel--project-buffer-name root))
          (scope ghostel-project-buffer-scope)
          (all (ghostel--all-buffers))
          (by-dir
@@ -5471,11 +5531,14 @@ synchronously on every cycle."
                 all)))
          (by-id
           (and (memq scope '(identity both))
-               (cl-remove-if-not
-                (lambda (b)
-                  (equal (buffer-local-value 'ghostel--buffer-identity b)
-                         identity-prefix))
-                all))))
+               (let ((pattern `((kind . term)
+                                (project-root . ,(ghostel--normalize-root
+                                                  root)))))
+                 (cl-remove-if-not
+                  (lambda (b)
+                    (ghostel-identity-match-p
+                     pattern (buffer-local-value 'ghostel-identity b)))
+                  all)))))
     (sort (cl-delete-duplicates (append by-dir by-id) :test #'eq)
           (lambda (a b) (string< (buffer-name a) (buffer-name b))))))
 

--- a/test/ghostel-bookmark-test.el
+++ b/test/ghostel-bookmark-test.el
@@ -18,11 +18,11 @@
 The directory goes under `location' so `bookmark-bmenu-list' shows it
 instead of \"-- Unknown location --\"."
   (ghostel-test--with-compile-buffer buf
-    (setq ghostel--buffer-identity "bm-make-record-identity")
+    (setq ghostel-identity '((kind . term) (instance . 42)))
     (let* ((default-directory "/tmp/ghostel-bookmark-make-record/")
            (record (ghostel--bookmark-make-record)))
       (should (equal (bookmark-prop-get record 'identity)
-                     "bm-make-record-identity"))
+                     '((kind . term) (instance . 42))))
       (should (eq (bookmark-prop-get record 'handler)
                   'ghostel--bookmark-handler))
       (should (equal (bookmark-prop-get record 'location)
@@ -67,22 +67,23 @@ The default `ghostel-buffer-name-function' renames buffers from the
 terminal title, so the name recorded at `bookmark-set' time is usually
 stale by jump time; the rename-stable identity must find the buffer."
   (ghostel-test--with-compile-buffer buf
-    (setq ghostel--buffer-identity "bm-reuse-identity"
-          default-directory "/tmp/ghostel-bm-reuse/")
-    (setq-local ghostel--process (ghostel-test--dummy-process "bm-reuse" nil))
-    (rename-buffer (generate-new-buffer-name " *ghostel-bm-renamed*"))
-    (unwind-protect
-        (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
-                  ((symbol-function 'ghostel--create)
-                   (lambda (&rest _)
-                     (ert-fail "Created a new buffer instead of reusing"))))
-          (with-temp-buffer
-            (ghostel--bookmark-handler
-             (ghostel-test--bookmark-record " *ghostel-bm-stale-name*"
-                                            "/tmp/ghostel-bm-reuse/"
-                                            "bm-reuse-identity"))
-            (should (eq (current-buffer) buf))))
-      (delete-process ghostel--process))))
+    (let ((id '((kind . term) (project-root . "~/bm-reuse/") (instance . 1))))
+      (setq ghostel-identity id
+            default-directory "/tmp/ghostel-bm-reuse/")
+      (setq-local ghostel--process (ghostel-test--dummy-process "bm-reuse" nil))
+      (rename-buffer (generate-new-buffer-name " *ghostel-bm-renamed*"))
+      (unwind-protect
+          (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                    ((symbol-function 'ghostel--create)
+                     (lambda (&rest _)
+                       (ert-fail "Created a new buffer instead of reusing"))))
+            (with-temp-buffer
+              (ghostel--bookmark-handler
+               (ghostel-test--bookmark-record " *ghostel-bm-stale-name*"
+                                              "/tmp/ghostel-bm-reuse/"
+                                              id))
+              (should (eq (current-buffer) buf))))
+        (delete-process ghostel--process)))))
 
 (ert-deftest ghostel-test-bookmark-handler-reuses-by-name-fallback ()
   "A record without identity (saved before identities) reuses by name."
@@ -107,34 +108,33 @@ After a dead-shell fall-through both the retained buffer and its
 replacement carry the bookmarked identity; when the dead one ranks
 higher in `buffer-list' the handler must still reuse the live one."
   (ghostel-test--with-compile-buffer dead
-    (setq ghostel--buffer-identity "bm-shadow-identity")
-    (let ((live (generate-new-buffer " *ghostel-bm-shadow-live*")))
-      (unwind-protect
-          (progn
-            (with-current-buffer live
-              (ghostel-mode)
-              (setq ghostel--buffer-identity "bm-shadow-identity"
-                    default-directory "/tmp/ghostel-bm-shadow/")
-              (setq-local ghostel--process
-                          (ghostel-test--dummy-process "bm-shadow" nil)))
-            (bury-buffer live)
-            ;; Precondition: the dead buffer outranks the live one.
-            (should (eq (ghostel--find-buffer-by-identity
-                         "bm-shadow-identity")
-                        dead))
-            (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
-                      ((symbol-function 'ghostel--create)
-                       (lambda (&rest _)
-                         (ert-fail "Created a new buffer instead of reusing"))))
-              (with-temp-buffer
-                (ghostel--bookmark-handler
-                 (ghostel-test--bookmark-record " *ghostel-bm-shadow-stale*"
-                                                "/tmp/ghostel-bm-shadow/"
-                                                "bm-shadow-identity"))
-                (should (eq (current-buffer) live)))))
-        (let ((p (buffer-local-value 'ghostel--process live)))
-          (when (processp p) (delete-process p)))
-        (kill-buffer live)))))
+    (let ((id '((kind . term) (instance . 9))))
+      (setq ghostel-identity id)
+      (let ((live (generate-new-buffer " *ghostel-bm-shadow-live*")))
+        (unwind-protect
+            (progn
+              (with-current-buffer live
+                (ghostel-mode)
+                (setq ghostel-identity id
+                      default-directory "/tmp/ghostel-bm-shadow/")
+                (setq-local ghostel--process
+                            (ghostel-test--dummy-process "bm-shadow" nil)))
+              (bury-buffer live)
+              ;; Precondition: the dead buffer outranks the live one.
+              (should (eq (ghostel--find-buffer-by-identity id) dead))
+              (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                        ((symbol-function 'ghostel--create)
+                         (lambda (&rest _)
+                           (ert-fail "Created a new buffer instead of reusing"))))
+                (with-temp-buffer
+                  (ghostel--bookmark-handler
+                   (ghostel-test--bookmark-record " *ghostel-bm-shadow-stale*"
+                                                  "/tmp/ghostel-bm-shadow/"
+                                                  id))
+                  (should (eq (current-buffer) live)))))
+          (let ((p (buffer-local-value 'ghostel--process live)))
+            (when (processp p) (delete-process p)))
+          (kill-buffer live))))))
 
 (ert-deftest ghostel-test-bookmark-handler-identity-record-skips-name ()
   "An identity-bearing record must not reuse an unrelated name match.
@@ -142,7 +142,7 @@ When the identity's buffer is gone, a live shell that merely holds the
 recorded (often generic) name must be left alone; the jump creates a
 fresh buffer instead of typing a `cd' into the unrelated one."
   (ghostel-test--with-compile-buffer buf
-    (setq ghostel--buffer-identity "bm-other-identity")
+    (setq ghostel-identity '((kind . term) (instance . 77)))
     (setq-local ghostel--process (ghostel-test--dummy-process "bm-other" nil))
     (let ((created nil))
       (unwind-protect
@@ -160,7 +160,8 @@ fresh buffer instead of typing a `cd' into the unrelated one."
               (ghostel--bookmark-handler
                (ghostel-test--bookmark-record (buffer-name buf)
                                               "/tmp/ghostel-bm-other/"
-                                              "bm-vanished-identity"))
+                                              '((kind . term)
+                                                (instance . 78))))
               (should created)
               (should (eq (current-buffer) created))))
         (delete-process ghostel--process)
@@ -172,7 +173,7 @@ With `ghostel-kill-buffer-on-exit' nil the buffer outlives its shell;
 typing a `cd' into the dead PTY would error mid-jump, so the handler
 must fall through to the create branch instead."
   (ghostel-test--with-compile-buffer buf
-    (setq ghostel--buffer-identity "bm-dead-identity")
+    (setq ghostel-identity '((kind . term) (instance . 5)))
     (let ((created nil))
       (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
                 ((symbol-function 'ghostel--create)
@@ -189,14 +190,18 @@ must fall through to the create branch instead."
               (ghostel--bookmark-handler
                (ghostel-test--bookmark-record (buffer-name buf)
                                               "/tmp/ghostel-bm-dead/"
-                                              "bm-dead-identity"))
+                                              '((kind . term)
+                                                (instance . 5))))
               (should created)
               (should (eq (current-buffer) created)))
           (when (buffer-live-p created)
             (kill-buffer created)))))))
 
 (ert-deftest ghostel-test-bookmark-handler-create-stamps-identity ()
-  "The create branch stamps the recorded identity, buffer name as fallback."
+  "The create branch stamps the recorded identity.
+Records without one (or with a pre-structured name string) get no
+identity: fabricating a slot would let plain `ghostel' claim the
+restored buffer."
   (let ((made nil))
     (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
               ((symbol-function 'ghostel--create)
@@ -213,19 +218,51 @@ must fall through to the create branch instead."
               (ghostel--bookmark-handler
                (ghostel-test--bookmark-record " *ghostel-bm-new*"
                                               "/tmp/ghostel-bm-create/"
-                                              "bm-create-identity")))
-            (should (equal (buffer-local-value 'ghostel--buffer-identity
-                                               (car made))
-                           "bm-create-identity"))
+                                              '((kind . term)
+                                                (project-root . "~/bm/")
+                                                (instance . 2)))))
+            (should (equal (buffer-local-value 'ghostel-identity (car made))
+                           '((kind . term)
+                             (project-root . "~/bm/")
+                             (instance . 2))))
+            ;; Legacy record: a string identity is treated as absent.
             (with-temp-buffer
               (ghostel--bookmark-handler
                (ghostel-test--bookmark-record " *ghostel-bm-old*"
-                                              "/tmp/ghostel-bm-create/")))
-            (should (equal (buffer-local-value 'ghostel--buffer-identity
-                                               (car made))
-                           " *ghostel-bm-old*")))
+                                              "/tmp/ghostel-bm-create/"
+                                              "bm-legacy-name")))
+            (should-not (buffer-local-value 'ghostel-identity (car made))))
         (dolist (b made)
           (when (buffer-live-p b) (kill-buffer b)))))))
+
+(ert-deftest ghostel-test-bookmark-handler-kind-identity-not-reused ()
+  "A kind-only identity (no `instance') is shared, so reuse goes by name.
+A live buffer of the same kind running a different program must not
+be hijacked; the jump creates a fresh buffer instead."
+  (ghostel-test--with-compile-buffer other
+    (setq ghostel-identity '((kind . eshell)))
+    (setq-local ghostel--process (ghostel-test--dummy-process "bm-kind" nil))
+    (let ((created nil))
+      (unwind-protect
+          (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                    ((symbol-function 'ghostel--create)
+                     (lambda (name &rest _)
+                       (let ((b (generate-new-buffer name)))
+                         (with-current-buffer b (ghostel-mode))
+                         (setq created b)
+                         b)))
+                    ((symbol-function 'ghostel--start-process) #'ignore)
+                    ((symbol-function 'ghostel--apply-initial-input-mode)
+                     #'ignore))
+            (with-temp-buffer
+              (ghostel--bookmark-handler
+               (ghostel-test--bookmark-record " *ghostel-bm-kind-stale*"
+                                              "/tmp/ghostel-bm-kind/"
+                                              '((kind . eshell))))
+              (should created)
+              (should (eq (current-buffer) created))))
+        (delete-process ghostel--process)
+        (when (buffer-live-p created) (kill-buffer created))))))
 
 (ert-deftest ghostel-test-bookmark-handler-creates-buffer ()
   "Jumping to a bookmark with no live buffer starts a fresh shell in its dir."

--- a/test/ghostel-bookmark-test.el
+++ b/test/ghostel-bookmark-test.el
@@ -264,6 +264,140 @@ be hijacked; the jump creates a fresh buffer instead."
         (delete-process ghostel--process)
         (when (buffer-live-p created) (kill-buffer created))))))
 
+(ert-deftest ghostel-test-bookmark-handler-reattaches-by-command ()
+  "A command record reattaches to the live buffer running that command.
+The buffer's (possibly uniquified) name is irrelevant; a different
+command does not match; no `cd' is typed into a command buffer."
+  (ghostel-test--with-compile-buffer running
+    (rename-buffer " *ghostel-bm-vim*<2>" t)
+    (setq ghostel-identity '((kind . eshell) (command . ("vim" "notes"))))
+    (setq-local ghostel--term 'fake-term)
+    (setq default-directory "/tmp/ghostel-bm-a/")
+    (setq-local ghostel--process (ghostel-test--dummy-process "bm-vim" nil))
+    (let (sent created)
+      (unwind-protect
+          (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+                    ((symbol-function 'ghostel-send-string)
+                     (lambda (s) (push s sent)))
+                    ((symbol-function 'ghostel-send-key)
+                     (lambda (&rest _) (push 'key sent)))
+                    ((symbol-function 'ghostel-exec)
+                     (lambda (buffer &rest _)
+                       (setq created buffer)
+                       (with-current-buffer buffer
+                         (setq major-mode 'ghostel-mode))
+                       'fake-proc)))
+            (with-temp-buffer
+              (ghostel--bookmark-handler
+               (ghostel-test--bookmark-record
+                " *ghostel-bm-vim*" "/tmp/ghostel-bm-b/"
+                '((kind . eshell) (command . ("vim" "notes")))))
+              (should (eq (current-buffer) running)))
+            (should-not sent)
+            (should-not created)
+            (with-temp-buffer
+              (ghostel--bookmark-handler
+               (ghostel-test--bookmark-record
+                " *ghostel-bm-vim*" "/tmp/ghostel-bm-b/"
+                '((kind . eshell) (command . ("vim" "other"))))))
+            (should created))
+        (delete-process ghostel--process)
+        (when (buffer-live-p created) (kill-buffer created))))))
+
+(ert-deftest ghostel-test-bookmark-handler-command-reattach-prefers-name ()
+  "The recorded name picks among several buffers running the same command.
+A stale recorded name falls back to any live command match."
+  (ghostel-test--with-compile-buffer first
+    (rename-buffer " *ghostel-bm-top*" t)
+    (setq ghostel-identity '((kind . eshell) (command . ("top"))))
+    (setq-local ghostel--process (ghostel-test--dummy-process "bm-top-a" nil))
+    (let ((first-proc ghostel--process))
+      (unwind-protect
+          (ghostel-test--with-compile-buffer second
+            (rename-buffer " *ghostel-bm-top*<2>" t)
+            (setq ghostel-identity '((kind . eshell) (command . ("top"))))
+            (setq-local ghostel--process
+                        (ghostel-test--dummy-process "bm-top-b" nil))
+            (unwind-protect
+                (cl-letf (((symbol-function 'ghostel--load-module) #'ignore))
+                  (with-temp-buffer
+                    (ghostel--bookmark-handler
+                     (ghostel-test--bookmark-record
+                      " *ghostel-bm-top*<2>" "/tmp/ghostel-bm-t/"
+                      '((kind . eshell) (command . ("top")))))
+                    (should (eq (current-buffer) second)))
+                  (with-temp-buffer
+                    (ghostel--bookmark-handler
+                     (ghostel-test--bookmark-record
+                      " *ghostel-bm-top*" "/tmp/ghostel-bm-t/"
+                      '((kind . eshell) (command . ("top")))))
+                    (should (eq (current-buffer) first)))
+                  (with-temp-buffer
+                    (ghostel--bookmark-handler
+                     (ghostel-test--bookmark-record
+                      " *ghostel-bm-top-gone*" "/tmp/ghostel-bm-t/"
+                      '((kind . eshell) (command . ("top")))))
+                    (should (memq (current-buffer) (list first second)))))
+              (delete-process ghostel--process)))
+        (delete-process first-proc)))))
+
+(ert-deftest ghostel-test-bookmark-handler-respawn-failure-cleans-up ()
+  "A failing spawn kills the partially created buffer and re-signals.
+Covers both the command respawn and the shell branch."
+  (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+            ((symbol-function 'ghostel-exec)
+             (lambda (&rest _) (error "Spawn failed"))))
+    (should-error
+     (ghostel--bookmark-handler
+      (ghostel-test--bookmark-record " *ghostel-bm-fail*"
+                                     "/tmp/ghostel-bm-f/"
+                                     '((kind . exec) (command . ("nope"))))))
+    (should-not (get-buffer " *ghostel-bm-fail*")))
+  (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+            ((symbol-function 'ghostel--create)
+             (lambda (name &rest _)
+               (let ((b (generate-new-buffer name)))
+                 (with-current-buffer b (ghostel-mode))
+                 b)))
+            ((symbol-function 'ghostel--start-process)
+             (lambda () (error "Spawn failed"))))
+    (should-error
+     (ghostel--bookmark-handler
+      (ghostel-test--bookmark-record " *ghostel-bm-fail-sh*"
+                                     "/tmp/ghostel-bm-f/")))
+    (should-not (get-buffer " *ghostel-bm-fail-sh*"))))
+
+(ert-deftest ghostel-test-bookmark-handler-respawns-command ()
+  "A command-bearing identity respawns the program instead of a shell."
+  (let ((exec-calls nil)
+        (shell-started nil))
+    (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
+              ((symbol-function 'ghostel-exec)
+               (lambda (buffer program &optional args identity)
+                 (push (list buffer program args identity) exec-calls)
+                 (with-current-buffer buffer
+                   (setq major-mode 'ghostel-mode)
+                   (setq-local ghostel-identity identity))
+                 'fake-proc))
+              ((symbol-function 'ghostel--start-process)
+               (lambda () (setq shell-started t))))
+      (unwind-protect
+          (progn
+            (with-temp-buffer
+              (ghostel--bookmark-handler
+               (ghostel-test--bookmark-record
+                " *ghostel-bm-htop*" "/tmp/ghostel-bm-cmd/"
+                '((kind . exec) (command . ("htop" "-d" "10"))))))
+            (should-not shell-started)
+            (should (= 1 (length exec-calls)))
+            (pcase-let ((`(,b ,prog ,args ,id) (car exec-calls)))
+              (should (equal (buffer-name b) " *ghostel-bm-htop*"))
+              (should (equal prog "htop"))
+              (should (equal args '("-d" "10")))
+              (should (equal (alist-get 'command id) '("htop" "-d" "10")))))
+        (when-let* ((b (get-buffer " *ghostel-bm-htop*")))
+          (kill-buffer b))))))
+
 (ert-deftest ghostel-test-bookmark-handler-creates-buffer ()
   "Jumping to a bookmark with no live buffer starts a fresh shell in its dir."
   :tags '(native)

--- a/test/ghostel-buffer-name-test.el
+++ b/test/ghostel-buffer-name-test.el
@@ -157,14 +157,13 @@
               (should (equal "*ghostel: Title A*" (buffer-name)))
               (ghostel--set-title "")
               (should (null ghostel--title))
-              (should (equal ghostel--buffer-identity (buffer-name)))
-              (should (equal ghostel--buffer-identity
-                             ghostel--managed-buffer-name))
+              (should (equal "*ghostel*" (buffer-name)))
+              (should (equal "*ghostel*" ghostel--managed-buffer-name))
               (ghostel--set-title "Title B")
               (should (equal "*ghostel: Title B*" (buffer-name)))
               (ghostel--set-title nil)
               (should (null ghostel--title))
-              (should (equal ghostel--buffer-identity (buffer-name))))))
+              (should (equal "*ghostel*" (buffer-name))))))
       (when (buffer-live-p buf) (kill-buffer buf)))))
 
 (ert-deftest ghostel-test-set-title-clear-respects-manual ()
@@ -192,7 +191,7 @@
 (ert-deftest ghostel-test-set-title-clear-unclaimed-keeps-name ()
   "A clear does not rename a buffer title tracking never renamed."
   (with-temp-buffer
-    (setq-local ghostel--buffer-identity "*ghostel-orig*")
+    (setq-local ghostel--initial-name "*ghostel-orig*")
     (let ((ghostel-buffer-name-function #'ghostel-buffer-name-by-title)
           (name (buffer-name)))
       (ghostel--set-title "")

--- a/test/ghostel-buffers-test.el
+++ b/test/ghostel-buffers-test.el
@@ -12,14 +12,14 @@
 (defun ghostel-buffers-test--make (name &optional dir identity)
   "Create a fake ghostel-mode buffer for tests.
 NAME is the buffer name.  Optional DIR sets `default-directory'
-and IDENTITY sets `ghostel--buffer-identity'.  The buffer claims
+and IDENTITY sets `ghostel-identity'.  The buffer claims
 `ghostel-mode' via `major-mode' without invoking the mode
 function (which would require the native module)."
   (let ((buf (generate-new-buffer name)))
     (with-current-buffer buf
       (setq major-mode 'ghostel-mode)
       (when dir (setq default-directory dir))
-      (when identity (setq-local ghostel--buffer-identity identity)))
+      (when identity (setq-local ghostel-identity identity)))
     buf))
 
 (defmacro ghostel-buffers-test--with-bufs (bindings &rest body)
@@ -230,20 +230,21 @@ Each BINDING is (VAR NAME [DIR [IDENTITY]])."
             (should-not (memq outside bufs))))))))
 
 (ert-deftest ghostel-test-project-buffers-identity ()
-  "Scope `identity' matches buffers whose identity is the project-prefixed name."
+  "Scope `identity' matches term slots tagged with the project root."
   (let* ((root (make-temp-file "ghostel-myproj" t))
          (root (file-name-as-directory root))
          (outside-root (file-name-as-directory
                         (make-temp-file "ghostel-other" t)))
          (ghostel-buffer-name "*ghostel*"))
     (ghostel-buffers-test--with-bufs
-        ((tagged "*ghostel-tagged*" outside-root "*myproj-ghostel*")
+        ((tagged "*ghostel-tagged*" outside-root
+                 `((kind . term)
+                   (project-root . ,(ghostel--normalize-root root))
+                   (instance . 1)))
          (untagged "*ghostel-untag*" root nil))
       (cl-letf (((symbol-function 'project-current)
                  (ghostel-buffers-test--proj-stub root))
-                ((symbol-function 'project-root) (lambda (p) (cdr p)))
-                ((symbol-function 'project-prefixed-buffer-name)
-                 (lambda (name) (format "*myproj-%s*" name))))
+                ((symbol-function 'project-root) (lambda (p) (cdr p))))
         (let ((default-directory root)
               (ghostel-project-buffer-scope 'identity))
           (let ((bufs (ghostel--project-buffers)))
@@ -259,14 +260,18 @@ Each BINDING is (VAR NAME [DIR [IDENTITY]])."
          (ghostel-buffer-name "*ghostel*"))
     (ghostel-buffers-test--with-bufs
         ((by-dir "*ghostel-d*" root nil)
-         (by-id "*ghostel-i*" outside-root "*myproj-ghostel*")
-         (both "*ghostel-b*" (expand-file-name "sub/" root) "*myproj-ghostel*")
+         (by-id "*ghostel-i*" outside-root
+                `((kind . term)
+                  (project-root . ,(ghostel--normalize-root root))
+                  (instance . 1)))
+         (both "*ghostel-b*" (expand-file-name "sub/" root)
+               `((kind . term)
+                 (project-root . ,(ghostel--normalize-root root))
+                 (instance . 2)))
          (neither "*ghostel-n*" outside-root nil))
       (cl-letf (((symbol-function 'project-current)
                  (ghostel-buffers-test--proj-stub root))
-                ((symbol-function 'project-root) (lambda (p) (cdr p)))
-                ((symbol-function 'project-prefixed-buffer-name)
-                 (lambda (name) (format "*myproj-%s*" name))))
+                ((symbol-function 'project-root) (lambda (p) (cdr p))))
         (let ((default-directory root)
               (ghostel-project-buffer-scope 'both))
           (let ((bufs (ghostel--project-buffers)))
@@ -275,6 +280,152 @@ Each BINDING is (VAR NAME [DIR [IDENTITY]])."
             (should (memq both bufs))
             (should-not (memq neither bufs))
             (should (= 1 (cl-count both bufs)))))))))
+
+;;; Structured identity
+
+(ert-deftest ghostel-test-identity-equal-order-insensitive ()
+  "`ghostel--identity-equal' ignores pair order but not content."
+  (should (ghostel--identity-equal
+           '((kind . term) (instance . 1))
+           '((instance . 1) (kind . term))))
+  (should-not (ghostel--identity-equal
+               '((kind . term) (instance . 1))
+               '((kind . term) (instance . 2))))
+  (should-not (ghostel--identity-equal
+               '((kind . term) (instance . 1))
+               '((kind . term) (instance . 1) (project-root . "~/a/b/")))))
+
+(ert-deftest ghostel-test-identity-match-p-subset ()
+  "`ghostel-identity-match-p' matches subsets, including composed contexts."
+  (let ((id '((kind . term) (project-root . "~/d/b/") (instance . 3))))
+    (should (ghostel-identity-match-p '((kind . term)) id))
+    (should (ghostel-identity-match-p '((project-root . "~/d/b/")) id))
+    (should (ghostel-identity-match-p
+             '((kind . term) (project-root . "~/d/b/")) id))
+    (should (ghostel-identity-match-p nil id))
+    (should-not (ghostel-identity-match-p '((project-root . "~/a/b/")) id))
+    (should-not (ghostel-identity-match-p '((kind . compile)) id))
+    (should-not (ghostel-identity-match-p '((kind . term)) nil))))
+
+(ert-deftest ghostel-test-project-buffers-same-name-projects-distinct ()
+  "Two projects sharing a directory basename do not conflate.
+This is the bug class where `ghostel-project' reused another
+project's terminal because both rendered the same buffer name."
+  (let* ((parent-a (file-name-as-directory (make-temp-file "ghostel-pa" t)))
+         (parent-b (file-name-as-directory (make-temp-file "ghostel-pb" t)))
+         (root-a (file-name-as-directory (expand-file-name "b" parent-a)))
+         (root-b (file-name-as-directory (expand-file-name "b" parent-b))))
+    (make-directory root-a)
+    (make-directory root-b)
+    (ghostel-buffers-test--with-bufs
+        ((in-a "*b-ghostel*"
+               root-a
+               `((kind . term)
+                 (project-root . ,(ghostel--normalize-root root-a))
+                 (instance . 1)))
+         (in-b "*b-ghostel*"
+               root-b
+               `((kind . term)
+                 (project-root . ,(ghostel--normalize-root root-b))
+                 (instance . 1))))
+      ;; Slot reuse: each root finds exactly its own buffer.
+      (should (eq in-a (ghostel--find-buffer-by-identity
+                        (buffer-local-value 'ghostel-identity in-a))))
+      (should (eq in-b (ghostel--find-buffer-by-identity
+                        (buffer-local-value 'ghostel-identity in-b))))
+      ;; Identity scope from project A sees only A's terminal.
+      (cl-letf (((symbol-function 'project-current)
+                 (ghostel-buffers-test--proj-stub root-a))
+                ((symbol-function 'project-root) (lambda (p) (cdr p))))
+        (let ((default-directory root-a)
+              (ghostel-project-buffer-scope 'identity))
+          (let ((bufs (ghostel--project-buffers)))
+            (should (memq in-a bufs))
+            (should-not (memq in-b bufs))))))))
+
+(ert-deftest ghostel-test-project-buffers-identity-includes-numbered ()
+  "Identity scope includes numbered instances of the project's slots."
+  (let* ((root (file-name-as-directory (make-temp-file "ghostel-num" t))))
+    (ghostel-buffers-test--with-bufs
+        ((first "*num-ghostel*" root
+                `((kind . term)
+                  (project-root . ,(ghostel--normalize-root root))
+                  (instance . 1)))
+         (second "*num-ghostel*<2>" root
+                 `((kind . term)
+                   (project-root . ,(ghostel--normalize-root root))
+                   (instance . 2))))
+      (cl-letf (((symbol-function 'project-current)
+                 (ghostel-buffers-test--proj-stub root))
+                ((symbol-function 'project-root) (lambda (p) (cdr p))))
+        (let ((default-directory root)
+              (ghostel-project-buffer-scope 'identity))
+          (let ((bufs (ghostel--project-buffers)))
+            (should (memq first bufs))
+            (should (memq second bufs))))))))
+
+(ert-deftest ghostel-test-project-buffers-identity-excludes-other-kinds ()
+  "Identity scope skips non-term kinds tagged with the same project."
+  (let* ((root (file-name-as-directory (make-temp-file "ghostel-kind" t))))
+    (ghostel-buffers-test--with-bufs
+        ((term "*kind-ghostel*" root
+               `((kind . term)
+                 (project-root . ,(ghostel--normalize-root root))
+                 (instance . 1)))
+         (compile "*kind-compile*" root
+                  `((kind . compile)
+                    (project-root . ,(ghostel--normalize-root root)))))
+      (cl-letf (((symbol-function 'project-current)
+                 (ghostel-buffers-test--proj-stub root))
+                ((symbol-function 'project-root) (lambda (p) (cdr p))))
+        (let ((default-directory root)
+              (ghostel-project-buffer-scope 'identity))
+          (let ((bufs (ghostel--project-buffers)))
+            (should (memq term bufs))
+            (should-not (memq compile bufs))))))))
+
+(ert-deftest ghostel-test-normalize-root-remote-unchanged ()
+  "Remote roots are not expanded or abbreviated during normalization."
+  (should (equal "/ssh:user@host:/tmp/proj/"
+                 (ghostel--normalize-root "/ssh:user@host:/tmp/proj/")))
+  (should (equal "/ssh:user@host:/tmp/proj/"
+                 (ghostel--normalize-root "/ssh:user@host:/tmp/proj"))))
+
+(ert-deftest ghostel-test-find-buffer-skips-non-ghostel-mode ()
+  "A slot identity surviving a major-mode change no longer claims the slot."
+  (let ((buf (generate-new-buffer "*ghostel-was*")))
+    (unwind-protect
+        (progn
+          (with-current-buffer buf
+            (setq major-mode 'ghostel-mode)
+            (setq-local ghostel-identity '((kind . term) (instance . 1))))
+          (should (eq (ghostel--find-buffer-by-identity
+                       '((kind . term) (instance . 1)))
+                      buf))
+          (with-current-buffer buf (fundamental-mode))
+          ;; The permanent-local identity survives the mode change ...
+          (should (equal (buffer-local-value 'ghostel-identity buf)
+                         '((kind . term) (instance . 1))))
+          ;; ... but the buffer no longer claims the slot.
+          (should-not (ghostel--find-buffer-by-identity
+                       '((kind . term) (instance . 1)))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-next-instance ()
+  "`ghostel--next-instance' returns 1 + the highest instance per context."
+  (should (= 1 (ghostel--next-instance '((kind . term)))))
+  (ghostel-buffers-test--with-bufs
+      ((_a "*ghostel*" nil '((kind . term) (instance . 1)))
+       (_b "*ghostel*<3>" nil '((kind . term) (instance . 3)))
+       (_c "*p-ghostel*" nil '((kind . term)
+                               (project-root . "~/p/")
+                               (instance . 7))))
+    ;; Global slots and project slots are separate contexts.
+    (should (= 4 (ghostel--next-instance '((kind . term)))))
+    (should (= 8 (ghostel--next-instance
+                  '((kind . term) (project-root . "~/p/")))))
+    (should (= 1 (ghostel--next-instance
+                  '((kind . term) (project-root . "~/q/")))))))
 
 (ert-deftest ghostel-test-project-next-without-project-errors ()
   "`ghostel-project-next' errors when there is no current project."

--- a/test/ghostel-exec-test.el
+++ b/test/ghostel-exec-test.el
@@ -69,15 +69,14 @@ buffer eventually shows up."
                                  (ghostel--kitty-mediums-bits))))))
       (kill-buffer buf))))
 
-(ert-deftest ghostel-test-exec-preserves-identity-bookkeeping ()
-  "`ghostel-exec' does not clobber buffer identity bookkeeping vars."
+(ert-deftest ghostel-test-exec-sets-identity ()
+  "`ghostel-exec' stamps the IDENTITY argument, defaulting to exec kind."
   (let ((buf (generate-new-buffer " *ghostel-exec-identity*")))
     (unwind-protect
         (progn
           (with-current-buffer buf
             (ghostel-mode)
-            (setq-local ghostel--managed-buffer-name "managed")
-            (setq-local ghostel--buffer-identity "identity"))
+            (setq-local ghostel--managed-buffer-name "managed"))
           (cl-letf (((symbol-function 'ghostel--load-module) #'ignore)
                     ((symbol-function 'ghostel--new)
                      (lambda (&rest _) 'fake-term))
@@ -89,7 +88,12 @@ buffer eventually shows up."
             (ghostel-exec buf "ls" nil)
             (with-current-buffer buf
               (should (equal ghostel--managed-buffer-name "managed"))
-              (should (equal ghostel--buffer-identity "identity")))))
+              (should (equal ghostel--initial-name (buffer-name)))
+              (should (equal ghostel-identity '((kind . exec)))))
+            (ghostel-exec buf "ls" nil '((kind . snowflake) (repl . "a")))
+            (with-current-buffer buf
+              (should (equal ghostel-identity
+                             '((kind . snowflake) (repl . "a")))))))
       (kill-buffer buf))))
 
 (defun ghostel-test-exec--pid-live-p (pid)

--- a/test/ghostel-exec-test.el
+++ b/test/ghostel-exec-test.el
@@ -85,11 +85,12 @@ buffer eventually shows up."
                     ((symbol-function 'ghostel--apply-bold-config) #'ignore)
                     ((symbol-function 'ghostel--spawn-pty)
                      (lambda (&rest _) 'fake-proc)))
-            (ghostel-exec buf "ls" nil)
+            (ghostel-exec buf "ls" '("-l"))
             (with-current-buffer buf
               (should (equal ghostel--managed-buffer-name "managed"))
               (should (equal ghostel--initial-name (buffer-name)))
-              (should (equal ghostel-identity '((kind . exec)))))
+              (should (equal ghostel-identity
+                             '((kind . exec) (command . ("ls" "-l"))))))
             (ghostel-exec buf "ls" nil '((kind . snowflake) (repl . "a")))
             (with-current-buffer buf
               (should (equal ghostel-identity

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -68,8 +68,9 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
   (let ((ghostel-buffer-name-function #'ghostel-buffer-name-by-title))
     (ghostel-test--with-pty-matrix backend
       (ghostel-test--with-raw-echo-buffer (buf proc)
-        (let ((identity ghostel--buffer-identity)
+        (let ((expected ghostel--initial-name)
               (round 0))
+          (should (equal expected (buffer-name)))
           (dolist (clear '("\e]2;\e\\" "\e]2;\a" "\e]0;\a"))
             (let ((title (format "Clear Me %S %d" backend
                                  (setq round (1+ round)))))
@@ -81,8 +82,8 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
               (ghostel-test--wait-until
                (lambda () (null ghostel--title)) proc 5)
               (should (null ghostel--title))
-              (should (equal identity (buffer-name)))
-              (should (equal identity ghostel--managed-buffer-name)))))))))
+              (should (equal expected (buffer-name)))
+              (should (equal expected ghostel--managed-buffer-name)))))))))
 
 (ert-deftest ghostel-test-osc9-notification ()
   "OSC 9 iTerm2-style notifications reach `ghostel-notification-function'."

--- a/test/ghostel-project-test.el
+++ b/test/ghostel-project-test.el
@@ -9,7 +9,7 @@
 (require 'ghostel-test-helpers)
 
 (ert-deftest ghostel-test-project-buffer-name ()
-  "Test that `ghostel-project' derives the buffer name correctly."
+  "`ghostel-project' derives the slot context and buffer name from the root."
   (require 'project)
   (let ((ghostel-buffer-name "*ghostel*")
         result)
@@ -19,47 +19,36 @@
                (lambda (proj) (cdr proj)))
               ((symbol-function 'project-prefixed-buffer-name)
                (lambda (name) (format "*myproj-%s*" name)))
-              ((symbol-function 'ghostel)
-               (lambda (&optional _)
-                 (setq result (cons default-directory ghostel-buffer-name)))))
+              ((symbol-function 'ghostel--start)
+               (lambda (context name &optional _arg)
+                 (setq result (list default-directory context name)))))
       (ghostel-project)
-      (should (equal "/tmp/myproj/" (car result)))
-      (should (string-match-p "ghostel" (cdr result)))
-      (should-not (string-match-p "\\*\\*" (cdr result))))))
+      (should (equal "/tmp/myproj/" (nth 0 result)))
+      (should (equal `((kind . term)
+                       (project-root . ,(ghostel--normalize-root
+                                         "/tmp/myproj/")))
+                     (nth 1 result)))
+      (should (string-match-p "ghostel" (nth 2 result)))
+      (should-not (string-match-p "\\*\\*" (nth 2 result))))))
 
 (ert-deftest ghostel-test-project-universal-arg ()
-  "`ghostel-project' forwards the prefix arg and binds `ghostel-buffer-name'."
+  "`ghostel-project' forwards the prefix arg to the slot core."
   (require 'project)
-  ;; Numeric prefix arg (C-5 M-x ghostel-project)
-  (let ((ghostel-buffer-name "*ghostel*")
-        captured)
-    (cl-letf (((symbol-function 'project-current)
-               (lambda (_maybe-prompt) '(transient . "/tmp/myproj/")))
-              ((symbol-function 'project-root)
-               (lambda (proj) (cdr proj)))
-              ((symbol-function 'project-prefixed-buffer-name)
-               (lambda (name) (format "*myproj-%s*" name)))
-              ((symbol-function 'ghostel)
-               (lambda (&optional arg)
-                 (setq captured (cons arg ghostel-buffer-name)))))
-      (ghostel-project 4)
-      (should (equal (car captured) 4))
-      (should (equal (cdr captured) "*myproj-ghostel*"))))
-  ;; Universal prefix arg (C-u M-x ghostel-project)
-  (let ((ghostel-buffer-name "*ghostel*")
-        captured)
-    (cl-letf (((symbol-function 'project-current)
-               (lambda (_maybe-prompt) '(transient . "/tmp/myproj/")))
-              ((symbol-function 'project-root)
-               (lambda (proj) (cdr proj)))
-              ((symbol-function 'project-prefixed-buffer-name)
-               (lambda (name) (format "*myproj-%s*" name)))
-              ((symbol-function 'ghostel)
-               (lambda (&optional arg)
-                 (setq captured (cons arg ghostel-buffer-name)))))
-      (ghostel-project '(4))
-      (should (equal (car captured) '(4)))
-      (should (equal (cdr captured) "*myproj-ghostel*")))))
+  (dolist (arg '(4 (4)))
+    (let ((ghostel-buffer-name "*ghostel*")
+          captured)
+      (cl-letf (((symbol-function 'project-current)
+                 (lambda (_maybe-prompt) '(transient . "/tmp/myproj/")))
+                ((symbol-function 'project-root)
+                 (lambda (proj) (cdr proj)))
+                ((symbol-function 'project-prefixed-buffer-name)
+                 (lambda (name) (format "*myproj-%s*" name)))
+                ((symbol-function 'ghostel--start)
+                 (lambda (_context name &optional a)
+                   (setq captured (cons a name)))))
+        (ghostel-project arg)
+        (should (equal (car captured) arg))
+        (should (equal (cdr captured) "*myproj-ghostel*"))))))
 
 (ert-deftest ghostel-test-project-buffer-name-remote ()
   "`ghostel--project-buffer-name' host-qualifies remote roots (bug #344)."
@@ -86,7 +75,11 @@ same name must get separate buffers."
         (progn
           (with-current-buffer local
             (ghostel-mode)
-            (setq-local ghostel--buffer-identity "*myproj-ghostel*")
+            (setq-local ghostel-identity
+                        `((kind . term)
+                          (project-root . ,(ghostel--normalize-root
+                                            "/tmp/myproj/"))
+                          (instance . 1)))
             (setq-local ghostel--term 'fake-term))
           (cl-letf (((symbol-function 'project-current)
                      (lambda (&rest _)
@@ -103,8 +96,12 @@ same name must get separate buffers."
             (setq result (ghostel-project)))
           (should (eq result created))
           (with-current-buffer created
-            (should (equal ghostel--buffer-identity
-                           "*myproj-ghostel@ssh:user@host*"))))
+            (should (ghostel--identity-equal
+                     ghostel-identity
+                     `((kind . term)
+                       (project-root . ,(ghostel--normalize-root
+                                         "/ssh:user@host:/tmp/myproj/"))
+                       (instance . 1))))))
       (dolist (b (list local created))
         (when (buffer-live-p b) (kill-buffer b))))))
 
@@ -119,8 +116,11 @@ same name must get separate buffers."
         (progn
           (with-current-buffer existing
             (ghostel-mode)
-            (setq-local ghostel--buffer-identity
-                        "*myproj-ghostel@ssh:user@host*")
+            (setq-local ghostel-identity
+                        `((kind . term)
+                          (project-root . ,(ghostel--normalize-root
+                                            "/ssh:user@host:/tmp/myproj/"))
+                          (instance . 1)))
             (setq-local ghostel--term 'fake-term))
           (cl-letf (((symbol-function 'project-current)
                      (lambda (&rest _)
@@ -149,14 +149,19 @@ same name must get separate buffers."
         (progn
           (with-current-buffer local
             (ghostel-mode)
-            (setq-local ghostel--buffer-identity "*myproj-ghostel*"))
+            (setq-local ghostel-identity
+                        `((kind . term)
+                          (project-root . ,(ghostel--normalize-root
+                                            "/tmp/myproj/"))
+                          (instance . 1))))
           (with-current-buffer remote
             (ghostel-mode)
-            (setq-local ghostel--buffer-identity
-                        "*myproj-ghostel@ssh:user@host*"))
-          (cl-letf (((symbol-function 'project-prefixed-buffer-name)
-                     (lambda (name) (format "*myproj-%s*" name)))
-                    ((symbol-function 'project-root)
+            (setq-local ghostel-identity
+                        `((kind . term)
+                          (project-root . ,(ghostel--normalize-root
+                                            "/ssh:user@host:/tmp/myproj/"))
+                          (instance . 1))))
+          (cl-letf (((symbol-function 'project-root)
                      (lambda (proj) (cdr proj))))
             (cl-letf (((symbol-function 'project-current)
                        (lambda (&rest _) '(transient . "/tmp/myproj/"))))
@@ -178,7 +183,8 @@ same name must get separate buffers."
         (progn
           (with-current-buffer existing
             (ghostel-mode)
-            (setq-local ghostel--buffer-identity "*ghostel*")
+            (setq-local ghostel-identity
+                        '((kind . term) (name . "*ghostel*") (instance . 1)))
             (setq-local ghostel--term 'fake-term))
           (with-current-buffer existing (rename-buffer "*ghostel: zsh*"))
           (cl-letf (((symbol-function 'ghostel--load-module) (lambda (&rest _) nil))
@@ -203,7 +209,11 @@ same name must get separate buffers."
         (progn
           (with-current-buffer existing
             (ghostel-mode)
-            (setq-local ghostel--buffer-identity project-name)
+            (setq-local ghostel-identity
+                        `((kind . term)
+                          (project-root . ,(ghostel--normalize-root
+                                            "/tmp/myproj/"))
+                          (instance . 1)))
             (setq-local ghostel--term 'fake-term))
           (with-current-buffer existing (rename-buffer "*ghostel: zsh*"))
           (cl-letf (((symbol-function 'project-current)
@@ -232,10 +242,43 @@ same name must get separate buffers."
                   ((symbol-function 'ghostel--start-process) #'ignore))
           (should (eq (ghostel) created))
           (with-current-buffer created
-            (should (equal ghostel--buffer-identity ghostel-buffer-name))
-            (should (equal ghostel--managed-buffer-name (buffer-name)))))
+            (should (ghostel--identity-equal
+                     ghostel-identity '((kind . term)
+                                        (name . "*ghostel-identity-test*")
+                                        (instance . 1))))
+            (should (equal ghostel--managed-buffer-name (buffer-name)))
+            (should (equal ghostel--initial-name (buffer-name)))))
       (when (buffer-live-p created)
         (kill-buffer created)))))
+
+(ert-deftest ghostel-test-let-bound-buffer-name-gets-own-slot ()
+  "A non-default `ghostel-buffer-name' keys its own slot family."
+  (let ((created (generate-new-buffer "*scratch-term*"))
+        (other nil))
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel--load-module) (lambda (&rest _) nil))
+                  ((symbol-function 'ghostel--create)
+                   (lambda (&rest _)
+                     (with-current-buffer created
+                       (setq major-mode 'ghostel-mode)
+                       (setq-local ghostel--term 'fake-term))
+                     created))
+                  ((symbol-function 'ghostel--start-process) #'ignore))
+          (let ((ghostel-buffer-name "*scratch-term*"))
+            (should (eq (ghostel) created)))
+          (with-current-buffer created
+            (should (equal (alist-get 'name ghostel-identity)
+                           "*scratch-term*")))
+          ;; A default-named `ghostel' must not reuse the named slot.
+          (setq other (generate-new-buffer "*ghostel*"))
+          (cl-letf (((symbol-function 'ghostel--create) (lambda (&rest _) other)))
+            (let ((ghostel-buffer-name "*ghostel*"))
+              (should (eq (ghostel) other)))
+            (with-current-buffer other
+              (should (equal (alist-get 'name ghostel-identity)
+                             "*ghostel*")))))
+      (dolist (b (list created other))
+        (when (buffer-live-p b) (kill-buffer b))))))
 
 (ert-deftest ghostel-test-init-buffer-clears-buffer ()
   "`ghostel--init-buffer' clears existing buffer contents."
@@ -264,7 +307,7 @@ same name must get separate buffers."
             (setq-local ghostel--term-rows 1)
             (setq-local ghostel--term-cols 2)
             (setq-local ghostel--managed-buffer-name "managed")
-            (setq-local ghostel--buffer-identity "identity"))
+            (setq-local ghostel-identity '((kind . exec))))
           (cl-letf (((symbol-function 'ghostel--new) (lambda (&rest _) 'new-term))
                     ((symbol-function 'ghostel--set-size) #'ignore)
                     ((symbol-function 'ghostel--apply-palette) #'ignore))
@@ -274,7 +317,7 @@ same name must get separate buffers."
             (should-not ghostel--term-rows)
             (should-not ghostel--term-cols)
             (should (equal ghostel--managed-buffer-name "managed"))
-            (should (equal ghostel--buffer-identity "identity"))))
+            (should (equal ghostel-identity '((kind . exec))))))
       (kill-buffer buf))))
 
 (ert-deftest ghostel-test-create-initializes-buffer ()
@@ -291,7 +334,8 @@ same name must get separate buffers."
             (should (eq ghostel--term 'fake-term))
             (should-not ghostel--term-rows)
             (should-not ghostel--term-cols)
-            (should (equal (buffer-name) ghostel--buffer-identity))))
+            ;; Identity is assigned by the caller, never by creation.
+            (should-not ghostel-identity)))
       (when (buffer-live-p buf)
         (kill-buffer buf)))))
 


### PR DESCRIPTION
Fixes #432.

## Problem

`ghostel-project` keyed terminals by a buffer name derived from the project directory's basename, so two projects sharing a basename (`~/a/b` and `~/d/b`) mapped to the same `*b-ghostel*` identity: the second project reused the first project's terminal, and the project cycle commands conflated the two.

## Change

Buffer identity becomes a structured alist instead of a name string (`ghostel-identity`, public):

- `kind` (mandatory): `term`, `compile`, `exec`, `eshell`, or a third-party symbol.
- Scope keys, composable: `project-root` for project terminals, `name` for plain terminals, `command` (program + args) for exec-style buffers; room for future scopes (tab, workspace).
- `instance` marks reusable slots.

Slot reuse compares whole identities; scoped listings match subsets via the new `ghostel-identity-match-p`. `ghostel` and `ghostel-project` are thin wrappers over a shared core; the buffer name is purely cosmetic. The identity-scope cycle commands include numbered instances and exclude non-terminal buffers (e.g. a running `ghostel-compile`). `ghostel-exec` gains an optional IDENTITY argument so third-party packages can tag and filter their own buffers.

Bookmarks store the identity alist. Bookmarks of exec/eshell-visual buffers become restorable: the recorded `command` reattaches to a live buffer running that command, or respawns it in the bookmarked directory (restored buffers are plain `ghostel-exec` buffers without kind-specific wiring; the argv is saved to the bookmark file in plaintext).

## Behavior changes

- A numeric prefix of 1 selects the default terminal (formerly a separate `*ghostel*<1>` buffer).
- Bookmarks saved by older versions still restore but spawn a fresh terminal instead of reusing a live one.
- With a non-nil `ghostel-buffer-name-function`, a title clear reverts to the creation-time name recorded in the new `ghostel--initial-name`.

## Testing

`make -j8 all` (elisp, native, zig, evil suites). New ERT coverage: same-basename collision repro, subset matching, numbered-instance scoping, next-free instances, kind exclusion, bookmark reattach/respawn/failure-cleanup, render-free title-clear revert. Live-verified in sandboxed Emacs sessions: plain slots, project flows (including `cd` cross-contamination), compile identity across the view-mode switch, eshell visual commands, bookmark reattach/respawn.