### PR TITLE
Lint all package files with a pinned package-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,9 @@ jobs:
         run: bash .github/scripts/install-emacs.sh
 
       - name: Run package-lint, checkdoc, docquotes
-        # `make package-lint' self-provisions its deps (package-lint +
-        # a local ghostel install) into an isolated package-user-dir.
+        # `make package-lint' provisions its deps itself: a package-lint
+        # checkout pinned by PACKAGE_LINT_REV in the Makefile, plus a
+        # local ghostel install in an isolated package-user-dir.
         run: make package-lint checkdoc docquotes
 
   test-zig:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- The bookmark functions are now public: `ghostel-bookmark-make-record`
+  and `ghostel-bookmark-handler`.  Bookmarks saved under the old
+  private handler name keep working through an obsolete alias.
+
 ### Fixed
 - The default of `ghostel-shell` reads `$SHELL` from the global
   environment instead of the current buffer's. Ghostel is normally

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,14 @@ MELPAZOID_DIR  ?= $(XDG_CACHE_HOME)/melpazoid
 EVIL_DIR       ?= $(XDG_CACHE_HOME)/evil
 LINT_ELPA_DIR  ?= $(XDG_CACHE_HOME)/ghostel-lint-elpa
 LINT_DEPS_STAMP := $(LINT_ELPA_DIR)/.deps-installed
+# Pinned purcell/package-lint revision: a red lint gate then always
+# means the repo changed, not the linter.  Bump to a newer commit SHA
+# deliberately.  (The tagged 0.26 release is too old: it predates the
+# `eshell/' prefix allowance.)  The checkout lives outside
+# LINT_ELPA_DIR so `package-initialize' never scans it.
+PACKAGE_LINT_REV ?= 87bf02ca387a37094e1a0057adefa9735d880cec
+PACKAGE_LINT_DIR := $(XDG_CACHE_HOME)/ghostel-package-lint/$(PACKAGE_LINT_REV)
+PACKAGE_LINT_EL := $(PACKAGE_LINT_DIR)/package-lint.el
 DOC_ELPA_DIR   ?= $(XDG_CACHE_HOME)/ghostel-doc-elpa
 DOC_DEPS_STAMP := $(DOC_ELPA_DIR)/.deps-installed
 
@@ -137,26 +145,65 @@ byte-compile: $(ELC)
 
 lint: byte-compile package-lint checkdoc docquotes
 
-# `package-lint' needs two things present that aren't on any default load path:
-# the linter itself, and a resolvable `ghostel' package.
-# Provision both into an isolated `package-user-dir'
-# so `make package-lint' runs standalone.
+# `package-lint' needs a resolvable `ghostel' package (for evil-ghostel's
+# dependency check) that isn't in any default package archive.  Provision
+# it into an isolated `package-user-dir' so `make package-lint' runs
+# standalone.
 $(LINT_DEPS_STAMP): $(CORE_PACKAGE_FILE)
 	$(EMACS) --batch $(EMACSFLAGS) -Q \
 		--eval "(setq package-user-dir \"$(LINT_ELPA_DIR)\")" \
 		--eval "(package-initialize)" \
 		--eval "(package-refresh-contents)" \
-		--eval "(package-install 'package-lint)" \
 		--eval "(package-install-file (expand-file-name \"$(CORE_PACKAGE_FILE)\"))"
 	@touch $@
 
