### PR TITLE
Fix stale titles after RIS and implement the xterm title stack

### DIFF
--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -54,7 +54,7 @@ pub fn init(
     };
     errdefer term.terminal.deinit(alloc);
 
-    term.stream = .initAlloc(alloc, .init(term, &term.terminal));
+    term.stream = .initAlloc(alloc, .init(alloc, term, &term.terminal));
     errdefer term.stream.deinit();
 
     term.renderer = try .init(alloc, env, &term.terminal);

--- a/src/NativeProcess.zig
+++ b/src/NativeProcess.zig
@@ -70,7 +70,7 @@ pub fn init(
     var event_writer = try EventWriter.init(event_fd);
     errdefer event_writer.close();
 
-    var stream: @TypeOf(self.stream) = .initAlloc(alloc, .init(self, term));
+    var stream: @TypeOf(self.stream) = .initAlloc(alloc, .init(alloc, self, term));
     errdefer stream.deinit();
 
     const replica_name = try alloc.dupeZ(u8, backend.replicaName());

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -2,19 +2,37 @@
 //! standard terminal handler but intercepts OSC-related actions so we can route
 //! them to Elisp callbacks instead of re-parsing the same bytes ourselves.
 
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
 const emacs = @import("emacs.zig");
 const gt = @import("ghostty-vt");
 const GhostelTerm = @import("GhostelTerm.zig");
+
+const log = std.log.scoped(.GhostelHandler);
+
+// xterm limits the title stack to 10 entries.
+const title_stack_max = 10;
 
 pub fn GhostelHandler(Context: type) type {
     return struct {
         const Self = @This();
 
+        alloc: Allocator,
         context: Context,
         inner: gt.TerminalStream.Handler,
+        // Null entries represent an unset title.
+        title_stack: [title_stack_max]?[]u8,
+        title_stack_len: usize,
 
-        pub fn init(context: Context, terminal: *gt.Terminal) Self {
-            var self = Self{ .context = context, .inner = .init(terminal) };
+        pub fn init(alloc: Allocator, context: Context, terminal: *gt.Terminal) Self {
+            var self = Self{
+                .alloc = alloc,
+                .context = context,
+                .inner = .init(terminal),
+                .title_stack = @splat(null),
+                .title_stack_len = 0,
+            };
             self.inner.effects.write_pty = &writePtyCallback;
             self.inner.effects.bell = &bellCallback;
             self.inner.effects.device_attributes = &deviceAttributesCallback;
@@ -25,6 +43,7 @@ pub fn GhostelHandler(Context: type) type {
 
         /// Called by `gt.Stream.deinit`.
         pub fn deinit(self: *Self) void {
+            self.clearTitleStack();
             self.inner.deinit();
         }
 
@@ -54,14 +73,19 @@ pub fn GhostelHandler(Context: type) type {
                 .show_desktop_notification => self.handleNotification(value),
                 .progress_report => self.handleProgressReport(value),
 
-                // RIS clears the stored title, so anything displaying it
-                // must hear about it.  Progress state lives only in elisp.
                 .full_reset => {
                     const had_title = self.inner.terminal.getTitle() != null;
+                    self.clearTitleStack();
                     self.inner.vt(action, value);
+                    // libghostty clears the title on RIS without firing title_changed.
                     if (had_title) titleChangedCallback(&self.inner);
+                    // Progress exists only in Elisp, so RIS must remove it explicitly.
                     self.handleProgressReport(.{ .state = .remove });
                 },
+
+                // The parser filters icon-title forms; indexed stacks are unsupported.
+                .title_push => if (value == 0) self.titlePush(),
+                .title_pop => if (value == 0) self.titlePop(),
 
                 else => self.inner.vt(action, value),
             }
@@ -124,6 +148,39 @@ pub fn GhostelHandler(Context: type) type {
             const self: *Self = @fieldParentPtr("inner", handler);
             const title = handler.terminal.getTitle() orelse "";
             self.context.effect("ghostel--set-title", .{title});
+        }
+
+        // ---------------------------------------------------------------------------
+        // CSI 22/23 t — window title stack
+        // ---------------------------------------------------------------------------
+
+        fn titlePush(self: *Self) void {
+            if (self.title_stack_len == title_stack_max) return;
+            const entry: ?[]u8 = if (self.inner.terminal.getTitle()) |t|
+                self.alloc.dupe(u8, t) catch {
+                    log.warn("title push dropped: out of memory", .{});
+                    return;
+                }
+            else
+                null;
+            self.title_stack[self.title_stack_len] = entry;
+            self.title_stack_len += 1;
+        }
+
+        // Route restores through the inner handler to synchronize native and Elisp state.
+        fn titlePop(self: *Self) void {
+            if (self.title_stack_len == 0) return;
+            self.title_stack_len -= 1;
+            const entry = self.title_stack[self.title_stack_len];
+            self.inner.vt(.window_title, .{ .title = entry orelse "" });
+            if (entry) |e| self.alloc.free(e);
+        }
+
+        fn clearTitleStack(self: *Self) void {
+            for (self.title_stack[0..self.title_stack_len]) |entry| {
+                if (entry) |e| self.alloc.free(e);
+            }
+            self.title_stack_len = 0;
         }
 
         // ---------------------------------------------------------------------------

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -55,11 +55,12 @@ pub fn GhostelHandler(Context: type) type {
                 .progress_report => self.handleProgressReport(value),
 
                 // RIS clears the stored title, so anything displaying it
-                // must hear about it.
+                // must hear about it.  Progress state lives only in elisp.
                 .full_reset => {
                     const had_title = self.inner.terminal.getTitle() != null;
                     self.inner.vt(action, value);
                     if (had_title) titleChangedCallback(&self.inner);
+                    self.handleProgressReport(.{ .state = .remove });
                 },
 
                 else => self.inner.vt(action, value),

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -54,6 +54,14 @@ pub fn GhostelHandler(Context: type) type {
                 .show_desktop_notification => self.handleNotification(value),
                 .progress_report => self.handleProgressReport(value),
 
+                // RIS clears the stored title, so anything displaying it
+                // must hear about it.
+                .full_reset => {
+                    const had_title = self.inner.terminal.getTitle() != null;
+                    self.inner.vt(action, value);
+                    if (had_title) titleChangedCallback(&self.inner);
+                },
+
                 else => self.inner.vt(action, value),
             }
         }

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -85,6 +85,43 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
               (should (equal expected (buffer-name)))
               (should (equal expected ghostel--managed-buffer-name)))))))))
 
