### PR TITLE
Make OSC 7 directory tracking robust to #, %, and escaped paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Directory tracking no longer corrupts or silently stalls on paths
+  containing `#` or percent-escapes.  The bash and zsh integrations
+  report the cwd with kitty's `kitty-shell-cwd://` OSC 7 scheme (path
+  sent verbatim) and fish percent-encodes its `file://` report,
+  matching ghostty; ghostel percent-decodes `file://` reports, so
+  escaped reports from foreign integrations (vte.sh, WezTerm) resolve
+  correctly, takes `kitty-shell-cwd://` paths as-is, and keeps raw
+  `#`/`?` in the path under either scheme.  For
+  emitters that escape only control characters (nushell) or nothing
+  at all (older ghostel scripts on remote hosts), a local directory
+  whose literal name looks percent-encoded still resolves via a
+  raw-spelling fallback; remote (TRAMP) reports of such names need
+  the updated scripts.
+
 ## [0.51.0] — 2026-08-20
 
 ### Added

--- a/README.org
+++ b/README.org
@@ -1195,9 +1195,10 @@ The two-clause gate covers both ways a remote ghostel shell can be reached:
 False positives - situations where the second clause matches but the session is
 not actually ghostel - include any =ssh= from a non-ghostel ghostty terminal,
 nested ssh hops carrying the same =TERM= through, and anyone who manually exports
