### PR TITLE
Suppress point-leave copy-mode entry on minibuffer arrivals

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2695,9 +2695,17 @@ command set the region, so the selection survives the switch."
              (not ghostel--inhibit-insert-forwarding))
     (ghostel--enter-readonly-input-mode ghostel-mark-activation-input-mode)))
 
+(defun ghostel--pos-on-cursor-p (pos)
+  "Non-nil if POS rides the live terminal cursor: on it, or at `point-max'.
+Positions between the cursor and `point-max' do not count."
+  (and ghostel--cursor-char-pos
+       (or (= pos ghostel--cursor-char-pos)
+           (= pos (point-max)))))
+
 (defun ghostel-maybe-leave-input (&rest _)
   "Leave semi-char for `ghostel-point-leave-input-mode' if point left the input.
-A no-op unless, in semi-char mode, point has moved off the live terminal cursor.
+A no-op unless, in semi-char mode, point has moved off the live terminal
+cursor (`ghostel--pos-on-cursor-p', so `point-max' counts as on it).
 Wired into `isearch-mode-end-hook' and `minibuffer-exit-hook'.
 Add it to other jump commands as a hook or `:after' advice (see the README)."
   (interactive)
@@ -2707,7 +2715,7 @@ Add it to other jump commands as a hook or `:after' advice (see the README)."
              ghostel--term
              ghostel--cursor-char-pos
              (not executing-kbd-macro)
-             (/= (point) ghostel--cursor-char-pos))
+             (not (ghostel--pos-on-cursor-p (point))))
     (ghostel--enter-readonly-input-mode ghostel-point-leave-input-mode)))
 
 (defun ghostel-readonly-exit ()
@@ -4635,16 +4643,14 @@ Windows on the daemon's dummy initial frame are excluded."
 
 (defun ghostel--window-on-cursor-p (window)
   "Non-nil if WINDOW's point rides the live terminal cursor.
-WINDOW's buffer must be current.  Riding means point exactly on the cursor or
-at `point-max'; positions between the two do not count.  An active region vetoes
-the ride, except in a non-selected window showing the selected window's buffer."
-  (and ghostel--cursor-char-pos
-       (not (and (region-active-p)
+WINDOW's buffer must be current.  Riding is `ghostel--pos-on-cursor-p'.
+An active region vetoes the ride, except in a non-selected window showing
+the selected window's buffer."
+  (and (not (and (region-active-p)
                  (or (eq window (selected-window))
                      (not (eq (window-buffer (selected-window))
                               (current-buffer))))))
-       (or (= (window-point window) ghostel--cursor-char-pos)
-           (= (window-point window) (point-max)))))
+       (ghostel--pos-on-cursor-p (window-point window))))
 
 (defun ghostel--window-follows-p (window)
   "Non-nil if WINDOW's point lets it follow live terminal output.
@@ -5120,14 +5126,20 @@ a Ghostel window making it lose its anchoring."
 
 (defun ghostel--minibuffer-exit-maybe-leave ()
   "Run `ghostel-maybe-leave-input' after a minibuffer command, deferred.
-Covers minibuffer-driven navigation such as `consult-line', whose marker-based
-point landing can lag minibuffer teardown.  Deferred so the originating window
-and point settle first.  See `ghostel-point-leave-input-mode'."
-  (run-at-time 0 nil
-               (lambda ()
-                 (when-let* ((buf (window-buffer (selected-window))))
-                   (with-current-buffer buf
-                     (when (derived-mode-p 'ghostel-mode)
+Deferred so the originating window and point settle first (`consult-line's
+marker-based point landing can lag minibuffer teardown).  Only fires in the
+buffer the minibuffer was entered from: switching to a ghostel buffer via
+the minibuffer is an arrival, often with a stale restored point, not point
+leaving the input.  See `ghostel-point-leave-input-mode'."
+  (when-let* ((win (minibuffer-selected-window))
+              (origin (window-buffer win))
+              ((provided-mode-derived-p
+                (buffer-local-value 'major-mode origin) 'ghostel-mode)))
+    (run-at-time 0 nil
+                 (lambda ()
+                   (when (and (buffer-live-p origin)
+                              (eq (window-buffer (selected-window)) origin))
+                     (with-current-buffer origin
                        (ghostel-maybe-leave-input)))))))
 
 (defun ghostel--kill-buffer-query ()

--- a/test/ghostel-modes-test.el
+++ b/test/ghostel-modes-test.el
@@ -1403,6 +1403,79 @@ so copy/Emacs mode entry runs without a live terminal or window."
                         (buffer-local-value 'isearch-mode-end-hook buf))))
       (kill-buffer buf))))
 
+(ert-deftest ghostel-test-auto-leave-point-max-counts-as-on-cursor ()
+  "Point at `point-max' with the cursor elsewhere stays in semi-char.
+Buffer end counts as riding the live output, not navigating away."
+  (ghostel-test--with-auto-leave-buffer
+    (let ((ghostel-point-leave-input-mode 'copy))
+      (setq-local ghostel--cursor-char-pos 3)
+      (goto-char (point-max))
+      (ghostel-maybe-leave-input)
+      (should (eq ghostel--input-mode 'semi-char)))))
+
+(defun ghostel-test--minibuffer-exit-leave-deferred ()
+  "Run the exit check with the selected window as the minibuffer origin.
+Return the deferred check as a closure, or nil when the origin gate
+skipped scheduling one."
+  (let (deferred)
+    (cl-letf (((symbol-function 'minibuffer-selected-window)
+               (lambda () (selected-window)))
+              ((symbol-function 'run-at-time)
+               (lambda (_time _repeat fn &rest args)
+                 (setq deferred (lambda () (apply fn args)))
+                 nil)))
+      (ghostel--minibuffer-exit-maybe-leave))
+    deferred))
+
+(ert-deftest ghostel-test-minibuffer-leave-skips-arrival ()
+  "A minibuffer exit landing in a foreign ghostel buffer is an arrival.
+No auto-switch, even with point off the cursor."
+  (ghostel-test--with-auto-leave-buffer
+    (let ((previous-buffer (window-buffer (selected-window)))
+          (origin (generate-new-buffer " *ghostel-test-mb-origin*"))
+          (ghostel-point-leave-input-mode 'copy))
+      (unwind-protect
+          (progn
+            (with-current-buffer origin (ghostel-mode))
+            (set-window-buffer (selected-window) origin)
+            (let ((check (ghostel-test--minibuffer-exit-leave-deferred)))
+              (should check)
+              ;; The minibuffer command lands in BUF, not in ORIGIN.
+              (set-window-buffer (selected-window) buf)
+              (goto-char (point-min))
+              (funcall check))
+            (should (eq ghostel--input-mode 'semi-char)))
+        (set-window-buffer (selected-window) previous-buffer)
+        (kill-buffer origin)))))
+
+(ert-deftest ghostel-test-minibuffer-leave-fires-from-origin ()
+  "A minibuffer entered from the ghostel buffer still auto-switches.
+This is the `consult-line' navigation case the hook exists for."
+  (ghostel-test--with-auto-leave-buffer
+    (let ((previous-buffer (window-buffer (selected-window)))
+          (ghostel-point-leave-input-mode 'copy))
+      (unwind-protect
+          (progn
+            (set-window-buffer (selected-window) buf)
+            (let ((check (ghostel-test--minibuffer-exit-leave-deferred)))
+              (should check)
+              (goto-char (point-min))
+              (funcall check))
+            (should (eq ghostel--input-mode 'copy)))
+        (set-window-buffer (selected-window) previous-buffer)))))
+
+(ert-deftest ghostel-test-minibuffer-leave-skips-non-ghostel-origin ()
+  "No deferred check is scheduled for a minibuffer entered elsewhere."
+  (ghostel-test--with-auto-leave-buffer
+    (let ((previous-buffer (window-buffer (selected-window)))
+          (origin (generate-new-buffer " *ghostel-test-mb-plain*")))
+      (unwind-protect
+          (progn
+            (set-window-buffer (selected-window) origin)
+            (should-not (ghostel-test--minibuffer-exit-leave-deferred)))
+        (set-window-buffer (selected-window) previous-buffer)
+        (kill-buffer origin)))))
+
 (defmacro ghostel-test--with-anchor-window-buffer (&rest body)
   "Run BODY in the selected window showing a fresh ghostel buffer.
 The buffer holds more rows than fit in the window, so a bottom-aligned


### PR DESCRIPTION
Fixes #630.

## Problem

Any minibuffer exit ran the point-leave check in whatever ghostel buffer occupied the selected window afterwards. A minibuffer command that merely **switches to** a ghostel buffer (`consult-buffer`, `C-x b`, `ghostel-list-buffers`) is an arrival, not navigation: the freshly displayed window can restore a stale point (a `window-prev-buffers` marker from an older layout, often the buffer end), and the deferred check saw the mismatch before the redisplay anchor could re-sync point — freezing the buffer into read-only copy mode seemingly at random. Live traces from an affected session showed both reported flavors: restored point at `point-max`, and restored point at position 1, each flipping the buffer on `vertico-exit`.

## Fix

- `ghostel--minibuffer-exit-maybe-leave` derives the minibuffer's originating buffer at exit time from `minibuffer-selected-window` (per-level correct, so nested minibuffers cannot clobber it) and only runs the deferred check when the exit lands back in that same ghostel buffer. For non-ghostel origins no timer is scheduled at all.
- Point at `point-max` counts as riding the cursor, now shared with the window-follow logic through the new `ghostel--pos-on-cursor-p`.

The intended behavior is unchanged: minibuffer navigation from within the buffer (`consult-line`, `goto-line`) still switches to the configured read-only mode, as do isearch and advised jump commands.

## Verification

- 4 new ERT tests (arrival suppressed, origin navigation fires, non-ghostel origin schedules nothing, point-max parity); full `make all` green.
- Deterministic live A/B in a sandboxed session: on `main` the arrival repros flip to `(copy t …)`; on this branch they stay `(semi-char nil …)`, while `goto-line` from inside the buffer still enters copy mode on both.