+(ert-deftest ghostel-test-full-reset-clears-title ()
+  "RIS (ESC c) clears the title and reverts the tracked buffer name."
+  :tags '(native)
+  (let ((ghostel-buffer-name-function #'ghostel-buffer-name-by-title))
+    (ghostel-test--with-pty-matrix backend
+      (ghostel-test--with-raw-echo-buffer (buf proc)
+        (let ((expected ghostel--initial-name)
+              (title (format "RIS Stale %S" backend)))
+          (ghostel--write-vt ghostel--term (format "\e]2;%s\e\\" title))
+          (ghostel-test--wait-until
+           (lambda () (equal title ghostel--title)) proc 5)
+          (should (equal (format "*ghostel: %s*" title) (buffer-name)))
+          (ghostel--write-vt ghostel--term "\ec")
+          (ghostel-test--wait-until
+           (lambda () (null ghostel--title)) proc 5)
+          (should (equal expected (buffer-name)))
+          (should (equal expected ghostel--managed-buffer-name)))))))
+
+(ert-deftest ghostel-test-full-reset-without-title-skips-callback ()
+  "RIS with no title ever set does not invoke `ghostel--set-title'.
+Callbacks defer FIFO, so once the sentinel's callback lands, a
+spurious RIS callback would already have landed — a plain text
+drain would return first and prove nothing."
+  :tags '(native)
+  (ghostel-test--with-pty-matrix backend
+    (ghostel-test--with-raw-echo-buffer (buf proc)
+      (let* ((calls 0)
+             (orig (symbol-function 'ghostel--set-title)))
+        (cl-letf (((symbol-function 'ghostel--set-title)
+                   (lambda (title)
+                     (setq calls (1+ calls))
+                     (funcall orig title))))
+          (ghostel--write-vt ghostel--term "\ec\e]2;SENTINEL\e\\")
+          (ghostel-test--wait-until
+           (lambda () (equal "SENTINEL" ghostel--title)) proc 5)
+          (should (equal 1 calls)))))))
+
 (ert-deftest ghostel-test-osc9-notification ()
   "OSC 9 iTerm2-style notifications reach `ghostel-notification-function'."
   :tags '(native)

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -270,6 +270,22 @@ ConEmu's CWD-reporting alias uses the same callback as OSC 7, so
           (ghostel-test--wait-until (lambda () calls) proc 5)
           (should (equal (list expected) calls)))))))
 
+(ert-deftest ghostel-test-full-reset-clears-progress ()
+  "RIS (ESC c) dispatches a progress remove so no stale indicator survives."
+  :tags '(native)
+  (ghostel-test--with-pty-matrix backend
+    (ghostel-test--with-raw-echo-buffer (buf proc)
+      (let* ((calls nil)
+             (ghostel-progress-function
+              (lambda (state progress) (push (list state progress) calls))))
+        (ghostel--write-vt ghostel--term "\e]9;4;1;50\e\\")
+        (ghostel-test--wait-until (lambda () calls) proc 5)
+        (should (equal '((set 50)) calls))
+        (setq calls nil)
+        (ghostel--write-vt ghostel--term "\ec")
+        (ghostel-test--wait-until (lambda () calls) proc 5)
+        (should (equal '((remove nil)) calls))))))
+
 (ert-deftest ghostel-test-osc-progress-dispatch ()
   "`ghostel--osc-progress' converts the state string to a symbol."
   (let ((calls nil))

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -86,7 +86,7 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
               (should (equal expected ghostel--managed-buffer-name)))))))))
 
 (ert-deftest ghostel-test-full-reset-clears-title ()
-  "RIS (ESC c) clears the title and reverts the tracked buffer name."
+  "RIS clears the title and reverts the tracked buffer name."
   :tags '(native)
   (let ((ghostel-buffer-name-function #'ghostel-buffer-name-by-title))
     (ghostel-test--with-pty-matrix backend
@@ -104,10 +104,7 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
           (should (equal expected ghostel--managed-buffer-name)))))))
 
 (ert-deftest ghostel-test-full-reset-without-title-skips-callback ()
-  "RIS with no title ever set does not invoke `ghostel--set-title'.
-Callbacks defer FIFO, so once the sentinel's callback lands, a
-spurious RIS callback would already have landed — a plain text
-drain would return first and prove nothing."
+  "RIS with no title does not invoke `ghostel--set-title'."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
     (ghostel-test--with-raw-echo-buffer (buf proc)
@@ -118,9 +115,105 @@ drain would return first and prove nothing."
                      (setq calls (1+ calls))
                      (funcall orig title))))
           (ghostel--write-vt ghostel--term "\ec\e]2;SENTINEL\e\\")
+          ;; Effects are FIFO, so observing SENTINEL drains any RIS callback.
           (ghostel-test--wait-until
            (lambda () (equal "SENTINEL" ghostel--title)) proc 5)
           (should (equal 1 calls)))))))