-package-lint: $(LINT_DEPS_STAMP) $(PACKAGE_FILES)
-	$(EMACS) --batch $(EMACSFLAGS) -Q -L lisp \
-		--eval "(setq package-user-dir \"$(LINT_ELPA_DIR)\")" \
-		--eval "(package-initialize)" \
-		--eval "(require 'package-lint)" \
-		-f package-lint-batch-and-exit \
-		$(PACKAGE_FILES)
+# Fetch the whole tree at the pinned revision: the linter loads its
+# symbol databases from data/ relative to its own file.  Extract to a
+# temp dir and move into place last, so an interrupted download never
+# leaves a half-written tree that satisfies this target.
+$(PACKAGE_LINT_EL):
+	rm -rf $(PACKAGE_LINT_DIR) $(PACKAGE_LINT_DIR).tmp
+	mkdir -p $(PACKAGE_LINT_DIR).tmp
+	curl -fsSL https://github.com/purcell/package-lint/archive/$(PACKAGE_LINT_REV).tar.gz \
+		| tar -xz -C $(PACKAGE_LINT_DIR).tmp --strip-components=1
+	mv $(PACKAGE_LINT_DIR).tmp $(PACKAGE_LINT_DIR)
+
+# All package files are linted, not just the main ones; sub-files need
+# `package-lint-main-file' so per-package header checks stay on the main
+# file.  `require' loads the pinned linter by filename so an installed
+# package-lint in `package-user-dir' cannot shadow it.
+# $(1): the package's main file; $(2): all of the package's files.
+define run-package-lint
+$(EMACS) --batch $(EMACSFLAGS) -Q -L lisp \
+	--eval "(setq package-user-dir \"$(LINT_ELPA_DIR)\")" \
+	--eval "(package-initialize)" \
+	--eval "(require 'package-lint \"$(PACKAGE_LINT_EL)\")" \
+	--eval "(setq package-lint-main-file \"$(1)\")" \
+	-f package-lint-batch-and-exit $(2)
+endef
+
+# One stamp per package (`ghostel' + each extensions/<pkg>), so repeat
+# lints with nothing changed are free.
+LINT_STAMPS_DIR := .build/lint
+LINT_PACKAGES := ghostel $(notdir $(wildcard extensions/*))
+LINT_STAMPS := $(patsubst %,$(LINT_STAMPS_DIR)/%.ok,$(LINT_PACKAGES))
+
+package-lint: $(LINT_STAMPS)
+
+$(LINT_STAMPS_DIR):
+	@mkdir -p $@
+
+$(LINT_STAMPS_DIR)/ghostel.ok: $(filter lisp/%,$(ELISP)) $(PACKAGE_LINT_EL) $(LINT_DEPS_STAMP) | $(LINT_STAMPS_DIR)
+	@printf '  PKGLINT %s\n' ghostel
+	@$(call run-package-lint,$(CORE_PACKAGE_FILE),$(filter lisp/%,$(ELISP)))
+	@touch $@
+
+# Each extensions/<pkg>/ is an independent package with main file
+# extensions/<pkg>/<pkg>.el.
+$(LINT_STAMPS_DIR)/%.ok: $(ELISP) $(PACKAGE_LINT_EL) $(LINT_DEPS_STAMP) | $(LINT_STAMPS_DIR)
+	@printf '  PKGLINT %s\n' $*
+	@$(call run-package-lint,extensions/$*/$*.el,$(filter extensions/$*/%,$(ELISP)))
+	@touch $@
 
 checkdoc: $(CHECKDOC_FILES)
 	$(EMACS) --batch $(EMACSFLAGS) -Q \

--- a/lisp/ghostel-bookmark.el
+++ b/lisp/ghostel-bookmark.el
@@ -13,7 +13,7 @@
 ;; starts a fresh shell in the bookmarked directory when none exists.
 ;;
 ;; `ghostel-mode' wires up `bookmark-make-record-function' to point at
-;; `ghostel--bookmark-make-record' (a quoted symbol, so ghostel.el needs
+;; `ghostel-bookmark-make-record' (a quoted symbol, so ghostel.el needs
 ;; no load-time dependency on this file).  Both the record maker and the
 ;; handler are autoloaded, so a bookmark saved in one session restores in
 ;; a fresh Emacs the first time it is used.
@@ -32,21 +32,21 @@ a `cd' to the bookmarked directory is typed into the shell."
   :group 'ghostel)
 
 ;;;###autoload
-(defun ghostel--bookmark-make-record ()
+(defun ghostel-bookmark-make-record ()
   "Return a bookmark record for the current ghostel buffer.
 Notes the working directory, buffer name, and buffer identity.
 An identity `command' key (an exec'd program and its arguments) is
 saved to the bookmark file in plaintext.
