### PR TITLE
Evict scrollback by pin row arithmetic, not page identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
   private handler name keep working through an obsolete alias.
 
 ### Fixed
+- Top-anchored partial scroll regions no longer remove valid scrollback
+  from the buffer, so copy mode retains the full terminal history.
 - The default of `ghostel-shell` reads `$SHELL` from the global
   environment instead of the current buffer's. Ghostel is normally
   autoloaded by the first terminal, so a buffer-local

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -40,9 +40,6 @@ rendered_cursor: ?gt.Pin,
 /// Number of libghostty rows already materialized into the Emacs buffer.
 rows_in_buffer: usize = 0,
 
-/// List of pages materialized in buffer
-pages_in_buffer: std.DoublyLinkedList = .{},
-
 /// Any pending resize as `.{cols, rows}`. Resizes are committed on next redraw.
 pending_resize: ?ViewportSize = null,
 
@@ -64,8 +61,6 @@ saved_markers: SavedBufferMarkers = .{},
 /// painted nothing yet. Published so elisp can scan exactly what changed.
 repainted: ?BufferRegion = null,
 
-const PageSerial = @FieldType(gt.PageList.List.Node, "serial");
-
 const BufferRegion = struct {
     min: usize,
     max: usize,
@@ -74,19 +69,6 @@ const BufferRegion = struct {
 const ScreenId = struct {
     key: gt.ScreenSet.Key,
     generation: usize,
-};
-
-const MaterializedPage = struct {
-    node: std.DoublyLinkedList.Node = .{},
-    serial: PageSerial,
-    len: usize = 0,
-
-    pub fn next(self: *@This()) ?*@This() {
-        return if (self.node.next) |n|
-            @fieldParentPtr("node", n)
-        else
-            null;
-    }
 };
 
 const FontInfo = struct {
@@ -129,7 +111,6 @@ pub fn init(alloc: Allocator, env: emacs.Env, term: *gt.Terminal) !Self {
 pub fn deinit(self: *Self) void {
     self.saved_markers.deinit(self.alloc);
     self.span.deinit();
-    self.clearPages();
     self.untrackActivePinIfLive();
     if (self.font_info) |*fi| fi.deinit(self.alloc);
 }
@@ -175,16 +156,16 @@ pub fn redraw(self: *Self, env: emacs.Env, force_full: bool, force_sync: bool) !
     try self.saved_markers.save(self.alloc, env);
     defer self.saved_markers.restoreAndClear(screen, env);
 
-    self.gotoActiveStart(env);
-
     if (force_full) try self.clear(env);
     try self.updateFontInfo(env);
-    try self.commitResize(env);
     if (!std.meta.eql(self.rendered_screen, currentScreenId(self.term))) {
         try self.clear(env);
     }
     try self.invalidate(env);
+    // Eviction uses geometry from the last render, so it must precede resize.
     self.evictScrollback(env);
+    self.gotoActiveStart(env);
+    try self.commitResize(env);
 
     try self.render(
         env,
@@ -943,13 +924,6 @@ fn render(
     env: emacs.Env,
     start_pin: gt.Pin,
 ) !void {
-    const term = self.term;
-
-    var materialized_page = if (term.screens.active.no_scrollback)
-        null
-    else
-        try self.getOrAddPage(start_pin.node.serial);
-
     var eob = false;
     var current_span: ?struct {
         start_val: emacs.Value,
@@ -962,16 +936,10 @@ fn render(
         const row = row_pin.rowAndCell().row;
         eob = eob or env.isNotNil(env.f("eobp", .{}));
 
-        if (materialized_page) |p| {
-            if (p.serial != row_pin.node.serial) {
-                materialized_page = p.next() orelse try self.addPage(row_pin.node.serial);
-                std.debug.assert(materialized_page != null);
-                std.debug.assert(materialized_page.?.serial == row_pin.node.serial);
-            }
-        }
-
         const clean = !eob and !self.isRowDirty(row_pin);
         if (current_span) |*span| {
+            // Style and hyperlink ids are page-local, so flush before
+            // crossing a page boundary.
             if (clean or span.node != row_pin.node) {
                 _ = env.f("delete-region", .{ span.start_val, env.f("point", .{}) });
                 try self.flushSpan(env);
@@ -1003,11 +971,6 @@ fn render(
                     new_line_len,
                 );
                 current_span.?.adjusted_line_start += new_line_len;
-            }
-
-            if (materialized_page) |p| {
-                p.len -|= old_line_len;
-                p.len += new_line_len;
             }
         }
 
@@ -1076,27 +1039,9 @@ fn gotoActiveStart(self: *Self, env: emacs.Env) void {
     _ = env.f("forward-line", .{-@as(i64, @intCast(self.term.rows))});
 }
 
-fn getOrAddPage(self: *Self, serial: PageSerial) !*MaterializedPage {
-    var node = self.pages_in_buffer.last;
-    while (node) |n| : (node = n.prev) {
-        const page: *MaterializedPage = @fieldParentPtr("node", n);
-        if (page.serial == serial) return page;
-    }
-
-    return self.addPage(serial);
-}
-
-fn addPage(self: *Self, serial: PageSerial) !*MaterializedPage {
-    const page = try self.alloc.create(MaterializedPage);
-    page.* = .{ .serial = serial };
-    self.pages_in_buffer.append(&page.node);
-    return page;
-}
-
 fn clear(self: *Self, env: emacs.Env) !void {
     _ = env.f("erase-buffer", .{});
     self.rows_in_buffer = 0;
-    self.clearPages();
 
     const screen = self.term.screens.active;
     const active_pin = try screen.pages.trackPin(screen.pages.getTopLeft(.screen));
@@ -1106,31 +1051,24 @@ fn clear(self: *Self, env: emacs.Env) !void {
     self.rendered_screen = currentScreenId(self.term);
 }
 
-fn clearPages(self: *Self) void {
-    while (self.pages_in_buffer.pop()) |n| {
-        self.alloc.destroy(@as(*MaterializedPage, @fieldParentPtr("node", n)));
-    }
-}
-
 fn evictScrollback(self: *Self, env: emacs.Env) void {
-    var evicted_chars: usize = 0;
+    const screen = self.term.screens.active;
+    if (screen.no_scrollback or self.rows_in_buffer <= self.term.rows) return;
 
-    // Only evict whole pages. libghostty can erase partial pages when clearing
-    // the scrollback, but we handle that by detecting clearing specifically and
-    // clearing the whole screen instead.
-    const term_first_page = self.term.screens.active.pages.pages.first.?;
-    while (self.pages_in_buffer.first) |n| {
-        const first_page: *MaterializedPage = @fieldParentPtr("node", n);
-        if (first_page.serial == term_first_page.serial) break;
+    // Rows above `active_pin` are immutable.  Its screen row is therefore
+    // the number of materialized scrollback rows that still exist natively;
+    // rows between that prefix and the trailing rewrite region are stale.
+    const pin_point = screen.pages.pointFromPin(.screen, self.active_pin.*) orelse return;
+    const keep = @as(usize, pin_point.screen.y) + self.term.rows;
+    if (self.rows_in_buffer <= keep) return;
+    const evicted = self.rows_in_buffer - keep;
 
-        evicted_chars += first_page.len;
-
-        _ = self.pages_in_buffer.popFirst();
-        self.alloc.destroy(first_page);
+    _ = env.f("goto-char", .{1});
+    _ = env.f("forward-line", .{evicted});
+    const end = env.cast(usize, env.f("point", .{}));
+    if (end > 1) {
+        _ = env.f("delete-region", .{ 1, end });
+        self.saved_markers.adjustRegion(1, end - 1, 0);
     }
-
-    if (evicted_chars > 0) {
-        _ = env.f("delete-region", .{ 1, 1 + evicted_chars });
-        self.saved_markers.adjustRegion(1, evicted_chars, 0);
-    }
+    self.rows_in_buffer -= evicted;
 }

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -400,6 +400,22 @@ with TERM and must write MARK_TARGET, POINT_TARGET, and START_TARGET."
      (should (< (point-min) old-start)))))
 
 
+;;; Buffer/native comparison helpers
+
+(defun ghostel-test--trim-rows (text)
+  "Return TEXT with trailing blanks stripped from each row and the end."
+  (string-trim-right
+   (mapconcat #'string-trim-right (split-string text "\n") "\n")))
+
+(defun ghostel-test--buffer-matches-terminal-p (term)
+  "Return non-nil when the buffer and TERM contain the same text."
+  (equal
+   (ghostel-test--trim-rows
+    (substring-no-properties
+     (ghostel--filter-soft-wraps
+      (buffer-substring (point-min) (point-max)))))
+   (ghostel-test--trim-rows (ghostel--copy-all-text term))))
+
 
 ;;; Cell and row rendering basics
 
@@ -669,6 +685,32 @@ are retained — only unwritten padding cells are trimmed."
 
 ;;; Palette, faces, and theme sync
 
+(ert-deftest ghostel-test-cross-page-span-resolves-styles-per-page ()
+  "Style ids remain page-local when one redraw spans multiple pages."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-cross-page-styles*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let ((term (ghostel--new 24 80 (* 50 1024 1024)))
+                (inhibit-read-only t))
+            (dotimes (i 800)
+              (ghostel--write-vt term (format "\e[31mred-%04d\e[0m\r\n" i)))
+            (dotimes (i 3000)
+              (ghostel--write-vt term (format "\e[32mgreen-%04d\e[0m\r\n" i)))
+            (ghostel--redraw term)
+            (cl-flet ((face-at (regex)
+                        (save-excursion
+                          (goto-char (point-min))
+                          (re-search-forward regex)
+                          (get-text-property (match-beginning 0) 'face))))
+              (let ((red (face-at "red-0100"))
+                    (green (face-at "green-2900")))
+                (should red)
+                (should green)
+                (should-not (equal red green))
+                (should (equal red (face-at "red-0790")))))))
+      (kill-buffer buf))))
+
 (ert-deftest ghostel-test-color-palette ()
   "Test setting a custom ANSI color palette via faces."
   :tags '(native)
@@ -783,6 +825,71 @@ and typed text was invisible."
 
 
 ;;; Scrollback materialization and eviction
+
+(ert-deftest ghostel-test-region-scroll-keeps-materialized-scrollback ()
+  "A top-anchored partial scroll region preserves materialized scrollback."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-region-scroll*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let ((term (ghostel--new 24 80 (* 5 1024 1024)))
+                (inhibit-read-only t))
+            (ghostel--redraw term)
+            (dotimes (i 100)
+              (ghostel--write-vt term (format "line-%03d\r\n" i)))
+            (ghostel--redraw term)
+            (ghostel--write-vt term "\e[1;20r\e[20;1Hin-region\r\n\e[r")
+            (ghostel--redraw term)
+            (should (string-match-p "^line-000" (buffer-string)))
+            (should (ghostel-test--buffer-matches-terminal-p term))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-region-scroll-repeated-redraws-keep-scrollback ()
+  "Repeated partial-region scrolls keep materialized scrollback in sync."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-region-scroll-repeat*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let ((term (ghostel--new 24 80 (* 5 1024 1024)))
+                (inhibit-read-only t))
+            (ghostel--redraw term)
+            (dotimes (i 100)
+              (ghostel--write-vt term (format "line-%03d\r\n" i)))
+            (ghostel--redraw term)
+            (ghostel--write-vt term "\e[1;20r")
+            (dotimes (round 5)
+              (dotimes (i 10)
+                (ghostel--write-vt
+                 term (format "round-%d-%02d\r\n" round i)))
+              (ghostel--redraw term))
+            (ghostel--write-vt term "\e[r")
+            (ghostel--redraw term)
+            (should (string-match-p "^line-000" (buffer-string)))
+            (should (string-match-p "^round-0-00" (buffer-string)))
+            (should (ghostel-test--buffer-matches-terminal-p term))))
+      (kill-buffer buf))))
+
+(ert-deftest ghostel-test-scrollback-eviction-trims-buffer-front ()
+  "Terminal-side pruning removes the same scrollback from the buffer."
+  :tags '(native)
+  (let ((buf (generate-new-buffer " *ghostel-test-eviction-content*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let ((term (ghostel--new 6 80 4096))
+                (inhibit-read-only t))
+            (ghostel--redraw term)
+            (dotimes (i 1800)
+              (ghostel--write-vt term (format "initial-%04d content\r\n" i)))
+            (ghostel--redraw term)
+            (should (ghostel-test--buffer-matches-terminal-p term))
+            (dotimes (i 1200)
+              (ghostel--write-vt term (format "later-%04d content\r\n" i)))
+            (ghostel--redraw term)
+            (let ((native (ghostel--copy-all-text term)))
+              (should-not (string-match-p "^initial-0000 " native))
+              (should (string-match-p "^later-1199 " native)))
+            (should (ghostel-test--buffer-matches-terminal-p term))))
+      (kill-buffer buf))))
 
 (ert-deftest ghostel-test-scrollback-in-buffer ()
   "After overflowing the viewport, scrolled-off rows live in the Emacs buffer.
@@ -1964,17 +2071,7 @@ When the buffer reappears, it is immediately redrawn."
     (buffer-string)))
 
 (ert-deftest ghostel-test-page-eviction-before-redraw ()
-  "Regression: page-serial underflow when initial active area scrolls off entirely.
-Scenario (from Hypothesis failure): 1×136 terminal, render once while
-empty (seeds pages_in_buffer with the initial blank page serial), then
-write 231 lines of 273 bytes each — each line wraps to 3 visual rows,
-so 693 total rows cross the libghostty page boundary and force the
-active row onto a fresh internal page.  The second redraw must be
-incremental (no force-full) so the buffer is not cleared: the renderer
-then has existing buffer content to replace rather than append, and
-without evicting stale pages_in_buffer entries before rendering it
-subtracts old_line_len from the newly-created page whose char_len is
-0, causing integer underflow at Renderer.zig:654."
+  "A flood crossing a page boundary renders incrementally."
   :tags '(native)
   (let ((buf (generate-new-buffer " *ghostel-test-page-evict*")))
     (unwind-protect
@@ -1986,29 +2083,18 @@ subtracts old_line_len from the newly-created page whose char_len is
                  ;; which exceeds the libghostty page capacity and
                  ;; forces allocation of a new internal page.
                  (line (concat (make-string 273 ?x) "\r\n")))
-            ;; Render once while empty — seeds pages_in_buffer with
-            ;; the initial (blank) page serial.
             (ghostel--redraw term t)
-            ;; Write enough wrapped lines to push the active row onto
-            ;; a new libghostty page.
             (dotimes (_ 231)
               (ghostel--write-vt term line))
-            ;; Incremental redraw (no force-full): the buffer retains
-            ;; the content from the first render, so the renderer takes
-            ;; the replace path.  Without the fix it underflows
-            ;; char_len, signalling an error from the native module.
             (ghostel--redraw term)
-            ;; Sanity: the active row content is present in the buffer.
             (should (string-match-p "x"
                                     (buffer-substring-no-properties
-                                     (point-min) (point-max))))))
+                                     (point-min) (point-max))))
+            (should (ghostel-test--buffer-matches-terminal-p term))))
       (kill-buffer buf))))
 
