### PR TITLE
Type file paths into the terminal for X11/pgtk drops and clipboard-image pastes

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -89,6 +89,7 @@
 (require 'cl-lib)
 (require 'comint)
 (require 'compat)
+(require 'dnd)
 (require 'format-spec)
 (require 'project)
 (require 'shell)
@@ -1915,6 +1916,28 @@ parity with `xterm-paste'."
 
 ;;; Drag and drop
 
+(defun ghostel--dnd-send-files (files)
+  "Send FILES to the terminal as shell-quoted paths, followed by a space."
+  (ghostel-send-string
+   (concat (mapconcat #'shell-quote-argument files " ") " ")))
+
+(defun ghostel--dnd-handle-file (uri action)
+  "Send the local file named by URI to the terminal, shell-quoted.
+Handles `dnd-protocol-alist' file drops on the ports that dispatch
+drops through `special-event-map' (X11, pgtk).  A non-local URI is
+ignored with a message; a drop into a dead terminal opens the file
+with ACTION instead."
+  (let* ((local (if (string-match-p "\\`file://[^/]" uri)
+                    (dnd-get-local-file-uri uri)
+                  uri))
+         (file (and local (dnd-get-local-file-name local))))
+    (cond ((null file)
+           (message "ghostel: ignoring dropped %s (not a local file)" uri))
+          ((process-live-p ghostel--process)
+           (ghostel--dnd-send-files (list file)))
+          (t (dnd-open-local-file local action))))
+  'private)
+
 (defun ghostel--drop (event)
   "Handle a drag-and-drop EVENT into the terminal.
 Dropped files insert their path (shell-quoted); dropped text is
@@ -1927,10 +1950,9 @@ pasted using bracketed paste."
     (when (and arg (not (eq arg 'lambda)))
       (let ((type (car arg))
             (objects (cddr arg)))
-        (ghostel--on-user-input)
         (if (eq type 'file)
-            (ghostel--send-string
-             (mapconcat #'shell-quote-argument objects " "))
+            (ghostel--dnd-send-files objects)
+          (ghostel--on-user-input)
           (ghostel--paste-text
            (mapconcat #'identity objects "\n")))))))
 
@@ -5138,6 +5160,16 @@ may change freely (`ghostel-compile' finalize relies on this)."
   (ghostel--buffer-identification-update)
   ;; bookmark this buffer's cwd (loads ghostel-bookmark.el lazily on use)
   (setq-local bookmark-make-record-function #'ghostel--bookmark-make-record)
+  ;; X11 and pgtk deliver drops through `special-event-map' and the
+  ;; `dnd-protocol-alist' machinery, so the `<drag-n-drop>' binding in
+  ;; `ghostel-mode-map' is never consulted there; intercept file drops
+  ;; buffer-locally instead.  NS and w32 bind `[drag-n-drop]' in the
+  ;; global map, which the keymap binding shadows.
+  (setq-local dnd-protocol-alist
+              (append '(("^file:///" . ghostel--dnd-handle-file)
+                        ("^file://"  . ghostel--dnd-handle-file)
+                        ("^file:"    . ghostel--dnd-handle-file))
+                      dnd-protocol-alist))
   (setq ghostel--input-mode 'semi-char)
   (setq ghostel--scroll-intercept-active t)
   ;; Let C-g reach the keymap instead of triggering keyboard-quit.

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -932,6 +932,10 @@ to nil to disable the regex fallback entirely (OSC 133 only)."
 (declare-function spinner-start "spinner")
 (declare-function spinner-stop "spinner")
 
+;; Emacs 29+; registration is `fboundp'-gated in `ghostel-mode'.
+(declare-function yank-media-handler "yank-media" (types handler))
+(defvar yank-media-preferred-types)     ; Emacs 31+
+
 ;; Lazily loaded on first bookmark use; see ghostel-bookmark.el.
 (declare-function ghostel--bookmark-make-record "ghostel-bookmark")
 
@@ -1937,6 +1941,23 @@ with ACTION instead."
            (ghostel--dnd-send-files (list file)))
           (t (dnd-open-local-file local action))))
   'private)
+
+(defun ghostel--yank-media-image (mimetype data)
+  "Write image DATA of MIMETYPE to a temp file and send its path.
+The file is created in the temp directory of the host the shell runs on.
+The shell receives the shell-quoted path followed by a space."
+  (unless (process-live-p ghostel--process)
+    (user-error "Terminal has no live process"))
+  (let* ((ext (pcase (cadr (split-string (symbol-name mimetype) "/"))
+                ("svg+xml" "svg")
+                (subtype subtype)))
+         (coding-system-for-write 'binary)
+         (temp (make-temp-file
+                (expand-file-name "ghostel-clipboard-"
+                                  (temporary-file-directory))
+                nil (concat "." ext) data)))
+    (ghostel--dnd-send-files
+     (list (or (file-remote-p temp 'localname) temp)))))
 
 (defun ghostel--drop (event)
   "Handle a drag-and-drop EVENT into the terminal.
@@ -5170,6 +5191,20 @@ may change freely (`ghostel-compile' finalize relies on this)."
                         ("^file://"  . ghostel--dnd-handle-file)
                         ("^file:"    . ghostel--dnd-handle-file))
                       dnd-protocol-alist))
+  ;; `yank-media' pastes a clipboard image as a temp-file path.
+  (when (fboundp 'yank-media-handler)   ; Emacs 29+
+    (yank-media-handler "image/.*" #'ghostel--yank-media-image))
+  ;; Accept any image flavor: stock autoselect only prefers png/jpeg,
+  ;; stranding e.g. TIFF-only clipboards (Qt apps on macOS).
+  (when (boundp 'yank-media-preferred-types)  ; Emacs 31+
+    (setq-local yank-media-preferred-types
+                (append yank-media-preferred-types
+                        (list (lambda (types)
+                                (seq-filter
+                                 (lambda (type)
+                                   (string-prefix-p "image/"
+                                                    (symbol-name type)))
+                                 types))))))
   (setq ghostel--input-mode 'semi-char)
   (setq ghostel--scroll-intercept-active t)
   ;; Let C-g reach the keymap instead of triggering keyboard-quit.

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1942,8 +1942,8 @@ with ACTION instead."
           (t (dnd-open-local-file local action))))
   'private)
 
-(defun ghostel--yank-media-image (mimetype data)
-  "Write image DATA of MIMETYPE to a temp file and send its path.
+(defun ghostel--yank-media-data (mimetype data)
+  "Write clipboard DATA of MIMETYPE to a temp file and send its path.
 The file is created in the temp directory of the host the shell runs on.
 The shell receives the shell-quoted path followed by a space."
   (unless (process-live-p ghostel--process)
@@ -5191,20 +5191,24 @@ may change freely (`ghostel-compile' finalize relies on this)."
                         ("^file://"  . ghostel--dnd-handle-file)
                         ("^file:"    . ghostel--dnd-handle-file))
                       dnd-protocol-alist))
-  ;; `yank-media' pastes a clipboard image as a temp-file path.
+  ;; `yank-media' pastes a clipboard image or PDF as a temp-file path.
   (when (fboundp 'yank-media-handler)   ; Emacs 29+
-    (yank-media-handler "image/.*" #'ghostel--yank-media-image))
-  ;; Accept any image flavor: stock autoselect only prefers png/jpeg,
-  ;; stranding e.g. TIFF-only clipboards (Qt apps on macOS).
+    (yank-media-handler '("image/.*" application/pdf)
+                        #'ghostel--yank-media-data))
+  ;; Accept any image flavor and PDF: stock autoselect only prefers
+  ;; png/jpeg, stranding e.g. TIFF-only clipboards (Qt apps on macOS).
   (when (boundp 'yank-media-preferred-types)  ; Emacs 31+
     (setq-local yank-media-preferred-types
                 (append yank-media-preferred-types
                         (list (lambda (types)
-                                (seq-filter
-                                 (lambda (type)
-                                   (string-prefix-p "image/"
-                                                    (symbol-name type)))
-                                 types))))))
+                                (append
+                                 (seq-filter
+                                  (lambda (type)
+                                    (string-prefix-p "image/"
+                                                     (symbol-name type)))
+                                  types)
+                                 (and (memq 'application/pdf types)
+                                      '(application/pdf))))))))
   (setq ghostel--input-mode 'semi-char)
   (setq ghostel--scroll-intercept-active t)
   ;; Let C-g reach the keymap instead of triggering keyboard-quit.

--- a/test/ghostel-dnd-test.el
+++ b/test/ghostel-dnd-test.el
@@ -1,0 +1,147 @@
+;;; ghostel-dnd-test.el --- Tests for ghostel: drag-and-drop -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; File drops routed through `dnd-protocol-alist' (the X11/pgtk path):
+;; buffer-local registration, shell quoting, multi-file drops, refusal
+;; of non-local URIs, and the dead-terminal fallback.  The dnd layer is
+;; driven directly, so these run without a window system or a live PTY.
+
+;;; Code:
+
+(require 'ghostel-test-helpers)
+(require 'dnd)
+(require 'url-util)
+
+(defun ghostel-dnd-test--dispatch (urls)
+  "Dispatch URLS through the dnd layer as the X11/pgtk port would.
+Return everything sent through `ghostel--send-string',
+concatenated."
+  (let ((sent ""))
+    (cl-letf (((symbol-function 'ghostel--send-string)
+               (lambda (string) (setq sent (concat sent string))))
+              ((symbol-function 'ghostel--on-user-input) #'ignore))
+      (if (fboundp 'dnd-handle-multiple-urls)
+          (dnd-handle-multiple-urls (selected-window) urls 'private)
+        (dolist (url urls)
+          (dnd-handle-one-url (selected-window) 'private url))))
+    sent))
+
+(defmacro ghostel-dnd-test--with-mode-buffer (&rest body)
+  "Run BODY in a `ghostel-mode' buffer shown in the selected window.
+The buffer must be displayed so its buffer-local
+`dnd-protocol-alist' is in effect when the dnd layer re-selects
+the drop window.  A live placeholder process is installed as
+`ghostel--process'."
+  (declare (indent 0) (debug t))
+  `(let ((buf (generate-new-buffer " *ghostel-dnd-test*")))
+     (unwind-protect
+         (progn
+           (with-current-buffer buf
+             (ghostel-mode)
+             (setq ghostel--process
+                   (start-process "ghostel-dnd-test" nil "sleep" "30")))
+           (set-window-buffer (selected-window) buf)
+           (with-current-buffer buf ,@body))
+       (with-current-buffer buf
+         (when (process-live-p ghostel--process)
+           (delete-process ghostel--process)))
+       (kill-buffer buf))))
+
+(ert-deftest ghostel-test-dnd-protocol-alist-registered ()
+  "`ghostel-mode' registers a buffer-local file-drop handler.
+The first `dnd-protocol-alist' entry matching a file URL must be
+ours, and the global value must stay untouched."
+  (with-temp-buffer
+    (ghostel-mode)
+    (should (local-variable-p 'dnd-protocol-alist))
+    (should (eq (cl-loop for (re . fn) in dnd-protocol-alist
+                         when (string-match re "file:///tmp/x") return fn)
+                'ghostel--dnd-handle-file))
+    (should-not (rassq 'ghostel--dnd-handle-file
+                       (default-value 'dnd-protocol-alist)))))
+
+(ert-deftest ghostel-test-dnd-file-drop-sends-path ()
+  "A file URL dispatched through the dnd layer sends the path."
+  (ghostel-dnd-test--with-mode-buffer
+    (let* ((file (make-temp-file "ghostel-dnd"))
+           (sent (unwind-protect
+                     (ghostel-dnd-test--dispatch (list (concat "file://" file)))
+                   (delete-file file))))
+      (should (equal sent (concat file " "))))))
+
+(ert-deftest ghostel-test-dnd-file-drop-shell-quotes ()
+  "A dropped path containing spaces and quotes arrives shell-quoted."
+  (ghostel-dnd-test--with-mode-buffer
+    (let* ((dir (make-temp-file "ghostel-dnd" t))
+           (file (expand-file-name "it's a file" dir))
+           (sent (unwind-protect
+                     (progn
+                       (write-region "" nil file nil 'silent)
+                       (ghostel-dnd-test--dispatch
+                        (list (concat "file://"
+                                      (url-hexify-string
+                                       file url-path-allowed-chars)))))
+                   (delete-directory dir t))))
+      (should (equal sent (concat (shell-quote-argument file) " "))))))
+
+(ert-deftest ghostel-test-dnd-multi-file-drop-space-separated ()
+  "Two dropped URLs produce both paths, space-separated."
+  (ghostel-dnd-test--with-mode-buffer
+    (let* ((a (make-temp-file "ghostel-dnd-a"))
+           (b (make-temp-file "ghostel-dnd-b"))
+           (sent (unwind-protect
+                     (ghostel-dnd-test--dispatch
+                      (list (concat "file://" a) (concat "file://" b)))
+                   (delete-file a)
+                   (delete-file b))))
+      (should (equal sent (concat a " " b " "))))))
+
+(ert-deftest ghostel-test-dnd-hostname-qualified-uri-accepted ()
+  "A file://<local hostname>/path URI resolves and sends the path."
+  (ghostel-dnd-test--with-mode-buffer
+    (let* ((file (make-temp-file "ghostel-dnd"))
+           (sent (unwind-protect
+                     (ghostel-dnd-test--dispatch
+                      (list (concat "file://" (downcase (system-name)) file)))
+                   (delete-file file))))
+      (should (equal sent (concat file " "))))))
+
+(ert-deftest ghostel-test-dnd-nonexistent-path-sent ()
+  "A local URI naming a nonexistent file still sends the path."
+  (ghostel-dnd-test--with-mode-buffer
+    (let ((file (make-temp-name "/nonexistent-")))
+      (should (equal (ghostel-dnd-test--dispatch (list (concat "file://" file)))
+                     (concat file " "))))))
+
+(ert-deftest ghostel-test-dnd-non-local-uri-refused ()
+  "A URI on a foreign host sends nothing and opens nothing.
+The handler still consumes the drop (returns `private') so the dnd
+layer runs no default handler such as `find-file'."
+  (ghostel-dnd-test--with-mode-buffer
+    (let ((opened nil))
+      (cl-letf (((symbol-function 'dnd-open-local-file)
+                 (lambda (&rest args) (setq opened args))))
+        (should (equal (ghostel-dnd-test--dispatch
+                        '("file://otherhost/no/such/file"))
+                       ""))
+        (should-not opened)))))
+
+(ert-deftest ghostel-test-dnd-dead-terminal-opens-file ()
+  "A drop into a dead terminal opens the file instead of sending."
+  (ghostel-dnd-test--with-mode-buffer
+    (delete-process ghostel--process)
+    (should-not (process-live-p ghostel--process))
+    (let* ((file (make-temp-file "ghostel-dnd"))
+           (opened nil))
+      (unwind-protect
+          (cl-letf (((symbol-function 'dnd-open-local-file)
+                     (lambda (uri _action) (setq opened uri) 'private)))
+            (should (equal (ghostel-dnd-test--dispatch
+                            (list (concat "file://" file)))
+                           ""))
+            (should (equal opened (concat "file://" file))))
+        (delete-file file)))))
+
+(provide 'ghostel-dnd-test)
+;;; ghostel-dnd-test.el ends here

--- a/test/ghostel-yank-media-test.el
+++ b/test/ghostel-yank-media-test.el
@@ -1,0 +1,120 @@
+;;; ghostel-yank-media-test.el --- Tests for ghostel: yank-media -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Clipboard-image paste via `yank-media': handler registration, raw
+;; byte round-trip to a temp file, extension mapping, remote-path
+;; handling, and the dead-terminal guard.  The handler is called
+;; directly (the `yank-media' dispatch needs a GUI clipboard), so
+;; these run without a window system or a live PTY.
+
+;;; Code:
+
+(require 'ghostel-test-helpers)
+
+(defvar yank-media--registered-handlers)
+
+(defmacro ghostel-yank-media-test--with-mode-buffer (&rest body)
+  "Run BODY in a `ghostel-mode' buffer with a live placeholder process.
+Paths passed to `ghostel--dnd-send-files' are collected in `sent-files';
+shell quoting itself is covered by the dnd tests."
+  (declare (indent 0) (debug t))
+  `(let ((buf (generate-new-buffer " *ghostel-yank-media-test*"))
+         (sent-files nil))
+     (unwind-protect
+         (with-current-buffer buf
+           (ghostel-mode)
+           (setq ghostel--process
+                 (start-process "ghostel-yank-media-test" nil "sleep" "30"))
+           (cl-letf (((symbol-function 'ghostel--dnd-send-files)
+                      (lambda (files)
+                        (setq sent-files (append sent-files files)))))
+             ,@body))
+       (with-current-buffer buf
+         (when (process-live-p ghostel--process)
+           (delete-process ghostel--process)))
+       (kill-buffer buf))))
+
+(ert-deftest ghostel-test-yank-media-handler-registered ()
+  "`ghostel-mode' registers a buffer-local image handler."
+  (skip-unless (fboundp 'yank-media-handler))
+  (with-temp-buffer
+    (ghostel-mode)
+    (should (local-variable-p 'yank-media--registered-handlers))
+    (should (eq (cdr (assoc "image/.*" yank-media--registered-handlers))
+                'ghostel--yank-media-image))
+    (should-not (assoc "image/.*"
+                       (default-value 'yank-media--registered-handlers)))))
+
+(ert-deftest ghostel-test-yank-media-image-round-trip ()
+  "PNG bytes are written raw to a .png temp file and its path sent."
+  (skip-unless (fboundp 'yank-media-handler))
+  (ghostel-yank-media-test--with-mode-buffer
+    (let* ((data (apply #'unibyte-string
+                        (append '(#x89 ?P ?N ?G ?\r ?\n 0 #xff #x80)
+                                (number-sequence 0 255))))
+           ;; A dos-EOL write default must not corrupt the bytes.
+           (buffer-file-coding-system 'utf-8-dos)
+           (path (progn (ghostel--yank-media-image 'image/png data)
+                        (car sent-files))))
+      (unwind-protect
+          (progn
+            (should (equal (length sent-files) 1))
+            (should (string-suffix-p ".png" path))
+            (should (file-exists-p path))
+            (with-temp-buffer
+              (set-buffer-multibyte nil)
+              (insert-file-contents-literally path)
+              (should (equal (buffer-string) data))))
+        (when (and path (file-exists-p path))
+          (delete-file path))))))
+
+(ert-deftest ghostel-test-yank-media-image-extension ()
+  "The temp-file extension follows the MIME subtype."
+  (skip-unless (fboundp 'yank-media-handler))
+  (ghostel-yank-media-test--with-mode-buffer
+    (let ((path (progn (ghostel--yank-media-image
+                        'image/jpeg (unibyte-string #xff #xd8))
+                       (car sent-files))))
+      (unwind-protect
+          (should (string-match-p "\\.jpe?g\\'" path))
+        (when (and path (file-exists-p path))
+          (delete-file path))))))
+
+(ert-deftest ghostel-test-yank-media-image-remote-sends-localname ()
+  "For a remote temp file the shell receives the localname."
+  (skip-unless (fboundp 'yank-media-handler))
+  (ghostel-yank-media-test--with-mode-buffer
+    (cl-letf (((symbol-function 'make-temp-file)
+               (lambda (&rest _) "/ssh:host:/tmp/ghostel-clipboard-x.png")))
+      (ghostel--yank-media-image 'image/png (unibyte-string 1 2)))
+    (should (equal sent-files '("/tmp/ghostel-clipboard-x.png")))))
+
+(ert-deftest ghostel-test-yank-media-autoselect-any-image ()
+  "Autoselect picks a non-preferred image flavor like TIFF-only clipboards."
+  (skip-unless (and (require 'yank-media nil t)
+                    (boundp 'yank-media-preferred-types)
+                    (fboundp 'yank-media-autoselect-function)))
+  (with-temp-buffer
+    (ghostel-mode)
+    ;; A TIFF-only clipboard (Qt apps on macOS) must autoselect.
+    (should (equal (yank-media-autoselect-function '(image/tiff))
+                   '(image/tiff)))
+    ;; Stock priorities still win when several flavors are offered.
+    (should (equal (yank-media-autoselect-function '(image/tiff image/png))
+                   '(image/png)))
+    ;; The catch-all is buffer-local; other modes keep stock behavior.
+    (should (> (length yank-media-preferred-types)
+               (length (default-value 'yank-media-preferred-types))))))
+
+(ert-deftest ghostel-test-yank-media-image-dead-terminal ()
+  "A dead terminal signals `user-error' and sends nothing."
+  (skip-unless (fboundp 'yank-media-handler))
+  (ghostel-yank-media-test--with-mode-buffer
+    (delete-process ghostel--process)
+    (should-error (ghostel--yank-media-image 'image/png (unibyte-string 1 2))
+                  :type 'user-error)
+    (should-not sent-files)))
+
+(provide 'ghostel-yank-media-test)
+;;; ghostel-yank-media-test.el ends here

--- a/test/ghostel-yank-media-test.el
+++ b/test/ghostel-yank-media-test.el
@@ -42,7 +42,9 @@ shell quoting itself is covered by the dnd tests."
     (ghostel-mode)
     (should (local-variable-p 'yank-media--registered-handlers))
     (should (eq (cdr (assoc "image/.*" yank-media--registered-handlers))
-                'ghostel--yank-media-image))
+                'ghostel--yank-media-data))
+    (should (eq (cdr (assoc 'application/pdf yank-media--registered-handlers))
+                'ghostel--yank-media-data))
     (should-not (assoc "image/.*"
                        (default-value 'yank-media--registered-handlers)))))
 
@@ -55,7 +57,7 @@ shell quoting itself is covered by the dnd tests."
                                 (number-sequence 0 255))))
            ;; A dos-EOL write default must not corrupt the bytes.
            (buffer-file-coding-system 'utf-8-dos)
-           (path (progn (ghostel--yank-media-image 'image/png data)
+           (path (progn (ghostel--yank-media-data 'image/png data)
                         (car sent-files))))
       (unwind-protect
           (progn
@@ -73,11 +75,30 @@ shell quoting itself is covered by the dnd tests."
   "The temp-file extension follows the MIME subtype."
   (skip-unless (fboundp 'yank-media-handler))
   (ghostel-yank-media-test--with-mode-buffer
-    (let ((path (progn (ghostel--yank-media-image
+    (let ((path (progn (ghostel--yank-media-data
                         'image/jpeg (unibyte-string #xff #xd8))
                        (car sent-files))))
       (unwind-protect
           (should (string-match-p "\\.jpe?g\\'" path))
+        (when (and path (file-exists-p path))
+          (delete-file path))))))
+
+(ert-deftest ghostel-test-yank-media-pdf-round-trip ()
+  "PDF bytes are written raw to a .pdf temp file and its path sent."
+  (skip-unless (fboundp 'yank-media-handler))
+  (ghostel-yank-media-test--with-mode-buffer
+    (let* ((data (apply #'unibyte-string
+                        (append (string-to-list "%PDF-1.4\n")
+                                '(0 #xff #x80 #x0a) '(?% ?% ?E ?O ?F))))
+           (path (progn (ghostel--yank-media-data 'application/pdf data)
+                        (car sent-files))))
+      (unwind-protect
+          (progn
+            (should (string-suffix-p ".pdf" path))
+            (with-temp-buffer
+              (set-buffer-multibyte nil)
+              (insert-file-contents-literally path)
+              (should (equal (buffer-string) data))))
         (when (and path (file-exists-p path))
           (delete-file path))))))
 
@@ -87,7 +108,7 @@ shell quoting itself is covered by the dnd tests."
   (ghostel-yank-media-test--with-mode-buffer
     (cl-letf (((symbol-function 'make-temp-file)
                (lambda (&rest _) "/ssh:host:/tmp/ghostel-clipboard-x.png")))
-      (ghostel--yank-media-image 'image/png (unibyte-string 1 2)))
+      (ghostel--yank-media-data 'image/png (unibyte-string 1 2)))
     (should (equal sent-files '("/tmp/ghostel-clipboard-x.png")))))
 
 (ert-deftest ghostel-test-yank-media-autoselect-any-image ()
@@ -103,6 +124,12 @@ shell quoting itself is covered by the dnd tests."
     ;; Stock priorities still win when several flavors are offered.
     (should (equal (yank-media-autoselect-function '(image/tiff image/png))
                    '(image/png)))
+    ;; PDF autoselects alone, images beat it when both are offered.
+    (should (equal (yank-media-autoselect-function '(application/pdf))
+                   '(application/pdf)))
+    (should (equal (yank-media-autoselect-function
+                    '(application/pdf image/tiff))
+                   '(image/tiff application/pdf)))
     ;; The catch-all is buffer-local; other modes keep stock behavior.
     (should (> (length yank-media-preferred-types)
                (length (default-value 'yank-media-preferred-types))))))
@@ -112,7 +139,7 @@ shell quoting itself is covered by the dnd tests."
   (skip-unless (fboundp 'yank-media-handler))
   (ghostel-yank-media-test--with-mode-buffer
     (delete-process ghostel--process)
-    (should-error (ghostel--yank-media-image 'image/png (unibyte-string 1 2))
+    (should-error (ghostel--yank-media-data 'image/png (unibyte-string 1 2))
                   :type 'user-error)
     (should-not sent-files)))
 


### PR DESCRIPTION
## Problem

On X11 and pgtk, dropping a file onto a ghostel buffer opened it with `find-file` instead of typing its path into the terminal. Those ports dispatch `drag-n-drop` through `special-event-map`, which is handled inside `read_char` before any key-sequence lookup — so the `<drag-n-drop>` binding in `ghostel-mode-map` never fires there. (NS and w32 bind the event in the global map instead, which the mode map shadows; that's why drops always worked on macOS.)

Relatedly, there was no way to paste a clipboard image (e.g. a screenshot) into the terminal at all: a PTY has no inbound image channel, so an image can only reach a terminal program as a file path.

## File drops (commit 1)

Register a buffer-local `dnd-protocol-alist` handler in `ghostel-mode` (the same mechanism dired uses). The handler:

- shell-quotes the dropped path and sends it to the PTY, followed by a separating space (also how ghostty/Terminal.app behave); multi-file drops arrive space-separated
- converts hostname-qualified local URIs (`file://<localhost>/path`) via `dnd-get-local-file-uri`, mirroring the stock `dnd-open-file` chain
- ignores foreign-host URIs with a message
- falls back to `dnd-open-local-file` when the terminal has no live process, so drops into a `[Process exited]` buffer behave like stock Emacs instead of vanishing into a retired PTY

The existing `<drag-n-drop>` keymap binding stays for NS/w32; its file branch now shares the same sending helper, so file drops end with a separating space on all ports.

## Clipboard images and PDFs via yank-media (commits 2-3)

Register a buffer-local `yank-media` handler (Emacs 29+) for `image/.*` and `application/pdf` that writes the clipboard bytes to a temp file and types its shell-quoted path, sharing the send path with drag-and-drop. The file is created in the temp directory of the host the shell runs on, so TRAMP terminals receive a valid host-side path; the bytes are written in the exclusive-create call under a binary coding system so a dos-EOL default cannot corrupt them. A paste into a dead terminal signals `user-error`.

Emacs 31's autoselect only prefers png/jpeg, which strands TIFF-only clipboards (Qt applications like Flameshot declare TIFF on macOS) with "No preferred MIME type to yank" — `ghostel-mode` appends a buffer-local catch-all to `yank-media-preferred-types` so any image flavor (and PDF, after images) autoselects while stock priorities still win.

## Verification

- Drag-and-drop verified live on Linux (Emacs 30.2 X11/GTK3 under Xvfb, real XDND ClientMessage drops); yank-media verified live on macOS (GUI Emacs 31 NS), including a genuinely TIFF-only pasteboard (`NSPasteboard declareTypes:` — AppleScript-set clipboards advertise synthesized flavors and don't reproduce the bug).
- 8 new ERT tests drive the real `dnd-handle-multiple-urls` entry point; 6 new ERT tests cover the yank-media handler (byte round-trip across all 256 byte values under a dos-EOL default, remote localname, autoselect, dead-terminal guard).

Known limitations, deliberately out of scope: Emacs 29 pgtk consults `dnd-protocol-alist` in the wrong buffer (no `with-selected-window` before Emacs 30; main supported version is 30+), Emacs 30+'s `dnd-handle-multiple-urls` delivers 3+-URI drops out of source order (upstream quirk in its collection loop), text/URL drops on X11 keep their stock behavior, and pasted temp files are left to OS temp reaping (the shell consumes the path after every ghostel-visible event has passed).
