### PR TITLE
Fix Windows-style PWD reports misclassifying local dirs as remote

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3499,6 +3499,22 @@ Kept in Elisp so input modes and integrations can decide whether
         (ghostel--cursor-blink-start)
       (ghostel--cursor-blink-stop))))
 
+(defun ghostel--windows-local-path (path)
+  "Return PATH in a spelling native Windows Emacs can resolve.
+Strips the slash from a slash-drive form (\"/d:/foo\"), which
+`expand-file-name' does not resolve, and rewrites MSYS \"/d/foo\" and
+Cygwin \"/cygdrive/d/foo\" mounts to the existing \"d:/foo\" directory."
+  (if (string-match-p "\\`/[[:alpha:]]:[/\\]" path)
+      (substring path 1)
+    (let ((translated
+           (and (string-match
+                 "\\`\\(?:/cygdrive\\)?/\\([[:alpha:]]\\)\\(/.*\\)?\\'" path)
+                (concat (match-string 1 path) ":"
+                        (or (match-string 2 path) "/")))))
+      (if (and translated (file-directory-p translated))
+          translated
+        path))))
+
 (defun ghostel--update-directory (dir)
   "Update `default-directory' from terminal's OSC 7 report.
 DIR may be a kitty-shell-cwd:// URL (raw, unencoded path), a file://
@@ -3532,7 +3548,19 @@ URL does not match the local machine, construct a TRAMP path."
                                     'utf-8-unix)))
                       ;; %00 never names a real directory, and a NUL
                       ;; would make `file-directory-p' signal.
-                      (if (string-match-p "\0" decoded) raw decoded)))))))
+                      (if (string-match-p "\0" decoded) raw decoded))))
+            ;; A Windows-style $PWD ("d:/...", no leading slash) glues
+            ;; its drive spec onto the authority: scheme://HOSTd:/...
+            ;; Only a local-host prefix disambiguates this from an RFC 3986
+            ;; empty-port authority; a foreign host keeps its glued spelling.
+            (if (and (string-match "\\`\\(.*\\)\\([a-z]:\\)\\'" host)
+                     (ghostel--local-host-p (match-string 1 host)))
+                (setq raw (concat (match-string 2 host) raw)
+                      filename (concat (match-string 2 host) filename)
+                      host (match-string 1 host))
+              ;; Trailing colon for an empty port is not part of a hostname
+              (when (string-suffix-p ":" host)
+                (setq host (substring host 0 -1)))))))
        ;; A URI with an unrecognized scheme is not a plain path (OSC 9;9).
        ((string-match-p "\\`[[:alpha:]][[:alnum:]+.-]*://" dir)
         (message "ghostel: ignoring OSC 7 report with unknown scheme: %s"
@@ -3563,6 +3591,8 @@ URL does not match the local machine, construct a TRAMP path."
             ;; synchronous TRAMP connections on every cd.
             (setq default-directory (file-name-as-directory path)
                   list-buffers-directory default-directory)
+          (when (eq system-type 'windows-nt)
+            (setq path (ghostel--windows-local-path path)))
           (when (file-directory-p path)
             (setq default-directory (file-name-as-directory path)
                   list-buffers-directory default-directory))))
@@ -3927,11 +3957,12 @@ verbatim.  `COLORTERM=truecolor' is exported unconditionally."
 
 (defun ghostel--logical-pwd-env (remote-p)
   "Return a PWD env entry naming the logical `default-directory', as a list.
-Nil when REMOTE-P.  Shells keep an inherited PWD that names the cwd
-\(same inode) and otherwise reset it from getcwd(), which resolves symlinks.
-Without this entry a shell started in a symlinked directory shows the
-physical path in its prompt and OSC 7."
-  (unless remote-p
+Shells keep an inherited PWD naming the cwd; without this entry a shell
+started in a symlinked directory shows the getcwd()-resolved physical
+path in its prompt and OSC 7.  Nil when REMOTE-P, and on Windows: an
+MSYS shell keeps the Windows-form value verbatim and reports it glued
+into its OSC 7 authority."
+  (unless (or remote-p (eq system-type 'windows-nt))
     (list (format "PWD=%s"
                   (directory-file-name (expand-file-name default-directory))))))
 

--- a/test/ghostel-environment-test.el
+++ b/test/ghostel-environment-test.el
@@ -135,6 +135,7 @@ stale or missing PWD, a shell started in a symlinked directory shows
 the physical path in its prompt and OSC 7.  The injected entry must
 override a stale inherited PWD, while a user PWD in
 `ghostel-environment' must win over the injected one."
+  :tags '(posix)
   (let* ((captured nil)
          (ghostel-shell "/bin/sh")
          (ghostel-shell-integration nil)
@@ -153,6 +154,13 @@ override a stale inherited PWD, while a user PWD in
       (let ((ghostel-environment '("PWD=/ghostel/user-override")))
         (ghostel--start-process))
       (should (equal captured "/ghostel/user-override")))))
+
+(ert-deftest ghostel-test-logical-pwd-env ()
+  "No PWD entry for remote spawns or on Windows."
+  (let ((system-type 'gnu/linux))
+    (should-not (ghostel--logical-pwd-env t)))
+  (let ((system-type 'windows-nt))
+    (should-not (ghostel--logical-pwd-env nil))))
 
 (ert-deftest ghostel-test-spawn-symlinked-dir-child-sees-logical-pwd ()
   "A child spawned in a symlinked directory sees the logical path in PWD.

--- a/test/ghostel-shell-test.el
+++ b/test/ghostel-shell-test.el
@@ -391,6 +391,92 @@ the path, `%0D' decodes to a carriage return, and when only the raw
                            (track (concat "file://" host base "/cr%0Dq"))))))
       (delete-directory base t))))
 
