### PR TITLE
Add a public terminal-buffer API and the consult-ghostel extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,42 @@ jobs:
             -l test/evil-ghostel-test.el \
             -f evil-ghostel-test-run
 
+  test-consult:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs_version:
+          - '29.4'
+          - 'snapshot'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ github.token }}
+
+      - name: Install pinned Emacs
+        env:
+          EMACS_VERSION: ${{ matrix.emacs_version }}
+        run: bash .github/scripts/install-emacs.sh
+
+      - name: Install consult
+        run: |
+          git clone --depth 1 https://github.com/minad/consult.git /tmp/consult
+
+      - name: Install marginalia
+        run: git clone --depth 1 https://github.com/minad/marginalia.git /tmp/marginalia
+
+      - name: Install compat
+        run: git clone --depth 1 https://github.com/emacs-compat/compat.git /tmp/compat
+
+      - name: Run consult-ghostel tests
+        run: |
+          emacs --batch -Q -L /tmp/compat -L /tmp/consult -L /tmp/marginalia -L lisp -L extensions/consult-ghostel \
+            -l ert \
+            -l test/consult-ghostel-test.el \
+            -f consult-ghostel-test-run
+
   build-native:
     strategy:
       fail-fast: false

--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -67,3 +67,30 @@ jobs:
           EXIST_OK: false
           WARN_IS_ERROR: true
         run: make -C ~/melpazoid
+
+  build-consult:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with: { python-version: '3.10' }
+      - name: Install
+        run: |
+          sudo apt-get install emacs && emacs --version
+          git clone https://github.com/riscy/melpazoid.git ~/melpazoid
+      - name: Install dependencies
+        run: |
+          emacs --batch -Q \
+            --eval "(require 'package)" \
+            --eval "(add-to-list 'package-archives '(\"melpa\" . \"https://melpa.org/packages/\") t)" \
+            --eval "(package-initialize)" \
+            --eval "(package-refresh-contents)" \
+            --eval "(package-install 'consult)"
+      - name: Run
+        env:
+          LOCAL_REPO: ${{ github.workspace }}
+          RECIPE: (consult-ghostel :fetcher github :repo "dakra/ghostel" :files ("extensions/consult-ghostel/consult-ghostel.el"))
+          EXIST_OK: false
+          WARN_IS_ERROR: true
+        run: make -C ~/melpazoid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ All notable changes to this project will be documented in this file.
   whose literal name looks percent-encoded still resolves via a
   raw-spelling fallback; remote (TRAMP) reports of such names need
   the updated scripts.
+
+### Added
+- New `consult-ghostel` extension package (under
+  `extensions/consult-ghostel/`): `M-x consult-ghostel` and
+  `M-x consult-ghostel-project` pick a ghostel terminal through `consult`
+  with live preview as you move through the candidate list — unlike the
+  built-in `ghostel-list-buffers`, which uses `read-buffer` and does not
+  preview.  Candidates are switch-ordered (recently-used first, current
+  buffer last), and submitting a name that matches no buffer creates a
+  new terminal; with a prefix argument the commands behave like
+  `ghostel` / `ghostel-project` instead, and a `New` picker group
+  offers the same default-named creation.  The `-hidden` source
+  variants are registered in `consult-buffer-sources` /
+  `consult-project-buffer-sources` at load, so the `g` narrow key
+  summons ghostel buffers in the global pickers.  Loading the package additionally makes
+  `consult-line` match across soft line wraps in ghostel buffers.
 - Public Lisp API for external integrations: `ghostel-create` creates and
   spawns an interactive shell terminal (reading `default-directory`, with an
   optional identity for later lookup), and `ghostel-buffer-list` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ All notable changes to this project will be documented in this file.
   whose literal name looks percent-encoded still resolves via a
   raw-spelling fallback; remote (TRAMP) reports of such names need
   the updated scripts.
+- Public Lisp API for external integrations: `ghostel-create` creates and
+  spawns an interactive shell terminal (reading `default-directory`, with an
+  optional identity for later lookup), and `ghostel-buffer-list` /
+  `ghostel-project-buffer-list` return the live ghostel buffers (all /
+  project-scoped).  These join the existing public `ghostel-exec` (run a
+  specific program in a TTY) and `ghostel-send-string` / `ghostel-send-key`.
 
 ## [0.51.0] — 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ All notable changes to this project will be documented in this file.
   `consult-line` match across soft line wraps in ghostel buffers and
   adds a `Ghostel` group to `consult-bookmark`, so the `g` narrow key
   restricts the candidates to ghostel bookmarks.
+- `M-x consult-ghostel-history` (in the `consult-ghostel` extension)
+  picks from the shell's own command history and types the selection
+  into the terminal, replacing the pending input.  Retrieval uses the
+  new core API `ghostel-shell-history-commands` / `ghostel-shell-history`:
+  bash, zsh, fish, and nushell work out of the box, remote terminals
+  query the remote host, and history managers like atuin plug in.
 - Public Lisp API for external integrations: `ghostel-create` creates and
   spawns an interactive shell terminal (reading `default-directory`, with an
   optional identity for later lookup), and `ghostel-buffer-list` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,9 @@ All notable changes to this project will be documented in this file.
   variants are registered in `consult-buffer-sources` /
   `consult-project-buffer-sources` at load, so the `g` narrow key
   summons ghostel buffers in the global pickers.  Loading the package additionally makes
-  `consult-line` match across soft line wraps in ghostel buffers.
+  `consult-line` match across soft line wraps in ghostel buffers and
+  adds a `Ghostel` group to `consult-bookmark`, so the `g` narrow key
+  restricts the candidates to ghostel bookmarks.
 - Public Lisp API for external integrations: `ghostel-create` creates and
   spawns an interactive shell terminal (reading `default-directory`, with an
   optional identity for later lookup), and `ghostel-buffer-list` /

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,16 @@ export EMACSFLAGS
 XDG_CACHE_HOME ?= $(HOME)/.cache
 MELPAZOID_DIR  ?= $(XDG_CACHE_HOME)/melpazoid
 EVIL_DIR       ?= $(XDG_CACHE_HOME)/evil