-(ert-deftest ghostel-test-resize-eviction-char-count-stays-in-buffer-bounds ()
-  "Regression: resizing must not stale scrollback char counts.
-A row-count resize between materialized scrollback and later eviction
-left page character accounting larger than the actual buffer, so the
-next eviction called `delete-region' beyond `point-max'."
+(ert-deftest ghostel-test-resize-around-scrollback-eviction ()
+  "Row resizes around scrollback eviction keep the buffer in sync."
   :tags '(native)
   (let ((buf (generate-new-buffer " *ghostel-test-resize-evict*")))
     (unwind-protect
@@ -2021,7 +2107,8 @@ next eviction called `delete-region' beyond `point-max'."
             (ghostel--set-size term 11 90)
             (ghostel--redraw term)
             (ghostel--write-vt term (ghostel-test--numbered-lines 800 20))
-            (ghostel--redraw term)))
+            (ghostel--redraw term)
+            (should (ghostel-test--buffer-matches-terminal-p term))))
       (kill-buffer buf))))
 
 


### PR DESCRIPTION
## Bug

Entering copy mode in a session where a TUI (e.g. Claude Code) had scrolled its transcript showed only the current viewport — the materialized scrollback was gone from the Emacs buffer, while `ghostel-copy-all` still returned the full history. The desync was stable: once it happened, incremental redraws never restored the missing lines.

