### PR TITLE
Improve evil experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to this project will be documented in this file.
   coupling correctness to redraw scheduling.  Incremental redraws skip clean
   rows above the first changed row, reducing the cost of the per-key feedback
   loop.
+- `evil-ghostel`: `C-c C-t` now enters copy mode in Evil normal state and
+  printable Vim navigation keys no longer trigger Ghostel's read-only fast
+  exit.  Copy mode stays frozen until `C-c C-t` or another explicit
+  input-mode switch exits it; accidentally entering insert state remains
+  recoverable with `ESC`, including on legacy TTY frames and over an
+  alt-screen terminal.
 
 ## [0.52.0] — 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Editing the live prompt with evil-ghostel no longer leaves characters behind
+  or desynchronizes point around wide characters, grapheme clusters, and soft
+  wraps.  Cursor moves and deletions now follow the position reported by the
+  terminal and stop if a key is ignored.  The new
+  `evil-ghostel-cursor-feedback-timeout` allows slow shell echoes without
+  coupling correctness to redraw scheduling.
+
 ## [0.52.0] — 2026-08-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ All notable changes to this project will be documented in this file.
   wraps.  Cursor moves and deletions now follow the position reported by the
   terminal and stop if a key is ignored.  The new
   `evil-ghostel-cursor-feedback-timeout` allows slow shell echoes without
-  coupling correctness to redraw scheduling.
+  coupling correctness to redraw scheduling.  Incremental redraws skip clean
+  rows above the first changed row, reducing the cost of the per-key feedback
+  loop.
 
 ## [0.52.0] — 2026-08-31
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ If you're an evil user you can install the [evil-ghostel](https://melpa.org/#/ev
   :hook (ghostel-mode . evil-ghostel-mode))
 ```
 
+With evil-ghostel active, `C-c C-t` enters frozen copy mode in normal state.
+Vim navigation keys therefore stay in the frozen buffer; `C-c C-t` toggles
+copy mode off again. Printable keys do not trigger Ghostel's read-only
+fast-exit behavior in evil-ghostel buffers. If you enter insert state in a
+read-only mode, `ESC` returns to normal state without exiting that mode.
+
 Note: in alt-screen apps — vim, less, fullscreen TUIs like Claude Code
 (`/tui fullscreen`) — ESC is by default sent to the app instead of switching
 to normal state, so you stay in insert state and a leader key like `SPC` goes

--- a/README.org
+++ b/README.org
@@ -1490,6 +1490,12 @@ subdirectory inside the ghostel monorepo:
 When =evil-ghostel-mode= is active:
 
 - Ghostel starts in *insert state* (terminal input works normally).
+- =C-c C-t= enters frozen copy mode in *normal state*, so Vim navigation keys
+  move through the buffer without leaving copy mode.  Press =C-c C-t= again (or
+  use another explicit input-mode switch) to exit; printable keys do not exit
+  Ghostel's read-only modes while =evil-ghostel-mode= is active.  If you enter
+  insert state in a read-only mode, =ESC= returns to normal state without
+  unfreezing or exiting it.
 - Pressing *ESC* enters normal state and snaps point to the terminal cursor
   (outside alt-screen; see [[#evil-escape-routing][ESC routing]] below).
 - Normal-mode navigation (=h=, =j=, =k=, =l=, =w=, =b=, =e=, =0=, =$=, ...) works as expected.

--- a/README.org
+++ b/README.org
@@ -1494,7 +1494,7 @@ When =evil-ghostel-mode= is active:
   (outside alt-screen; see [[#evil-escape-routing][ESC routing]] below).
 - Normal-mode navigation (=h=, =j=, =k=, =l=, =w=, =b=, =e=, =0=, =$=, ...) works as expected.
 - *Insert/append* (=i=, =a=, =I=, =A=) sync the terminal cursor to point before entering
-  insert state.
+  insert state, including around wide characters, grapheme clusters, and soft wraps.
 - *Delete* (=d=, =dw=, =dd=, =D=, =x=, =X=) yanks text to the kill ring and deletes via the
   shell.
 - *Change* (=c=, =cw=, =cc=, =C=, =s=, =S=) deletes then enters insert state.
@@ -1517,6 +1517,10 @@ When =evil-ghostel-mode= is active:
 
 The initial state is configurable via =evil-ghostel-initial-state= (default
 =insert=).
+
+Cursor-driven commands follow the position reported by the terminal after
+each key and stop if the shell ignores it.  Delayed shell echoes are allowed
+up to =evil-ghostel-cursor-feedback-timeout= seconds (default 0.5).
 
 *** ESC routing
 :properties:

--- a/extensions/evil-ghostel/README.md
+++ b/extensions/evil-ghostel/README.md
@@ -18,6 +18,10 @@ terminal, and the editing operators (`d`, `c`, `x`, `r`, `p`, `u`, …) drive
 the shell's line editor over the PTY. See the
 [manual](https://dakra.github.io/ghostel/#evil-mode) for the full list.
 
+Cursor-driven commands follow the position reported by the terminal after
+each key, keeping edits aligned around wide characters, grapheme clusters,
+and soft wraps and stopping if the shell ignores a key.
+
 ## Word boundaries
 
 Word motions use Vim-style word boundaries: `w`, `b`, `e`, `ciw` stop at

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -20,9 +20,9 @@
 ;; the commands that drive the shell's line editor are customized:
 ;; operators (d c x s r and line variants) clamp their range to
 ;; [input-start, input-end] and apply it over the PTY (arrows, backspaces,
-;; bracketed paste); i a I A drive the shell cursor to point; ^ jumps past
-;; the prompt; j / G stay on the live prompt; p / P paste; u sends
-;; readline undo.
+;; bracketed paste), following renderer feedback after each key; i a I A
+;; drive the shell cursor to point; ^ jumps past the prompt; j / G stay on
+;; the live prompt; p / P paste; u sends readline undo.
 ;;
 ;; Outside semi-char input mode (`line' / `copy' / `emacs' / `char' modes,
 ;; or an alt-screen TUI) every command falls through to `evil-*'.

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -878,6 +878,22 @@ YANK-HANDLER is used by Evil outside live terminal input.  Covers P."
 Bindings for normal/visual editing commands and insert-state Ctrl
 passthrough are installed via `evil-define-key*'.")
 