+
+(ert-deftest ghostel-test-title-stack-restores-title ()
+  "CSI 22/23 t saves and restores the window title."
+  :tags '(native)
+  (ghostel-test--with-pty-matrix backend
+    (ghostel-test--with-raw-echo-buffer (buf proc)
+      (let ((outer (format "Outer %S" backend))
+            (inner (format "Inner %S" backend)))
+        (ghostel--write-vt ghostel--term (format "\e]2;%s\e\\" outer))
+        (ghostel-test--wait-until
+         (lambda () (equal outer ghostel--title)) proc 5)
+        (ghostel--write-vt ghostel--term
+                           (format "\e[22;0t\e]2;%s\e\\" inner))
+        (ghostel-test--wait-until
+         (lambda () (equal inner ghostel--title)) proc 5)
+        (ghostel--write-vt ghostel--term "\e[23;0t")
+        (ghostel-test--wait-until
+         (lambda () (equal outer ghostel--title)) proc 5)
+        ;; Push again to verify that pop restored terminal state as well as Elisp state.
+        (ghostel--write-vt ghostel--term "\e[22;0t\e]2;transient\e\\\e[23;0t")
+        (ghostel-test--wait-until
+         (lambda () (equal outer ghostel--title)) proc 5)))))
+
+(ert-deftest ghostel-test-title-stack-drops-push-when-full ()
+  "Pushes beyond xterm's 10-entry title stack limit are dropped."
+  :tags '(native)
+  (ghostel-test--with-pty-matrix backend
+    (ghostel-test--with-raw-echo-buffer (buf proc)
+      ;; The 11th push exceeds the limit.
+      (dotimes (i 11)
+        (ghostel--write-vt ghostel--term
+                           (format "\e]2;T%d\e\\\e[22;0t" i)))
+      (ghostel--write-vt ghostel--term "\e]2;final\e\\\e[23;0t")
+      (ghostel-test--wait-until
+       (lambda () (equal "T9" ghostel--title)) proc 5)
+      (dotimes (_ 9)
+        (ghostel--write-vt ghostel--term "\e[23;0t"))
+      (ghostel-test--wait-until
+       (lambda () (equal "T0" ghostel--title)) proc 5))))
+
+(ert-deftest ghostel-test-title-stack-restores-no-title ()
+  "Vim's push/set/pop sequence restores an unset title."
+  :tags '(native)
+  (ghostel-test--with-pty-matrix backend
+    (ghostel-test--with-raw-echo-buffer (buf proc)
+      ;; Vim also saves the icon title; the parser drops those forms.
+      (ghostel--write-vt ghostel--term
+                         (concat "\e[22;2t\e[22;1t"
+                                 "\e]2;file +  - VIM\a"
+                                 "\e]2;Thanks for flying Vim\a"))
+      (ghostel-test--wait-until
+       (lambda () (equal "Thanks for flying Vim" ghostel--title)) proc 5)
+      (ghostel--write-vt ghostel--term "\e[23;2t\e[23;1t")
+      (ghostel-test--wait-until
+       (lambda () (null ghostel--title)) proc 5))))
+
+(ert-deftest ghostel-test-title-stack-empty-pop-is-no-op ()
+  "Popping an empty title stack leaves the title unchanged."
+  :tags '(native)
+  (ghostel-test--with-pty-matrix backend
+    (ghostel-test--with-raw-echo-buffer (buf proc)
+      (ghostel--write-vt ghostel--term "\e]2;KEEP\e\\\e[23;0t")
+      (ghostel-test--wait-until
+       (lambda () (equal "KEEP" ghostel--title)) proc 5))))
+
+(ert-deftest ghostel-test-title-stack-indexed-operations-are-no-ops ()
+  "Indexed title stack operations leave the default stack unchanged."
+  :tags '(native)
+  (ghostel-test--with-pty-matrix backend
+    (ghostel-test--with-raw-echo-buffer (buf proc)
+      ;; Try indexed push 5, set the title to IDX, then perform a default pop.
+      ;; Since the indexed push is ignored, the pop has nothing to restore.
+      (ghostel--write-vt ghostel--term "\e[22;0;5t\e]2;IDX\e\\\e[23;0t")
+      (ghostel-test--wait-until
+       (lambda () (equal "IDX" ghostel--title)) proc 5)
+      ;; Push IDX onto the default stack, set the title to AFTER, then try
+      ;; indexed pop 5.  The indexed pop leaves AFTER displayed and IDX saved.
+      (ghostel--write-vt ghostel--term
+                         "\e[22;0t\e]2;AFTER\e\\\e[23;0;5t")
+      (ghostel-test--wait-until
+       (lambda () (equal "AFTER" ghostel--title)) proc 5)
+      ;; A default pop restores IDX, proving that indexed pop 5 did not consume it.
+      (ghostel--write-vt ghostel--term "\e[23;0t")
+      (ghostel-test--wait-until
+       (lambda () (equal "IDX" ghostel--title)) proc 5))))
+
+(ert-deftest ghostel-test-full-reset-clears-title-stack ()
+  "RIS discards saved title stack entries."
+  :tags '(native)
+  (ghostel-test--with-pty-matrix backend
+    (ghostel-test--with-raw-echo-buffer (buf proc)
+      (ghostel--write-vt ghostel--term
+                         "\e]2;BEFORE\e\\\e[22;0t\ec\e]2;AFTER\e\\\e[23;0t")
+      (ghostel-test--wait-until
+       (lambda () (equal "AFTER" ghostel--title)) proc 5))))
 
 (ert-deftest ghostel-test-osc9-notification ()
   "OSC 9 iTerm2-style notifications reach `ghostel-notification-function'."
@@ -271,7 +364,7 @@ ConEmu's CWD-reporting alias uses the same callback as OSC 7, so
           (should (equal (list expected) calls)))))))
 
 (ert-deftest ghostel-test-full-reset-clears-progress ()
-  "RIS (ESC c) dispatches a progress remove so no stale indicator survives."
+  "RIS dispatches a progress removal."
   :tags '(native)
   (ghostel-test--with-pty-matrix backend
     (ghostel-test--with-raw-echo-buffer (buf proc)


### PR DESCRIPTION
Fixes the two stale-title paths reported in the [follow-up on #619](https://github.com/dakra/ghostel/issues/619#issuecomment-5280801420), plus one adjacent case of the same bug class.

## RIS (`ESC c`) never reached elisp

`Terminal.fullReset()` clears the stored title, but the `full_reset` stream arm never fires the `title_changed` effect, so `ghostel--title` (mode line, title-derived buffer names) kept the pre-reset title after `reset`(1). The handler now intercepts `full_reset`, forwards it, and fires the title callback — gated on a title actually having been set, so a bare `reset` stays free of elisp side effects.

Same class, same interception point: a program reporting ConEmu OSC 9;4 progress that gets `reset` left the (default-on) progress indicator stuck. The arm now dispatches a progress `remove`, mirroring ghostty's own `StreamHandler.fullReset`.

## `CSI 22/23 t` window-title stack

Previously in the no-effect arm, so a program that saves the title, sets its own, and restores it on exit left its final title stuck. This is not theoretical: vim's xterm detection is a TERM name-prefix match that `xterm-ghostty` satisfies, so vim pushes/pops the stack unconditionally, and with `set title` it left "Thanks for flying Vim" in the mode line on every exit. (Ghostty proper has the same gap but masks it by rewriting the title from shell integration at every prompt; ghostel's shell integration deliberately never touches the title, so nothing self-heals.)

Implementation, kept minimal:
- bounded per-terminal stack (10 entries, xterm's documented limit); pushes beyond the limit are dropped
- only the window-title selectors reach the handler (the parser drops icon-only forms), and only the default stack index 0 acts — slot addressing stays unimplemented
- pop restores through the standard `window_title` path so native terminal state and the elisp callback stay in sync; restoring a no-title push clears the title
- RIS and handler deinit discard the stack

## Verification

- 7 new native ERT tests (both PTY backends), including a byte-for-byte replay of vim's captured push/set/pop sequence, a pop→push round trip that pins native/elisp sync, an 11-push overflow test, and a FIFO-sentinel test proving the RIS gate
- red/green checked: the RIS tests fail against the unfixed handler, and the gate test fails against an ungated one
- live-verified in a real session: vim exit leaves no stale title; `reset` clears a stale title and a stale progress dispatch
- `make -j8 all` green