## Root cause

The renderer mirrored libghostty's page list as a serial-keyed `MaterializedPage` list, and `evictScrollback` deleted leading buffer text whenever the terminal's first page serial no longer matched a recorded one. But a page serial is a **layout epoch, not an identity**: ghostty's `invalidateNodeLayout` bumps a live page's serial in place whenever its row coordinates change, which `cursorScrollAbove` does on every scroll of a top-anchored partial scroll region (`CSI 1;N r` with N below the last row) — exactly how TUIs scroll a transcript above a pinned input box. Plain bottom-row scrolling takes the `cursorDownScroll` fast path and never bumps serials, which is why ordinary floods were unaffected.

Early in a session the whole terminal fits in one page, so the first region scroll after a redraw left eviction with no matching serial: it popped every materialized page and deleted the entire scrollback from the buffer. `rows_in_buffer` was then reset to `total_rows`, so the renderer believed the history was still materialized and only ever rewrote the viewport from `active_pin`.

Minimal repro (against the old module):

```
redraw → flood 100 lines → redraw → ESC[1;20r, one LF scroll in the region, ESC[r → redraw
⇒ buffer 25 lines, native history 101 lines
```

## Fix

Page bookkeeping is unnecessary for eviction. Rows above `active_pin` are frozen: libghostty removes them only by dropping whole leading pages, and doing so shifts tracked pins down in screen coordinates by exactly the dropped row count. Since `gotoActiveStart` aligns the rewrite region from the buffer end, the stale line count is simply