-See `ghostel--bookmark-handler' for how they are restored."
+See `ghostel-bookmark-handler' for how they are restored."
   `(nil
-    (handler . ghostel--bookmark-handler)
+    (handler . ghostel-bookmark-handler)
     (location . ,default-directory)
     (buf-name . ,(buffer-name))
     (identity . ,ghostel-identity)
     (defaults . nil)))
 
 ;;;###autoload
-(defun ghostel--bookmark-handler (bmk)
+(defun ghostel-bookmark-handler (bmk)
   "Restore the ghostel bookmark BMK.
 Reuse a live ghostel buffer: slot identities match whole, command
 records match a live buffer running the recorded command, other
@@ -135,6 +135,16 @@ is non-nil, a `cd' is typed into it; command buffers are left alone."
     (set-buffer buf)))
 
 ;; Fills the Type column of `bookmark-bmenu-list' (Emacs 29+).
+(put 'ghostel-bookmark-handler 'bookmark-handler-type "Ghostel")
+
+;; Bookmarks saved by older versions name the handler
+;; `ghostel--bookmark-handler'; keep that symbol autoloadable so they
+;; still restore.  (Standalone cookie: package-lint warns when a cookie
+;; directly precedes a private-named definition.)
+;;;###autoload (autoload 'ghostel--bookmark-handler "ghostel-bookmark")
+
+(define-obsolete-function-alias 'ghostel--bookmark-handler
+  #'ghostel-bookmark-handler "0.51.0")
 (put 'ghostel--bookmark-handler 'bookmark-handler-type "Ghostel")
 
 (provide 'ghostel-bookmark)

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -941,7 +941,7 @@ to nil to disable the regex fallback entirely (OSC 133 only)."
 (defvar yank-media-preferred-types)     ; Emacs 31+
 
 ;; Lazily loaded on first bookmark use; see ghostel-bookmark.el.
-(declare-function ghostel--bookmark-make-record "ghostel-bookmark")
+(declare-function ghostel-bookmark-make-record "ghostel-bookmark")
 
 
 ;;; Native module loading
@@ -5188,7 +5188,7 @@ may change freely (`ghostel-compile' finalize relies on this)."
   (setq-local list-buffers-directory (expand-file-name default-directory))
   (ghostel--buffer-identification-update)
   ;; bookmark this buffer's cwd (loads ghostel-bookmark.el lazily on use)
-  (setq-local bookmark-make-record-function #'ghostel--bookmark-make-record)
+  (setq-local bookmark-make-record-function #'ghostel-bookmark-make-record)
   ;; X11 and pgtk deliver drops through `special-event-map' and the
   ;; `dnd-protocol-alist' machinery, so the `<drag-n-drop>' binding in
   ;; `ghostel-mode-map' is never consulted there; intercept file drops

--- a/test/ghostel-bookmark-test.el
+++ b/test/ghostel-bookmark-test.el
@@ -14,17 +14,17 @@
 (require 'ghostel-bookmark)
 
 (ert-deftest ghostel-test-bookmark-make-record ()
-  "`ghostel--bookmark-make-record' captures handler, dir, name, and identity.
+  "`ghostel-bookmark-make-record' captures handler, dir, name, and identity.
 The directory goes under `location' so `bookmark-bmenu-list' shows it
 instead of \"-- Unknown location --\"."
   (ghostel-test--with-compile-buffer buf
     (setq ghostel-identity '((kind . term) (instance . 42)))
     (let* ((default-directory "/tmp/ghostel-bookmark-make-record/")
-           (record (ghostel--bookmark-make-record)))
+           (record (ghostel-bookmark-make-record)))
       (should (equal (bookmark-prop-get record 'identity)
                      '((kind . term) (instance . 42))))
       (should (eq (bookmark-prop-get record 'handler)
-                  'ghostel--bookmark-handler))
+                  'ghostel-bookmark-handler))
       (should (equal (bookmark-prop-get record 'location)
                      "/tmp/ghostel-bookmark-make-record/"))
       ;; `bookmark-location' is what the bmenu File column shows.  Point
@@ -36,6 +36,15 @@ instead of \"-- Unknown location --\"."
 
 (ert-deftest ghostel-test-bookmark-handler-type ()
   "The handler carries a `bookmark-handler-type' for the bmenu Type column."
+  (should (equal (get 'ghostel-bookmark-handler 'bookmark-handler-type)
+                 "Ghostel")))
+
+(ert-deftest ghostel-test-bookmark-old-handler-name-restores ()
+  "Records naming the pre-rename private handler still restore.
+Bookmark files persist the handler symbol, so the old name must stay
+funcall-able and carry the bmenu Type property."
+  (should (eq (indirect-function 'ghostel--bookmark-handler)
+              (indirect-function 'ghostel-bookmark-handler)))
   (should (equal (get 'ghostel--bookmark-handler 'bookmark-handler-type)
                  "Ghostel")))
 
@@ -44,10 +53,10 @@ instead of \"-- Unknown location --\"."
 `bookmark-make-record' is the entry point bookmark.el itself uses on
 `bookmark-set'; the handler and buffer name must survive its post-processing."
   (ghostel-test--with-compile-buffer buf
-    (should (eq bookmark-make-record-function #'ghostel--bookmark-make-record))
+    (should (eq bookmark-make-record-function #'ghostel-bookmark-make-record))
     (let ((record (bookmark-make-record)))
       (should (eq (bookmark-prop-get record 'handler)
-                  'ghostel--bookmark-handler))
+                  'ghostel-bookmark-handler))
       (should (equal (bookmark-prop-get record 'buf-name) (buffer-name))))))
 
 (defun ghostel-test--bookmark-record (buf-name dir &optional identity)
@@ -55,7 +64,7 @@ instead of \"-- Unknown location --\"."
 Non-nil IDENTITY adds an `identity' property; omitting it mimics a
 record saved before identities were recorded."
   `(,buf-name
-    (handler . ghostel--bookmark-handler)
+    (handler . ghostel-bookmark-handler)
     (location . ,dir)
     (buf-name . ,buf-name)
     ,@(and identity `((identity . ,identity)))
@@ -78,7 +87,7 @@ stale by jump time; the rename-stable identity must find the buffer."
                      (lambda (&rest _)
                        (ert-fail "Created a new buffer instead of reusing"))))
             (with-temp-buffer
-              (ghostel--bookmark-handler
+              (ghostel-bookmark-handler
                (ghostel-test--bookmark-record " *ghostel-bm-stale-name*"
                                               "/tmp/ghostel-bm-reuse/"
                                               id))
@@ -96,7 +105,7 @@ stale by jump time; the rename-stable identity must find the buffer."
                    (lambda (&rest _)
                      (ert-fail "Created a new buffer instead of reusing"))))
           (with-temp-buffer
-            (ghostel--bookmark-handler
+            (ghostel-bookmark-handler
              (ghostel-test--bookmark-record (buffer-name buf)
                                             "/tmp/ghostel-bm-name/"))
             (should (eq (current-buffer) buf))))
@@ -127,7 +136,7 @@ higher in `buffer-list' the handler must still reuse the live one."
                          (lambda (&rest _)
                            (ert-fail "Created a new buffer instead of reusing"))))
                 (with-temp-buffer
-                  (ghostel--bookmark-handler
+                  (ghostel-bookmark-handler
                    (ghostel-test--bookmark-record " *ghostel-bm-shadow-stale*"
                                                   "/tmp/ghostel-bm-shadow/"
                                                   id))
@@ -157,7 +166,7 @@ fresh buffer instead of typing a `cd' into the unrelated one."
                     ((symbol-function 'ghostel--apply-initial-input-mode)
                      #'ignore))
             (with-temp-buffer
-              (ghostel--bookmark-handler
+              (ghostel-bookmark-handler
                (ghostel-test--bookmark-record (buffer-name buf)
                                               "/tmp/ghostel-bm-other/"
                                               '((kind . term)
@@ -187,7 +196,7 @@ must fall through to the create branch instead."
                  #'ignore))
         (unwind-protect
             (with-temp-buffer
-              (ghostel--bookmark-handler
+              (ghostel-bookmark-handler
                (ghostel-test--bookmark-record (buffer-name buf)
                                               "/tmp/ghostel-bm-dead/"
                                               '((kind . term)
@@ -215,7 +224,7 @@ restored buffer."
       (unwind-protect
           (progn
             (with-temp-buffer
-              (ghostel--bookmark-handler
+              (ghostel-bookmark-handler
                (ghostel-test--bookmark-record " *ghostel-bm-new*"
                                               "/tmp/ghostel-bm-create/"
                                               '((kind . term)
@@ -227,7 +236,7 @@ restored buffer."
                              (instance . 2))))
             ;; Legacy record: a string identity is treated as absent.
             (with-temp-buffer
-              (ghostel--bookmark-handler
+              (ghostel-bookmark-handler
                (ghostel-test--bookmark-record " *ghostel-bm-old*"
                                               "/tmp/ghostel-bm-create/"
                                               "bm-legacy-name")))
@@ -255,7 +264,7 @@ be hijacked; the jump creates a fresh buffer instead."
                     ((symbol-function 'ghostel--apply-initial-input-mode)
                      #'ignore))
             (with-temp-buffer
-              (ghostel--bookmark-handler
+              (ghostel-bookmark-handler
                (ghostel-test--bookmark-record " *ghostel-bm-kind-stale*"
                                               "/tmp/ghostel-bm-kind/"
                                               '((kind . eshell))))
@@ -288,7 +297,7 @@ command does not match; no `cd' is typed into a command buffer."
                          (setq major-mode 'ghostel-mode))
                        'fake-proc)))
             (with-temp-buffer
-              (ghostel--bookmark-handler
+              (ghostel-bookmark-handler
                (ghostel-test--bookmark-record
                 " *ghostel-bm-vim*" "/tmp/ghostel-bm-b/"
                 '((kind . eshell) (command . ("vim" "notes")))))
@@ -296,7 +305,7 @@ command does not match; no `cd' is typed into a command buffer."
             (should-not sent)
             (should-not created)
             (with-temp-buffer
-              (ghostel--bookmark-handler
+              (ghostel-bookmark-handler
                (ghostel-test--bookmark-record
                 " *ghostel-bm-vim*" "/tmp/ghostel-bm-b/"
                 '((kind . eshell) (command . ("vim" "other"))))))
@@ -321,19 +330,19 @@ A stale recorded name falls back to any live command match."
             (unwind-protect
                 (cl-letf (((symbol-function 'ghostel--load-module) #'ignore))
                   (with-temp-buffer
-                    (ghostel--bookmark-handler
+                    (ghostel-bookmark-handler
                      (ghostel-test--bookmark-record
                       " *ghostel-bm-top*<2>" "/tmp/ghostel-bm-t/"
                       '((kind . eshell) (command . ("top")))))
                     (should (eq (current-buffer) second)))
                   (with-temp-buffer
-                    (ghostel--bookmark-handler
+                    (ghostel-bookmark-handler
                      (ghostel-test--bookmark-record
                       " *ghostel-bm-top*" "/tmp/ghostel-bm-t/"
                       '((kind . eshell) (command . ("top")))))
                     (should (eq (current-buffer) first)))
                   (with-temp-buffer
-                    (ghostel--bookmark-handler
+                    (ghostel-bookmark-handler
                      (ghostel-test--bookmark-record
                       " *ghostel-bm-top-gone*" "/tmp/ghostel-bm-t/"
                       '((kind . eshell) (command . ("top")))))
@@ -348,7 +357,7 @@ Covers both the command respawn and the shell branch."
             ((symbol-function 'ghostel-exec)
              (lambda (&rest _) (error "Spawn failed"))))
     (should-error
-     (ghostel--bookmark-handler
+     (ghostel-bookmark-handler
       (ghostel-test--bookmark-record " *ghostel-bm-fail*"
                                      "/tmp/ghostel-bm-f/"
                                      '((kind . exec) (command . ("nope"))))))
@@ -362,7 +371,7 @@ Covers both the command respawn and the shell branch."
             ((symbol-function 'ghostel--start-process)
              (lambda () (error "Spawn failed"))))
     (should-error
-     (ghostel--bookmark-handler
+     (ghostel-bookmark-handler
       (ghostel-test--bookmark-record " *ghostel-bm-fail-sh*"
                                      "/tmp/ghostel-bm-f/")))
     (should-not (get-buffer " *ghostel-bm-fail-sh*"))))
@@ -384,7 +393,7 @@ Covers both the command respawn and the shell branch."
       (unwind-protect
           (progn
             (with-temp-buffer
-              (ghostel--bookmark-handler
+              (ghostel-bookmark-handler
                (ghostel-test--bookmark-record
                 " *ghostel-bm-htop*" "/tmp/ghostel-bm-cmd/"
                 '((kind . exec) (command . ("htop" "-d" "10"))))))
@@ -407,7 +416,7 @@ Covers both the command respawn and the shell branch."
          (buf nil))
     (unwind-protect
         (progn
-          (ghostel--bookmark-handler
+          (ghostel-bookmark-handler
            (ghostel-test--bookmark-record buf-name dir))
           (setq buf (get-buffer buf-name))
           (should (buffer-live-p buf))
@@ -442,7 +451,7 @@ too timing-sensitive to drive a real shell through here).  With
                 ((symbol-function 'ghostel-send-key)
                  (lambda (k &rest _) (push (cons 'key k) sent))))
         ;; Enabled + differing dir: a quoted `cd' with the TRAMP prefix stripped.
-        (ghostel--bookmark-handler
+        (ghostel-bookmark-handler
          (ghostel-test--bookmark-record (buffer-name) remote))
         (should (equal (nreverse sent)
                        `((string . ,(concat "cd " (shell-quote-argument
@@ -451,7 +460,7 @@ too timing-sensitive to drive a real shell through here).  With
         ;; Disabled: nothing is typed even though the dirs differ.
         (setq sent nil)
         (let ((ghostel-bookmark-check-dir nil))
-          (ghostel--bookmark-handler
+          (ghostel-bookmark-handler
            (ghostel-test--bookmark-record (buffer-name) "/tmp/elsewhere/")))
         (should-not sent)))))
 


### PR DESCRIPTION
## Problem

The `package-lint` gate only checked the two package main files (the ones with a `Package-Requires:` header), so sub-files were never package-linted.  That hid issues like private-named autoloads and would hide sub-file symbols newer than the declared minimum Emacs version.

The linter also came from the latest tagged release (0.26), which is old enough to flag the `eshell/` command prefix that upstream has since allowed.

## Fix

**All package files are linted.**  Every `lisp/*.el` is linted with `package-lint-main-file` pointing at `$(CORE_PACKAGE_FILE)`, and each `extensions/<pkg>/` gets its own invocation as an independent package with `extensions/<pkg>/<pkg>.el` as its main file — adding a sub-file or a second extension needs no Makefile edit.  Per-package stamps under `.build/lint` make repeat lints free.

**The linter is pinned.**  `PACKAGE_LINT_REV` pins an upstream revision, fetched as one tarball into a temp dir and moved into place last (an interrupted download never satisfies the target).  A red lint gate then always means the repo changed, not the linter; bumps are deliberate.  The checkout lives outside the lint ELPA dir so `package-initialize` never scans it, and `require` loads it by filename so an installed package-lint cannot shadow it.

**The two real findings are fixed, not exempted.**  The autoloaded bookmark functions are renamed to public names (`ghostel-bookmark-make-record`, `ghostel-bookmark-handler`) — an autoloaded symbol is a public entry point, and the handler is even persisted inside saved bookmark files.  An autoloaded obsolete alias (standalone `;;;###autoload (autoload ...)` cookie) keeps records saved under the old handler name restoring in a fresh session, including their bmenu Type column entry.  The gate is strict for both errors and warnings, with zero exemptions.

## Other info

Verified: fresh provisioning + full lint green on the pinned rev; unchanged reruns are no-ops; touching an extension file re-lints only that extension; old-name bookmark restoration exercised end-to-end (autoload stub → load → alias) plus a new regression test.