### PR TITLE
Read the default shell from the global environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- The default of `ghostel-shell` reads `$SHELL` from the global
+  environment instead of the current buffer's. Ghostel is normally
+  autoloaded by the first terminal, so a buffer-local
+  `process-environment` — as bound by, for example `buffer-env`,
+  `envrc` or `mise.el` — used to decide which shell every terminal
+  ran. A nix devshell exports a `$SHELL` built without readline, which
+  prints the `\[` / `\]` zero-width markers of the user's prompt
+  literally.
+
 ## [0.50.0] — 2026-08-13
 
 ### Added

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -112,7 +112,11 @@
   :group 'terminals
   :prefix "ghostel-")
 
-(defcustom ghostel-shell (or (getenv "SHELL") "/bin/sh")
+(defcustom ghostel-shell
+  ;; Read past any buffer-local `process-environment' (e.g. envrc, buffer-env)
+  (or (let ((process-environment (default-value 'process-environment)))
+        (getenv "SHELL"))
+      "/bin/sh")
   "Shell program to run in the terminal.
 
 Either a string (just the executable path) or a list whose first


### PR DESCRIPTION
`ghostel-shell` defaults to (getenv "SHELL"), evaluated when ghostel loads -- and ghostel is normally autoloaded by the first terminal, so that read happens in whatever buffer was current at that moment.

For example, `buffer-env`, `envrc` and `mise.el` bind `process-environment` buffer-locally to a project's dev shell, so opening the first terminal from such a buffer pinned every later terminal to that project's shell. Dev shells rarely name an interactive shell: a nix devshell exports a bash built without readline, which prints the `\[` / `\]` zero-width markers of the user's PS1 literally and turns every prompt into garbage.

Read past any buffer-local binding so the buffer that happens to open the first terminal cannot decide which shell the user gets.