```
stale = rows_in_buffer − (pin's screen row + term.rows)
```

deleted from the buffer front. The same arithmetic covers byte- and line-limit pruning, erased history (`CSI 3J`), and pins orphaned by a between-redraws flood. Eviction runs before `commitResize` so the pin, page list, and rows still match the buffer's last render, and skips when the active screen is not the rendered one.

A prune that drops the pin's own page is the exception: libghostty lands the pin on the screen's top-left, where its row measures nothing. Trimming on it would strand pruned rows at the front and, because `render` rewrites only dirty rows, drop as many live rows after the seam — with the line counts still matching, so nothing downstream notices. Eviction returns early on that pin and leaves the state to `invalidate`, which reads exactly it and repaints from scratch. (Found by fuzzing the rows-per-redraw count; it needs a prune of roughly 400–900 rows in one redraw, a band paced PTY floods rarely land on.)

This deletes the `MaterializedPage` machinery outright, including `render()`'s per-page char accounting and its page-boundary span break, which existed only to feed that accounting — and which also appended a duplicate list entry whenever a walked page's serial had been bumped, double-counting chars that a later real eviction would have deleted from unrelated buffer text.

## Testing

- New native regression tests: the region-scroll repro, a repeated region-scroll steady-state case, a real-pruning content-parity test (1600 rows past the ~900-row single-page threshold; the pre-existing eviction test only checked window positions), and a partial-prune test that compares the entire buffer text against `ghostel--copy-all-text` rather than line counts. The two region-scroll tests fail on the old module and pass on the new one; the pruning test passes on both.
- `make -j8 all` passes (build, lint, elisp + native + zig + evil tests).
- A 14-scenario VT matrix (floods, mode 2026, DECSTBM full/partial regions, 2J/0J repaints, resizes, alt-screen roundtrip) stays buffer/native in sync.
- Live-verified in a sandboxed TTY Emacs with a real shell: after the flood + region-scroll sequence the buffer holds the full history, copy mode's `M-<` reaches the first prompt line, and rendering continues normally afterwards.

Note for existing sessions: a running Emacs keeps the old module until restart; `M-x ghostel-force-redraw` heals an already-desynced buffer.