+(defun evil-ghostel-copy-mode ()
+  "Toggle `ghostel-copy-mode', entering Evil normal state on entry.
+Copy mode must not inherit Evil's insert state: otherwise its first
+printable motion key is handled as self-insert.  With Ghostel's fast
+read-only exit enabled, that key would immediately leave copy mode and
+reach the terminal instead of navigating the frozen buffer."
+  (interactive)
+  (ghostel-copy-mode)
+  (when (eq ghostel--input-mode 'copy)
+    (evil-normal-state)))
+
+;; Keep the core binding (and any user binding of `ghostel-copy-mode') while
+;; adding Evil's state transition whenever the command is invoked.
+(define-key evil-ghostel-mode-map [remap ghostel-copy-mode]
+            #'evil-ghostel-copy-mode)
+
 (defconst evil-ghostel--ctrl-passthrough-keys
   '("a" "b" "d" "e" "f" "k" "l" "n" "o" "p" "q" "r" "s" "t" "u" "v" "w" "y")
   "Ctrl+key combinations to pass through to the terminal in insert state.
@@ -978,26 +994,33 @@ Valid values: `auto', `terminal', `evil'.")
 
 (defun evil-ghostel--escape ()
   "Dispatch insert-state ESC based on `evil-ghostel--escape-mode'.
-Terminal-bound ESC runs through `ghostel--on-user-input'.  Falling back to
-evil uses `evil-force-normal-state' when the `evil-insert-state-map'
+In copy and Emacs modes, always return to Evil normal state.  Otherwise,
+terminal-bound ESC runs through `ghostel--on-user-input'.  Falling back
+to evil uses `evil-force-normal-state' when the `evil-insert-state-map'
 binding is missing or a chord prefix (e.g. `evil-escape''s `jk'), so the
 keystroke is never dropped."
   (interactive)
-  (let* ((mode evil-ghostel--escape-mode)
-         (to-terminal (or (eq mode 'terminal)
-                          (and (eq mode 'auto)
-                               (ghostel-alt-screen-p)))))
-    (if to-terminal
-        (progn
-          (ghostel--on-user-input)
-          (ghostel--send-encoded "escape" "")
-          (when (and (eq mode 'auto) (not evil-ghostel--escape-hint-shown))
-            (setq evil-ghostel--escape-hint-shown t)
-            (message (substitute-command-keys
-                      "ESC sent to the terminal app (alt-screen); \
+  ;; Insert state cannot edit a read-only Ghostel view.  ESC must remain a
+  ;; reliable way back to normal state there, even when the frozen terminal
+  ;; is an alt-screen app whose ESC would normally be routed to the PTY.
+  (if (memq ghostel--input-mode '(copy emacs))
+      (evil-force-normal-state)
+    (let* ((mode evil-ghostel--escape-mode)
+           (to-terminal (or (eq mode 'terminal)
+                            (and (eq mode 'auto)
+                                 (ghostel-alt-screen-p)))))
+      (if to-terminal
+          (progn
+            (ghostel--on-user-input)
+            (ghostel--send-encoded "escape" "")
+            (when (and (eq mode 'auto) (not evil-ghostel--escape-hint-shown))
+              (setq evil-ghostel--escape-hint-shown t)
+              (message (substitute-command-keys
+                        "ESC sent to the terminal app (alt-screen); \
 \\[evil-ghostel-toggle-send-escape] routes it to evil instead"))))
-      (let ((cmd (lookup-key evil-insert-state-map (kbd "<escape>"))))
-        (call-interactively (if (commandp cmd) cmd #'evil-force-normal-state))))))
+        (let ((cmd (lookup-key evil-insert-state-map (kbd "<escape>"))))
+          (call-interactively
+           (if (commandp cmd) cmd #'evil-force-normal-state)))))))
 
 (defun evil-ghostel-toggle-send-escape (&optional arg)
   "Toggle or set the ESC routing mode for the current buffer.
@@ -1032,9 +1055,10 @@ the default."
 
 ;; The <escape> function-key event exists on GUI frames, on ttys with
 ;; the kitty keyboard protocol (kkp.el), and on legacy ttys in ghostel
-;; terminal-input buffers via ghostel's lone-ESC `input-decode-map'
-;; filter.  Fast C-c M-... chords still decode as meta there: the
-;; filter sees the pending follow-up byte and leaves ESC alone.
+;; buffers via ghostel's lone-ESC `input-decode-map' filter (extended below
+;; to Evil insert state in read-only modes).  Fast C-c M-... chords still
+;; decode as Meta: the filter sees the pending follow-up byte and leaves
+;; ESC alone.
 (define-key evil-ghostel-mode-map (kbd "C-c <escape>")
             #'evil-force-normal-state)
 
@@ -1076,6 +1100,48 @@ is nil, or when the table is already installed."
     (set-syntax-table evil-ghostel--saved-syntax-table)
     (setq evil-ghostel--saved-syntax-table nil)))
 
+(defun evil-ghostel--around-tty-esc (orig-fn map)
+  "Let lone TTY ESC reach Evil insert state in read-only Ghostel modes.
+ORIG-FN is `ghostel--tty-esc' and MAP is its wrapped decode map.
+Ghostel normally translates ESC only in terminal-input modes; temporarily
+present a read-only Evil insert state as semi-char so ESC becomes the
+`escape' event, while Meta chords and terminal escape sequences still pass
+through MAP unchanged."
+  (if (and evil-ghostel-mode
+           (evil-insert-state-p)
+           (memq ghostel--input-mode '(copy emacs)))
+      (let ((ghostel--input-mode 'semi-char))
+        (funcall orig-fn map))
+    (funcall orig-fn map)))
+
+(defvar-local evil-ghostel--saved-readonly-fast-exit nil
+  "Saved buffer-local state of `ghostel-readonly-fast-exit'.
+The value is (WAS-LOCAL VALUE), or nil when there is nothing to restore.")
+
+(defun evil-ghostel--disable-readonly-fast-exit ()
+  "Keep Ghostel's read-only modes active while Evil navigation runs."
+  (unless evil-ghostel--saved-readonly-fast-exit
+    (setq evil-ghostel--saved-readonly-fast-exit
+          (list (local-variable-p 'ghostel-readonly-fast-exit)
+                ghostel-readonly-fast-exit)))
+  (setq-local ghostel-readonly-fast-exit nil)
+  ;; `setq-local' bypasses the option's custom setter.  Refresh a read-only
+  ;; map explicitly when evil-ghostel is enabled after copy/Emacs mode.
+  (when (memq ghostel--input-mode '(copy emacs))
+    (use-local-map (ghostel--readonly-keymap))))
+
+(defun evil-ghostel--restore-readonly-fast-exit ()
+  "Restore the setting saved by `evil-ghostel--disable-readonly-fast-exit'."
+  (when evil-ghostel--saved-readonly-fast-exit
+    (pcase-let ((`(,was-local ,value)
+                 evil-ghostel--saved-readonly-fast-exit))
+      (if was-local
+          (setq-local ghostel-readonly-fast-exit value)
+        (kill-local-variable 'ghostel-readonly-fast-exit)))
+    (kill-local-variable 'evil-ghostel--saved-readonly-fast-exit)
+    (when (memq ghostel--input-mode '(copy emacs))
+      (use-local-map (ghostel--readonly-keymap)))))
+
 (defun evil-ghostel--any-active-elsewhere-p (except-buffer)
   "Return non-nil if any buffer but EXCEPT-BUFFER has `evil-ghostel-mode' on.
 Decides whether the global advice can be removed on the last disable."
@@ -1106,6 +1172,10 @@ Enabling installs global advice while any buffer has the mode enabled."
         ;; so it still picks its own mode.
         (setq-local ghostel-mark-activation-input-mode nil)
         (evil-ghostel--install-word-boundaries)
+        ;; Evil's navigation keys are printable characters.  A copy-mode
+        ;; entered from insert state must keep them in the frozen buffer
+        ;; instead of treating the first one as Ghostel's fast exit.
+        (evil-ghostel--disable-readonly-fast-exit)
         (add-hook 'evil-insert-state-entry-hook
                   #'evil-ghostel--insert-state-entry nil t)
         ;; Reuse the insert-state sync when entering emacs-state — both
@@ -1119,6 +1189,8 @@ Enabling installs global advice while any buffer has the mode enabled."
         (advice-add 'ghostel--redraw :around #'evil-ghostel--around-redraw)
         (advice-add 'ghostel--apply-cursor-style :around
                     #'evil-ghostel--override-cursor-style)
+        (advice-add 'ghostel--tty-esc :around
+                    #'evil-ghostel--around-tty-esc)
         (evil-refresh-cursor))
     (remove-hook 'evil-insert-state-entry-hook
                  #'evil-ghostel--insert-state-entry t)
@@ -1127,12 +1199,15 @@ Enabling installs global advice while any buffer has the mode enabled."
     (remove-hook 'ghostel-inhibit-anchor-functions
                  #'evil-ghostel--anchor-inhibit t)
     (kill-local-variable 'ghostel-mark-activation-input-mode)
+    (evil-ghostel--restore-readonly-fast-exit)
     (evil-ghostel--restore-word-boundaries)
     (kill-local-variable 'evil-ghostel--saved-syntax-table)
     (unless (evil-ghostel--any-active-elsewhere-p (current-buffer))
       (advice-remove 'ghostel--redraw #'evil-ghostel--around-redraw)
       (advice-remove 'ghostel--apply-cursor-style
-                     #'evil-ghostel--override-cursor-style))))
+                     #'evil-ghostel--override-cursor-style)
+      (advice-remove 'ghostel--tty-esc
+                     #'evil-ghostel--around-tty-esc))))
 
 (provide 'evil-ghostel)
 ;;; evil-ghostel.el ends here

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -84,10 +84,11 @@ buffer with \\[evil-ghostel-toggle-send-escape]."
                  (const :tag "Always to terminal" terminal)
                  (const :tag "Always to evil" evil)))
 
-(defcustom evil-ghostel-sync-render-max-iterations 10
-  "Iteration cap for waiting on terminal output to settle.
-Each iteration waits up to 50 ms, bounding the total wait at ~500 ms."
-  :type 'integer)
+(defcustom evil-ghostel-cursor-feedback-timeout 0.5
+  "Seconds to wait for the terminal cursor to react to an editing key.
+The wait returns as soon as renderer feedback moves the cursor.  This timeout
+only applies when the shell ignores a key or its echo is delayed."
+  :type 'number)
 
 (defvar evil-ghostel-syntax-table (make-syntax-table ghostel-mode-syntax-table)
   "Syntax table installed in ghostel buffers while `evil-ghostel-mode' is on.
@@ -165,11 +166,31 @@ and `ghostel--line-input-end', so evil's operators apply directly."
 
 (defun evil-ghostel--reset-cursor-point ()
   "Move Emacs point to the terminal cursor.
-`ghostel--cursor-pos' is viewport-relative; its row is offset by scrollback."
-  (when (and ghostel--term ghostel--term-rows ghostel--cursor-pos)
+Prefer `ghostel--cursor-char-pos', the buffer position the renderer
+publishes for the terminal cursor: it is cell-accurate, so unlike the
+viewport row/column fallback it stays correct under wide glyphs and
+grapheme clusters (a wide char is one buffer character but two terminal
+cells, so `move-to-column' on the cell column lands on the wrong char).
+Falls back to the viewport-relative row/column math only before the
+first render has published a cursor position."
+  (cond
+   ((and ghostel--cursor-char-pos
+         (>= ghostel--cursor-char-pos (point-min))
+         (<= ghostel--cursor-char-pos (point-max)))
+    (goto-char ghostel--cursor-char-pos))
+   ((and ghostel--term ghostel--term-rows ghostel--cursor-pos)
     (goto-char (point-min))
     (forward-line (+ (evil-ghostel--scrollback-lines) (cdr ghostel--cursor-pos)))
-    (move-to-column (car ghostel--cursor-pos))))
+    (move-to-column (car ghostel--cursor-pos)))))
+
+(defun evil-ghostel--cursor-char-pos ()
+  "Return the renderer's terminal-cursor buffer position, or nil.
+Coerces to nil when out of buffer range, so closed-loop guards treat a
+stale or pre-render value as absent rather than driving off it."
+  (and ghostel--cursor-char-pos
+       (>= ghostel--cursor-char-pos (point-min))
+       (<= ghostel--cursor-char-pos (point-max))
+       ghostel--cursor-char-pos))
 
 (defun evil-ghostel--point-viewport-row ()
   "Return the viewport row of point, 0-indexed, or nil.
@@ -381,60 +402,151 @@ word) can't over-delete past the live input.  END is never below BEG."
 ;; PTY-driven input editing.  Drive the shell's line editor (readline /
 ;; zle / prompt_toolkit) with arrow keys, backspaces, and bracketed paste
 ;; over the PTY.  Only meaningful in semi-char input mode.
+;;
+;; Cursor movements use a closed feedback loop like `vterm-goto-char':
+;; send one arrow, drain the shell echo via `evil-ghostel--drain-output',
+;; re-read the renderer's cell-accurate `ghostel--cursor-char-pos', and
+;; repeat until point reaches the target.  Open-loop column math (Emacs
+;; char columns vs terminal cell columns) diverges on wide glyphs and
+;; grapheme clusters — the renderer skips spacer cells, so one wide char
+;; is one buffer character but two terminal cells — which left single
+;; characters behind and desynced point.  Buffer positions from the
+;; renderer (`ghostel--cursor-char-pos', `ghostel--viewport-row-at') are
+;; the cell-accurate ground truth this loops on.
 
-(defun evil-ghostel--sync-render ()
-  "Drain pending PTY output so cursor state reflects the latest echo.
-Loops `accept-process-output' (capped by
-`evil-ghostel-sync-render-max-iterations'), then flushes any deferred redraw."
+(defun evil-ghostel--drain-output (previous-pos)
+  "Process PTY output until the cursor moves from PREVIOUS-POS or times out.
+Each `accept-process-output' returns as soon as output arrives.  If that batch
+does not move the cursor, keep waiting within
+`evil-ghostel-cursor-feedback-timeout'.  Force deferred redraws so every
+comparison uses renderer feedback rather than timer state."
   (when ghostel--process
-    (let ((iter 0))
-      (while (and (< iter evil-ghostel-sync-render-max-iterations)
-                  (accept-process-output ghostel--process 0.05 nil t))
-        (setq iter (1+ iter))))
-    (when ghostel--redraw-timer
-      (ghostel--redraw-now (current-buffer)))))
+    (let ((deadline (+ (float-time) evil-ghostel-cursor-feedback-timeout)))
+      (while (and (equal (evil-ghostel--cursor-char-pos) previous-pos)
+                  (process-live-p ghostel--process)
+                  (< (float-time) deadline))
+        (accept-process-output ghostel--process
+                               (- deadline (float-time)) nil t)
+        (when ghostel--redraw-timer
+          (ghostel--redraw-now (current-buffer)))))))
+
+(defun evil-ghostel--cursor-direction (current target target-row)
+  "Return the safe cursor key direction from CURRENT toward TARGET.
+TARGET-ROW is TARGET's viewport row.
+Use Left or Right across renderer-created soft wraps.  Up and Down remain
+available for real multiline input, where they avoid walking every character."
+  (let ((current-row (cdr ghostel--cursor-pos))
+        (target-row (or target-row (cdr ghostel--cursor-pos))))
+    (cond
+     ((= current-row target-row)
+      (if (< current target) "right" "left"))
+     ((< current target)
+      (if (save-excursion
+            (goto-char current)
+            (get-text-property (line-end-position) 'ghostel-wrap))
+          "right"
+        "down"))
+     ((save-excursion
+        (goto-char current)
+        (let ((bol (line-beginning-position)))
+          (and (> bol (point-min))
+               (get-text-property (1- bol) 'ghostel-wrap))))
+      "left")
+     (t "up"))))
+
+(defun evil-ghostel--drive-cursor (target-pos)
+  "Drive the terminal cursor monotonically to TARGET-POS.
+Send one cursor key, wait for renderer feedback, and stop unless the reported
+cursor moved strictly toward the target without passing its row or position.
+Vertical moves reach the target row first; horizontal moves finish there.
+Strict progress makes a separate iteration cap unnecessary."
+  (let ((moving t))
+    (while (and moving
+                (evil-ghostel--cursor-char-pos)
+                (/= (evil-ghostel--cursor-char-pos) target-pos))
+      (let* ((previous (evil-ghostel--cursor-char-pos))
+             (previous-row (cdr ghostel--cursor-pos))
+             (target-row (or (ghostel--viewport-row-at target-pos)
+                             previous-row))
+             (direction (evil-ghostel--cursor-direction
+                         previous target-pos target-row)))
+        (ghostel--send-encoded direction "")
+        (evil-ghostel--drain-output previous)
+        (let ((next (evil-ghostel--cursor-char-pos))
+              (next-row (cdr ghostel--cursor-pos)))
+          (setq moving
+                (and next
+                     (pcase direction
+                       ("left"
+                        (and (< next previous) (>= next target-pos)))
+                       ("right"
+                        (and (> next previous) (<= next target-pos)))
+                       ("up"
+                        (and (< next-row previous-row)
+                             (>= next-row target-row)))
+                       ("down"
+                        (and (> next-row previous-row)
+                             (<= next-row target-row)))))))))
+    (equal (evil-ghostel--cursor-char-pos) target-pos)))
 
 (defun evil-ghostel-goto-input-position (pos)
   "Drive the terminal cursor and Emacs point to buffer position POS.
-On the cursor row a rightward target is clamped to `evil-ghostel--input-end',
-so the move never right-arrows across a trailing autosuggestion, which the
-shell would accept (zsh-autosuggestions / fish).  Only meaningful in
-semi-char mode.  Returns non-nil when it ran."
+A closed feedback loop: send one arrow at a time and re-read the
+renderer's cell-accurate `ghostel--cursor-char-pos' after each, instead
+of open-loop column math that breaks on wide glyphs.  Rightward,
+on-cursor-row targets are clamped to `evil-ghostel--input-end' so a move
+never right-arrows across a trailing autosuggestion, which the shell
+would accept (zsh-autosuggestions / fish).  Only meaningful in semi-char
+mode.  Returns non-nil when the cursor reaches POS."
   (when (and ghostel--term ghostel--cursor-pos)
-    (let* ((start-col (car ghostel--cursor-pos))
-           (start-row-vp (cdr ghostel--cursor-pos))
+    (let* ((start-row-vp (cdr ghostel--cursor-pos))
            (target-row-vp (or (ghostel--viewport-row-at pos) start-row-vp))
-           (dy (- target-row-vp start-row-vp)))
-      ;; Clamp only a rightward, same-row target: at end-of-input a right
-      ;; arrow accepts the greyed suggestion.
-      ;; `input-end' excludes it, so stopping there means we never accept.
-      (when (and (zerop dy)
-                 ghostel--cursor-char-pos
-                 (> pos ghostel--cursor-char-pos))
-        (setq pos (min pos (or (evil-ghostel--input-end) pos))))
-      (let ((dx (- (save-excursion (goto-char pos) (current-column)) start-col)))
-        (cond ((> dy 0) (dotimes (_ dy) (ghostel--send-encoded "down" "")))
-              ((< dy 0) (dotimes (_ (abs dy)) (ghostel--send-encoded "up" ""))))
-        (cond ((> dx 0) (dotimes (_ dx) (ghostel--send-encoded "right" "")))
-              ((< dx 0) (dotimes (_ (abs dx)) (ghostel--send-encoded "left" ""))))
-        (when (or (/= dx 0) (/= dy 0))
-          (evil-ghostel--sync-render))
-        (goto-char pos)
-        t))))
+           (dy (- target-row-vp start-row-vp))
+           ;; Clamp only a rightward, same-row target: at end-of-input a
+           ;; right arrow accepts the greyed suggestion; `input-end'
+           ;; excludes it, so stopping there means we never accept.
+           (pos (if (and (zerop dy)
+                         (evil-ghostel--cursor-char-pos)
+                         (> pos (evil-ghostel--cursor-char-pos)))
+                    (min pos (or (evil-ghostel--input-end) pos))
+                  pos)))
+      (evil-ghostel--drive-cursor pos)
+      ;; Point follows where the terminal actually landed.  In particular,
+      ;; do not claim POS when the shell swallowed an arrow and the loop bailed.
+      (evil-ghostel--reset-cursor-point)
+      (equal (evil-ghostel--cursor-char-pos) pos))))
 
 (defun evil-ghostel-delete-input-region (beg end)
   "Delete BEG..END from input by backspacing over the PTY; return the count.
-Soft-wrap newlines are skipped (renderer artifacts).  Leaves point at BEG;
-the delete lands when the shell echoes it.  Semi-char only."
-  (let ((count (length (ghostel--filter-soft-wraps (buffer-substring beg end)))))
+Soft-wrap newlines are skipped (renderer artifacts).  Drives the cursor to
+END with a closed feedback loop, then sends a backspace per real input
+character, re-reading the live cursor after each so a wide glyph or a
+shell that refuses a backspace (bracketed-paste guard, read-only) doesn't
+leave a stray character.  Leaves point at the terminal cursor (BEG after a
+complete delete).  Semi-char only."
+  (let ((count (length (ghostel--filter-soft-wraps (buffer-substring beg end))))
+        (deleted 0))
     (when (> count 0)
-      (evil-ghostel-goto-input-position end)
-      (dotimes (_ count)
-        (ghostel--send-encoded "backspace" ""))
-      ;; Keep cursor state current for commands that continue editing.
-      (evil-ghostel--sync-render)
-      (goto-char beg))
-    count))
+      ;; Do not delete from the wrong place when cursor positioning failed.
+      (when (evil-ghostel-goto-input-position end)
+        (let ((iter 0)
+              (moving t))
+          ;; Stop by renderer position, not by key count: one backspace may
+          ;; remove a multi-codepoint grapheme (and cross a soft-wrap newline).
+          (while (and moving
+                      (< iter count)
+                      (> (evil-ghostel--cursor-char-pos) beg))
+            (let ((prev (evil-ghostel--cursor-char-pos)))
+              (ghostel--send-encoded "backspace" "")
+              (evil-ghostel--drain-output prev)
+              (let ((next (evil-ghostel--cursor-char-pos)))
+                (unless (and next (< next prev) (>= next beg))
+                  (setq moving nil))))
+            (cl-incf iter))
+          (when (equal (evil-ghostel--cursor-char-pos) beg)
+            (setq deleted count))))
+      (evil-ghostel--reset-cursor-point))
+    deleted))
 
 (defun evil-ghostel-replace-input-region (beg end string)
   "Replace the BEG..END range with STRING via the terminal PTY.
@@ -544,8 +656,9 @@ $ would walk into non-typed cells).  Off the cursor row, unchanged."
     (evil-insert-state 1))
    (t
     (let* ((cur (ghostel-cursor-point))
+           (cursor-pos (evil-ghostel--cursor-char-pos))
            (target
-            (if (and cur (>= (point) cur)
+            (if (and cur cursor-pos (>= (point) cursor-pos)
                      (save-excursion
                        (goto-char cur)
                        (or (eolp) (looking-at-p "[ \t]"))))

--- a/src/Renderer.zig
+++ b/src/Renderer.zig
@@ -924,6 +924,24 @@ fn render(
     env: emacs.Env,
     start_pin: gt.Pin,
 ) !void {
+    var render_start = start_pin;
+    // Incremental redraws can jump over the clean prefix; a new buffer must
+    // still visit every terminal row so it can materialize them.
+    if (self.rows_in_buffer > 0) {
+        var skipped: usize = 0;
+        var first_dirty: ?gt.Pin = null;
+        var clean_it = start_pin.rowIterator(.right_down, null);
+        while (clean_it.next()) |row_pin| : (skipped += 1) {
+            if (self.isRowDirty(row_pin)) {
+                first_dirty = row_pin;
+                break;
+            }
+        }
+
+        render_start = first_dirty orelse return;
+        if (skipped > 0) _ = env.f("forward-line", .{skipped});
+    }
+
     var eob = false;
     var current_span: ?struct {
         start_val: emacs.Value,
@@ -931,7 +949,7 @@ fn render(
         adjusted_line_start: usize,
     } = null;
 
-    var it = start_pin.rowIterator(.right_down, null);
+    var it = render_start.rowIterator(.right_down, null);
     while (it.next()) |row_pin| {
         const row = row_pin.rowAndCell().row;
         eob = eob or env.isNotNil(env.f("eobp", .{}));

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -81,6 +81,74 @@ Uses mocks for native functions."
            ,@body)
        (delete-process ghostel--process))))
 
+(defmacro evil-ghostel-test--with-input-fixture (prompt input &rest body)
+  "Set up a mock terminal buffer containing PROMPT followed by INPUT.
+PROMPT carries `ghostel-prompt'.  The mocked terminal cursor starts at
+the end of INPUT.  Run BODY with Evil and `evil-ghostel-mode' enabled."
+  (declare (indent 2) (debug t))
+  `(let ((buf (generate-new-buffer " *evil-ghostel-test-input*"))
+         (proc (evil-ghostel-test--live-process)))
+     (unwind-protect
+         (with-current-buffer buf
+           (ghostel-mode)
+           (let ((inhibit-read-only t))
+             (insert (propertize ,prompt 'ghostel-prompt t))
+             (insert ,input))
+           (setq ghostel--term 'fake
+                 ghostel--term-rows 1
+                 ghostel--process proc
+                 ghostel--cursor-char-pos (point)
+                 ghostel--cursor-pos (cons (current-column) 0))
+           (evil-local-mode 1)
+           (evil-ghostel-mode 1)
+           (cl-letf (((symbol-function 'ghostel--alt-screen-p)
+                      (lambda (&rest _) nil)))
+             ,@body))
+       (delete-process proc)
+       (kill-buffer buf))))
+
+(defun evil-ghostel-test--echo-key (key)
+  "Update the mocked renderer cursor after sending KEY."
+  (pcase key
+    ((or "left" "backspace")
+     (setq ghostel--cursor-pos
+           (cons (max 0 (1- (car ghostel--cursor-pos)))
+                 (cdr ghostel--cursor-pos)))
+     (when ghostel--cursor-char-pos
+       (cl-decf ghostel--cursor-char-pos)
+       ;; Soft-wrap newlines are renderer artifacts, not terminal cells.
+       (when (get-text-property ghostel--cursor-char-pos 'ghostel-wrap)
+         (cl-decf ghostel--cursor-char-pos))))
+    ("right"
+     (setq ghostel--cursor-pos
+           (cons (1+ (car ghostel--cursor-pos))
+                 (cdr ghostel--cursor-pos)))
+     (when ghostel--cursor-char-pos
+       (cl-incf ghostel--cursor-char-pos)))
+    ((or "up" "down")
+     (let* ((delta (if (equal key "up") -1 1))
+            (row (max 0 (+ (cdr ghostel--cursor-pos) delta)))
+            (col (car ghostel--cursor-pos)))
+       (setq ghostel--cursor-pos (cons col row))
+       (when ghostel--cursor-char-pos
+         (setq ghostel--cursor-char-pos
+               (save-excursion
+                 (goto-char (or (ghostel--viewport-start) (point-min)))
+                 (forward-line row)
+                 ;; A real render pads a short cursor row to COL.  The mock
+                 ;; buffer is static, so use the equivalent numeric position.
+                 (+ (line-beginning-position) col))))))))
+
+(defmacro evil-ghostel-test--with-echo-send (keys-sent &rest body)
+  "Record sent key names in KEYS-SENT and echo them while running BODY."
+  (declare (indent 1) (debug t))
+  `(cl-letf (((symbol-function 'ghostel--send-encoded)
+              (lambda (key _mods &rest _)
+                (push key ,keys-sent)
+                (evil-ghostel-test--echo-key key)))
+             ((symbol-function 'evil-ghostel--drain-output) #'ignore))
+     ,@body))
+
 ;; -----------------------------------------------------------------------
 ;; Test: mode activation
 ;; -----------------------------------------------------------------------
@@ -649,9 +717,7 @@ algorithm; this one walks scrollback math and viewport offsets too)."
   (evil-ghostel-test--with-buffer 5 40 "$ echo hello world"
                                   (should (equal '(18 . 0) ghostel--cursor-pos))
                                   (let ((keys-sent '()))
-                                    (cl-letf (((symbol-function 'ghostel--send-encoded)
-                                               (lambda (key _mods &rest _)
-                                                 (push key keys-sent))))
+                                    (evil-ghostel-test--with-echo-send keys-sent
                                       ;; Target: position 8 = column 7
                                       ;; (start of "hello").
                                       (evil-ghostel-goto-input-position 8))
@@ -692,9 +758,7 @@ diffing — otherwise dy is wrong by the scrollback line count."
                            (move-to-column (car tpos))
                            (point))))
         (let ((keys-sent '()))
-          (cl-letf (((symbol-function 'ghostel--send-encoded)
-                     (lambda (key _mods &rest _)
-                       (push key keys-sent))))
+          (evil-ghostel-test--with-echo-send keys-sent
             (evil-ghostel-goto-input-position target-pos))
           (should (= 1 (length keys-sent)))
           (should (equal "up" (car keys-sent))))))))
@@ -968,20 +1032,16 @@ was exposing."
   (evil-ghostel-test--with-input-fixture "$ " "hello"
     (evil-normal-state)
     (let ((keys-sent '()))
-      (cl-letf (((symbol-function 'ghostel--send-encoded)
-                 (lambda (key mods &rest _)
-                   (push (cons key mods) keys-sent)))
-                ((symbol-function 'evil-ghostel--sync-render) #'ignore)
-                ;; Mock the entry hook to avoid double-counting arrows: in
-                ;; tests `sync-render' is a no-op so `ghostel--cursor-pos'
-                ;; doesn't track the move, and the hook's idempotent re-run
-                ;; would otherwise re-send the same arrows.
-                ((symbol-function 'evil-ghostel--insert-state-entry) #'ignore))
-        (evil-ghostel-insert-line))
+      ;; Mock the entry hook to avoid double-counting arrows: the echo
+      ;; mock updates cursor-pos per key, and the hook's idempotent
+      ;; re-run would otherwise re-send the same arrows.
+      (cl-letf (((symbol-function 'evil-ghostel--insert-state-entry) #'ignore))
+        (evil-ghostel-test--with-echo-send keys-sent
+          (evil-ghostel-insert-line)))
       ;; Cursor at col 7 (end of "hello"), input-start at col 2 → 5 lefts.
-      (should (= 5 (cl-count '("left" . "") keys-sent :test #'equal)))
+      (should (= 5 (cl-count "left" keys-sent :test #'equal)))
       ;; Critically: no readline C-a — Bug B (#264) determinism.
-      (should-not (cl-find '("a" . "ctrl") keys-sent :test #'equal))
+      (should-not (member "a" keys-sent))
       (should (evil-insert-state-p)))))
 
 (ert-deftest evil-ghostel-test-append-line-sends-arrows-to-row-end ()
@@ -995,7 +1055,6 @@ regardless of shell vi-mode."
       (cl-letf (((symbol-function 'ghostel--send-encoded)
                  (lambda (key mods &rest _)
                    (push (cons key mods) keys-sent)))
-                ((symbol-function 'evil-ghostel--sync-render) #'ignore)
                 ((symbol-function 'evil-ghostel--insert-state-entry) #'ignore))
         (evil-ghostel-append-line))
       ;; Cursor at col 7, row-end at col 7 (after "hello", no padding) →
@@ -1010,10 +1069,10 @@ After the vterm-style rewrite point is set deterministically before
 right prompt (Bug A's \"until first keystroke\" symptom)."
   (evil-ghostel-test--with-input-fixture "$ " "hello"
     (evil-normal-state)
-    (cl-letf (((symbol-function 'ghostel--send-encoded) #'ignore)
-              ((symbol-function 'evil-ghostel--sync-render) #'ignore)
-              ((symbol-function 'evil-ghostel--insert-state-entry) #'ignore))
-      (evil-ghostel-insert-line))
+    (let ((keys-sent '()))
+      (cl-letf (((symbol-function 'evil-ghostel--insert-state-entry) #'ignore))
+        (evil-ghostel-test--with-echo-send keys-sent
+          (evil-ghostel-insert-line))))
     (should (= 3 (point))) ; right after "$ "
     (should (evil-insert-state-p))))
 
@@ -1023,7 +1082,6 @@ right prompt (Bug A's \"until first keystroke\" symptom)."
     (evil-normal-state)
     (goto-char (point-min))
     (cl-letf (((symbol-function 'ghostel--send-encoded) #'ignore)
-              ((symbol-function 'evil-ghostel--sync-render) #'ignore)
               ((symbol-function 'evil-ghostel--insert-state-entry) #'ignore))
       (evil-ghostel-append-line))
     (should (= 8 (point))) ; end of "hello"
@@ -1092,9 +1150,7 @@ arrows are sent."
   (evil-ghostel-test--with-buffer 5 40 "$ echo hello"
                                   ;; Delete "hello" (col 7-12)
                                   (let ((keys-sent '()))
-                                    (cl-letf (((symbol-function 'ghostel--send-encoded)
-                                               (lambda (key _mods &rest _)
-                                                 (push key keys-sent))))
+                                    (evil-ghostel-test--with-echo-send keys-sent
                                       (evil-ghostel-delete-input-region 8 13))
                                     ;; Should send arrow keys to move cursor, then 5 backspaces
                                     (should (= 5 (cl-count "backspace" keys-sent :test #'equal))))))
@@ -1103,47 +1159,14 @@ arrows are sent."
 ;; Test: input-region helpers (input-end, clamp)
 ;; -----------------------------------------------------------------------
 
-(defmacro evil-ghostel-test--with-input-fixture (prompt input &rest body)
-  "Set up a mock terminal buffer with PROMPT (carrying `ghostel-prompt')
-followed by INPUT, with `ghostel--cursor-char-pos' positioned at the
-end of INPUT.  Runs BODY in the buffer.
-
-Evil and `evil-ghostel-mode' are enabled so tests can invoke evil
-commands.  Mocks the terminal handle and viewport so the
-input-region helpers can derive prompt boundaries and viewport rows
-without a real native module."
-  (declare (indent 2))
-  `(let ((buf (generate-new-buffer " *evil-ghostel-test-input*"))
-         (proc (evil-ghostel-test--live-process)))
-     (unwind-protect
-         (with-current-buffer buf
-           (ghostel-mode)
-           (let ((inhibit-read-only t))
-             (insert (propertize ,prompt 'ghostel-prompt t))
-             (insert ,input))
-           (setq ghostel--term 'fake)
-           (setq ghostel--term-rows 1)
-           (setq ghostel--process proc)
-           (setq ghostel--cursor-char-pos (point))
-           (setq ghostel--cursor-pos (cons (current-column) 0))
-           (evil-local-mode 1)
-           (evil-ghostel-mode 1)
-           (cl-letf (((symbol-function 'ghostel--alt-screen-p)
-                      (lambda (&rest _) nil)))
-             ,@body))
-       (delete-process proc)
-       (kill-buffer buf))))
-
 (ert-deftest evil-ghostel-test-goto-input-position-sends-arrows-unit ()
   "Unit: |dx| left arrows are sent when point is left of the cursor."
   (evil-ghostel-test--with-input-fixture "$ " "hello world"
     ;; cursor-pos col 13 (after "$ hello world"); target is col 7 (start
     ;; of "hello"), so 6 LEFT arrows.
     (let ((keys-sent '()))
-      (cl-letf (((symbol-function 'ghostel--send-encoded)
-                 (lambda (key _mods &rest _)
-                   (push key keys-sent))))
-        (evil-ghostel-goto-input-position 8)) ; pos 8 = column 7
+      (evil-ghostel-test--with-echo-send keys-sent
+        (evil-ghostel-goto-input-position 8))           ; pos 8 = column 7
       (should (= 6 (length keys-sent)))
       (should (cl-every (lambda (k) (equal k "left")) keys-sent)))))
 
@@ -1156,6 +1179,111 @@ without a real native module."
                    (push key keys-sent))))
         (evil-ghostel-goto-input-position ghostel--cursor-char-pos))
       (should (zerop (length keys-sent))))))
+
+(ert-deftest evil-ghostel-test-goto-input-position-stops-on-no-op ()
+  "A swallowed arrow stops the drive without moving point to the target."
+  (evil-ghostel-test--with-input-fixture "$ " "abc"
+    (let ((keys-sent '()))
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key _mods &rest _) (push key keys-sent)))
+                ((symbol-function 'evil-ghostel--drain-output) #'ignore))
+        (should-not (evil-ghostel-goto-input-position 3)))
+      (should (equal '("left") keys-sent))
+      (should (= (point) ghostel--cursor-char-pos)))))
+
+(ert-deftest evil-ghostel-test-goto-input-position-waits-for-delayed-echo ()
+  "Cursor driving waits beyond the immediate-redraw scheduling interval."
+  (evil-ghostel-test--with-input-fixture "$ " "abc"
+    (let ((evil-ghostel-cursor-feedback-timeout 0.2)
+          (ghostel-immediate-redraw-interval 0.05)
+          (waited 0.0)
+          (keys-sent nil)
+          (target (1- ghostel--cursor-char-pos)))
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key _mods &rest _) (push key keys-sent)))
+                ((symbol-function 'accept-process-output)
+                 (lambda (_process timeout &rest _)
+                   (cl-incf waited timeout)
+                   (when (>= waited 0.1)
+                     (cl-decf ghostel--cursor-char-pos)
+                     (cl-decf (car ghostel--cursor-pos))
+                     t))))
+        (should (evil-ghostel-goto-input-position target)))
+      (should (equal '("left") keys-sent))
+      (should (>= waited 0.1)))))
+
+(ert-deftest evil-ghostel-test-goto-input-position-stops-on-reverse-motion ()
+  "A cursor key moving away from the target stops after one attempt."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "abcdefghijklmnop")
+   (let ((ghostel--cursor-pos '(5 . 0))
+         (ghostel--cursor-char-pos 6)
+         (keys-sent nil))
+     (cl-letf (((symbol-function 'ghostel--send-encoded)
+                (lambda (key _mods &rest _)
+                  (push key keys-sent)
+                  ;; Simulate a custom binding or redraw that moves the
+                  ;; cursor opposite to the requested Left direction.
+                  (cl-incf ghostel--cursor-char-pos)
+                  (cl-incf (car ghostel--cursor-pos))))
+               ((symbol-function 'evil-ghostel--drain-output) #'ignore))
+       (should-not (evil-ghostel-goto-input-position 5)))
+     (should (equal '("left") keys-sent)))))
+
+(ert-deftest evil-ghostel-test-goto-input-position-crosses-soft-wrap-with-left ()
+  "A soft-wrap boundary is crossed with Left, never shell-history Up."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "ab")
+   (insert (propertize "\n" 'ghostel-wrap t))
+   (insert "cd")
+   ;; Cursor at column zero of the wrapped row.  One Left lands before `b',
+   ;; whose renderer buffer position is 2 after skipping the fake newline.
+   (let ((ghostel--cursor-pos '(0 . 1))
+         (ghostel--cursor-char-pos 4)
+         (keys-sent nil))
+     (evil-ghostel-test--with-echo-send keys-sent
+       (should (evil-ghostel-goto-input-position 2)))
+     (should (equal '("left") keys-sent)))))
+
+(ert-deftest evil-ghostel-test-goto-input-position-stops-after-vertical-no-op ()
+  "A swallowed vertical arrow must not trigger horizontal keys on the wrong row."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "one\ntwo")
+   (let ((ghostel--cursor-pos '(3 . 1))
+         (ghostel--cursor-char-pos (point-max))
+         (keys-sent nil))
+     (cl-letf (((symbol-function 'ghostel--send-encoded)
+                (lambda (key _mods &rest _) (push key keys-sent)))
+               ((symbol-function 'evil-ghostel--drain-output) #'ignore))
+       (should-not (evil-ghostel-goto-input-position (point-min))))
+     (should (equal '("up") keys-sent))
+     (should (= (point) ghostel--cursor-char-pos)))))
+
+(ert-deftest evil-ghostel-test-goto-input-position-finishes-after-vertical-overshoot ()
+  "A vertical move may cross the target position before moving horizontally."
+  (evil-ghostel-test--with-evil-buffer
+   (setq-local ghostel--term t)
+   (insert "12345678\nabcdefgh")
+   ;; Move from row 0, column 8 to row 1, column 0.  Down preserves the
+   ;; terminal column and lands numerically past the target at position 18.
+   (let ((ghostel--cursor-pos '(8 . 0))
+         (ghostel--cursor-char-pos 9)
+         (keys-sent nil))
+     (evil-ghostel-test--with-echo-send keys-sent
+       (should (evil-ghostel-goto-input-position 10)))
+     (should (equal (cons "down" (make-list 8 "left"))
+                    (nreverse keys-sent)))
+     (should (= 10 ghostel--cursor-char-pos))
+     ;; The reverse trip crosses position 9 when Up preserves column zero.
+     (setq keys-sent nil)
+     (evil-ghostel-test--with-echo-send keys-sent
+       (should (evil-ghostel-goto-input-position 9)))
+     (should (equal (cons "up" (make-list 8 "right"))
+                    (nreverse keys-sent)))
+     (should (= 9 ghostel--cursor-char-pos)))))
 
 (defmacro evil-ghostel-test--with-cursor-fixture (prompt typed trail &rest body)
   "Mock terminal: PROMPT (`ghostel-prompt') + TYPED (`ghostel-input') + TRAIL,
@@ -1198,7 +1326,6 @@ correction is emitted (issue #493)."
     (let ((sent '()))
       (cl-letf (((symbol-function 'ghostel--send-encoded)
                  (lambda (key mods &rest _) (push (cons key mods) sent)))
-                ((symbol-function 'evil-ghostel--sync-render) #'ignore)
                 ;; Suggestion trails the cursor -> the input end is the cursor.
                 ((symbol-function 'evil-ghostel--input-end)
                  (lambda () ghostel--cursor-char-pos)))
@@ -1215,100 +1342,46 @@ correction is emitted (issue #493)."
 suggestion clamp does not over-restrict (issue #493)."
   (evil-ghostel-test--with-cursor-fixture "$ " "hel" "lo"
     (let ((sent '()))
-      (cl-letf (((symbol-function 'ghostel--send-encoded)
-                 (lambda (key mods &rest _) (push (cons key mods) sent)))
-                ((symbol-function 'evil-ghostel--sync-render) #'ignore)
-                ;; Real input end is two cells right of the cursor.
-                ((symbol-function 'evil-ghostel--input-end)
-                 (lambda () (+ ghostel--cursor-char-pos 2))))
-        (evil-ghostel-goto-input-position (+ ghostel--cursor-char-pos 2)))
-      (should (= 2 (cl-count "right" sent :key #'car :test #'equal)))
-      (should-not (cl-find '("_" . "ctrl") sent :test #'equal))
-      (should-not (cl-find "backspace" sent :key #'car :test #'equal)))))
-
-(ert-deftest evil-ghostel-test-sync-render-forces-deferred-redraw ()
-  "`sync-render' force-runs `ghostel--redraw-now' after a bulk-output drain.
-The filter only takes the synchronous redraw path for small echoes
-arriving within `ghostel-immediate-redraw-interval' of the last
-keystroke.  Larger echoes (e.g. `cc' sending 100 backspaces) take
-the bulk-output branch, which queues a timer-driven redraw — so
-`ghostel--cursor-pos' / `ghostel--cursor-char-pos' are stale until
-the timer fires.  `sync-render' must close the gap by forcing the
-deferred redraw before returning, otherwise the next operator
-(e.g. `i' after `cc') reads stale cursor state and computes a
-wrong arrow delta."
-  (evil-ghostel-test--with-input-fixture "$ " "hello"
-    (let* ((redraw-calls 0)
-           ;; Pretend the filter deferred a redraw to its timer.
-           (fake-timer (run-with-timer 999 nil #'ignore))
-           (ghostel--redraw-timer fake-timer)
-           (ghostel--process 'fake-proc))
-      (unwind-protect
-          (cl-letf (((symbol-function 'accept-process-output)
-                     (lambda (&rest _) nil))
-                    ;; Stubbed redraw stands in for the real
-                    ;; `ghostel--redraw-now', which cancels the timer.
-                    ((symbol-function 'ghostel--redraw-now)
-                     (lambda (_buf) (cl-incf redraw-calls))))
-            (evil-ghostel--sync-render)
-            (should (= 1 redraw-calls)))
-        (when (timerp fake-timer) (cancel-timer fake-timer))))))
-
-(ert-deftest evil-ghostel-test-sync-render-no-op-when-nothing-deferred ()
-  "`sync-render' does NOT force a redraw when the filter handled the echo.
-Small interactive echoes are drawn synchronously inside
-`ghostel--filter''s immediate-redraw branch, which clears
-`ghostel--redraw-timer'.  In that state `sync-render' must not call
-`ghostel--redraw-now' a second time — the cursor state is already
-current."
-  (evil-ghostel-test--with-input-fixture "$ " "hello"
-    (let ((redraw-calls 0)
-          (ghostel--redraw-timer nil)
-          (ghostel--process 'fake-proc))
-      (cl-letf (((symbol-function 'accept-process-output)
-                 (lambda (&rest _) nil))
-                ((symbol-function 'ghostel--redraw-now)
-                 (lambda (_buf) (cl-incf redraw-calls))))
-        (evil-ghostel--sync-render)
-        (should (zerop redraw-calls))))))
-
-(ert-deftest evil-ghostel-test-sync-render-drain-loop-respects-cap ()
-  "`sync-render' caps the drain loop at `*-max-iterations'.
-A runaway shell that returns non-nil from every
-`accept-process-output' call must not hang the caller.  The cap
-bounds total wait at ~max-iter × 50 ms."
-  (evil-ghostel-test--with-input-fixture "$ " "hello"
-    (let ((accept-calls 0)
-          (evil-ghostel-sync-render-max-iterations 5)
-          (ghostel--redraw-timer nil)
-          (ghostel--process 'fake-proc))
-      (cl-letf (((symbol-function 'accept-process-output)
-                 (lambda (&rest _) (cl-incf accept-calls) t))
-                ((symbol-function 'ghostel--redraw-now) #'ignore))
-        (evil-ghostel--sync-render)
-        ;; Loop exits via the iteration cap, not via accept returning nil.
-        (should (= 5 accept-calls))))))
+      (evil-ghostel-test--with-echo-send sent
+        (cl-letf (;; Real input end is two cells right of the cursor.
+                  ((symbol-function 'evil-ghostel--input-end)
+                   (lambda () (+ ghostel--cursor-char-pos 2))))
+          (evil-ghostel-goto-input-position (+ ghostel--cursor-char-pos 2))))
+      (should (= 2 (cl-count "right" sent :test #'equal)))
+      (should-not (member "_" sent))
+      (should-not (member "backspace" sent)))))
 
 (ert-deftest evil-ghostel-test-delete-input-region-sends-backspaces ()
   "`evil-ghostel-delete-input-region' sends one backspace per meaningful char."
   (evil-ghostel-test--with-input-fixture "$ " "hello"
     (let ((keys-sent '()))
-      (cl-letf (((symbol-function 'ghostel--send-encoded)
-                 (lambda (key _mods &rest _)
-                   (push key keys-sent))))
+      (evil-ghostel-test--with-echo-send keys-sent
         (evil-ghostel-delete-input-region 3 ghostel--cursor-char-pos))
       (should (= 5 (cl-count "backspace" keys-sent :test #'equal))))))
+
+(ert-deftest evil-ghostel-test-delete-input-region-stops-at-grapheme-boundary ()
+  "One shell backspace may remove a multi-codepoint grapheme."
+  (evil-ghostel-test--with-input-fixture "$ " "é"
+    (let ((keys-sent '())
+          (beg 3))
+      (cl-letf (((symbol-function 'ghostel--send-encoded)
+                 (lambda (key _mods &rest _)
+                   (push key keys-sent)
+                   (setq ghostel--cursor-char-pos beg)))
+                ((symbol-function 'evil-ghostel--drain-output) #'ignore))
+        (should (= 2 (evil-ghostel-delete-input-region
+                      beg ghostel--cursor-char-pos))))
+      (should (equal '("backspace") keys-sent)))))
 
 (ert-deftest evil-ghostel-test-replace-input-region-deletes-then-pastes ()
   "`evil-ghostel-replace-input-region' first deletes, then pastes new text."
   (evil-ghostel-test--with-input-fixture "$ " "abc"
     (let ((pasted nil)
           (keys-sent '()))
-      (cl-letf (((symbol-function 'ghostel--send-encoded)
-                 (lambda (key _mods &rest _) (push key keys-sent)))
-                ((symbol-function 'ghostel--paste-text)
-                 (lambda (text) (setq pasted text))))
-        (evil-ghostel-replace-input-region 3 ghostel--cursor-char-pos "XYZ"))
+      (evil-ghostel-test--with-echo-send keys-sent
+        (cl-letf (((symbol-function 'ghostel--paste-text)
+                   (lambda (text) (setq pasted text))))
+          (evil-ghostel-replace-input-region 3 ghostel--cursor-char-pos "XYZ")))
       (should (= 3 (cl-count "backspace" keys-sent :test #'equal)))
       (should (equal "XYZ" pasted)))))
 
@@ -1323,17 +1396,13 @@ bounds total wait at ~max-iter × 50 ms."
    (insert "hello world")
    (goto-char (point-min))
    (cl-letf (((symbol-function 'ghostel--alt-screen-p) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(0 . 0))
-             ((symbol-function 'evil-ghostel-goto-input-position) #'ignore))
+             (ghostel--cursor-pos '(11 . 0))
+             (ghostel--cursor-char-pos 12))  ; end of "hello world"
      (evil-normal-state)
-     (let ((bs-count 0))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _)
-                    (when (equal key "backspace")
-                      (cl-incf bs-count)))))
-         ;; Delete 5 chars (simulates dw on "hello")
+     (let ((keys-sent '()))
+       (evil-ghostel-test--with-echo-send keys-sent
          (evil-ghostel-delete 1 6 'inclusive nil nil))
-       (should (= 5 bs-count))))))
+       (should (= 5 (cl-count "backspace" keys-sent :test #'equal)))))))
 
 (ert-deftest evil-ghostel-test-delete-line-same-row-uses-backspaces ()
   "`dd' on the cursor's own line routes through `delete-input-region'.
@@ -1351,17 +1420,14 @@ shortcut is invoked."
    (cl-letf (((symbol-function 'ghostel--alt-screen-p) (lambda (&rest _) nil)))
      (evil-normal-state)
      (let ((keys-sent '()))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key mods &rest _)
-                    (push (cons key mods) keys-sent)))
-                 ((symbol-function 'evil-ghostel--sync-render) #'ignore))
-         (evil-ghostel-delete (line-beginning-position) (line-end-position)
-                              'line nil nil))
-       ;; 5 backspaces — one per char of "hello".
-       (should (= 5 (cl-count '("backspace" . "") keys-sent :test #'equal)))
-       ;; No readline shortcuts.
-       (should-not (cl-find '("e" . "ctrl") keys-sent :test #'equal))
-       (should-not (cl-find '("u" . "ctrl") keys-sent :test #'equal))))))
+      (evil-ghostel-test--with-echo-send keys-sent
+        (evil-ghostel-delete (line-beginning-position) (line-end-position)
+                             'line nil nil))
+      ;; 5 backspaces — one per char of "hello".
+      (should (= 5 (cl-count "backspace" keys-sent :test #'equal)))
+      ;; No readline shortcuts.
+      (should-not (member "e" keys-sent))
+      (should-not (member "u" keys-sent))))))
 
 (ert-deftest evil-ghostel-test-change-line-same-row-uses-backspaces ()
   "`cc' on the cursor's own line routes through `delete-input-region'
@@ -1376,19 +1442,16 @@ then enters insert state.  Same vterm-style shape as `dd'."
    (cl-letf (((symbol-function 'ghostel--alt-screen-p) (lambda (&rest _) nil)))
      (evil-normal-state)
      (let ((keys-sent '()))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key mods &rest _)
-                    (push (cons key mods) keys-sent)))
-                 ((symbol-function 'evil-ghostel--sync-render) #'ignore)
-                 ((symbol-function 'evil-ghostel--insert-state-entry) #'ignore))
-         (evil-ghostel-change (line-beginning-position) (line-end-position)
-                              'line nil nil))
-       (should (= 5 (cl-count '("backspace" . "") keys-sent :test #'equal)))
-       (should-not (cl-find '("e" . "ctrl") keys-sent :test #'equal))
-       (should-not (cl-find '("u" . "ctrl") keys-sent :test #'equal))
-       ;; Point lands at input-start (pos 3, just after "$ ").
-       (should (= 3 (point)))
-       (should (eq evil-state 'insert))))))
+      (cl-letf (((symbol-function 'evil-ghostel--insert-state-entry) #'ignore))
+        (evil-ghostel-test--with-echo-send keys-sent
+          (evil-ghostel-change (line-beginning-position) (line-end-position)
+                               'line nil nil)))
+      (should (= 5 (cl-count "backspace" keys-sent :test #'equal)))
+      (should-not (member "e" keys-sent))
+      (should-not (member "u" keys-sent))
+      ;; Point lands at input-start (pos 3, just after "$ ").
+      (should (= 3 (point)))
+      (should (eq evil-state 'insert))))))
 
 (ert-deftest evil-ghostel-test-delete-line-multiline-syncs-cursor ()
   "Regression for #218: line-type delete syncs terminal cursor first.
@@ -1400,24 +1463,23 @@ line)."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "line one\nline two\nline three")
-   ;; Terminal cursor reported at end of line three (col 10, row 2)
+   ;; Terminal cursor reported at end of line three (col 10, row 2, pos 29).
    (cl-letf (((symbol-function 'ghostel--alt-screen-p) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(10 . 2)))
+             (ghostel--cursor-pos '(10 . 2))
+             (ghostel--cursor-char-pos 29))
      (evil-normal-state)
      (goto-char (point-min))
      (let ((keys-sent '()))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key mods &rest _)
-                    (push (cons key mods) keys-sent))))
-         ;; Line 1 spans positions 1..10 ("line one" + newline = 9 chars)
-         (evil-ghostel-delete 1 10 'line nil nil))
-       ;; Sync from row 2 to row 1 (end of deleted region = bol of line 2)
-       (should (= 1 (cl-count '("up" . "") keys-sent :test #'equal)))
-       ;; Sync from col 10 to col 0
-       (should (= 10 (cl-count '("left" . "") keys-sent :test #'equal)))
-       ;; "line one\n" = 9 chars deleted via backspace
-       (should (= 9 (cl-count '("backspace" . "") keys-sent :test #'equal)))
-       (should-not (cl-find '("u" . "ctrl") keys-sent :test #'equal))))))
+      (evil-ghostel-test--with-echo-send keys-sent
+        ;; Line 1 spans positions 1..10 ("line one" + newline = 9 chars)
+        (evil-ghostel-delete 1 10 'line nil nil))
+      ;; Sync from row 2 to row 1 (end of deleted region = bol of line 2)
+      (should (= 1 (cl-count "up" keys-sent :test #'equal)))
+      ;; Sync from col 10 to col 0
+      (should (= 10 (cl-count "left" keys-sent :test #'equal)))
+      ;; "line one\n" = 9 chars deleted via backspace
+      (should (= 9 (cl-count "backspace" keys-sent :test #'equal)))
+      (should-not (member "u" keys-sent))))))
 
 (ert-deftest evil-ghostel-test-delete-char ()
   "`evil-ghostel-delete-char' (x) routes through PTY and stays in normal."
@@ -1444,16 +1506,13 @@ line)."
    (insert "hello world")
    (goto-char (point-min))
    (cl-letf (((symbol-function 'ghostel--alt-screen-p) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(0 . 0))
-             ((symbol-function 'evil-ghostel-goto-input-position) #'ignore))
+             (ghostel--cursor-pos '(11 . 0))
+             (ghostel--cursor-char-pos 12))  ; end of "hello world"
      (evil-normal-state)
-     (let ((bs-count 0))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _)
-                    (when (equal key "backspace")
-                      (cl-incf bs-count)))))
+     (let ((keys-sent '()))
+       (evil-ghostel-test--with-echo-send keys-sent
          (evil-ghostel-change 1 6 'inclusive nil nil))
-       (should (= 5 bs-count))
+       (should (= 5 (cl-count "backspace" keys-sent :test #'equal)))
        (should (eq evil-state 'insert))))))
 
 (ert-deftest evil-ghostel-test-change-whole-line ()
@@ -1480,24 +1539,16 @@ line)."
    (insert "hello")
    (goto-char (point-min))
    (cl-letf (((symbol-function 'ghostel--alt-screen-p) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(0 . 0))
-             ((symbol-function 'evil-ghostel-goto-input-position) #'ignore))
+             (ghostel--cursor-pos '(5 . 0))
+             (ghostel--cursor-char-pos 6))  ; end of "hello"
      (evil-normal-state)
-     (let ((bs-count 0)
-           (pasted nil))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _)
-                    (when (equal key "backspace")
-                      (cl-incf bs-count))))
-                 ((symbol-function 'ghostel--paste-text)
-                  (lambda (text) (setq pasted text))))
-         (evil-ghostel-replace 1 4 'inclusive ?X))
-       (should (= 3 bs-count))
+     (let ((keys-sent '()) (pasted nil))
+       (evil-ghostel-test--with-echo-send keys-sent
+         (cl-letf (((symbol-function 'ghostel--paste-text)
+                    (lambda (text) (setq pasted text))))
+           (evil-ghostel-replace 1 4 'inclusive ?X)))
+       (should (= 3 (cl-count "backspace" keys-sent :test #'equal)))
        (should (equal "XXX" pasted))))))
-
-;; -----------------------------------------------------------------------
-;; Test: evil-paste advice
-;; -----------------------------------------------------------------------
 
 (ert-deftest evil-ghostel-test-paste-after ()
   "`evil-ghostel-paste-after' pastes the kill ring's head via PTY."
@@ -1610,17 +1661,16 @@ Prevents up/down arrows being sent as history navigation."
   (evil-ghostel-test--with-evil-buffer
    (setq-local ghostel--term t)
    (insert "hello world")
-   ;; Terminal cursor on row 0, col 0
+   ;; Terminal cursor on row 0, col 0 (buffer pos 1).
    (cl-letf (((symbol-function 'ghostel--alt-screen-p) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(0 . 0)))
+             (ghostel--cursor-pos '(0 . 0))
+             (ghostel--cursor-char-pos 1))
      (evil-normal-state)
      ;; Move point to col 5 on the same row
      (goto-char (point-min))
      (move-to-column 5)
      (let ((keys-sent '()))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _)
-                    (push key keys-sent))))
+       (evil-ghostel-test--with-echo-send keys-sent
          (evil-insert-state))
        ;; Should have sent right arrows to sync column
        (should (member "right" keys-sent))
@@ -2010,14 +2060,13 @@ Trailing whitespace in single-line ranges is real user content."
    (goto-char (point-min))
    (move-to-column 5)  ; start of word2
    (cl-letf (((symbol-function 'ghostel--alt-screen-p) (lambda (&rest _) nil))
-             (ghostel--cursor-pos '(14 . 0)))
-     (let ((bs-count 0))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _)
-                    (when (equal key "backspace") (cl-incf bs-count)))))
+             (ghostel--cursor-pos '(14 . 0))
+             (ghostel--cursor-char-pos 15))
+     (let ((keys-sent '()))
+       (evil-ghostel-test--with-echo-send keys-sent
          ;; `dw' from col 5 deletes "word " (chars 6..10, exclusive end 11).
          (evil-ghostel-delete 6 11 'exclusive nil nil))
-       (should (= 5 bs-count))))))
+       (should (= 5 (cl-count "backspace" keys-sent :test #'equal)))))))
 
 (ert-deftest evil-ghostel-test-delete-word-on-last-word-clamps-overshoot ()
   "Regression: `dw' on the last input word clamps motion overshoot.
@@ -2040,16 +2089,14 @@ padding/blanks past end-of-input."
              (ghostel--cursor-pos '(7 . 0))
              (ghostel--cursor-char-pos 8))
      (evil-normal-state)
-     (let ((bs-count 0))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _)
-                    (when (equal key "backspace") (cl-incf bs-count)))))
+     (let ((keys-sent '()))
+       (evil-ghostel-test--with-echo-send keys-sent
          ;; Motion `w' from pos 8 walks past end-of-input to a blank
          ;; row below — simulate by passing END beyond the cursor row.
          (evil-ghostel-delete 8 13 'exclusive nil nil))
        ;; Clamp trims END to row-end (pos 12, after "word"), so the
        ;; delete sends 4 backspaces for "word", not 5+ for "word\n..."
-       (should (= 4 bs-count))))))
+       (should (= 4 (cl-count "backspace" keys-sent :test #'equal)))))))
 
 (ert-deftest evil-ghostel-test-change-partial-no-post-delete-sync ()
   "After `cw' (count > 0) the post-delete `evil-ghostel-insert' is idempotent.
@@ -2065,30 +2112,9 @@ mirror that drain behaviour."
    (move-to-column 6)
    (setq ghostel--cursor-pos '(17 . 0))
    (setq ghostel--cursor-char-pos (+ (point-min) 17))
-   (cl-letf (((symbol-function 'ghostel--alt-screen-p) (lambda (&rest _) nil))
-             ((symbol-function 'evil-ghostel--sync-render)
-              (lambda (&rest _) nil))) ; we already update pos inline
+   (cl-letf (((symbol-function 'ghostel--alt-screen-p) (lambda (&rest _) nil)))
      (let ((keys-sent '()))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _)
-                    (push key keys-sent)
-                    ;; Simulate the shell echo updating cursor-pos.
-                    (pcase key
-                      ((or "left" "backspace")
-                       (let ((col (car ghostel--cursor-pos))
-                             (row (cdr ghostel--cursor-pos)))
-                         (setq ghostel--cursor-pos (cons (max 0 (1- col)) row))
-                         (when ghostel--cursor-char-pos
-                           (setq ghostel--cursor-char-pos
-                                 (max (point-min)
-                                      (1- ghostel--cursor-char-pos))))))
-                      ("right"
-                       (let ((col (car ghostel--cursor-pos))
-                             (row (cdr ghostel--cursor-pos)))
-                         (setq ghostel--cursor-pos (cons (1+ col) row))
-                         (when ghostel--cursor-char-pos
-                           (setq ghostel--cursor-char-pos
-                                 (1+ ghostel--cursor-char-pos)))))))))
+       (evil-ghostel-test--with-echo-send keys-sent
          (evil-ghostel-change 7 12 'exclusive nil nil))
        (let* ((seq (nreverse keys-sent))
               (left-count (cl-count "left" seq :test #'equal))
@@ -2600,16 +2626,15 @@ character, so it must not consume a backspace or a replacement char."
    (cl-letf (((symbol-function 'ghostel--alt-screen-p) (lambda (&rest _) nil))
              (ghostel--cursor-pos '(1 . 0))
              (ghostel--cursor-char-pos (point-max))
-             ((symbol-function 'evil-ghostel-goto-input-position) #'ignore))
+             ((symbol-function 'evil-ghostel-goto-input-position)
+              (lambda (&rest _) t)))
      (evil-normal-state)
-     (let ((bs-count 0) (pasted nil))
-       (cl-letf (((symbol-function 'ghostel--send-encoded)
-                  (lambda (key _mods &rest _)
-                    (when (equal key "backspace") (cl-incf bs-count))))
-                 ((symbol-function 'ghostel--paste-text)
-                  (lambda (text) (setq pasted text))))
-         (evil-ghostel-replace (point-min) (point-max) 'inclusive ?X))
-       (should (= 3 bs-count))
+     (let ((keys-sent '()) (pasted nil))
+       (evil-ghostel-test--with-echo-send keys-sent
+         (cl-letf (((symbol-function 'ghostel--paste-text)
+                    (lambda (text) (setq pasted text))))
+           (evil-ghostel-replace (point-min) (point-max) 'inclusive ?X)))
+       (should (= 3 (cl-count "backspace" keys-sent :test #'equal)))
        (should (equal "XXX" pasted))))))
 
 (ert-deftest evil-ghostel-test-change-registered-for-cw-to-ce ()

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -203,10 +203,86 @@ overwrite the position evil assigns at operator/visual completion."
 (ert-deftest evil-ghostel-test-mode-deactivation ()
   "Test that `evil-ghostel-mode' cleans up on deactivation."
   (evil-ghostel-test--with-evil-buffer
+   (should (local-variable-p 'ghostel-readonly-fast-exit))
+   (should-not ghostel-readonly-fast-exit)
    (evil-ghostel-mode -1)
    (should-not evil-ghostel-mode)
+   (should-not (local-variable-p 'ghostel-readonly-fast-exit))
+   (should ghostel-readonly-fast-exit)
    (should-not (memq 'evil-ghostel--insert-state-entry
                      evil-insert-state-entry-hook))))
+
+(ert-deftest evil-ghostel-test-disable-restores-local-readonly-fast-exit ()
+  "Disabling evil-ghostel restores a pre-existing buffer-local fast-exit value."
+  (with-temp-buffer
+    (ghostel-mode)
+    (setq-local ghostel-readonly-fast-exit t)
+    (evil-local-mode 1)
+    (evil-ghostel-mode 1)
+    (should-not ghostel-readonly-fast-exit)
+    (evil-ghostel-mode -1)
+    (should (local-variable-p 'ghostel-readonly-fast-exit))
+    (should ghostel-readonly-fast-exit)))
+
+(ert-deftest evil-ghostel-test-copy-mode-enters-normal-and-toggles ()
+  "The Evil copy-mode remap freezes navigation until explicitly toggled off."
+  (evil-ghostel-test--with-evil-buffer
+   (insert "abc")
+   (goto-char (point-max))
+   (should (evil-insert-state-p))
+   (should (eq #'evil-ghostel-copy-mode
+               (command-remapping #'ghostel-copy-mode)))
+   (evil-ghostel-copy-mode)
+   (should (eq ghostel--input-mode 'copy))
+   (should (evil-normal-state-p))
+   (should-not ghostel-readonly-fast-exit)
+   (should (eq (current-local-map) ghostel-readonly-mode-map))
+   (should (eq (key-binding (kbd "h")) #'evil-backward-char))
+   (let ((before (point)))
+     (call-interactively (key-binding (kbd "h")))
+     (should (< (point) before)))
+   (should (eq ghostel--input-mode 'copy))
+   ;; Entering insert state cannot modify the read-only buffer, but ESC is
+   ;; still a recovery path to normal state and must not unfreeze copy mode.
+   (call-interactively (key-binding (kbd "i")))
+   (should (evil-insert-state-p))
+   (let ((last-command-event ?x))
+     (should-error (self-insert-command 1) :type 'buffer-read-only))
+   (let (sent)
+     (cl-letf (((symbol-function 'ghostel--alt-screen-p)
+                (lambda (&rest _) t))
+               ((symbol-function 'ghostel--send-encoded)
+                (lambda (&rest _) (setq sent t))))
+       (evil-ghostel--escape))
+     (should-not sent))
+   (should (evil-normal-state-p))
+   (should (eq ghostel--input-mode 'copy))
+   (evil-ghostel-copy-mode)
+   (should (eq ghostel--input-mode 'semi-char))))
+
+(ert-deftest evil-ghostel-test-tty-esc-recovers-from-readonly-insert-state ()
+  "A lone legacy-TTY ESC is decoded while Evil insert state is read-only."
+  (evil-ghostel-test--with-evil-buffer
+   (evil-ghostel-copy-mode)
+   (evil-insert 1)
+   (setq-local ghostel--term 'fake)
+   (let ((saved-map (make-sparse-keymap)))
+     (cl-letf (((symbol-function 'this-single-command-keys)
+                (lambda () [27]))
+               ((symbol-function 'sit-for) (lambda (_seconds) t)))
+       (should (equal [escape] (ghostel--tty-esc saved-map)))))))
+
+(ert-deftest evil-ghostel-test-enable-in-copy-mode-refreshes-keymap ()
+  "Enabling evil-ghostel replaces an already-active fast-exit map."
+  (with-temp-buffer
+    (ghostel-mode)
+    (ghostel-copy-mode)
+    (should (eq (current-local-map) ghostel-readonly-fast-exit-mode-map))
+    (evil-local-mode 1)
+    (evil-ghostel-mode 1)
+    (should-not ghostel-readonly-fast-exit)
+    (should (eq (current-local-map) ghostel-readonly-mode-map))
+    (evil-ghostel-mode -1)))
 
 (ert-deftest evil-ghostel-test-visual-inhibits-mark-copy-mode ()
   "Entering evil visual must not flip ghostel into copy mode.
@@ -242,7 +318,7 @@ buffer-locally so that chain yields to evil's own selection model."
    (should-not (local-variable-p 'ghostel-mark-activation-input-mode))))
 
 (ert-deftest evil-ghostel-test-advice-survives-disable-in-other-buffer ()
-  "Global `ghostel--redraw' / cursor-style advice survives one buffer disabling.
+  "Global redraw, cursor-style, and TTY ESC advice survives one disable.
 The advice is global but the mode is buffer-local; `advice-remove'
 during disable must wait until the LAST `evil-ghostel-mode' buffer
 is gone, otherwise toggling off in one buffer silently strips the
@@ -263,18 +339,24 @@ wrapper from every other ghostel buffer."
             (evil-ghostel-mode 1))
           (should (advice-member-p #'evil-ghostel--around-redraw
                                    'ghostel--redraw))
+          (should (advice-member-p #'evil-ghostel--around-tty-esc
+                                   'ghostel--tty-esc))
           ;; Disable in A — B still has the mode on, advice must stay.
           (with-current-buffer a (evil-ghostel-mode -1))
           (should (advice-member-p #'evil-ghostel--around-redraw
                                    'ghostel--redraw))
           (should (advice-member-p #'evil-ghostel--override-cursor-style
                                    'ghostel--apply-cursor-style))
+          (should (advice-member-p #'evil-ghostel--around-tty-esc
+                                   'ghostel--tty-esc))
           ;; Disable in B — no buffers left, advice removed.
           (with-current-buffer b (evil-ghostel-mode -1))
           (should-not (advice-member-p #'evil-ghostel--around-redraw
                                        'ghostel--redraw))
           (should-not (advice-member-p #'evil-ghostel--override-cursor-style
-                                       'ghostel--apply-cursor-style)))
+                                       'ghostel--apply-cursor-style))
+          (should-not (advice-member-p #'evil-ghostel--around-tty-esc
+                                       'ghostel--tty-esc)))
       (when (buffer-live-p a) (kill-buffer a))
       (when (buffer-live-p b) (kill-buffer b)))))
 


### PR DESCRIPTION
Hi! This project is amazing. It feels rock solid and is incredibly fast, great work!

What held me back from using it more was evil support. Whenever I would use vim motions like `ciw`, or just delete things around, the cursor/point would feel "stuck", like it would sometimes not delete a character and leave some garbage in the ghostel buffer. It would also not understand my evil motions fully.

I have fixed evil support so that it handles wide glyphs and graphemes correctly, and updated the syntax table so that it "understands" vim motions. I am happy to report that I have found all my issues with ghostel fixed with these changes! The evil experience is now truly silky smooth and I have dropped vterm.