+CONSULT_DIR    ?= $(XDG_CACHE_HOME)/consult
+MARGINALIA_DIR ?= $(XDG_CACHE_HOME)/marginalia
 LINT_ELPA_DIR  ?= $(XDG_CACHE_HOME)/ghostel-lint-elpa
 LINT_DEPS_STAMP := $(LINT_ELPA_DIR)/.deps-installed
 DOC_ELPA_DIR   ?= $(XDG_CACHE_HOME)/ghostel-doc-elpa
 DOC_DEPS_STAMP := $(DOC_ELPA_DIR)/.deps-installed
 
 ELISP_FILES := $(filter-out %-autoloads.el,$(wildcard lisp/ghostel*.el) \
-                                      $(wildcard extensions/evil-ghostel/*.el))
+                                      $(wildcard extensions/evil-ghostel/*.el) \
+                                      $(wildcard extensions/consult-ghostel/*.el))
 PACKAGE_FILES := $(shell grep -l '^;; Package-Requires:' $(ELISP_FILES) 2>/dev/null)
 CORE_PACKAGE_FILE := $(firstword $(filter lisp/%,$(PACKAGE_FILES)))
 ELISP := $(CORE_PACKAGE_FILE) $(filter-out $(CORE_PACKAGE_FILE),$(ELISP_FILES))
@@ -54,12 +57,12 @@ ZIG_BUILD_FLAGS := --prefix . -Doptimize=ReleaseFast -Dcpu=baseline $(ZIG_TARGET
 ZIG_SOURCES := $(wildcard src/*.zig src/*.c build.zig build.zig.zon symbols.map) \
                $(wildcard vendor/*.h)
 
-.PHONY: all build test test-native test-zig test-hypothesis test-hypothesis-cases test-all test-evil lint melpazoid melpazoid-ghostel melpazoid-evil-ghostel byte-compile checkdoc docquotes package-lint bench bench-quick bench-e2e bench-tui-partial html clean regen-terminfo
+.PHONY: all build test test-native test-zig test-hypothesis test-hypothesis-cases test-all test-evil test-consult lint melpazoid melpazoid-ghostel melpazoid-evil-ghostel melpazoid-consult-ghostel byte-compile checkdoc docquotes package-lint bench bench-quick bench-e2e bench-tui-partial html clean regen-terminfo
 
 # Recommended invocation: `make -j$(nproc) all' on Linux,
 # `make -j$(sysctl -n hw.ncpu) all' on macOS.  GNU make 4+ also accepts
 # bare `-j' (unlimited); pair with `-l$(nproc)' to cap by load.
-all: build test-all test-evil lint
+all: build test-all test-evil test-consult lint
 
 build: $(MODULE)
 
@@ -82,16 +85,26 @@ test-hypothesis-cases: build
 lisp/%.elc: lisp/%.el
 	$(EMACS) --batch $(EMACSFLAGS) -Q -L lisp --eval "(setq byte-compile-error-on-warn t load-prefer-newer t)" -f batch-byte-compile $<
 
-# Extension packages depend on third-party libraries; reuse the evil
-# checkout that `test-evil' manages.
+# Extension packages depend on third-party libraries; reuse the
+# checkouts that `test-evil' / `test-consult' manage.
 $(EVIL_DIR):
 	git clone --depth 1 https://github.com/emacs-evil/evil.git "$@"
+
+$(CONSULT_DIR):
+	git clone --depth 1 https://github.com/minad/consult.git "$@"
+
+$(MARGINALIA_DIR):
+	git clone --depth 1 https://github.com/minad/marginalia.git "$@"
 
 # Depend on the core .elc files: `require' prefers a stale core .elc over
 # the fresh .el, so a parallel build could otherwise compile the extension
 # before a core function it uses exists in the loaded bytecode.
 extensions/evil-ghostel/%.elc: extensions/evil-ghostel/%.el $(filter lisp/%.elc,$(ELC)) | $(EVIL_DIR)
 	$(EMACS) --batch $(EMACSFLAGS) -Q -L "$(EVIL_DIR)" -L lisp -L extensions/evil-ghostel \
+		--eval "(setq byte-compile-error-on-warn t load-prefer-newer t)" -f batch-byte-compile $<
+
+extensions/consult-ghostel/%.elc: extensions/consult-ghostel/%.el $(filter lisp/%.elc,$(ELC)) | $(CONSULT_DIR) $(MARGINALIA_DIR)
+	$(EMACS) --batch $(EMACSFLAGS) -Q -L "$(CONSULT_DIR)" -L "$(MARGINALIA_DIR)" -L lisp -L extensions/consult-ghostel \
 		--eval "(setq byte-compile-error-on-warn t load-prefer-newer t)" -f batch-byte-compile $<
 
 # Per-topic test files.  Each file becomes its own Make target with a
@@ -133,6 +146,10 @@ test-all: test test-zig test-native
 test-evil: build $(ELC) | $(EVIL_DIR)
 	$(EMACS) --batch $(EMACSFLAGS) -Q -L "$(EVIL_DIR)" -L lisp -L extensions/evil-ghostel \
 		-l ert -l test/evil-ghostel-test.el -f evil-ghostel-test-run
+
+test-consult: $(ELC) | $(CONSULT_DIR) $(MARGINALIA_DIR)
+	$(EMACS) --batch $(EMACSFLAGS) -Q -L "$(CONSULT_DIR)" -L "$(MARGINALIA_DIR)" -L lisp -L extensions/consult-ghostel \
+		-l ert -l test/consult-ghostel-test.el -f consult-ghostel-test-run
 
 byte-compile: $(ELC)
 
@@ -201,7 +218,7 @@ docquotes: $(DOCQUOTE_FILES)
 	$(EMACS) --batch $(EMACSFLAGS) -Q -l $(LINT_HELPERS) \
 		-f ghostel-lint-docquotes $(DOCQUOTE_FILES)
 
-melpazoid: melpazoid-ghostel melpazoid-evil-ghostel
+melpazoid: melpazoid-ghostel melpazoid-evil-ghostel melpazoid-consult-ghostel
 
 $(MELPAZOID_DIR):
 	git clone https://github.com/riscy/melpazoid.git "$@"
@@ -213,6 +230,11 @@ melpazoid-ghostel: | $(MELPAZOID_DIR)
 
 melpazoid-evil-ghostel: | $(MELPAZOID_DIR)
 	RECIPE='(evil-ghostel :fetcher github :repo "dakra/ghostel" :files ("extensions/evil-ghostel/evil-ghostel.el"))' \
+		LOCAL_REPO=$(CURDIR) \
+		make -C "$(MELPAZOID_DIR)"
+
+melpazoid-consult-ghostel: | $(MELPAZOID_DIR)
+	RECIPE='(consult-ghostel :fetcher github :repo "dakra/ghostel" :files ("extensions/consult-ghostel/consult-ghostel.el"))' \
 		LOCAL_REPO=$(CURDIR) \
 		make -C "$(MELPAZOID_DIR)"
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,24 @@ with a prefix argument the pickers behave like `ghostel` / `ghostel-project`
 ```emacs-lisp
 (use-package consult-ghostel
   :after (ghostel consult)
-  :bind (:map ghostel-semi-char-mode-map
-         ("C-c M" . consult-ghostel-project)))
+  :demand t
+  :bind (("C-x m" . consult-ghostel)
+         :map project-prefix-map
+         ("m" . consult-ghostel-project)
+         :map ghostel-semi-char-mode-map
+         ("C-c h" . consult-ghostel-history)))
+```
+
+`consult-ghostel-history` picks from the shell's own command history and
+types the selection into the terminal, replacing what's already on the
+command line.  The history is retrieved per shell (bash, zsh, fish, and
+nushell work out of the box); users of a history manager can point their
+shell's entry in `ghostel-shell-history-commands` at it, e.g. for
+[atuin](https://atuin.sh):
+
+```emacs-lisp
+(setf (alist-get 'zsh ghostel-shell-history-commands)
+      "atuin history list --cmd-only --print0 --reverse false")
 ```
 
 Loading consult-ghostel also adds a `Ghostel` group to `consult-bookmark`

--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ other Quail-based method), add Ghostel support:
   :hook (ghostel-mode . ghostel-ime-mode))
 ```
 
+## Consult
+Pick a Ghostel terminal via [consult](https://github.com/minad/consult) with live
+preview (and create-on-miss) with the [consult-ghostel](https://melpa.org/#/consult-ghostel) extension;
+with a prefix argument the pickers behave like `ghostel` / `ghostel-project`
+(`C-u` creates a new terminal):
+
+```emacs-lisp
+(use-package consult-ghostel
+  :after (ghostel consult)
+  :bind (:map ghostel-semi-char-mode-map
+         ("C-c M" . consult-ghostel-project)))
+```
+
 ## Evil
 If you're an evil user you can install the [evil-ghostel](https://melpa.org/#/evil-ghostel) extension:
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ with a prefix argument the pickers behave like `ghostel` / `ghostel-project`
          ("C-c M" . consult-ghostel-project)))
 ```
 
+Loading consult-ghostel also adds a `Ghostel` group to `consult-bookmark`
+(narrow with `g`) and makes `consult-line` match across soft line wraps in
+ghostel buffers.
+
 ## Evil
 If you're an evil user you can install the [evil-ghostel](https://melpa.org/#/evil-ghostel) extension:
 

--- a/README.org
+++ b/README.org
@@ -1444,11 +1444,11 @@ tables below group them by area; defaults shown are the out-of-the-box values.
 * Extensions
 :properties:
 :custom_id: extensions
-:description: Evil, compile, eshell, comint, and input methods
+:description: Evil, compile, eshell, comint, consult, and input methods
 :end:
 
-These features live in separate files (or, for evil, a separate package) so the
-core stays lean.  Load only what you use.
+These features live in separate files (or, for evil and consult, separate
+packages) so the core stays lean.  Load only what you use.
 
 ** Evil-mode
 :properties:
@@ -1783,6 +1783,76 @@ filter continues to handle progress bars, =read -s= prompts, etc.
 For best performance, xterm-color's advice to disable font-locking in shell
 buffers applies here too - see the docstring of =ghostel-comint-mode=.
 
+** Consult integration
+:properties:
+:custom_id: consult-integration
+:end:
+#+cindex: consult
+#+findex: consult-ghostel
+#+findex: consult-ghostel-project
+
+=consult-ghostel= picks a Ghostel terminal through [[https://github.com/minad/consult][consult]] with *live preview*:
+moving through the candidate list previews each terminal in the target window,
+the way =consult-buffer= does.  The built-in =ghostel-list-buffers= uses
+=read-buffer=, which has no preview.
+
+=consult-ghostel= is distributed as an independent MELPA package that depends on
+=ghostel= and =consult=.  Install it alongside them:
+
+#+begin_src emacs-lisp
+(use-package consult-ghostel
+  :ensure t
+  :after (ghostel consult)
+  :demand t
+  :bind (:map ghostel-semi-char-mode-map
+         ("C-c M" . consult-ghostel-project)))
+#+end_src
+
+Or from source (Emacs 30+); =:lisp-dir= points package-vc at this extension's
+subdirectory inside the ghostel monorepo:
+
+#+begin_src emacs-lisp
+(use-package consult-ghostel
+  :vc (:url "https://github.com/dakra/ghostel"
+       :lisp-dir "extensions/consult-ghostel"
+       :rev :newest)
+  :after (ghostel consult)
+  :demand t
+  :bind (:map ghostel-semi-char-mode-map
+         ("C-c M" . consult-ghostel-project)))
+#+end_src
+
+- =M-x consult-ghostel= - pick any Ghostel terminal.
+- =M-x consult-ghostel-project= - pick a terminal in the current project.
+
+Candidates are ordered for switching (recently-used first, the current buffer
+last) and annotated with the terminal title ([[#picker-annotations][Picker annotations]]).
+With [[https://github.com/minad/marginalia][marginalia]] installed, the title is prepended to marginalia's buffer
+annotations instead, in every buffer prompt.
+Submitting a name that matches no buffer *creates a new terminal* with that
+name (reach-or-create); the project command roots the new terminal at the project.
+With a prefix argument the commands behave like =ghostel= / =ghostel-project=
+instead: =C-u= creates a new terminal, a numeric argument picks that numbered
+terminal.  A /New/ group at the bottom of the picker offers the same
+default-named creation from inside the minibuffer (narrow key =n=).
+
+Loading the package also registers hidden sources in =consult-buffer= and
+=consult-project-buffer=: Ghostel buffers already appear in the default
+/Buffer/ view, so they stay invisible there until the =g= narrow key summons
+them exclusively.  To opt out:
+
+#+begin_src emacs-lisp
+(setq consult-buffer-sources
+      (delq 'consult-ghostel-source-hidden consult-buffer-sources))
+#+end_src
+
+The =g= narrow key (or any other source property) can be changed with
+=consult-customize=, e.g. ~(consult-customize consult-ghostel-source-hidden :narrow ?t)~.
+
+Loading the package also makes =consult-line= match across soft line wraps in
+Ghostel buffers: rows joined by wrap newlines become one search candidate, so a
+path or command that wrapped mid-word is still found.
+
 ** Emacs Lisp input methods
 :properties:
 :custom_id: emacs-lisp-input-methods
@@ -1869,8 +1939,9 @@ terminals like =*ghostel*= and =*ghostel*<2>= easy to tell apart.
 for the full title.
 
 [[https://github.com/minad/marginalia][Marginalia]] replaces annotations for the whole =buffer= category with its own,
-which hides the title.  You can prepend the title to marginalia's annotator to
-show it in every buffer prompt (=C-x b=, =consult-buffer=, and ghostel's own):
+which hides the title.  The [[#consult-integration][consult-ghostel]] package handles this
+automatically; without it, you can prepend the title to marginalia's annotator
+to show it in every buffer prompt (=C-x b=, =consult-buffer=, and ghostel's own):
 
 #+begin_src emacs-lisp
 (with-eval-after-load 'marginalia
@@ -2257,7 +2328,8 @@ src/emacs.zig         Zig wrapper for the Emacs module C API
 The Elisp sources live in =lisp/=, the Zig sources in =src/=, vendored upstream
 headers in =vendor/=, the bundled compiled terminfo in =etc/terminfo/=, and shell
 integration assets in =etc/shell/=.  Optional MELPA extensions that depend on
-=ghostel= live under =extensions/<package>/= (currently =evil-ghostel=).
+=ghostel= live under =extensions/<package>/= (currently =evil-ghostel= and
+=consult-ghostel=).
 
 ** PTY and process ownership
 :properties:

--- a/README.org
+++ b/README.org
@@ -1907,6 +1907,38 @@ Both operate on the current buffer; wrap in =with-current-buffer= when driving
 another ghostel buffer.  Calling either outside a ghostel buffer signals a
 =user-error=.
 
+** Creating and listing terminals from Lisp
+:properties:
+:custom_id: creating-terminals-from-lisp
+:end:
+#+findex: ghostel-create
+#+findex: ghostel-exec
+#+findex: ghostel-buffer-list
+#+findex: ghostel-project-buffer-list
+
+For packages that build on ghostel, a small public API creates and enumerates
+terminals without reaching into internals:
+
+#+begin_src emacs-lisp
+(ghostel-create)                      ; new interactive shell terminal, returns its buffer
+(ghostel-create "*build*")            ; ... with a specific buffer name
+(let ((default-directory "/tmp/"))    ; ... in a specific directory
+  (ghostel-create "*scratch-sh*"))
+
+(ghostel-exec (get-buffer-create "*tig*") "tig")  ; run one program in a TTY instead of a shell
+
+(ghostel-buffer-list)                 ; all live ghostel buffers
+(ghostel-project-buffer-list)         ; ghostel buffers in the current project
+#+end_src
+
+=ghostel-create= runs =ghostel-shell= with shell integration, like =M-x ghostel=
+but always creating a fresh terminal; =ghostel-exec= runs a single program in
+a real TTY with no shell integration.  Both read =default-directory=, and both
+accept an optional IDENTITY alist stored as the buffer's =ghostel-identity=
+for later lookup.
+=ghostel-project-buffer-list= prompts to choose a project when there is no
+current one.
+
 ** Project integration
 :properties:
 :custom_id: project-integration

--- a/README.org
+++ b/README.org
@@ -1851,7 +1851,9 @@ The =g= narrow key (or any other source property) can be changed with
 
 Loading the package also makes =consult-line= match across soft line wraps in
 Ghostel buffers: rows joined by wrap newlines become one search candidate, so a
-path or command that wrapped mid-word is still found.
+path or command that wrapped mid-word is still found.  It also adds a /Ghostel/
+group to =consult-bookmark=, so the =g= narrow key restricts the candidates to
+Ghostel bookmarks ([[#bookmarks][Bookmarks]]).
 
 ** Emacs Lisp input methods
 :properties:

--- a/README.org
+++ b/README.org
@@ -1804,8 +1804,11 @@ the way =consult-buffer= does.  The built-in =ghostel-list-buffers= uses
   :ensure t
   :after (ghostel consult)
   :demand t
-  :bind (:map ghostel-semi-char-mode-map
-         ("C-c M" . consult-ghostel-project)))
+  :bind (("C-x m" . consult-ghostel)
+         :map project-prefix-map
+         ("m" . consult-ghostel-project)
+         :map ghostel-semi-char-mode-map
+         ("C-c h" . consult-ghostel-history)))
 #+end_src
 
 Or from source (Emacs 30+); =:lisp-dir= points package-vc at this extension's
@@ -1818,8 +1821,11 @@ subdirectory inside the ghostel monorepo:
        :rev :newest)
   :after (ghostel consult)
   :demand t
-  :bind (:map ghostel-semi-char-mode-map
-         ("C-c M" . consult-ghostel-project)))
+  :bind (("C-x m" . consult-ghostel)
+         :map project-prefix-map
+         ("m" . consult-ghostel-project)
+         :map ghostel-semi-char-mode-map
+         ("C-c h" . consult-ghostel-history)))
 #+end_src
 
 - =M-x consult-ghostel= - pick any Ghostel terminal.
@@ -1854,6 +1860,21 @@ Ghostel buffers: rows joined by wrap newlines become one search candidate, so a
 path or command that wrapped mid-word is still found.  It also adds a /Ghostel/
 group to =consult-bookmark=, so the =g= narrow key restricts the candidates to
 Ghostel bookmarks ([[#bookmarks][Bookmarks]]).
+
+#+findex: consult-ghostel-history
+=M-x consult-ghostel-history= picks from the *shell's own command history* and
+types the selection into the terminal.  The typed input before the cursor
+pre-fills the minibuffer and is replaced by the selection; the entry is not
+submitted, so it stays editable at the prompt.  The history is retrieved by
+running the shell's entry from =ghostel-shell-history-commands= — bash, zsh,
+fish, and nushell work out of the box, and a remote terminal queries the
+remote host.  Users of a history manager can point their shell's entry at it,
+e.g. for [[https://atuin.sh][atuin]]:
+
+#+begin_src emacs-lisp
+(setf (alist-get 'zsh ghostel-shell-history-commands)
+      "atuin history list --cmd-only --print0 --reverse false")
+#+end_src
 
 ** Emacs Lisp input methods
 :properties:

--- a/extensions/consult-ghostel/README.md
+++ b/extensions/consult-ghostel/README.md
@@ -23,9 +23,20 @@ Install from [MELPA](https://melpa.org/#/consult-ghostel):
 (use-package consult-ghostel
   :after (ghostel consult)
   :demand t
-  :bind (:map ghostel-semi-char-mode-map
-         ("C-c M" . consult-ghostel-project)))
+  :bind (("C-x m" . consult-ghostel)
+         :map project-prefix-map
+         ("m" . consult-ghostel-project)
+         :map ghostel-semi-char-mode-map
+         ("C-c h" . consult-ghostel-history)))
 ```
+
+`M-x consult-ghostel-history` picks from the shell's own command history
+and types the selection into the terminal: the typed input before the
+cursor pre-fills the minibuffer and is completed or replaced by the
+selection, which stays editable at the prompt. The history is retrieved per shell via
+`ghostel-shell-history-commands` (bash, zsh, fish, and nushell work out
+of the box; remote terminals query the remote host; history managers
+like [atuin](https://atuin.sh) plug in through the same alist).
 
 Loading the package also registers hidden sources in the regular
 `consult-buffer` lists: ghostel buffers stay in the default *Buffer*

--- a/extensions/consult-ghostel/README.md
+++ b/extensions/consult-ghostel/README.md
@@ -1,0 +1,49 @@
+# consult-ghostel
+
+[Consult](https://github.com/minad/consult) integration for the
+[ghostel](https://github.com/dakra/ghostel) terminal emulator.
+
+`M-x consult-ghostel` and `M-x consult-ghostel-project` pick a ghostel
+terminal (all / project-scoped) with live preview: moving through the
+candidate list previews each terminal in the target window, the way
+`consult-buffer` does. Candidates are ordered for switching
+(recently-used first, current buffer last) and annotated with the
+terminal title, and submitting a name that matches no buffer creates a
+new terminal with that name. With a prefix argument they behave like
+`ghostel` / `ghostel-project` instead (`C-u` creates a new terminal); a
+`New` group inside the picker offers the same default-named creation.
+When
+[marginalia](https://github.com/minad/marginalia) is installed, the
+title is prepended to marginalia's buffer annotations instead, in every
+buffer prompt.
+
+Install from [MELPA](https://melpa.org/#/consult-ghostel):
+
+```emacs-lisp
+(use-package consult-ghostel
+  :after (ghostel consult)
+  :demand t
+  :bind (:map ghostel-semi-char-mode-map
+         ("C-c M" . consult-ghostel-project)))
+```
+
+Loading the package also registers hidden sources in the regular
+`consult-buffer` lists: ghostel buffers stay in the default *Buffer*
+view only, until the `g` narrow key summons them exclusively.  To opt
+out:
+
+```emacs-lisp
+(setq consult-buffer-sources
+      (delq 'consult-ghostel-source-hidden consult-buffer-sources))
+```
+
+The `g` narrow key (or any other source property) can be changed with
+`consult-customize`, e.g.
+`(consult-customize consult-ghostel-source-hidden :narrow ?t)`.
+
+Loading the package also makes `consult-line` match across soft line
+wraps in ghostel buffers: rows joined by wrap newlines become one search
+candidate, so a path or command that wrapped mid-word is still found.
+
+See [the manual](https://dakra.github.io/ghostel/#consult-integration)
+for details.

--- a/extensions/consult-ghostel/README.md
+++ b/extensions/consult-ghostel/README.md
@@ -44,6 +44,8 @@ The `g` narrow key (or any other source property) can be changed with
 Loading the package also makes `consult-line` match across soft line
 wraps in ghostel buffers: rows joined by wrap newlines become one search
 candidate, so a path or command that wrapped mid-word is still found.
+It also adds a `Ghostel` group to `consult-bookmark`, so the `g` narrow
+key restricts the candidates to ghostel bookmarks.
 
 See [the manual](https://dakra.github.io/ghostel/#consult-integration)
 for details.

--- a/extensions/consult-ghostel/consult-ghostel.el
+++ b/extensions/consult-ghostel/consult-ghostel.el
@@ -1,0 +1,349 @@
+;;; consult-ghostel.el --- Consult integration for ghostel -*- lexical-binding: t; -*-
+
+;; Copyright (c) 2026 Daniel Kraus <daniel@kraus.my>
+
+;; Author: Daniel Kraus <daniel@kraus.my>
+;; URL: https://github.com/dakra/ghostel
+;; Version: 0.50.0
+;; Package-Requires: ((emacs "28.1") (consult "1.5") (ghostel "0.50.0"))
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is NOT part of GNU Emacs.
+
+;;; Commentary:
+
+;; Pick a ghostel buffer through `consult', so moving through the
+;; candidate list previews each ghostel buffer in the target window.
+;; Ghostel's own `ghostel-list-buffers' / `ghostel-project-list-buffers'
+;; route through `read-buffer', which has no preview.
+;;
+;;   `consult-ghostel'          all ghostel buffers
+;;   `consult-ghostel-project'  ghostel buffers in this project
+;;
+;; Candidates are ordered for switching (recently-used first, current
+;; buffer last) and annotated with the terminal title, and submitting a
+;; name that matches no buffer creates a new ghostel terminal with that
+;; name (reach-or-create, like `consult-buffer's create-on-miss).
+;; With a prefix argument the buffer pickers behave like `ghostel' /
+;; `ghostel-project' instead (C-u creates a new terminal); a "New"
+;; group inside the picker offers the same default-named creation.
+;; When marginalia is installed, the title is prepended to marginalia's
+;; buffer annotations instead, in every buffer prompt.
+;;
+;; Loading also registers hidden sources in `consult-buffer' and
+;; `consult-project-buffer': ghostel buffers already appear in the
+;; default "Buffer" view, so they stay invisible there until the `g'
+;; narrow key summons them exclusively.  Opt out with:
+;;
+;;   (setq consult-buffer-sources
+;;         (delq 'consult-ghostel-source-hidden consult-buffer-sources))
+;;
+;; Loading this package also makes `consult-line' match across soft
+;; line wraps in ghostel buffers: rows joined by wrap newlines become
+;; one candidate.
+;;
+;; Enable by adding to your init:
+;;
+;;   (use-package consult-ghostel
+;;     :after (ghostel consult)
+;;     :demand t
+;;     :bind (:map ghostel-semi-char-mode-map
+;;            ("C-c M" . consult-ghostel-project)))
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'consult)
+(require 'ghostel)
+(require 'marginalia nil 'noerror)
+
+(defvar consult-ghostel-history nil
+  "Minibuffer history for the `consult-ghostel' commands.")
+
+(defun consult-ghostel--pairs (buffers)
+  "Return `consult' (name . buffer) pairs for BUFFERS, switch-ordered.
+Runs BUFFERS through `consult--buffer-query', so consult's visibility
+order (recently-used first, current buffer last),
+`consult-buffer-list-function', and `consult-buffer-filter' all apply."
+  (consult--buffer-query :sort 'visibility
+                         :predicate (lambda (buf) (memq buf buffers))
+                         :as #'consult--buffer-pair))
+
+(defvar consult-ghostel-source
+  `( :name     "Ghostel"
+     :narrow   ?g
+     :category buffer
+     :face     consult-buffer
+     :history  buffer-name-history
+     :annotate ,#'ghostel-annotate-buffer
+     :state    ,#'consult--buffer-state
+     :new      ,#'consult-ghostel--spawn
+     :items    ,(lambda () (consult-ghostel--pairs (ghostel-buffer-list))))
+  "`consult' source for all ghostel buffers.")
+
+(defvar consult-ghostel-project-source
+  `( :name     "Ghostel (Project)"
+     :narrow   ?g
+     :category buffer
+     :face     consult-buffer
+     :history  buffer-name-history
+     :annotate ,#'ghostel-annotate-buffer
+     :state    ,#'consult--buffer-state
+     ;; Resolve the project through consult so the source agrees with
+     ;; `consult-project-function'.
+     :enabled  ,(lambda () (consult--project-root))
+     :new      ,(lambda (name)
+                  ;; Allocate in `ghostel-project's own slot family, so
+                  ;; the new terminal is exactly the buffer `ghostel-project'
+                  ;; finds and reuses; NAME only names the buffer.
+                  (let ((default-directory (consult--project-root t)))
+                    (if (member name '(nil ""))
+                        (ghostel-project t)
+                      (let* ((context `((kind . term)
+                                        (project-root
+                                         . ,(ghostel--normalize-root
+                                             default-directory))))
+                             (next-instance (ghostel--next-instance context))
+                             (identity
+                              `(,@context (instance . ,next-instance))))
+                        (consult-ghostel--spawn name identity)))))
+     :items    ,(lambda ()
+                  ;; The `project-current' check keeps
+                  ;; `ghostel-project-buffer-list' from prompting for a
+                  ;; project when project.el finds none under the root
+                  ;; (e.g. a projectile-only project).
+                  (when-let* ((default-directory (consult--project-root))
+                              ((project-current)))
+                    (consult-ghostel--pairs (ghostel-project-buffer-list)))))
+  "`consult' source for ghostel buffers in the current project.
+Project membership is determined by `ghostel-project-buffer-scope'.")
+
+(defvar consult-ghostel-source-new
+  `( :name     "New"
+     :narrow   ?n
+     :category ghostel-new
+     :face     font-lock-constant-face
+     :action   ,(lambda (_) (ghostel t))
+     :items    ("Create a new Ghostel terminal"))
+  "`consult' source offering creation of a default-named terminal.
+Selecting the candidate behaves like \\[universal-argument] `ghostel'.")
+
+(defvar consult-ghostel-project-source-new
+  `( :name     "New"
+     :narrow   ?n
+     :category ghostel-new
+     :face     font-lock-constant-face
+     :enabled  ,(lambda () (consult--project-root))
+     :action   ,(lambda (_) (ghostel-project t))
+     :items    ("Create a new project Ghostel terminal"))
+  "`consult' source offering creation of a project terminal.
+Selecting the candidate behaves like \\[universal-argument] `ghostel-project'.")
+
+;; `copy-sequence', or the spliced tail would be shared structure and
+;; `consult-customize' on one variable would mutate the other.
+(defvar consult-ghostel-source-hidden
+  `(:hidden t :narrow (?g . "Ghostel") ,@(copy-sequence consult-ghostel-source))
+  "Like `consult-ghostel-source' but hidden by default.
+Registered in `consult-buffer-sources' at load: ghostel buffers stay
+in the default \"Buffer\" view and the `g' narrow key summons them
+exclusively.")
+
+(defvar consult-ghostel-project-source-hidden
+  `( :hidden t :narrow (?g . "Ghostel")
+     ,@(copy-sequence consult-ghostel-project-source))
+  "Like `consult-ghostel-project-source' but hidden by default.
+Registered in `consult-project-buffer-sources' at load.")
+
+(add-to-list 'consult-buffer-sources 'consult-ghostel-source-hidden t)
+(add-to-list 'consult-project-buffer-sources
+             'consult-ghostel-project-source-hidden t)
+
+(defun consult-ghostel--display (buffer &optional norecord)
+  "Pop to BUFFER like ghostel's own buffer commands.
+Uses the same-window action under the `comint' display category so
+`display-buffer-alist' rules match `ghostel-list-buffers'.  NORECORD is
+passed through to `pop-to-buffer'."
+  (pop-to-buffer buffer
+                 (append display-buffer--same-window-action
+                         '((category . comint)))
+                 norecord))
+
+(defun consult-ghostel--spawn (name &optional identity)
+  "Create and display a new ghostel terminal named NAME in `default-directory'.
+Displays through `consult--buffer-display', so the other-window/-frame
+variants of `consult-buffer' place a created terminal like a picked
+one.  IDENTITY is passed through to `ghostel-create'."
+  (funcall consult--buffer-display (ghostel-create name nil identity)))
+
+(defun consult-ghostel--switch (sources prompt)
+  "Pick a ghostel buffer from SOURCES via `consult--multi' with PROMPT.
+Previews candidates; a non-matching name creates a new terminal via the
+first source's `:new' handler."
+  (let ((consult--buffer-display #'consult-ghostel--display))
+    (consult--multi sources
+                    :require-match (confirm-nonexistent-file-or-buffer)
+                    :prompt prompt
+                    :history 'consult-ghostel-history
+                    :sort nil)))
+
+;;;###autoload
+(defun consult-ghostel (&optional arg)
+  "Switch to a ghostel buffer, previewing candidates.
+Submitting a name that matches no buffer creates a new ghostel
+terminal; the \"New\" candidate creates one with the default name.
+With prefix ARG, behave like `ghostel' called with ARG instead
+\(\\[universal-argument] creates a new terminal, a numeric arg picks
+that numbered terminal)."
+  (interactive "P")
+  (if arg
+      (ghostel arg)
+    (consult-ghostel--switch
+     '(consult-ghostel-source consult-ghostel-source-new)
+     "Ghostel buffer: ")))
+
+;;;###autoload
+(defun consult-ghostel-project (&optional arg)
+  "Switch to a ghostel buffer in the current project, previewing candidates.
+Submitting a name that matches no buffer creates a new ghostel terminal
+rooted at the project; the \"New\" candidate creates one with the
+default name.  With prefix ARG, behave like `ghostel-project' called
+with ARG.  Project membership is determined by
+`ghostel-project-buffer-scope'."
+  (interactive "P")
+  (if arg
+      (ghostel-project arg)
+    ;; The source's `:enabled' guard is not enough: `consult--multi' with
+    ;; zero enabled sources still opens an (empty) picker and errors on
+    ;; submit, so refuse before entering the minibuffer.
+    (unless (consult--project-root)
+      (user-error "No current project"))
+    (consult-ghostel--switch
+     '(consult-ghostel-project-source consult-ghostel-project-source-new)
+     "Project ghostel buffer: ")))
+
+;;; Marginalia integration
+
+;; Keep the byte-compile clean when marginalia is not installed.
+(declare-function marginalia-annotate-buffer "marginalia" (cand))
+(defvar marginalia-annotators)
+
+(defun consult-ghostel-marginalia-annotate (cand)
+  "Annotate buffer CAND like marginalia, prefixed with the terminal title."
+  (concat (when-let* ((annotation (ghostel-annotate-buffer cand)))
+            (propertize annotation 'face 'marginalia-value))
+          (marginalia-annotate-buffer cand)))
+
+;; The registry variable gates the registration: `marginalia-annotators'
+;; only exists since marginalia 2.1.
+(when (boundp 'marginalia-annotators)
+  ;; Marginalia's own `buffer' annotator takes precedence over the
+  ;; sources' `:annotate', hiding the title, so prepend the title
+  ;; through marginalia's annotator registry instead.
+  (dolist (category '(buffer project-buffer))
+    (cl-pushnew #'consult-ghostel-marginalia-annotate
+                (alist-get category marginalia-annotators))))
+
+;;; consult-line over logical lines
+
+(defun consult-ghostel--line-candidates (orig top curr-line)
+  "Build consult-line candidates from logical lines in ghostel buffers.
+Rows joined by wrap newlines become one candidate with the newlines
+spliced out, so matching works across soft wraps.  Outside ghostel
+buffers, call ORIG with TOP and CURR-LINE unchanged."
+  (if (not (derived-mode-p 'ghostel-mode))
+      (funcall orig top curr-line)
+    (let ((buffer (current-buffer))
+          (line (line-number-at-pos (point-min) consult-line-numbers-widen))
+          default-cand candidates)
+      (save-excursion
+        (goto-char (point-min))
+        (while (not (eobp))
+          ;; Core's helpers define the logical line (including the row
+          ;; cap), so consult-line agrees with the link scanner and
+          ;; `consult-ghostel--wrap-corrected-dest'.
+          (let* ((beg (point))
+                 (end (ghostel--soft-wrap-line-end
+                       beg ghostel--soft-wrap-row-limit))
+                 ;; `count-lines' skips the final row when END sits at
+                 ;; a beginning of line (empty continuation row), which
+                 ;; would drift the line counter.
+                 (rows (max 1 (+ (count-lines beg end)
+                                 (if (and (> end beg)
+                                          (save-excursion (goto-char end)
+                                                          (bolp)))
+                                     1
+                                   0))))
+                 (str (car (ghostel--wrap-joined-region
+                            beg end ghostel--soft-wrap-row-limit))))
+            (unless (string-match-p "\\`[ \t]*\\'" str)
+              ;; The property gates the point-placement advice: only
+              ;; candidates built here are wrap-joined.
+              (push (propertize
+                     (consult--location-candidate str (cons buffer beg)
+                                                  line line)
+                     'consult-ghostel--joined t)
+                    candidates)
+              ;; Default to the logical line CONTAINING curr-line: its
+              ;; first row may be above point when point sits on a
+              ;; continuation row.
+              (when (and (not default-cand) (> (+ line rows) curr-line))
+                (setq default-cand candidates)))
+            (setq line (+ line rows))
+            (goto-char (min (1+ end) (point-max))))))
+      (unless candidates
+        (user-error "No lines"))
+      (nreverse
+       (if (or top (not default-cand))
+           candidates
+         (let ((before (cdr default-cand)))
+           (setcdr default-cand nil)
+           (nconc before candidates)))))))
+
+(advice-add 'consult--line-candidates :around
+            #'consult-ghostel--line-candidates)
+
+(defun consult-ghostel--wrap-corrected-dest (pos offset)
+  "Return the buffer position for OFFSET into POS's wrap-joined line.
+The candidate string has the wrap newlines spliced out while the
+buffer still contains them; core's chunk map translates between the
+two.  An offset at a row boundary lands past the wrap newline, on
+the match itself."
+  (with-current-buffer (if (markerp pos) (marker-buffer pos) (current-buffer))
+    (let* ((end (ghostel--soft-wrap-line-end
+                 pos ghostel--soft-wrap-row-limit))
+           (chunks (cdr (ghostel--wrap-joined-region
+                         pos end ghostel--soft-wrap-row-limit))))
+      ;; No chunks to map through when the buffer shrank under the
+      ;; candidate (eviction, screen clear) and POS clamped to
+      ;; `point-max'; land on POS rather than crashing the jump.
+      (or (ghostel--wrap-offset-to-pos offset chunks) pos))))
+
+(defun consult-ghostel--line-point-placement
+    (orig selected candidates highlighted &rest ignored-faces)
+  "Place point correctly on wrap-joined ghostel candidates.
+consult computes the destination as buffer position + offset in the
+candidate string; with the wrap newlines spliced out of the string
+that arithmetic lands short past every wrap boundary, so map through
+the wrap chunks instead.  For candidates without the wrap-joined
+property (`consult-line-multi' candidates are per-row even in ghostel
+buffers) call ORIG unchanged.  SELECTED, CANDIDATES, HIGHLIGHTED, and
+IGNORED-FACES are as for `consult--line-point-placement'."
+  (let* ((pos (and highlighted (consult--lookup-location selected candidates)))
+         (buf (cond ((markerp pos) (marker-buffer pos))
+                    (pos (current-buffer)))))
+    (if (not (and buf (buffer-live-p buf)
+                  (get-text-property 0 'consult-ghostel--joined
+                                     (car candidates))))
+        (apply orig selected candidates highlighted ignored-faces)
+      (let* ((matches (apply #'consult--point-placement highlighted 0
+                             ignored-faces))
+             (dest (consult-ghostel--wrap-corrected-dest pos (car matches))))
+        (when (and (markerp pos) (not (eq buf (current-buffer))))
+          (setq dest (move-marker (make-marker) dest buf)))
+        (cons dest (cdr matches))))))
+
+(advice-add 'consult--line-point-placement :around
+            #'consult-ghostel--line-point-placement)
+
+(provide 'consult-ghostel)
+;;; consult-ghostel.el ends here

--- a/extensions/consult-ghostel/consult-ghostel.el
+++ b/extensions/consult-ghostel/consult-ghostel.el
@@ -19,6 +19,7 @@
 ;;
 ;;   `consult-ghostel'          all ghostel buffers
 ;;   `consult-ghostel-project'  ghostel buffers in this project
+;;   `consult-ghostel-history'  pick from the shell's command history
 ;;
 ;; Candidates are ordered for switching (recently-used first, current
 ;; buffer last) and annotated with the terminal title, and submitting a
@@ -30,10 +31,14 @@
 ;; When marginalia is installed, the title is prepended to marginalia's
 ;; buffer annotations instead, in every buffer prompt.
 ;;
+;; `consult-ghostel-history' picks from the shell's own command history
+;; (retrieved per shell via `ghostel-shell-history-commands') and types
+;; the selection into the terminal, completing or replacing the pending
+;; command line.
+;;
 ;; Loading also registers hidden sources in `consult-buffer' and
-;; `consult-project-buffer': ghostel buffers already appear in the
-;; default "Buffer" view, so they stay invisible there until the `g'
-;; narrow key summons them exclusively.  Opt out with:
+;; `consult-project-buffer' that enable the `g' narrow key: it
+;; restricts the view to ghostel buffers only.  Opt out with:
 ;;
 ;;   (setq consult-buffer-sources
 ;;         (delq 'consult-ghostel-source-hidden consult-buffer-sources))
@@ -48,8 +53,11 @@
 ;;   (use-package consult-ghostel
 ;;     :after (ghostel consult)
 ;;     :demand t
-;;     :bind (:map ghostel-semi-char-mode-map
-;;            ("C-c M" . consult-ghostel-project)))
+;;     :bind (("C-x m" . consult-ghostel)
+;;            :map project-prefix-map
+;;            ("m" . consult-ghostel-project)
+;;            :map ghostel-semi-char-mode-map
+;;            ("C-c h" . consult-ghostel-history)))
 
 ;;; Code:
 
@@ -58,14 +66,13 @@
 (require 'ghostel)
 (require 'marginalia nil 'noerror)
 
-(defvar consult-ghostel-history nil
-  "Minibuffer history for the `consult-ghostel' commands.")
+(defvar consult-ghostel--buffer-history nil
+  "Minibuffer history for the buffer-picking `consult-ghostel' commands.")
 
 (defun consult-ghostel--pairs (buffers)
   "Return `consult' (name . buffer) pairs for BUFFERS, switch-ordered.
-Runs BUFFERS through `consult--buffer-query', so consult's visibility
-order (recently-used first, current buffer last),
-`consult-buffer-list-function', and `consult-buffer-filter' all apply."
+Runs BUFFERS through `consult--buffer-query', so its visibility sort,
+`consult-buffer-list-function', and `consult-buffer-filter' apply."
   (consult--buffer-query :sort 'visibility
                          :predicate (lambda (buf) (memq buf buffers))
                          :as #'consult--buffer-pair))
@@ -98,7 +105,7 @@ order (recently-used first, current buffer last),
                   ;; the new terminal is exactly the buffer `ghostel-project'
                   ;; finds and reuses; NAME only names the buffer.
                   (let ((default-directory (consult--project-root t)))
-                    (if (member name '(nil ""))
+                    (if (equal name "")
                         (ghostel-project t)
                       (let* ((context `((kind . term)
                                         (project-root
@@ -184,7 +191,7 @@ first source's `:new' handler."
     (consult--multi sources
                     :require-match (confirm-nonexistent-file-or-buffer)
                     :prompt prompt
-                    :history 'consult-ghostel-history
+                    :history 'consult-ghostel--buffer-history
                     :sort nil)))
 
 ;;;###autoload
@@ -206,10 +213,9 @@ that numbered terminal)."
 (defun consult-ghostel-project (&optional arg)
   "Switch to a ghostel buffer in the current project, previewing candidates.
 Submitting a name that matches no buffer creates a new ghostel terminal
-rooted at the project; the \"New\" candidate creates one with the
-default name.  With prefix ARG, behave like `ghostel-project' called
-with ARG.  Project membership is determined by
-`ghostel-project-buffer-scope'."
+rooted at the project; the \"New\" candidate creates one with the default name.
+With prefix ARG, behave like `ghostel-project' called with ARG.
+Project membership is determined by `ghostel-project-buffer-scope'."
   (interactive "P")
   (if arg
       (ghostel-project arg)
@@ -222,9 +228,116 @@ with ARG.  Project membership is determined by
      '(consult-ghostel-project-source consult-ghostel-project-source-new)
      "Project ghostel buffer: ")))
 
+;;; Shell command history
+
+;; Defined in ghostel-line-mode.el
+(defvar ghostel--line-input-start)
+(defvar ghostel--line-input-end)
+
+(defvar consult-ghostel--shell-history nil
+  "Minibuffer history for `consult-ghostel-history'.")
+
+(defun consult-ghostel--input-start (cursor)
+  "Return where the pending input on CURSOR's logical line begins, or nil.
+The prompt sits on the logical line's first row, bounding input that
+soft-wraps onto continuation rows; when that row shows no prompt,
+falls back to `ghostel-input-start-point'."
+  (save-excursion
+    (goto-char cursor)
+    (forward-line 0)
+    (let ((cursor-row (point))
+          (bol (ghostel--soft-wrap-line-beginning
+                cursor ghostel--soft-wrap-row-limit)))
+      (if (= bol cursor-row)
+          (ghostel-input-start-point)
+        (goto-char bol)
+        (let* ((eol (line-end-position))
+               (pos eol))
+          ;; Input begins after the rightmost `ghostel-prompt' char
+          ;; (as in `ghostel-input-start-point').
+          (while (and (> pos bol)
+                      (not (get-text-property (1- pos) 'ghostel-prompt)))
+            (setq pos (1- pos)))
+          (cond ((> pos bol) pos)
+                ((ghostel--regex-prompt-end eol))
+                ((ghostel-input-start-point))))))))
+
+(defun consult-ghostel--input-region ()
+  "Return (BEG . END) of the pending command-line input, or nil.
+In line mode this is the editable input region; otherwise the text
+between the prompt and the terminal cursor."
+  (if (eq ghostel--input-mode 'line)
+      (let ((beg (and (markerp ghostel--line-input-start)
+                      (marker-position ghostel--line-input-start)))
+            (end (and (markerp ghostel--line-input-end)
+                      (marker-position ghostel--line-input-end))))
+        (and beg end (<= beg end) (cons beg end)))
+    (let* ((end ghostel--cursor-char-pos)
+           (beg (and end (consult-ghostel--input-start end))))
+      (and beg (<= beg end) (cons beg end)))))
+
+;;;###autoload
+(defun consult-ghostel-history ()
+  "Pick a shell history entry and type it into the terminal.
+The typed input before the cursor pre-fills the minibuffer.
+The entry is pasted, not submitted, so it stays editable: a pending
+line that prefixes the entry is completed in place, any other is
+aborted with Ctrl-C first.
+Refuses while a command is running (needs shell integration's OSC 133 marks).
+History comes from `ghostel-shell-history-commands'."
+  (interactive)
+  (when ghostel--command-running
+    (user-error "The shell is busy running a command"))
+  (let* ((history (consult--remove-dups (ghostel-shell-history)))
+         (region (consult-ghostel--input-region))
+         ;; The wrap newlines in a soft-wrapped pending line are buffer
+         ;; artifacts, not typed characters; keep them out of `:initial'.
+         (input (and region
+                     (if (eq ghostel--input-mode 'line)
+                         (buffer-substring-no-properties
+                          (car region) (cdr region))
+                       (car (ghostel--wrap-joined-region
+                             (car region) (cdr region)
+                             ghostel--soft-wrap-row-limit)))))
+         (entry (consult--read history
+                               :prompt "Shell history: "
+                               :initial input
+                               :history 'consult-ghostel--shell-history
+                               :require-match t
+                               :sort nil))
+         ;; Terminal output arriving during selection moves the input
+         ;; region, so re-read it rather than trusting the snapshot.
+         (region (consult-ghostel--input-region)))
+    (if (and (eq ghostel--input-mode 'line) region)
+        (progn
+          (delete-region (car region) (cdr region))
+          (goto-char (car region))
+          (insert entry))
+      (when (memq ghostel--input-mode '(copy emacs))
+        (ghostel-readonly-exit))
+      ;; A pending line that prefixes the entry (cursor at its end,
+      ;; nothing beyond it) is completed by pasting just the rest.
+      ;; Any other line is aborted with Ctrl-C first because erasing in place
+      ;; is not portable: readline's vi command mode binds neither bracketed
+      ;; paste nor backspace-as-erase, and executes raw bytes as vi commands.
+      ;; The paste keeps an embedded newline from acting as Enter.
+      (let ((typed (and region
+                        (string-blank-p
+                         (buffer-substring-no-properties
+                          (cdr region)
+                          (ghostel--soft-wrap-line-end
+                           (cdr region) ghostel--soft-wrap-row-limit)))
+                        (car (ghostel--wrap-joined-region
+                              (car region) (cdr region)
+                              ghostel--soft-wrap-row-limit)))))
+        (if (and typed (string-prefix-p typed entry))
+            (unless (equal entry typed)
+              (ghostel-paste-string (substring entry (length typed))))
+          (ghostel-send-key "c" "ctrl")
+          (ghostel-paste-string entry))))))
+
 ;;; Marginalia integration
 
-;; Keep the byte-compile clean when marginalia is not installed.
 (declare-function marginalia-annotate-buffer "marginalia" (cand))
 (defvar marginalia-annotators)
 
@@ -282,7 +395,7 @@ buffers, call ORIG with TOP and CURR-LINE unchanged."
                                    0))))
                  (str (car (ghostel--wrap-joined-region
                             beg end ghostel--soft-wrap-row-limit))))
-            (unless (string-match-p "\\`[ \t]*\\'" str)
+            (unless (string-blank-p str)
               ;; The property gates the point-placement advice: only
               ;; candidates built here are wrap-joined.
               (push (propertize
@@ -311,10 +424,9 @@ buffers, call ORIG with TOP and CURR-LINE unchanged."
 
 (defun consult-ghostel--wrap-corrected-dest (pos offset)
   "Return the buffer position for OFFSET into POS's wrap-joined line.
-The candidate string has the wrap newlines spliced out while the
-buffer still contains them; core's chunk map translates between the
-two.  An offset at a row boundary lands past the wrap newline, on
-the match itself."
+The candidate string has the wrap newlines spliced out while the buffer
+still contains them; core's chunk map translates between the two.
+An offset at a row boundary lands past the wrap newline, on the match itself."
   (with-current-buffer (if (markerp pos) (marker-buffer pos) (current-buffer))
     (let* ((end (ghostel--soft-wrap-line-end
                  pos ghostel--soft-wrap-row-limit))

--- a/extensions/consult-ghostel/consult-ghostel.el
+++ b/extensions/consult-ghostel/consult-ghostel.el
@@ -40,7 +40,8 @@
 ;;
 ;; Loading this package also makes `consult-line' match across soft
 ;; line wraps in ghostel buffers: rows joined by wrap newlines become
-;; one candidate.
+;; one candidate.  It also adds a "Ghostel" group to `consult-bookmark',
+;; so the `g' narrow key restricts the candidates to ghostel bookmarks.
 ;;
 ;; Enable by adding to your init:
 ;;
@@ -242,6 +243,12 @@ with ARG.  Project membership is determined by
   (dolist (category '(buffer project-buffer))
     (cl-pushnew #'consult-ghostel-marginalia-annotate
                 (alist-get category marginalia-annotators))))
+
+;;; consult-bookmark narrowing
+
+(unless (cl-member 'ghostel-bookmark-handler consult-bookmark-narrow
+                   :test #'memq)
+  (push '(?g "Ghostel" ghostel-bookmark-handler) consult-bookmark-narrow))
 
 ;;; consult-line over logical lines
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -5536,7 +5536,6 @@ the buffer name for a new instance-1 buffer.  ARG follows
 `ghostel''s prefix conventions: a number selects that instance, any
 other non-nil value creates the next free instance.  Returns the
 buffer."
-  (ghostel--load-module t)
   (let* ((fresh (and arg (not (numberp arg))))
          (instance (cond ((numberp arg) arg)
                          (fresh (ghostel--next-instance context))
@@ -5546,21 +5545,15 @@ buffer."
          (display-action (append display-buffer--same-window-action
                                  '((category . comint))))
          (existing (and (not fresh)
-                        (ghostel--find-buffer-by-identity identity)))
-         (buffer (or existing (ghostel--create buf-name display-action))))
+                        (ghostel--find-buffer-by-identity identity))))
     (if existing
         (progn
           (unless (buffer-local-value 'ghostel--term existing)
             (user-error "Ghostel buffer %s has no terminal"
                         (buffer-name existing)))
-          (pop-to-buffer existing display-action))
-      (with-current-buffer buffer
-        (setq ghostel--managed-buffer-name (buffer-name)
-              ghostel--initial-name (buffer-name)
-              ghostel-identity identity)
-        (ghostel--start-process)
-        (ghostel--apply-initial-input-mode)))
-    buffer))
+          (pop-to-buffer existing display-action)
+          existing)
+      (ghostel-create buf-name display-action identity))))
 
 ;;;###autoload
 (defun ghostel (&optional arg)
@@ -5617,6 +5610,43 @@ Signals `user-error' if BUFFER already has a live ghostel process."
       (let ((remote-p (file-remote-p default-directory)))
         (ghostel--spawn-pty program args nil remote-p)))))
 
+(defun ghostel-create (&optional name display identity)
+  "Create and return a new ghostel terminal running `ghostel-shell'.
+
+NAME is the buffer name (default `ghostel-buffer-name'), uniquified
+when already taken.  DISPLAY, when non-nil, is a `display-buffer'
+ACTION used to show the buffer.  The terminal starts in
+`default-directory'.
+
+Always creates a fresh terminal; reuse is the caller's job.
+IDENTITY, when non-nil, is stored verbatim as the buffer's `ghostel-identity';
+it defaults to the plain-terminal slot identity for NAME with the next free
+instance - the same slot `ghostel' would allocate.
+To run a specific program instead of a shell, see `ghostel-exec'."
+  (ghostel--load-module t)
+  ;; An empty name (a create-on-miss minibuffer submission) would make
+  ;; `generate-new-buffer' signal; treat it as nil.
+  (let* ((name (if (and name (not (string= name ""))) name
+                 ghostel-buffer-name))
+         (buf-name name))
+    (unless identity
+      (let* ((context `((kind . term) (name . ,name)))
+             (instance (ghostel--next-instance context)))
+        (setq identity `(,@context (instance . ,instance)))
+        ;; Keep `ghostel--start's NAME<N> = instance N convention, so the
+        ;; name suffix and the slot number cannot drift apart after a
+        ;; kill-then-create.
+        (when (> instance 1)
+          (setq buf-name (format "%s<%d>" name instance)))))
+    (let ((buffer (ghostel--create buf-name display)))
+      (with-current-buffer buffer
+        (setq ghostel--managed-buffer-name (buffer-name)
+              ghostel--initial-name (buffer-name)
+              ghostel-identity identity)
+        (ghostel--start-process)
+        (ghostel--apply-initial-input-mode))
+      buffer)))
+
 (defun ghostel--project-buffer-name (root)
   "Return the project-prefixed ghostel buffer name for project ROOT.
 For remote ROOTs the TRAMP prefix is folded into the name so a local
@@ -5663,7 +5693,7 @@ Returns the buffer."
                                             '((category . comint))))
       (ghostel (and bufs t)))))
 
-(defun ghostel--all-buffers ()
+(defun ghostel-buffer-list ()
   "Return all live `ghostel-mode' buffers, sorted alphabetically by name.
 Sorted (not `buffer-list' order) so cycle commands advance through
 the same sequence regardless of recent buffer-switch history."
@@ -5672,10 +5702,10 @@ the same sequence regardless of recent buffer-switch history."
          (buffer-list))
         (lambda (a b) (string< (buffer-name a) (buffer-name b)))))
 
-(defun ghostel--project-buffers ()
+(defun ghostel-project-buffer-list ()
   "Return ghostel buffers belonging to the current project, sorted by name.
-Scoping is controlled by `ghostel-project-buffer-scope'.  Signals
-`user-error' if there is no current project.
+Scoping is controlled by `ghostel-project-buffer-scope'.
+Prompts to choose a project when there is none.
 
 Buffers whose `default-directory' is remote are skipped in the
 `default-directory' scope branch — querying `project-current'
@@ -5684,7 +5714,7 @@ synchronously on every cycle."
   (let* ((proj (project-current t))
          (root (project-root proj))
          (scope ghostel-project-buffer-scope)
-         (all (ghostel--all-buffers))
+         (all (ghostel-buffer-list))
          (by-dir
           (and (memq scope '(default-directory both))
                (cl-remove-if-not
@@ -5734,7 +5764,7 @@ the first or last entry depending on DIRECTION."
 (defun ghostel-next ()
   "Switch to the next ghostel buffer (sorted by name, wraps around)."
   (interactive)
-  (ghostel--cycle (ghostel--all-buffers) +1
+  (ghostel--cycle (ghostel-buffer-list) +1
                   "No ghostel buffers"
                   "Only one ghostel buffer"))
 
@@ -5742,7 +5772,7 @@ the first or last entry depending on DIRECTION."
 (defun ghostel-previous ()
   "Switch to the previous ghostel buffer (sorted by name, wraps around)."
   (interactive)
-  (ghostel--cycle (ghostel--all-buffers) -1
+  (ghostel--cycle (ghostel-buffer-list) -1
                   "No ghostel buffers"
                   "Only one ghostel buffer"))
 
@@ -5751,7 +5781,7 @@ the first or last entry depending on DIRECTION."
   "Switch to the next ghostel buffer in the current project (wraps around).
 Project membership is determined by `ghostel-project-buffer-scope'."
   (interactive)
-  (ghostel--cycle (ghostel--project-buffers) +1
+  (ghostel--cycle (ghostel-project-buffer-list) +1
                   "No ghostel buffers in this project"
                   "Only one ghostel buffer in this project"))
 
@@ -5760,7 +5790,7 @@ Project membership is determined by `ghostel-project-buffer-scope'."
   "Switch to the previous ghostel buffer in the current project (wraps around).
 Project membership is determined by `ghostel-project-buffer-scope'."
   (interactive)
-  (ghostel--cycle (ghostel--project-buffers) -1
+  (ghostel--cycle (ghostel-project-buffer-list) -1
                   "No ghostel buffers in this project"
                   "Only one ghostel buffer in this project"))
 
@@ -5800,7 +5830,7 @@ signals `user-error' if BUFS is empty."
 (defun ghostel-list-buffers ()
   "Pick a ghostel buffer to switch to via `read-buffer'."
   (interactive)
-  (pop-to-buffer (ghostel--read-buffer "Ghostel buffer: " (ghostel--all-buffers))
+  (pop-to-buffer (ghostel--read-buffer "Ghostel buffer: " (ghostel-buffer-list))
                  (append display-buffer--same-window-action
                          '((category . comint)))))
 
@@ -5810,7 +5840,7 @@ signals `user-error' if BUFS is empty."
 Project membership is determined by `ghostel-project-buffer-scope'."
   (interactive)
   (pop-to-buffer (ghostel--read-buffer "Project ghostel buffer: "
-                                       (ghostel--project-buffers))
+                                       (ghostel-project-buffer-list))
                  (append display-buffer--same-window-action
                          '((category . comint)))))
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -642,6 +642,30 @@ load shell integration scripts without requiring changes to the user's
 shell configuration files.  Supports bash, zsh, fish, and nushell."
   :type 'boolean)
 
+(defcustom ghostel-shell-history-commands
+  '((bash . "bash -ic 'history -r; fc -lnr 1'")
+    (zsh  . "zsh -ic 'fc -R; fc -lnr 1'")
+    (fish . "fish -c 'history -z'")
+    (nu   . "nu -c 'history | get command | reverse | to text'"))
+  "Command printing a shell's history, keyed by shell type.
+Keys are shell type symbols (`bash', `zsh', `fish', `nu').  A string
+value is run with \"/bin/sh -c\" through `process-file', so a remote
+buffer queries the remote host; it must print one history entry per
+line, newest first.  Output containing a NUL byte is split on NUL
+instead, letting multi-line entries survive (e.g. fish's `history -z').
+Entries are trimmed of surrounding whitespace.
+
+A function value is called with no arguments in the terminal's buffer
+and must return the list of entries itself, newest first.  History
+managers replace the shell's entry, e.g.:
+
+  (setf (alist-get \\='zsh ghostel-shell-history-commands)
+        \"atuin history list --cmd-only --print0 --reverse false\")
+
+Used by `ghostel-shell-history'."
+  :type '(alist :key-type symbol
+                :value-type (choice string function)))
+
 (defcustom ghostel-macos-login-shell (eq system-type 'darwin)
   "Wrap shell invocations on macOS so the shell starts as a login shell.
 
@@ -1061,6 +1085,10 @@ process that stands in for the native child when Ghostel owns the PTY.")
   "Operating-system process id for the terminal child process.
 For remote Emacs-owned processes this is whatever `process-id' returns;
 local code should not assume it is signalable unless the process is local.")
+
+(defvar-local ghostel--shell-program nil
+  "Shell program resolved at spawn time by `ghostel--start-process'.
+Nil for buffers running an arbitrary command (`ghostel-exec').")
 
 (defvar-local ghostel--event-buf nil
   "Partial native event data not yet readable as a complete Lisp form.")
@@ -4592,6 +4620,7 @@ run the shell on the remote host."
          (spawn-args (cdr spawn-spec))
          (proc (ghostel--spawn-pty spawn-program spawn-args
                                    extra-env remote-p)))
+    (setq ghostel--shell-program shell)
     (when remote-integration
       (let ((files (plist-get remote-integration :temp-files))
             (dirs (plist-get remote-integration :temp-dirs)))
@@ -5804,6 +5833,48 @@ The annotation is the terminal title, capped at
                      (truncate-string-to-width
                       title ghostel-annotation-title-width nil nil t)
                    title))))
+
+(defun ghostel--shell-history-run (command)
+  "Run shell COMMAND via `process-file' and return its parsed entries.
+Splits the output on NUL when present, else on newline; trims each
+entry and drops blanks.  Signals `user-error' on a non-zero exit,
+including the command's first stderr line."
+  (let ((stderr-file (make-temp-file "ghostel-history")))
+    (unwind-protect
+        (with-temp-buffer
+          (let ((status (process-file "/bin/sh" nil (list t stderr-file) nil
+                                      "-c" command)))
+            (unless (eql status 0)
+              (user-error "Shell history command failed (%s): %s" status
+                          (with-temp-buffer
+                            (insert-file-contents stderr-file)
+                            (buffer-substring (point-min)
+                                              (line-end-position)))))
+            (let ((output (buffer-string)))
+              (split-string output
+                            (if (string-search "\0" output) "\0" "\n")
+                            t "[ \t\r\n]+"))))
+      (delete-file stderr-file))))
+
+(defun ghostel-shell-history ()
+  "Return the current buffer's shell history, newest first.
+Runs the shell's entry from `ghostel-shell-history-commands' (which
+see for the output contract).  Signals `user-error' when the buffer's
+shell is unrecognized, no command is configured for it, the command
+fails, or the history is empty."
+  (ghostel--ensure-ghostel-buffer)
+  (let ((shell-type (and ghostel--shell-program
+                         (ghostel--detect-shell ghostel--shell-program))))
+    (unless shell-type
+      (user-error "Buffer has no recognized shell"))
+    (let ((command (alist-get shell-type ghostel-shell-history-commands)))
+      (unless command
+        (user-error
+         "No entry for `%s' in `ghostel-shell-history-commands'" shell-type))
+      (or (if (functionp command)
+              (funcall command)
+            (ghostel--shell-history-run command))
+          (user-error "History is empty")))))
 
 (defun ghostel--read-buffer (prompt bufs)
   "Prompt with PROMPT for one of BUFS via `read-buffer'.

--- a/test/consult-ghostel-test.el
+++ b/test/consult-ghostel-test.el
@@ -83,6 +83,11 @@ the other."
     (should (memq #'consult-ghostel-marginalia-annotate
                   (alist-get category marginalia-annotators)))))
 
+(ert-deftest consult-ghostel-test-bookmark-narrow-registered ()
+  "Loading adds a Ghostel group for ghostel's bookmark handler."
+  (should (member '(?g "Ghostel" ghostel-bookmark-handler)
+                  consult-bookmark-narrow)))
+
 (ert-deftest consult-ghostel-test-hidden-sources-registered ()
   "Loading registers the hidden sources in the global consult lists."
   (should (memq 'consult-ghostel-source-hidden consult-buffer-sources))

--- a/test/consult-ghostel-test.el
+++ b/test/consult-ghostel-test.el
@@ -1,0 +1,362 @@
+;;; consult-ghostel-test.el --- Tests for consult-ghostel -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Run with:
+;;   emacs --batch -Q -L <consult> -L lisp -L extensions/consult-ghostel \
+;;     -l ert -l test/consult-ghostel-test.el -f consult-ghostel-test-run
+;;
+;; `consult-ghostel' source plists and their item/enabled/arrange logic,
+;; against the real consult.  The interactive commands run
+;; `consult--multi' in the minibuffer and are covered by live testing,
+;; not here.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'ert)
+(require 'consult)
+(require 'ghostel)
+(require 'consult-ghostel)
+
+(defun consult-ghostel-test--fake-buffer (name)
+  "Return a buffer NAME claiming `ghostel-mode' without the native module."
+  (let ((buf (generate-new-buffer name)))
+    (with-current-buffer buf
+      (setq major-mode 'ghostel-mode))
+    buf))
+
+(ert-deftest consult-ghostel-test-source-properties ()
+  "Sources carry the consult properties that drive preview and create-on-miss."
+  (dolist (src (list consult-ghostel-source consult-ghostel-project-source))
+    (should (eq (plist-get src :category) 'buffer))
+    (should (eq (plist-get src :state) 'consult--buffer-state))
+    (should (eq (plist-get src :annotate) 'ghostel-annotate-buffer))
+    (should (functionp (plist-get src :new))))
+  ;; Hidden variants inherit those and add `:hidden'.
+  (dolist (src (list consult-ghostel-source-hidden
+                     consult-ghostel-project-source-hidden))
+    (should (plist-get src :hidden))
+    (should (eq (plist-get src :category) 'buffer))
+    (should (eq (plist-get src :state) 'consult--buffer-state))
+    (should (eq (plist-get src :annotate) 'ghostel-annotate-buffer))
+    (should (functionp (plist-get src :new)))))
+
+(ert-deftest consult-ghostel-test-hidden-sources-independent ()
+  "Hidden variants share no structure with the base sources.
+A shared tail would make `consult-customize' on one variable mutate
+the other."
+  (should-not (eq (last consult-ghostel-source-hidden)
+                  (last consult-ghostel-source)))
+  (should-not (eq (last consult-ghostel-project-source-hidden)
+                  (last consult-ghostel-project-source))))
+
+(ert-deftest consult-ghostel-test-annotate-title ()
+  "Source `:annotate' returns the terminal title for a buffer object.
+`consult--multi' passes the pair's buffer object, not the candidate name."
+  (let ((buf (consult-ghostel-test--fake-buffer " *consult-ghostel-ann*")))
+    (unwind-protect
+        (let ((fun (plist-get consult-ghostel-source :annotate)))
+          (should-not (funcall fun buf))
+          (with-current-buffer buf
+            (setq ghostel--title "make -j8"))
+          (should (equal (funcall fun buf) "  make -j8")))
+      (kill-buffer buf))))
+
+(ert-deftest consult-ghostel-test-marginalia-annotate ()
+  "The marginalia wrapper prepends the title to marginalia's annotation."
+  (let ((buf (consult-ghostel-test--fake-buffer " *consult-ghostel-marg*")))
+    (unwind-protect
+        (cl-letf (((symbol-function 'marginalia-annotate-buffer)
+                   (lambda (_) " orig")))
+          (should (equal (consult-ghostel-marginalia-annotate buf) " orig"))
+          (with-current-buffer buf
+            (setq ghostel--title "make -j8"))
+          (should (equal (consult-ghostel-marginalia-annotate buf)
+                         "  make -j8 orig")))
+      (kill-buffer buf))))
+
+(ert-deftest consult-ghostel-test-marginalia-registered ()
+  "Loading with marginalia present registers the wrapper for both categories."
+  (skip-unless (featurep 'marginalia))
+  (dolist (category '(buffer project-buffer))
+    (should (memq #'consult-ghostel-marginalia-annotate
+                  (alist-get category marginalia-annotators)))))
+
+(ert-deftest consult-ghostel-test-hidden-sources-registered ()
+  "Loading registers the hidden sources in the global consult lists."
+  (should (memq 'consult-ghostel-source-hidden consult-buffer-sources))
+  (should (memq 'consult-ghostel-project-source-hidden
+                consult-project-buffer-sources)))
+
+(ert-deftest consult-ghostel-test-source-items ()
+  "`consult-ghostel-source' :items returns (name . buffer) pairs."
+  (let ((a (consult-ghostel-test--fake-buffer "*consult-ghostel-a*"))
+        (b (consult-ghostel-test--fake-buffer "*consult-ghostel-b*")))
+    (unwind-protect
+        (let* ((items (funcall (plist-get consult-ghostel-source :items)))
+               (bufs (mapcar #'cdr items)))
+          (should (memq a bufs))
+          (should (memq b bufs))
+          (should (equal (car (rassq a items)) (buffer-name a))))
+      (kill-buffer a)
+      (kill-buffer b))))
+
+(ert-deftest consult-ghostel-test-pairs-current-last ()
+  "`consult-ghostel--pairs' preserves the set and puts current buffer last."
+  (let ((a (generate-new-buffer "*consult-ghostel-arrange-a*"))
+        (b (generate-new-buffer "*consult-ghostel-arrange-b*")))
+    (unwind-protect
+        (with-current-buffer a
+          (let ((ordered (mapcar #'cdr (consult-ghostel--pairs (list a b)))))
+            ;; Same set, no dupes/drops.
+            (should (equal (sort (mapcar #'buffer-name ordered) #'string<)
+                           (sort (list (buffer-name a) (buffer-name b))
+                                 #'string<)))
+            ;; Current buffer is last (you rarely switch to where you are).
+            (should (eq (car (last ordered)) a))))
+      (kill-buffer a)
+      (kill-buffer b))))
+
+(ert-deftest consult-ghostel-test-new-empty-string ()
+  "`:new' forwards a blank (empty-submission) name to `ghostel-create' verbatim."
+  (let (created)
+    (cl-letf (((symbol-function 'ghostel-create)
+               (lambda (name &rest _) (setq created name) (current-buffer))))
+      (funcall (plist-get consult-ghostel-source :new) "")
+      (should (equal created "")))))
+
+(ert-deftest consult-ghostel-test-project-items-need-project-el ()
+  "The project source yields nothing when project.el finds no project.
+`ghostel-project-buffer-list' would otherwise prompt for one during
+candidate collection (e.g. under a projectile-only root)."
+  (cl-letf (((symbol-function 'consult--project-root)
+             (lambda (&optional _) "/consult-ghostel-nonexistent/"))
+            ((symbol-function 'project-current)
+             (lambda (&rest _) nil)))
+    (should-not
+     (funcall (plist-get consult-ghostel-project-source :items)))))
+
+(ert-deftest consult-ghostel-test-project-source-no-project ()
+  "Project source is disabled and yields no items (no error) outside a project."
+  (require 'project)
+  (let ((project-find-functions nil))
+    (should-not (funcall (plist-get consult-ghostel-project-source :enabled)))
+    (should-not (funcall (plist-get consult-ghostel-project-source :items)))))
+
+(ert-deftest consult-ghostel-test-project-command-no-project-errors ()
+  "`consult-ghostel-project' refuses cleanly outside a project.
+Without the guard, `consult--multi' with zero enabled sources opens an
+empty picker and crashes on submit."
+  (require 'project)
+  (let ((project-find-functions nil)
+        (default-directory temporary-file-directory))
+    (should-error (consult-ghostel-project) :type 'user-error)))
+
+(ert-deftest consult-ghostel-test-prefix-delegates-to-ghostel ()
+  "A prefix argument bypasses the picker and calls `ghostel' with it."
+  (let (called)
+    (cl-letf (((symbol-function 'ghostel)
+               (lambda (&optional arg) (setq called arg)))
+              ((symbol-function 'consult--multi)
+               (lambda (&rest _) (error "Picker entered"))))
+      (consult-ghostel '(4)))
+    (should (equal called '(4)))))
+
+(ert-deftest consult-ghostel-test-project-prefix-delegates ()
+  "A prefix argument calls `ghostel-project', skipping the project guard.
+`ghostel-project' prompts for a project itself when there is none."
+  (require 'project)
+  (let ((project-find-functions nil)
+        (default-directory temporary-file-directory)
+        called)
+    (cl-letf (((symbol-function 'ghostel-project)
+               (lambda (&optional arg) (setq called arg)))
+              ((symbol-function 'consult--multi)
+               (lambda (&rest _) (error "Picker entered"))))
+      (consult-ghostel-project 3))
+    (should (equal called 3))))
+
+(ert-deftest consult-ghostel-test-new-source-actions ()
+  "The \"New\" sources create like a prefixed `ghostel'/`ghostel-project'."
+  (let (calls)
+    (cl-letf (((symbol-function 'ghostel)
+               (lambda (&optional arg) (push (cons 'ghostel arg) calls)))
+              ((symbol-function 'ghostel-project)
+               (lambda (&optional arg) (push (cons 'ghostel-project arg) calls))))
+      (funcall (plist-get consult-ghostel-source-new :action) "x")
+      (funcall (plist-get consult-ghostel-project-source-new :action) "x"))
+    (should (equal calls '((ghostel-project . t) (ghostel . t))))))
+
+(ert-deftest consult-ghostel-test-pickers-include-new-source ()
+  "Both pickers pass their \"New\" source to `consult--multi'."
+  (let (got)
+    (cl-letf (((symbol-function 'consult--multi)
+               (lambda (sources &rest _) (setq got sources) nil)))
+      (consult-ghostel)
+      (should (memq 'consult-ghostel-source-new got))
+      (cl-letf (((symbol-function 'consult--project-root)
+                 (lambda (&optional _) "/tmp/")))
+        (consult-ghostel-project))
+      (should (memq 'consult-ghostel-project-source-new got)))))
+
+(ert-deftest consult-ghostel-test-project-new-identity ()
+  "Project create-on-miss allocates in `ghostel-project's slot family.
+The identity carries no `name' key, so `ghostel-project' finds and
+reuses the buffer; the submitted name only names the buffer."
+  (let (spawned)
+    (cl-letf (((symbol-function 'ghostel-create)
+               (lambda (name _display &optional identity)
+                 (setq spawned (cons name identity)) (current-buffer)))
+              ((symbol-function 'project-current)
+               (lambda (&rest _) '(transient . "/tmp/cg-proj/")))
+              ((symbol-function 'project-root)
+               (lambda (_) "/tmp/cg-proj/")))
+      (funcall (plist-get consult-ghostel-project-source :new) "*pbuild*")
+      (should (equal (car spawned) "*pbuild*"))
+      (should (equal (cdr spawned)
+                     `((kind . term)
+                       (project-root . ,(ghostel--normalize-root
+                                         "/tmp/cg-proj/"))
+                       (instance . 1)))))))
+
+(ert-deftest consult-ghostel-test-project-new-shares-slot-family ()
+  "Create-on-miss numbers instances in `ghostel-project's own sequence.
+An empty submission gets `ghostel-project's default buffer name with
+the instance suffix."
+  (let ((existing (generate-new-buffer " *cg-proj-existing*"))
+        spawned)
+    (unwind-protect
+        (cl-letf (((symbol-function 'ghostel-create)
+                   (lambda (name _display &optional identity)
+                     (setq spawned (cons name identity)) (current-buffer)))
+                  ((symbol-function 'ghostel--load-module) #'ignore)
+                  ((symbol-function 'project-current)
+                   (lambda (&rest _) '(transient . "/tmp/cg-proj/")))
+                  ((symbol-function 'project-root)
+                   (lambda (_) "/tmp/cg-proj/"))
+                  ((symbol-function 'ghostel--project-buffer-name)
+                   (lambda (_) "*P*")))
+          (with-current-buffer existing
+            (setq-local ghostel-identity
+                        `((kind . term)
+                          (project-root . ,(ghostel--normalize-root
+                                            "/tmp/cg-proj/"))
+                          (instance . 1))))
+          (funcall (plist-get consult-ghostel-project-source :new) "")
+          (should (equal (car spawned) "*P*<2>"))
+          (should (= (alist-get 'instance (cdr spawned)) 2)))
+      (kill-buffer existing))))
+
+;;; consult-line over logical lines
+
+(ert-deftest consult-ghostel-test-line-candidates-advice-installed ()
+  "The logical-line candidate builder advises `consult--line-candidates'."
+  (should (advice-member-p #'consult-ghostel--line-candidates
+                           'consult--line-candidates))
+  (should (advice-member-p #'consult-ghostel--line-point-placement
+                           'consult--line-point-placement)))
+
+(defun consult-ghostel-test--insert-rows (rows)
+  "Insert ROWS, a list of (STRING . WRAPPED-P) conses.
+A non-nil WRAPPED-P marks the row's newline as a soft wrap joining
+it to the next row."
+  (dolist (row rows)
+    (insert (car row))
+    (insert (if (cdr row) (propertize "\n" 'ghostel-wrap t) "\n"))))
+
+(defun consult-ghostel-test--strip-tofu (cand)
+  "Return CAND's text without properties and trailing tofu chars.
+`consult--location-candidate' appends an invisible disambiguation
+char to every candidate string."
+  (let ((s (substring-no-properties cand)))
+    (while (and (> (length s) 0)
+                (>= (aref s (1- (length s))) consult--tofu-char))
+      (setq s (substring s 0 -1)))
+    s))
+
+(defun consult-ghostel-test--candidates (rows curr-line)
+  "Return candidate strings for ROWS with point context CURR-LINE."
+  (with-temp-buffer
+    (setq major-mode 'ghostel-mode)
+    (consult-ghostel-test--insert-rows rows)
+    (mapcar #'consult-ghostel-test--strip-tofu
+            (consult-ghostel--line-candidates
+             (lambda (&rest _) (error "Fallback must not run")) nil
+             curr-line))))
+
+(ert-deftest consult-ghostel-test-line-candidates-join-wraps ()
+  "Rows joined by wrap newlines become one candidate, spliced."
+  (should (equal (consult-ghostel-test--candidates
+                  '(("alpha" . t) ("beta" . nil) ("gamma" . nil)) 1)
+                 '("alphabeta" "gamma"))))
+
+(ert-deftest consult-ghostel-test-line-candidates-default-on-continuation ()
+  "Point on a continuation row defaults to the containing logical line.
+The default candidate is returned first."
+  (should (equal (car (consult-ghostel-test--candidates
+                       '(("one" . nil) ("two" . t) ("2cont" . nil)
+                         ("three" . nil))
+                       3))                ; row 3 = continuation of "two2cont"
+                 "two2cont")))
+
+(ert-deftest consult-ghostel-test-line-candidates-row-cap ()
+  "Wrap joining is bounded like core's, by `ghostel--soft-wrap-row-limit'.
+The cap is the number of wrap newlines crossed, so a capped candidate
+holds limit + 1 rows - the same logical line the link scanner sees."
+  (let* ((rows (append (make-list 60 '("x" . t)) '(("end" . nil))))
+         (strs (consult-ghostel-test--candidates rows 1))
+         (cap (1+ ghostel--soft-wrap-row-limit)))
+    (should (equal (mapcar #'length strs)
+                   (list cap (+ (- 60 cap) 3))))))
+
+(ert-deftest consult-ghostel-test-line-counter-empty-continuation-row ()
+  "An empty continuation row still counts toward the line numbers.
+Otherwise the counter drifts and the default candidate lands one
+logical line too far."
+  (should (equal (car (consult-ghostel-test--candidates
+                       '(("aaaa" . t) ("" . nil) ("bbb" . nil)
+                         ("ccc" . nil))
+                       3))               ; row 3 = "bbb"
+                 "bbb")))
+
+(ert-deftest consult-ghostel-test-wrap-corrected-dest-clamped ()
+  "A position with no wrap chunks (buffer shrank under the candidate)
+falls back to the position itself instead of returning nil."
+  (with-temp-buffer
+    (insert "text")
+    (should (= (consult-ghostel--wrap-corrected-dest (point-max) 2)
+               (point-max)))))
+
+(ert-deftest consult-ghostel-test-point-placement-gates-on-joined ()
+  "Candidates without the wrap-joined property fall through to ORIG.
+`consult-line-multi' candidates are per-row even in ghostel buffers."
+  (with-temp-buffer
+    (insert "row\n")
+    (let ((cand (consult--location-candidate
+                 "row" (cons (current-buffer) 1) 1 1))
+          orig-args)
+      (consult-ghostel--line-point-placement
+       (lambda (&rest args) (setq orig-args args) nil)
+       cand (list cand) cand)
+      (should orig-args))))
+
+(ert-deftest consult-ghostel-test-wrap-corrected-dest ()
+  "Buffer destinations skip the wrap newlines spliced from candidates."
+  (with-temp-buffer
+    (setq major-mode 'ghostel-mode)
+    ;; Buffer: a(1) b(2) c(3) d(4) wrap-\n(5) e(6) f(7) g(8) h(9) \n(10)
+    ;; Candidate string: "abcdefgh".
+    (consult-ghostel-test--insert-rows '(("abcd" . t) ("efgh" . nil)))
+    ;; String offset 6 is ?g, buffer position 8.
+    (should (= (consult-ghostel--wrap-corrected-dest 1 6) 8))
+    ;; String offset 4 is ?e just past the wrap; the newline is skipped.
+    (should (= (consult-ghostel--wrap-corrected-dest 1 4) 6))
+    ;; Offset 0 stays put.
+    (should (= (consult-ghostel--wrap-corrected-dest 1 0) 1))))
+
+(defun consult-ghostel-test-run ()
+  "Run all consult-ghostel tests."
+  (ert-run-tests-batch-and-exit "^consult-ghostel-test-"))
+
+;;; consult-ghostel-test.el ends here

--- a/test/consult-ghostel-test.el
+++ b/test/consult-ghostel-test.el
@@ -253,6 +253,204 @@ the instance suffix."
           (should (= (alist-get 'instance (cdr spawned)) 2)))
       (kill-buffer existing))))
 
+;;; Shell command history
+
+(ert-deftest consult-ghostel-test-history-input-region ()
+  "The pending input spans prompt end to cursor on the cursor's row."
+  (with-temp-buffer
+    (setq major-mode 'ghostel-mode)
+    (setq-local ghostel--input-mode 'semi-char)
+    (insert (propertize "$ " 'ghostel-prompt t) "echo fo")
+    (setq-local ghostel--cursor-char-pos (point-max))
+    (should (equal (consult-ghostel--input-region)
+                   (cons 3 (point-max))))))
+
+(ert-deftest consult-ghostel-test-history-input-region-wrapped ()
+  "A cursor on a continuation row still finds the prompt rows above."
+  (with-temp-buffer
+    (setq major-mode 'ghostel-mode)
+    (setq-local ghostel--input-mode 'semi-char)
+    (insert (propertize "$ " 'ghostel-prompt t) "echo wraps")
+    (insert (propertize "\n" 'ghostel-wrap t) "over")
+    (setq-local ghostel--cursor-char-pos (point-max))
+    (should (equal (consult-ghostel--input-region)
+                   (cons 3 (point-max))))))
+
+(ert-deftest consult-ghostel-test-history-replaces-input ()
+  "Selecting aborts the pending line with Ctrl-C and pastes the entry.
+Wrap newlines inside the pending input are buffer artifacts and stay
+out of the `:initial' text."
+  (with-temp-buffer
+    (setq major-mode 'ghostel-mode)
+    (setq-local ghostel--input-mode 'semi-char)
+    (insert (propertize "$ " 'ghostel-prompt t) "echo wraps")
+    (insert (propertize "\n" 'ghostel-wrap t) "over")
+    (setq-local ghostel--cursor-char-pos (point-max))
+    (let (keys pasted read-args)
+      (cl-letf (((symbol-function 'ghostel-shell-history)
+                 (lambda () '("make -j8" "ls")))
+                ((symbol-function 'ghostel-send-key)
+                 (lambda (key &optional mods) (push (cons key mods) keys)))
+                ((symbol-function 'ghostel-paste-string)
+                 (lambda (s) (setq pasted s)))
+                ((symbol-function 'consult--read)
+                 (lambda (cands &rest opts)
+                   (setq read-args (cons cands opts))
+                   "make -j8")))
+        (consult-ghostel-history))
+      (should (equal (car read-args) '("make -j8" "ls")))
+      (should (equal (plist-get (cdr read-args) :initial) "echo wrapsover"))
+      (should (equal keys '(("c" . "ctrl"))))
+      (should (equal pasted "make -j8")))))
+
+(ert-deftest consult-ghostel-test-history-blank-line-skips-abort ()
+  "A blank pending line is pasted into directly, without the Ctrl-C."
+  (with-temp-buffer
+    (setq major-mode 'ghostel-mode)
+    (setq-local ghostel--input-mode 'semi-char)
+    (insert (propertize "$ " 'ghostel-prompt t))
+    (setq-local ghostel--cursor-char-pos (point-max))
+    (let (keys pasted)
+      (cl-letf (((symbol-function 'ghostel-shell-history)
+                 (lambda () '("ls")))
+                ((symbol-function 'ghostel-send-key)
+                 (lambda (key &optional mods) (push (cons key mods) keys)))
+                ((symbol-function 'ghostel-paste-string)
+                 (lambda (s) (setq pasted s)))
+                ((symbol-function 'consult--read)
+                 (lambda (&rest _) "ls")))
+        (consult-ghostel-history))
+      (should-not keys)
+      (should (equal pasted "ls")))))
+
+(ert-deftest consult-ghostel-test-history-prefix-completes-in-place ()
+  "A pending line that prefixes the entry gets only the rest pasted."
+  (with-temp-buffer
+    (setq major-mode 'ghostel-mode)
+    (setq-local ghostel--input-mode 'semi-char)
+    (insert (propertize "$ " 'ghostel-prompt t) "bre")
+    (setq-local ghostel--cursor-char-pos (point-max))
+    (let (keys pasted)
+      (cl-letf (((symbol-function 'ghostel-shell-history)
+                 (lambda () '("brew update")))
+                ((symbol-function 'ghostel-send-key)
+                 (lambda (key &optional mods) (push (cons key mods) keys)))
+                ((symbol-function 'ghostel-paste-string)
+                 (lambda (s) (setq pasted s)))
+                ((symbol-function 'consult--read)
+                 (lambda (&rest _) "brew update")))
+        (consult-ghostel-history))
+      (should-not keys)
+      (should (equal pasted "w update")))))
+
+(ert-deftest consult-ghostel-test-history-wrapped-prefix-completes ()
+  "Prefix comparison joins the pending line across soft wraps."
+  (with-temp-buffer
+    (setq major-mode 'ghostel-mode)
+    (setq-local ghostel--input-mode 'semi-char)
+    (insert (propertize "$ " 'ghostel-prompt t) "echo wraps")
+    (insert (propertize "\n" 'ghostel-wrap t) "over")
+    (setq-local ghostel--cursor-char-pos (point-max))
+    (let (keys pasted)
+      (cl-letf (((symbol-function 'ghostel-shell-history)
+                 (lambda () '("echo wrapsoverflow")))
+                ((symbol-function 'ghostel-send-key)
+                 (lambda (key &optional mods) (push (cons key mods) keys)))
+                ((symbol-function 'ghostel-paste-string)
+                 (lambda (s) (setq pasted s)))
+                ((symbol-function 'consult--read)
+                 (lambda (&rest _) "echo wrapsoverflow")))
+        (consult-ghostel-history))
+      (should-not keys)
+      (should (equal pasted "flow")))))
+
+(ert-deftest consult-ghostel-test-history-exact-entry-sends-nothing ()
+  "An entry equal to the pending line sends no bytes at all."
+  (with-temp-buffer
+    (setq major-mode 'ghostel-mode)
+    (setq-local ghostel--input-mode 'semi-char)
+    (insert (propertize "$ " 'ghostel-prompt t) "ls")
+    (setq-local ghostel--cursor-char-pos (point-max))
+    (let (keys pasted)
+      (cl-letf (((symbol-function 'ghostel-shell-history)
+                 (lambda () '("ls")))
+                ((symbol-function 'ghostel-send-key)
+                 (lambda (key &optional mods) (push (cons key mods) keys)))
+                ((symbol-function 'ghostel-paste-string)
+                 (lambda (s) (setq pasted s)))
+                ((symbol-function 'consult--read)
+                 (lambda (&rest _) "ls")))
+        (consult-ghostel-history))
+      (should-not keys)
+      (should-not pasted))))
+
+(ert-deftest consult-ghostel-test-history-input-after-cursor-aborts ()
+  "Input beyond the cursor still counts as a pending line to abort."
+  (with-temp-buffer
+    (setq major-mode 'ghostel-mode)
+    (setq-local ghostel--input-mode 'semi-char)
+    (insert (propertize "$ " 'ghostel-prompt t) "echo")
+    (setq-local ghostel--cursor-char-pos 3)
+    (let (keys)
+      (cl-letf (((symbol-function 'ghostel-shell-history)
+                 (lambda () '("ls")))
+                ((symbol-function 'ghostel-send-key)
+                 (lambda (key &optional mods) (push (cons key mods) keys)))
+                ((symbol-function 'ghostel-paste-string) #'ignore)
+                ((symbol-function 'consult--read)
+                 (lambda (&rest _) "ls")))
+        (consult-ghostel-history))
+      (should (equal keys '(("c" . "ctrl")))))))
+
+(ert-deftest consult-ghostel-test-history-refuses-while-running ()
+  "The command refuses to run while a shell command is running.
+Its Ctrl-C line abort would interrupt the command."
+  (with-temp-buffer
+    (setq major-mode 'ghostel-mode)
+    (setq-local ghostel--command-running t)
+    (should-error (consult-ghostel-history) :type 'user-error)))
+
+(ert-deftest consult-ghostel-test-history-line-mode-inserts ()
+  "In line mode the entry replaces the editable input region in-buffer."
+  (with-temp-buffer
+    (setq major-mode 'ghostel-mode)
+    (setq-local ghostel--input-mode 'line)
+    (insert "$ old")
+    (setq-local ghostel--line-input-start (copy-marker 3))
+    (setq-local ghostel--line-input-end (copy-marker (point-max) t))
+    (cl-letf (((symbol-function 'ghostel-shell-history)
+               (lambda () '("new one")))
+              ((symbol-function 'consult--read)
+               (lambda (&rest _) "new one")))
+      (consult-ghostel-history))
+    (should (equal (buffer-string) "$ new one"))
+    (should (= (marker-position ghostel--line-input-end) (point-max)))))
+
+(ert-deftest consult-ghostel-test-history-multiline-pastes ()
+  "A multi-line entry arrives intact through the paste.
+Sent raw, its embedded newlines would act as Enter."
+  (with-temp-buffer
+    (setq major-mode 'ghostel-mode)
+    (setq-local ghostel--input-mode 'semi-char)
+    (insert (propertize "$ " 'ghostel-prompt t))
+    (setq-local ghostel--cursor-char-pos (point-max))
+    (let ((entry "for f in *\necho $f\nend")
+          pasted)
+      (cl-letf (((symbol-function 'ghostel-shell-history)
+                 (lambda () (list entry)))
+                ((symbol-function 'ghostel-send-key) #'ignore)
+                ((symbol-function 'ghostel-paste-string)
+                 (lambda (s) (setq pasted s)))
+                ((symbol-function 'consult--read)
+                 (lambda (&rest _) entry)))
+        (consult-ghostel-history))
+      (should (equal pasted entry)))))
+
+(ert-deftest consult-ghostel-test-history-requires-ghostel-buffer ()
+  "Outside a ghostel buffer the command refuses to run."
+  (with-temp-buffer
+    (should-error (consult-ghostel-history) :type 'user-error)))
+
 ;;; consult-line over logical lines
 
 (ert-deftest consult-ghostel-test-line-candidates-advice-installed ()

--- a/test/ghostel-buffers-test.el
+++ b/test/ghostel-buffers-test.el
@@ -2,7 +2,8 @@
 
 ;;; Commentary:
 
-;; Cycle commands, list pickers, and project-scoped variants.
+;; Cycle commands, list pickers, project-scoped variants, and the
+;; public `ghostel-create' API.
 ;; All tests are pure elisp — no native module required.
 
 ;;; Code:
@@ -35,20 +36,20 @@ Each BINDING is (VAR NAME [DIR [IDENTITY]])."
                  bindings))))
 
 (ert-deftest ghostel-test-all-buffers-sorted ()
-  "`ghostel--all-buffers' returns ghostel buffers sorted by name."
+  "`ghostel-buffer-list' returns ghostel buffers sorted by name."
   (ghostel-buffers-test--with-bufs ((c "*ghostel-c*")
                                     (a "*ghostel-a*")
                                     (b "*ghostel-b*"))
-    (let ((bufs (ghostel--all-buffers)))
+    (let ((bufs (ghostel-buffer-list)))
       (should (equal (mapcar #'buffer-name bufs)
                      '("*ghostel-a*" "*ghostel-b*" "*ghostel-c*"))))))
 
 (ert-deftest ghostel-test-all-buffers-excludes-non-ghostel ()
-  "`ghostel--all-buffers' skips buffers without `ghostel-mode'."
+  "`ghostel-buffer-list' skips buffers without `ghostel-mode'."
   (ghostel-buffers-test--with-bufs ((g "*ghostel-x*"))
     (let ((other (generate-new-buffer "*not-ghostel*")))
       (unwind-protect
-          (let ((bufs (ghostel--all-buffers)))
+          (let ((bufs (ghostel-buffer-list)))
             (should (memq g bufs))
             (should-not (memq other bufs)))
         (kill-buffer other)))))
@@ -258,7 +259,7 @@ Each BINDING is (VAR NAME [DIR [IDENTITY]])."
                  (lambda (name) (format "*myproj-%s*" name))))
         (let ((default-directory root)
               (ghostel-project-buffer-scope 'default-directory))
-          (let ((bufs (ghostel--project-buffers)))
+          (let ((bufs (ghostel-project-buffer-list)))
             (should (memq inside bufs))
             (should (memq also-in bufs))
             (should-not (memq outside bufs))))))))
@@ -281,7 +282,7 @@ Each BINDING is (VAR NAME [DIR [IDENTITY]])."
                 ((symbol-function 'project-root) (lambda (p) (cdr p))))
         (let ((default-directory root)
               (ghostel-project-buffer-scope 'identity))
-          (let ((bufs (ghostel--project-buffers)))
+          (let ((bufs (ghostel-project-buffer-list)))
             (should (memq tagged bufs))
             (should-not (memq untagged bufs))))))))
 
@@ -308,7 +309,7 @@ Each BINDING is (VAR NAME [DIR [IDENTITY]])."
                 ((symbol-function 'project-root) (lambda (p) (cdr p))))
         (let ((default-directory root)
               (ghostel-project-buffer-scope 'both))
-          (let ((bufs (ghostel--project-buffers)))
+          (let ((bufs (ghostel-project-buffer-list)))
             (should (memq by-dir bufs))
             (should (memq by-id bufs))
             (should (memq both bufs))
@@ -373,7 +374,7 @@ project's terminal because both rendered the same buffer name."
                 ((symbol-function 'project-root) (lambda (p) (cdr p))))
         (let ((default-directory root-a)
               (ghostel-project-buffer-scope 'identity))
-          (let ((bufs (ghostel--project-buffers)))
+          (let ((bufs (ghostel-project-buffer-list)))
             (should (memq in-a bufs))
             (should-not (memq in-b bufs))))))))
 
@@ -394,7 +395,7 @@ project's terminal because both rendered the same buffer name."
                 ((symbol-function 'project-root) (lambda (p) (cdr p))))
         (let ((default-directory root)
               (ghostel-project-buffer-scope 'identity))
-          (let ((bufs (ghostel--project-buffers)))
+          (let ((bufs (ghostel-project-buffer-list)))
             (should (memq first bufs))
             (should (memq second bufs))))))))
 
@@ -414,7 +415,7 @@ project's terminal because both rendered the same buffer name."
                 ((symbol-function 'project-root) (lambda (p) (cdr p))))
         (let ((default-directory root)
               (ghostel-project-buffer-scope 'identity))
-          (let ((bufs (ghostel--project-buffers)))
+          (let ((bufs (ghostel-project-buffer-list)))
             (should (memq term bufs))
             (should-not (memq compile bufs))))))))
 
@@ -467,6 +468,102 @@ project's terminal because both rendered the same buffer name."
              (lambda (&optional maybe-prompt &rest _)
                (when maybe-prompt (user-error "No project")))))
     (should-error (ghostel-project-next) :type 'user-error)))
+
+;;; Public create API
+
+(defmacro ghostel-buffers-test--with-create-stubs (&rest body)
+  "Run BODY with the native entry points and process spawn stubbed.
+Same stub set as the buffer-naming tests: `ghostel-create' runs its
+full buffer setup, but no module or process is involved."
+  (declare (indent 0))
+  `(cl-letf (((symbol-function 'ghostel--new)
+              (lambda (&rest _args) 'fake-term))
+             ((symbol-function 'ghostel--set-size) #'ignore)
+             ((symbol-function 'ghostel--apply-palette)
+              (lambda (&rest _args) nil))
+             ((symbol-function 'ghostel--start-process)
+              (lambda () nil)))
+     ,@body))
+
+(ert-deftest ghostel-test-create-default-name-and-identity ()
+  "`ghostel-create' defaults NAME and keys the identity to it."
+  (ghostel-buffers-test--with-create-stubs
+    (let ((ghostel-buffer-name "*ghostel-create-default*")
+          buf)
+      (unwind-protect
+          (progn
+            (setq buf (ghostel-create))
+            (should (equal (buffer-name buf) ghostel-buffer-name))
+            (should (equal (buffer-local-value 'ghostel-identity buf)
+                           '((kind . term)
+                             (name . "*ghostel-create-default*")
+                             (instance . 1)))))
+        (when (buffer-live-p buf) (kill-buffer buf))))))
+
+(ert-deftest ghostel-test-create-always-fresh-uniquified ()
+  "`ghostel-create' never reuses; the second buffer gets the next slot.
+The default identity keys the requested NAME with the next free
+instance, so `ghostel''s slot arithmetic can find the buffer."
+  (ghostel-buffers-test--with-create-stubs
+    (let (a b)
+      (unwind-protect
+          (progn
+            (setq a (ghostel-create "*ghostel-fresh*")
+                  b (ghostel-create "*ghostel-fresh*"))
+            (should-not (eq a b))
+            (should (equal (buffer-name b) "*ghostel-fresh*<2>"))
+            (should (equal (buffer-local-value 'ghostel-identity b)
+                           '((kind . term)
+                             (name . "*ghostel-fresh*")
+                             (instance . 2))))
+            (should (eq b (ghostel--find-buffer-by-identity
+                           '((kind . term)
+                             (name . "*ghostel-fresh*")
+                             (instance . 2))))))
+        (dolist (buf (list a b))
+          (when (buffer-live-p buf) (kill-buffer buf)))))))
+
+(ert-deftest ghostel-test-create-identity-override-verbatim ()
+  "A non-nil IDENTITY is stored verbatim, like `ghostel-exec's."
+  (ghostel-buffers-test--with-create-stubs
+    (let ((identity '((kind . term) (tab . "work") (instance . 1)))
+          buf)
+      (unwind-protect
+          (progn
+            (setq buf (ghostel-create "*ghostel-tab*" nil identity))
+            (should (eq (buffer-local-value 'ghostel-identity buf) identity)))
+        (when (buffer-live-p buf) (kill-buffer buf))))))
+
+(ert-deftest ghostel-test-create-suffix-matches-instance-after-kill ()
+  "The NAME<N> suffix follows the allocated instance, not name collisions.
+After killing instance 1 its plain name is free again, but the next
+slot is 3; the new buffer must be named for its instance so `ghostel'
+still reaches every slot by number."
+  (ghostel-buffers-test--with-create-stubs
+    (let (a b c)
+      (unwind-protect
+          (progn
+            (setq a (ghostel-create "*ghostel-refill*")
+                  b (ghostel-create "*ghostel-refill*"))
+            (kill-buffer a)
+            (setq c (ghostel-create "*ghostel-refill*"))
+            (should (equal (buffer-name c) "*ghostel-refill*<3>"))
+            (should (equal (alist-get 'instance
+                                      (buffer-local-value 'ghostel-identity c))
+                           3)))
+        (dolist (buf (list a b c))
+          (when (buffer-live-p buf) (kill-buffer buf)))))))
+
+(ert-deftest ghostel-test-create-empty-name-uses-default ()
+  "An empty NAME falls back to `ghostel-buffer-name'."
+  (ghostel-buffers-test--with-create-stubs
+    (let ((ghostel-buffer-name "*ghostel-create-empty*")
+          buf)
+      (unwind-protect
+          (progn
+            (setq buf (ghostel-create ""))
+            (should (equal (buffer-name buf) ghostel-buffer-name)))
+        (when (buffer-live-p buf) (kill-buffer buf))))))
 
 (provide 'ghostel-buffers-test)
 ;;; ghostel-buffers-test.el ends here

--- a/test/ghostel-project-test.el
+++ b/test/ghostel-project-test.el
@@ -165,11 +165,11 @@ same name must get separate buffers."
                      (lambda (proj) (cdr proj))))
             (cl-letf (((symbol-function 'project-current)
                        (lambda (&rest _) '(transient . "/tmp/myproj/"))))
-              (should (equal (ghostel--project-buffers) (list local))))
+              (should (equal (ghostel-project-buffer-list) (list local))))
             (cl-letf (((symbol-function 'project-current)
                        (lambda (&rest _)
                          '(transient . "/ssh:user@host:/tmp/myproj/"))))
-              (should (equal (ghostel--project-buffers) (list remote))))))
+              (should (equal (ghostel-project-buffer-list) (list remote))))))
       (dolist (b (list local remote))
         (when (buffer-live-p b) (kill-buffer b))))))
 

--- a/test/ghostel-shell-history-test.el
+++ b/test/ghostel-shell-history-test.el
@@ -1,0 +1,71 @@
+;;; ghostel-shell-history-test.el --- Tests for ghostel: shell history -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; `ghostel-shell-history' retrieval: shell-type dispatch, output
+;; parsing (newline and NUL contracts), and the error paths.  Runs the
+;; real /bin/sh with fake commands; no shell history files are touched.
+
+;;; Code:
+
+(require 'ghostel-test-helpers)
+
+(defmacro ghostel-shell-history-test--with-buffer (program &rest body)
+  "Run BODY in a fake ghostel buffer whose spawned shell was PROGRAM."
+  (declare (indent 1))
+  `(with-temp-buffer
+     (setq major-mode 'ghostel-mode)
+     (setq-local ghostel--shell-program ,program)
+     ,@body))
+
+(ert-deftest ghostel-test-shell-history-newline-parse ()
+  "Newline output parses into trimmed entries, order preserved."
+  (ghostel-shell-history-test--with-buffer "zsh"
+    (let ((ghostel-shell-history-commands
+           '((zsh . "printf '\\t ls -l\\nmake -j8\\n\\n  \\ngit st\\n'"))))
+      (should (equal (ghostel-shell-history)
+                     '("ls -l" "make -j8" "git st"))))))
+
+(ert-deftest ghostel-test-shell-history-nul-parse ()
+  "Output containing NUL splits on NUL, preserving embedded newlines."
+  (ghostel-shell-history-test--with-buffer "fish"
+    (let ((ghostel-shell-history-commands
+           '((fish . "printf 'for f in *\\necho $f\\nend\\0ls\\0'"))))
+      (should (equal (ghostel-shell-history)
+                     '("for f in *\necho $f\nend" "ls"))))))
+
+(ert-deftest ghostel-test-shell-history-function-entry ()
+  "A function-valued entry supplies the list directly."
+  (ghostel-shell-history-test--with-buffer "bash"
+    (let ((ghostel-shell-history-commands
+           (list (cons 'bash (lambda () '("one" "two"))))))
+      (should (equal (ghostel-shell-history) '("one" "two"))))))
+
+(ert-deftest ghostel-test-shell-history-shell-detection ()
+  "The spawned program picks the alist entry, including path and variants."
+  (ghostel-shell-history-test--with-buffer "/opt/homebrew/bin/fish"
+    (let ((ghostel-shell-history-commands '((fish . "echo fish-hist"))))
+      (should (equal (ghostel-shell-history) '("fish-hist"))))))
+
+(ert-deftest ghostel-test-shell-history-errors ()
+  "Unrecognized shell, missing entry, failing command, empty history."
+  ;; `ghostel-exec' buffers never record a shell program.
+  (ghostel-shell-history-test--with-buffer nil
+    (should-error (ghostel-shell-history) :type 'user-error))
+  ;; Recognized program without an alist entry.
+  (ghostel-shell-history-test--with-buffer "zsh"
+    (let ((ghostel-shell-history-commands nil))
+      (should-error (ghostel-shell-history) :type 'user-error)))
+  ;; Non-zero exit surfaces stderr in the error message.
+  (ghostel-shell-history-test--with-buffer "zsh"
+    (let ((ghostel-shell-history-commands
+           '((zsh . "echo broken-pipe >&2; exit 3"))))
+      (let ((err (should-error (ghostel-shell-history) :type 'user-error)))
+        (should (string-match-p "broken-pipe" (cadr err))))))
+  ;; Success with no output.
+  (ghostel-shell-history-test--with-buffer "zsh"
+    (let ((ghostel-shell-history-commands '((zsh . "true"))))
+      (should-error (ghostel-shell-history) :type 'user-error))))
+
+(provide 'ghostel-shell-history-test)
+;;; ghostel-shell-history-test.el ends here


### PR DESCRIPTION
Two commits:

**Add a public terminal-buffer API** (`lisp/ghostel.el`)
- New `ghostel-create`: create a fresh terminal running `ghostel-shell`, with optional name, display action, and identity override; always creates (reuse is the caller's job). `ghostel--start` now routes through it.
- `ghostel--all-buffers` → `ghostel-buffer-list`, `ghostel--project-buffers` → `ghostel-project-buffer-list` (public, no aliases).
- README section on creating and listing terminals from Lisp; tests for slot-identity allocation, verbatim identity override, and empty-name handling.

**Add the consult-ghostel extension package** (`extensions/consult-ghostel/`)
- Independent MELPA package (like evil-ghostel): `consult-ghostel` / `consult-ghostel-project` pick a terminal via `consult--multi` with live preview, MRU-first ordering, and create-on-miss through the new public API (project variant stamps a project-rooted identity). Hidden source variants for `consult-buffer` / `consult-project-buffer`.
- Candidates are annotated with the terminal title via `ghostel-annotate-buffer`; with marginalia installed, the title is prepended to marginalia's buffer annotations instead through its annotator registry (works in every buffer prompt, no configuration).
- Loading the package makes `consult-line` match across soft line wraps in ghostel buffers, with wrap-corrected point placement.
- Makefile/CI: consult + marginalia checkouts for compile and tests, `test-consult` target and CI job, melpazoid job for the new recipe.

Note: the `(ghostel "0.50.0")` dependency floor must be bumped to 0.51.0 at the release that first ships `ghostel-create`.