+(ert-deftest ghostel-test-update-directory-windows-drive-glued-host ()
+  "A drive glued onto the local authority tracks as the drive path.
+No TRAMP host is fabricated from the glued spelling."
+  ;; Bind `system-type' inside `cl-letf': installing the stub may
+  ;; native-compile a trampoline, which must run on the real platform.
+  (let ((ghostel--last-directory nil)
+        (default-directory temporary-file-directory)
+        list-buffers-directory)
+    (cl-letf (((symbol-function 'file-directory-p)
+               (lambda (f) (equal f "d:/repos/foo"))))
+      (let ((system-type 'windows-nt))
+        (ghostel--update-directory
+         (concat "kitty-shell-cwd://" (system-name) "d:/repos/foo")))
+      (should (equal "d:/repos/foo/" default-directory)))))
+
+(ert-deftest ghostel-test-update-directory-authority-trailing-colon ()
+  "A trailing-colon authority never rewrites a foreign host.
+The empty-port colon is stripped; a local empty-port authority
+stays local."
+  (let ((ghostel-tramp-default-method "ssh"))
+    (dolist (case '(("kitty-shell-cwd://otherhostd:/repos/foo"
+                     . "/ssh:otherhostd:/repos/foo/")
+                    ("file://otherhost:/home/user"
+                     . "/ssh:otherhost:/home/user/")))
+      (let ((ghostel--last-directory nil)
+            (default-directory temporary-file-directory)
+            list-buffers-directory)
+        (ghostel--update-directory (car case))
+        (should (equal (cdr case) default-directory))))
+    (let ((base (make-temp-file "ghostel-osc7-" t)))
+      (unwind-protect
+          ;; A drive-lettered BASE would re-trigger the glue parse;
+          ;; the empty-port form is only unambiguous for POSIX paths.
+          (unless (string-match-p "\\`[[:alpha:]]:/" base)
+            (let ((ghostel--last-directory nil)
+                  (default-directory temporary-file-directory)
+                  list-buffers-directory)
+              (ghostel--update-directory
+               (concat "file://" (system-name) ":" base))
+              (should (equal (file-name-as-directory base)
+                             default-directory))))
+        (delete-directory base)))))
+
+(ert-deftest ghostel-test-update-directory-windows-slash-drive ()
+  "On Windows a slash-drive URL path (/d:/foo) resolves to d:/foo."
+  (dolist (case '(("/d:/repos/foo" . "d:/repos/foo")
+                  ("/c:\\repos\\foo" . "c:\\repos\\foo")))
+    (let ((ghostel--last-directory nil)
+          (default-directory temporary-file-directory)
+          list-buffers-directory)
+      (cl-letf (((symbol-function 'file-directory-p)
+                 (lambda (f) (equal f (cdr case)))))
+        (let ((system-type 'windows-nt))
+          (ghostel--update-directory
+           (concat "file://" (system-name) (car case))))
+        (should (equal (file-name-as-directory (cdr case))
+                       default-directory))))))
+
+(ert-deftest ghostel-test-update-directory-windows-msys-path ()
+  "On Windows the MSYS and Cygwin mount spellings resolve to the drive path.
+A lookalike on the current drive must not shadow the translation."
+  (dolist (case '(("/d/repos/foo" ("d:/repos/foo"))
+                  ("/cygdrive/d/repos/foo" ("d:/repos/foo"))
+                  ("/d/repos/foo" ("/d/repos/foo" "d:/repos/foo"))))
+    (let ((ghostel--last-directory nil)
+          (default-directory temporary-file-directory)
+          list-buffers-directory)
+      (cl-letf (((symbol-function 'file-directory-p)
+                 (lambda (f) (member f (cadr case)))))
+        (let ((system-type 'windows-nt))
+          (ghostel--update-directory
+           (concat "kitty-shell-cwd://" (system-name) (car case))))
+        (should (equal "d:/repos/foo/" default-directory))))))
+
+(ert-deftest ghostel-test-update-directory-windows-plain-path ()
+  "Plain-path reports (OSC 9;9) get the same Windows normalization."
+  (dolist (dir '("/d/repos/foo" "/d:/repos/foo"))
+    (let ((ghostel--last-directory nil)
+          (default-directory temporary-file-directory)
+          list-buffers-directory)
+      (cl-letf (((symbol-function 'file-directory-p)
+                 (lambda (f) (equal f "d:/repos/foo"))))
+        (let ((system-type 'windows-nt))
+          (ghostel--update-directory dir))
+        (should (equal "d:/repos/foo/" default-directory))))))
+
 (ert-deftest ghostel-test-list-buffers-directory ()
   "Test that `ghostel-mode' exposes cwd via `list-buffers-directory'."
   (let ((default-directory (file-name-as-directory


### PR DESCRIPTION
Fixes #650.

On native Windows Emacs the injected logical `PWD` is a drive-form path (`d:/repos/foo`, no leading slash). MSYS bash keeps such an inherited `PWD` verbatim, so its OSC 7 report glues the drive spec onto the URL authority (`kitty-shell-cwd://HOSTd:/repos/foo`). The host/path split at the first slash then produced the bogus host `HOSTd:`, which failed the local-host check and flipped `default-directory` to a TRAMP path on a nonexistent host — every buffer switch triggered failing remote connections.

Three-part fix:

- **Reattach a trailing `letter:` drive spec** from the authority to the path, but only when the de-glued prefix names the local host: an RFC 3986 empty-port authority ends the same way, and a foreign host must never be rewritten into a different one. A trailing colon on the local host itself is dropped as an empty port.
- **Normalize local Windows path spellings** before the directory gate, for URL and plain (OSC 9;9) reports alike: strip the slash from `/d:/foo` (unresolvable by `expand-file-name`) and rewrite the MSYS `/d/foo` and Cygwin `/cygdrive/d/foo` mount forms to `d:/foo` when the rewrite names a directory — previously such reports silently stalled tracking on Windows.
- **Stop injecting the logical `PWD` on Windows**: MSYS shells expect a POSIX-style `PWD`, and the drive-form value is what corrupted the OSC 7 report in the first place. (Emacs itself may still pass a drive-form `PWD` when launched from a console, which the parser repair above covers.)

Covered by new ERT tests for the glued-host, trailing-colon-authority, slash-drive, MSYS/Cygwin, and plain-path (OSC 9;9) cases; they run in the elisp group on all platforms. Verified live on macOS (bash + fish `cd` tracking unaffected); Windows verification would be appreciated — the signal is `ghostel-debug-info` showing a plain `d:/...` default directory with no `/scp:` prefix.