-=TERM=xterm-ghostty=.  Sourcing the integration in those cases is harmless (OSC 7
-/ OSC 133 work in plain ghostty too; =ghostel_cmd= becomes a no-op without ghostel
-on the other end).
+=TERM=xterm-ghostty=.  Sourcing the integration in those cases is harmless: OSC 7
+/ OSC 133 work in plain ghostty and kitty too (the cwd report uses kitty's
+=kitty-shell-cwd://= scheme, which other terminals ignore), and =ghostel_cmd=
+becomes a no-op without ghostel on the other end.
 
 If you customize =ghostel-term= to something other than =xterm-ghostty=, the
 second clause will not match.  Drop it and rely on TRAMP-launched ghostel for

--- a/etc/shell/ghostel.bash
+++ b/etc/shell/ghostel.bash
@@ -38,9 +38,11 @@ else
     __ghostel_host=$HOSTNAME
 fi
 
-# Report working directory to the terminal via OSC 7
+# Report working directory via OSC 7.  kitty's kitty-shell-cwd://
+# scheme carries the path verbatim; ghostty and kitty parse it too
+# when this script runs under them.
 __ghostel_osc7() {
-    printf '\e]7;file://%s%s\a' "$__ghostel_host" "$PWD"
+    printf '\e]7;kitty-shell-cwd://%s%s\a' "$__ghostel_host" "$PWD"
 }
 
 # --- Semantic prompt markers (OSC 133) ---

--- a/etc/shell/ghostel.fish
+++ b/etc/shell/ghostel.fish
@@ -18,8 +18,10 @@ functions -q __ghostel_osc7; and return
 # In fish 3.0+, $hostname is gethostname(2) verbatim, matching
 # Emacs `system-name'. The local-host check needs exactly this,
 # not an FQDN-canonicalized value like zsh's $HOST.
+# The path is percent-encoded (string escape --style=url, fish 2.7+)
+# so `#', `?', and `%' survive the file:// URI parse.
 function __ghostel_osc7 --on-event fish_prompt
-    printf '\e]7;file://%s%s\a' "$hostname" "$PWD"
+    printf '\e]7;file://%s%s\a' "$hostname" (string escape --style=url "$PWD")
 end
 
 # --- Semantic prompt markers (OSC 133) ---

--- a/etc/shell/ghostel.zsh
+++ b/etc/shell/ghostel.zsh
@@ -26,10 +26,12 @@
 __ghostel_host=$(command hostname 2>/dev/null) || __ghostel_host=$HOST
 [[ -n $__ghostel_host ]] || __ghostel_host=$HOST
 
-# Report working directory to the terminal via OSC 7
+# Report working directory via OSC 7.  kitty's kitty-shell-cwd://
+# scheme carries the path verbatim; ghostty and kitty parse it too
+# when this script runs under them.
 __ghostel_osc7() {
     builtin emulate -L zsh -o no_warn_create_global -o no_aliases
-    builtin printf '\e]7;file://%s%s\a' "$__ghostel_host" "$PWD"
+    builtin printf '\e]7;kitty-shell-cwd://%s%s\a' "$__ghostel_host" "$PWD"
 }
 
 # --- Semantic prompt markers (OSC 133) ---

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3615,28 +3615,62 @@ Kept in Elisp so input modes and integrations can decide whether
 
 (defun ghostel--update-directory (dir)
   "Update `default-directory' from terminal's OSC 7 report.
-DIR may be a file:// URL or a plain path.  When the hostname in a
-file:// URL does not match the local machine, construct a TRAMP path."
+DIR may be a kitty-shell-cwd:// URL (raw, unencoded path), a file://
+URL (path percent-decoded), or a plain path.  When the hostname in a
+URL does not match the local machine, construct a TRAMP path."
   (when (and dir (not (equal dir ghostel--last-directory)))
     (setq ghostel--last-directory dir)
-    (let (path)
-      (if (string-prefix-p "file://" dir)
-          (let* ((url (url-generic-parse-url dir))
-                 (host (url-host url))
-                 (filename (url-filename url)))
-            (if (ghostel--local-host-p host)
-                (setq path filename)
-              ;; Remote host — construct a TRAMP path.
-              ;; Reuse the full remote prefix from default-directory
-              ;; when available (preserves multi-hop, method, user).
-              (let ((prefix (file-remote-p default-directory)))
-                (setq path (if prefix
-                               (concat prefix filename)
-                             (format "/%s:%s:%s"
-                                     (or ghostel-tramp-default-method
-                                         tramp-default-method)
-                                     host filename))))))
-        (setq path dir))
+    (let (host raw filename path)
+      (cond
+       ;; Split scheme://host/path by hand: `url-generic-parse-url' would treat
+       ;; `#'/`?' in the path as fragment/query, but emitters that don't escape
+       ;; them (kitty-shell-cwd verbatim contract, nushell) send them literally.
+       ((string-match "\\`\\(kitty-shell-cwd\\|file\\)://" dir)
+        (let* ((rest (substring dir (match-end 0)))
+               (slash (string-search "/" rest)))
+          (when slash
+            ;; Downcased like `url-host' - a mixed-case hostname must
+            ;; not fork the TRAMP connection identity.
+            (setq host (downcase (substring rest 0 slash))
+                  raw (substring rest slash)
+                  filename
+                  (if (equal (match-string 1 dir) "kitty-shell-cwd")
+                      raw
+                    ;; The encode step keeps `url-unhex-string' from
+                    ;; mangling multibyte text that arrived unescaped;
+                    ;; utf-8-unix stops eol detection from rewriting a
+                    ;; %0D carriage return to LF.
+                    (let ((decoded (decode-coding-string
+                                    (url-unhex-string
+                                     (encode-coding-string raw 'utf-8) t)
+                                    'utf-8-unix)))
+                      ;; %00 never names a real directory, and a NUL
+                      ;; would make `file-directory-p' signal.
+                      (if (string-match-p "\0" decoded) raw decoded)))))))
+       ;; A URI with an unrecognized scheme is not a plain path (OSC 9;9).
+       ((string-match-p "\\`[[:alpha:]][[:alnum:]+.-]*://" dir)
+        (message "ghostel: ignoring OSC 7 report with unknown scheme: %s"
+                 (truncate-string-to-width dir 40)))
+       (t (setq path dir)))
+      (when filename
+        (if (ghostel--local-host-p host)
+            ;; Emitters that don't escape `%' (nushell) send `%XX' literally.
+            ;; When only the raw spelling names a directory, it is the real one.
+            (setq path (if (and raw
+                                (not (file-directory-p filename))
+                                (file-directory-p raw))
+                           raw
+                         filename))
+          ;; Remote host - construct a TRAMP path.
+          ;; Reuse the full remote prefix from default-directory
+          ;; when available (preserves multi-hop, method, user).
+          (let ((prefix (file-remote-p default-directory)))
+            (setq path (if prefix
+                           (concat prefix filename)
+                         (format "/%s:%s:%s"
+                                 (or ghostel-tramp-default-method
+                                     tramp-default-method)
+                                 host filename))))))
       (when (and path (not (string= path "")))
         (if (file-remote-p path)
             ;; Trust the shell's report; skip file-directory-p to avoid

--- a/test/ghostel-shell-test.el
+++ b/test/ghostel-shell-test.el
@@ -307,6 +307,90 @@ skips it), and `--execute' enters an interactive shell."
       (ghostel--update-directory file-url)
       (should (equal old ghostel--last-directory)))))       ; dedup
 
+(ert-deftest ghostel-test-update-directory-kitty-scheme ()
+  "OSC 7 kitty-shell-cwd:// reports carry the path verbatim.
+`#', `?', and `%XX' stay literal."
+  :tags '(posix)
+  (let* ((host (system-name))
+         (base (make-temp-file "ghostel-osc7-" t))
+         (weird (expand-file-name "a#b?c%20d" base)))
+    (unwind-protect
+        (progn
+          (make-directory weird)
+          (let ((ghostel--last-directory nil)
+                (default-directory temporary-file-directory)
+                list-buffers-directory)
+            (ghostel--update-directory
+             (concat "kitty-shell-cwd://" host weird))
+            (should (equal (file-name-as-directory weird)
+                           default-directory)))
+          ;; Scheme without a path is ignored.
+          (let ((ghostel--last-directory nil)
+                (default-directory temporary-file-directory)
+                list-buffers-directory)
+            (ghostel--update-directory (concat "kitty-shell-cwd://" host))
+            (should (equal temporary-file-directory default-directory))))
+      (delete-directory base t))))
+
+(ert-deftest ghostel-test-update-directory-kitty-scheme-remote ()
+  "A report from a foreign host builds a TRAMP path with `#' intact."
+  (let ((ghostel-tramp-default-method "ssh"))
+    (dolist (uri '("kitty-shell-cwd://otherhost.example.com/tmp/a b#c"
+                   "file://otherhost.example.com/tmp/a b#c"))
+      (let ((ghostel--last-directory nil)
+            (default-directory temporary-file-directory)
+            list-buffers-directory)
+        (ghostel--update-directory uri)
+        (should (equal "/ssh:otherhost.example.com:/tmp/a b#c/"
+                       default-directory))))))
+
+(ert-deftest ghostel-test-update-directory-file-url-decodes ()
+  "OSC 7 file:// reports are percent-decoded, UTF-8 aware.
+Unescaped ASCII input round-trips unchanged, raw `#' and `?' stay in
+the path, `%0D' decodes to a carriage return, and when only the raw
+`%XX' spelling names a directory the raw spelling wins."
+  :tags '(posix)
+  (let* ((host (system-name))
+         (base (make-temp-file "ghostel-osc7-" t))
+         (spaced (expand-file-name "a b" base))
+         (unicode (expand-file-name "päth" base))
+         (percent (expand-file-name "50%off" base))
+         (rawonly (expand-file-name "e%20f" base))
+         (hashed (expand-file-name "f#g?h" base))
+         (creturn (expand-file-name "cr\rq" base)))
+    (unwind-protect
+        (progn
+          (dolist (d (list spaced unicode percent rawonly hashed creturn))
+            (make-directory d))
+          (cl-flet ((track (uri)
+                      (let ((ghostel--last-directory nil)
+                            (default-directory temporary-file-directory)
+                            list-buffers-directory)
+                        (ghostel--update-directory uri)
+                        default-directory)))
+            (should (equal (file-name-as-directory spaced)
+                           (track (concat "file://" host base "/a%20b"))))
+            (should (equal (file-name-as-directory unicode)
+                           (track (concat "file://" host base "/p%C3%A4th"))))
+            (should (equal (file-name-as-directory percent)
+                           (track (concat "file://" host base "/50%25off"))))
+            (should (equal (file-name-as-directory spaced)
+                           (track (concat "file://" host spaced))))
+            ;; Only the literal "e%20f" exists — raw spelling wins.
+            (should (equal (file-name-as-directory rawonly)
+                           (track (concat "file://" host rawonly))))
+            ;; Both "a b" and a literal "a%20b" exist — decoded wins.
+            (make-directory (expand-file-name "a%20b" base))
+            (should (equal (file-name-as-directory spaced)
+                           (track (concat "file://" host base "/a%20b"))))
+            ;; Raw `#'/`?' stay in the path.
+            (should (equal (file-name-as-directory hashed)
+                           (track (concat "file://" host hashed))))
+            ;; %0D is a carriage return, not eol-converted to LF.
+            (should (equal (file-name-as-directory creturn)
+                           (track (concat "file://" host base "/cr%0Dq"))))))
+      (delete-directory base t))))
+
 (ert-deftest ghostel-test-list-buffers-directory ()
   "Test that `ghostel-mode' exposes cwd via `list-buffers-directory'."
   (let ((default-directory (file-name-as-directory
@@ -354,8 +438,8 @@ the buffer is misclassified as remote, switching on TRAMP."
                      (call-process "bash" nil (current-buffer) nil
                                    "--noprofile" "--norc" "-c" probe)
                      (buffer-string))))
-      ;; Probe emits: \e]7;file://HOST/\a
-      (should (string-match "\e\\]7;file://\\([^/]*\\)/" output))
+      ;; Probe emits: \e]7;kitty-shell-cwd://HOST/\a
+      (should (string-match "\e\\]7;kitty-shell-cwd://\\([^/]*\\)/" output))
       (let ((emitted (match-string 1 output)))
         ;; Polluted $HOSTNAME must not appear in the OSC 7 host.
         (should-not (equal emitted fake))
@@ -632,14 +716,67 @@ would) and puts a fake `hostname' on PATH; the integration must emit the fake
                              (call-process "zsh" nil (current-buffer) nil
                                            "-f" "-c" probe)
                              (buffer-string))))
-              ;; Probe emits: \e]7;file://HOST/\a
-              (should (string-match "\e\\]7;file://\\([^/]*\\)/" output))
+              ;; Probe emits: \e]7;kitty-shell-cwd://HOST/\a
+              (should (string-match "\e\\]7;kitty-shell-cwd://\\([^/]*\\)/" output))
               (let ((emitted (match-string 1 output)))
                 ;; Reports gethostname(2) (the fake `hostname'), …
                 (should (equal emitted fake))
                 ;; … not the canonicalized $HOST FQDN.
                 (should-not (equal emitted fqdn)))))
         (delete-directory bindir t)))))
+
+(ert-deftest ghostel-test-bash-osc7-weird-path-round-trip ()
+  "A `#'/`%'/space path survives bash's OSC 7 into `default-directory'."
+  :tags '(posix)
+  (skip-unless (executable-find "bash"))
+  (let* ((root (or (ghostel--resource-root)
+                   (file-name-directory (locate-library "ghostel"))))
+         (shell-bash (expand-file-name "etc/shell/ghostel.bash" root)))
+    (skip-unless (file-exists-p shell-bash))
+    (let* ((base (make-temp-file "ghostel-osc7-" t))
+           (dir (expand-file-name "a b#c%d" base)))
+      (unwind-protect
+          (progn
+            (make-directory dir)
+            (let ((output (with-temp-buffer
+                            (call-process "bash" nil (current-buffer) nil
+                                          "--noprofile" "--norc" "-c"
+                                          (format "cd '%s'; source '%s'; __ghostel_osc7"
+                                                  dir shell-bash))
+                            (buffer-string))))
+              (should (string-match "\e\\]7;\\([^\a]*\\)\a" output))
+              (let ((ghostel--last-directory nil)
+                    (default-directory temporary-file-directory)
+                    list-buffers-directory)
+                (ghostel--update-directory (match-string 1 output))
+                (should (equal (file-name-as-directory dir)
+                               default-directory)))))
+        (delete-directory base t)))))
+
+(ert-deftest ghostel-test-fish-osc7-percent-encodes-path ()
+  "Fish OSC 7 percent-encodes $PWD so `#'/`%'/spaces survive the URI parse."
+  :tags '(:fish posix)
+  (skip-unless (executable-find "fish"))
+  (let* ((root (or (ghostel--resource-root)
+                   (file-name-directory (locate-library "ghostel"))))
+         (shell-fish (expand-file-name "etc/shell/ghostel.fish" root)))
+    (skip-unless (file-exists-p shell-fish))
+    (let* ((base (make-temp-file "ghostel-osc7-" t))
+           (dir (expand-file-name "a b#c%d" base)))
+      (unwind-protect
+          (progn
+            (make-directory dir)
+            (let ((output (with-temp-buffer
+                            (call-process "fish" nil (current-buffer) nil
+                                          "--no-config" "-c"
+                                          (format "cd '%s'; source '%s'; __ghostel_osc7"
+                                                  dir shell-fish))
+                            (buffer-string))))
+              (should (string-match "\e\\]7;file://[^/]*\\(/[^\a]*\\)\a"
+                                    output))
+              (should (string-suffix-p "/a%20b%23c%25d"
+                                       (match-string 1 output)))))
+        (delete-directory base t)))))
 
 (ert-deftest ghostel-test-zsh-line-init-fallback-no-fresh-line ()
   "Use 133;P (not 133;A) in the `zle-line-init' fallback emit.


### PR DESCRIPTION
## Problem

The shell integrations emit the raw $PWD inside a `file://` URI and the Emacs side takes the parsed path verbatim. That round trip is self-consistent but fragile:

- A `#` in any directory component is split off as a URI fragment by `url-generic-parse-url`. Locally, tracking silently stalls (the `file-directory-p` guard rejects the truncated path); remotely, a wrong TRAMP `default-directory` is committed without a check.
- Percent-encoded reports from foreign emitters — vte.sh, WezTerm, fish's builtin OSC 7, nushell's native reporting (which escapes control characters) — leave literal `%20` etc. in `default-directory`.

## Fix

Adopts the kitty/ghostty two-scheme model on both sides (ghostty's shell integrations are the reference):

- **bash/zsh** emit kitty's `kitty-shell-cwd://` scheme, which carries the path verbatim — no shell-side encoder needed, and ghostty/kitty parse it too when the remote script runs under them (previously ghostty rejected our raw-space `file://` URIs outright).
- **fish** percent-encodes its `file://` report via the `string escape --style=url` builtin, exactly like ghostty's fish integration.
- **`ghostel--update-directory`** takes `kitty-shell-cwd://` paths as-is (substring split so newlines survive; host downcased to keep the TRAMP connection identity consistent with `file://` reports) and percent-decodes `file://` paths UTF-8-aware, with `%0A`/`%0D` preserved and `%00` rejected. When only the raw `%XX` spelling names a local directory (nushell, stale integration scripts), the raw spelling wins. A URI with an unrecognized scheme is reported instead of being mistaken for a plain OSC 9;9 path.

## Compatibility

- Updated ghostel still understands old raw `file://` scripts (unescaped ASCII round-trips unchanged; literal-`%XX` names resolve locally via the raw-spelling fallback).
- Remote (TRAMP) reports of literal-`%XX` names need the updated scripts; an old ghostel receiving the new scheme ignores it until both sides are current.

## Verification

- `make -j8 all` green (elisp + native + zig tests, checkdoc, package-lint).
- New tests: kitty-scheme verbatim handling (`#`/`?`/literal `%20`), kitty-scheme remote TRAMP construction, `file://` decoding (space, UTF-8, escaped `%`, raw fallback, decoded-wins-when-both-exist), a bash emitter→parser end-to-end round trip for a `#`/`%`/space path, and a fish wire-format probe. Windows-incompatible fixtures are tagged `posix`.
- Live-verified in a sandboxed Emacs: bash, zsh, fish, and nushell each tracked `a#b?c`, literal `50%20off`, and `päth` directories correctly, with raw OSC 7 wire captures confirming the emitted forms.