### PR TITLE
Expose terminal title as public variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ All notable changes to this project will be documented in this file.
   the updated scripts.
 
 ### Added
+- The terminal title is now public as the buffer-local `ghostel-title`
+  variable (formerly the private `ghostel--title`).  It holds the current
+  title reported via OSC 0/2, or nil when no title is set.
 - New `consult-ghostel` extension package (under
   `extensions/consult-ghostel/`): `M-x consult-ghostel` and
   `M-x consult-ghostel-project` pick a ghostel terminal through `consult`

--- a/README.org
+++ b/README.org
@@ -1948,6 +1948,17 @@ Enable it for any Emacs Lisp input method:
 | =M-x ghostel-download-module=          | Download the pre-built native module.                                     |
 | =M-x ghostel-module-compile=           | Compile the native module from source.                                    |
 
+** Terminal title
+:properties:
+:custom_id: terminal-title
+:end:
+#+vindex: ghostel-title
+
+=ghostel-title= holds the current terminal title reported via OSC 0/2.  It is
+buffer-local and nil until the terminal reports a title or after the title is
+cleared.  Read another terminal buffer's title with
+=(buffer-local-value 'ghostel-title BUFFER)=.
+
 ** Picker annotations
 :properties:
 :custom_id: picker-annotations

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -973,8 +973,10 @@ local code should not assume it is signalable unless the process is local.")
 (defvar-local ghostel--last-directory nil
   "Last known working directory from OSC 7, used for dedup.")
 
-(defvar-local ghostel--title nil
-  "Last terminal title reported by OSC 0/2; nil when unset or cleared.")
+(defvar-local ghostel-title nil
+  "Current terminal title reported by OSC 0/2.
+This buffer-local value is read-only and nil when no title has been reported
+or the title has been cleared.")
 
 (defvar-local ghostel--managed-buffer-name nil
   "Last buffer name managed by Ghostel title tracking.
@@ -3368,13 +3370,13 @@ A nil or empty TITLE clears the title and reverts a title-derived
 name to the slot's creation-style name.  Renames via
 `ghostel-buffer-name-function' and `ghostel--rename-managed', which
 declines after a manual rename."
-  (setq ghostel--title (and title (not (string= "" title)) title))
+  (setq ghostel-title (and title (not (string= "" title)) title))
   (when ghostel-buffer-name-function
     (ghostel--rename-managed
-     (or (funcall ghostel-buffer-name-function ghostel--title)
+     (or (funcall ghostel-buffer-name-function ghostel-title)
          ;; Revert only names title tracking has claimed; a clear must
          ;; not rename a buffer it never touched.
-         (and (null ghostel--title)
+         (and (null ghostel-title)
               ghostel--managed-buffer-name
               ghostel--initial-name))))
   (ghostel--buffer-identification-update))
@@ -3384,7 +3386,7 @@ declines after a manual rename."
 See `ghostel-buffer-identification-format' for the specs.
 %b stays a live mode-line construct.
 A FORMAT with %t returns the plain buffer name while the terminal has no title."
-  (if (and (null ghostel--title)
+  (if (and (null ghostel-title)
            ;; Skip quoted percents so e.g. "50%%tests" is not read as a
            ;; title reference.
            (string-match-p "%[ 0<>^_-]*[0-9]*\\(?:\\.[0-9]+\\)?t"
@@ -3397,8 +3399,8 @@ A FORMAT with %t returns the plain buffer name while the terminal has no title."
             (format-spec (replace-regexp-in-string
                           "%[ 0<>^_-]*[0-9]*\\(?:\\.[0-9]+\\)?b" "%b" format)
                          `((?b . "\0")
-                           (?t . ,(propertize (or ghostel--title "")
-                                              'help-echo ghostel--title))
+                           (?t . ,(propertize (or ghostel-title "")
+                                              'help-echo ghostel-title))
                            (?d . ,(abbreviate-file-name
                                    (directory-file-name default-directory))))
                          'ignore))
@@ -3598,7 +3600,7 @@ URL does not match the local machine, construct a TRAMP path."
                   list-buffers-directory default-directory))))
       (when ghostel-buffer-name-function
         (ghostel--rename-managed
-         (funcall ghostel-buffer-name-function ghostel--title)))
+         (funcall ghostel-buffer-name-function ghostel-title)))
       (ghostel--buffer-identification-update))))
 
 
@@ -4990,7 +4992,7 @@ spawn after initialization."
           ghostel--process nil
           ghostel--pid nil
           ghostel--last-directory nil
-          ghostel--title nil
+          ghostel-title nil
           ghostel--command-running nil
           ghostel--event-buf nil
           ghostel--redraw-timer nil
@@ -5380,7 +5382,7 @@ Project membership is determined by `ghostel-project-buffer-scope'."
 The annotation is the terminal title, capped at
 `ghostel-annotation-title-width' columns."
   (when-let* ((buffer (get-buffer name))
-              (title (buffer-local-value 'ghostel--title buffer)))
+              (title (buffer-local-value 'ghostel-title buffer)))
     (concat "  " (if ghostel-annotation-title-width
                      (truncate-string-to-width
                       title ghostel-annotation-title-width nil nil t)

--- a/test/consult-ghostel-test.el
+++ b/test/consult-ghostel-test.el
@@ -59,7 +59,7 @@ the other."
         (let ((fun (plist-get consult-ghostel-source :annotate)))
           (should-not (funcall fun buf))
           (with-current-buffer buf
-            (setq ghostel--title "make -j8"))
+            (setq ghostel-title "make -j8"))
           (should (equal (funcall fun buf) "  make -j8")))
       (kill-buffer buf))))
 
@@ -71,7 +71,7 @@ the other."
                    (lambda (_) " orig")))
           (should (equal (consult-ghostel-marginalia-annotate buf) " orig"))
           (with-current-buffer buf
-            (setq ghostel--title "make -j8"))
+            (setq ghostel-title "make -j8"))
           (should (equal (consult-ghostel-marginalia-annotate buf)
                          "  make -j8 orig")))
       (kill-buffer buf))))

--- a/test/ghostel-buffer-name-test.el
+++ b/test/ghostel-buffer-name-test.el
@@ -44,6 +44,16 @@
 
 ;;; Title path (OSC 2) -- pure elisp
 
+(ert-deftest ghostel-test-title-is-buffer-local ()
+  "`ghostel-title' stores each terminal buffer's title independently."
+  (with-temp-buffer
+    (ghostel--set-title "first")
+    (with-temp-buffer
+      (should (null ghostel-title))
+      (ghostel--set-title "second")
+      (should (equal "second" ghostel-title)))
+    (should (equal "first" ghostel-title))))
+
 (ert-deftest ghostel-test-set-title-renames-and-respects-manual ()
   "An OSC 2 title renames via the by-title function; a manual rename wins."
   (let (buf)
@@ -62,7 +72,7 @@
               (should (equal "*ghostel*" (buffer-name)))
               (should (equal "*ghostel*" ghostel--managed-buffer-name))
               (ghostel--set-title "Title A")
-              (should (equal "Title A" ghostel--title))
+              (should (equal "Title A" ghostel-title))
               (should (equal "*ghostel: Title A*" (buffer-name)))
               (should (equal "*ghostel: Title A*" ghostel--managed-buffer-name))
               (ghostel--set-title "Title A2")
@@ -90,7 +100,7 @@
             (with-current-buffer buf
               (should (equal "*ghostel*" (buffer-name)))
               (ghostel--set-title "Ignored")
-              (should (equal "Ignored" ghostel--title))
+              (should (equal "Ignored" ghostel-title))
               (should (equal "*ghostel*" (buffer-name)))
               (should (equal "*ghostel*" ghostel--managed-buffer-name)))))
       (when (buffer-live-p buf) (kill-buffer buf)))))
@@ -139,7 +149,7 @@
       (when (buffer-live-p buf) (kill-buffer buf)))))
 
 (ert-deftest ghostel-test-set-title-clear-reverts-name ()
-  "An empty or nil title clears `ghostel--title' and reverts the name."
+  "An empty or nil title clears `ghostel-title' and reverts the name."
   (let (buf)
     (unwind-protect
         (cl-letf (((symbol-function 'ghostel--new)
@@ -156,13 +166,13 @@
               (ghostel--set-title "Title A")
               (should (equal "*ghostel: Title A*" (buffer-name)))
               (ghostel--set-title "")
-              (should (null ghostel--title))
+              (should (null ghostel-title))
               (should (equal "*ghostel*" (buffer-name)))
               (should (equal "*ghostel*" ghostel--managed-buffer-name))
               (ghostel--set-title "Title B")
               (should (equal "*ghostel: Title B*" (buffer-name)))
               (ghostel--set-title nil)
-              (should (null ghostel--title))
+              (should (null ghostel-title))
               (should (equal "*ghostel*" (buffer-name))))))
       (when (buffer-live-p buf) (kill-buffer buf)))))
 
@@ -184,7 +194,7 @@
               (ghostel--set-title "Title A")
               (rename-buffer "manual title" t)
               (ghostel--set-title "")
-              (should (null ghostel--title))
+              (should (null ghostel-title))
               (should (equal "manual title" (buffer-name))))))
       (when (buffer-live-p buf) (kill-buffer buf)))))
 
@@ -195,7 +205,7 @@
     (let ((ghostel-buffer-name-function #'ghostel-buffer-name-by-title)
           (name (buffer-name)))
       (ghostel--set-title "")
-      (should (null ghostel--title))
+      (should (null ghostel-title))
       (should (equal name (buffer-name))))))
 
 (ert-deftest ghostel-test-set-title-clear-by-directory-keeps-name ()
@@ -218,7 +228,7 @@
                 (ghostel--set-title "ignored")
                 (should (equal expected (buffer-name)))
                 (ghostel--set-title "")
-                (should (null ghostel--title))
+                (should (null ghostel-title))
                 (should (equal expected (buffer-name)))))))
       (when (buffer-live-p buf) (kill-buffer buf)))))
 
@@ -293,7 +303,7 @@ Guards against renaming to \"*ghostel: nil*\" before a title is set."
         (ghostel-buffer-name-function #'ghostel-buffer-name-by-title))
     (unwind-protect
         (ghostel-test--with-terminal-buffer (_buf _term 25 80 1000)
-          (should (null ghostel--title))
+          (should (null ghostel-title))
           (let ((before (buffer-name)))
             (ghostel--update-directory dir)
             (should (equal before (buffer-name)))
@@ -314,7 +324,7 @@ Guards against renaming to \"*ghostel: nil*\" before a title is set."
 (ert-deftest ghostel-test-buffer-identification-title-and-dir ()
   "%t and %d substitute; %b stays a live mode-line construct."
   (with-temp-buffer
-    (setq-local ghostel--title "vim main.c")
+    (setq-local ghostel-title "vim main.c")
     (let ((default-directory "/tmp/some/dir/"))
       (should (equal `("" ("%b") ,(format " (vim main.c) [%s]"
                                           (abbreviate-file-name
@@ -324,7 +334,7 @@ Guards against renaming to \"*ghostel: nil*\" before a title is set."
 (ert-deftest ghostel-test-buffer-identification-truncates-title ()
   "A precision modifier caps the title; `help-echo' keeps the full title."
   (with-temp-buffer
-    (setq-local ghostel--title "abcdefgh")
+    (setq-local ghostel-title "abcdefgh")
     (let* ((construct (ghostel--buffer-identification "%b %.5t"))
            (seg (car (last construct))))
       (should (equal '("" ("%b") " abcde") construct))
@@ -335,14 +345,14 @@ Guards against renaming to \"*ghostel: nil*\" before a title is set."
 (ert-deftest ghostel-test-buffer-identification-empty-title-fallback ()
   "A format referencing %t collapses to the buffer name without a title."
   (with-temp-buffer
-    (setq-local ghostel--title nil)
+    (setq-local ghostel-title nil)
     (should (equal '("%b")
                    (ghostel--buffer-identification "%b (%.30t)")))))
 
 (ert-deftest ghostel-test-buffer-identification-no-title-spec-renders ()
   "A format without %t renders even when the terminal has no title."
   (with-temp-buffer
-    (setq-local ghostel--title nil)
+    (setq-local ghostel-title nil)
     (let ((default-directory "/tmp/some/dir/"))
       (should (equal `("" ("%b") ,(format " [%s]"
                                           (abbreviate-file-name
@@ -352,14 +362,14 @@ Guards against renaming to \"*ghostel: nil*\" before a title is set."
 (ert-deftest ghostel-test-buffer-identification-escapes-percent ()
   "A % in the title is escaped instead of parsed as a mode-line construct."
   (with-temp-buffer
-    (setq-local ghostel--title "100% done")
+    (setq-local ghostel-title "100% done")
     (should (equal '("" ("%b") " (100%% done)")
                    (ghostel--buffer-identification "%b (%t)")))))
 
 (ert-deftest ghostel-test-buffer-identification-b-ignores-modifiers ()
   "Width/precision modifiers on %b are dropped, not applied to the placeholder."
   (with-temp-buffer
-    (setq-local ghostel--title "title")
+    (setq-local ghostel-title "title")
     (dolist (fmt '("%-10b (%t)" "%12b (%t)" "%.0b (%t)"))
       (should (equal '("" ("%b") " (title)")
                      (ghostel--buffer-identification fmt))))))
@@ -367,7 +377,7 @@ Guards against renaming to \"*ghostel: nil*\" before a title is set."
 (ert-deftest ghostel-test-buffer-identification-quoted-percent-not-title ()
   "A quoted %% before t is not read as a %t reference."
   (with-temp-buffer
-    (setq-local ghostel--title nil)
+    (setq-local ghostel-title nil)
     ;; No fallback: the format does not reference the title.
     (should (equal '("" ("%b") " 50%%tests")
                    (ghostel--buffer-identification "%b 50%%tests")))))
@@ -376,9 +386,9 @@ Guards against renaming to \"*ghostel: nil*\" before a title is set."
   "Titles sharing a truncated prefix still refresh the `help-echo'."
   (with-temp-buffer
     (let ((ghostel-buffer-identification-format "%b %.5t"))
-      (setq-local ghostel--title "abcdeXX")
+      (setq-local ghostel-title "abcdeXX")
       (ghostel--buffer-identification-update)
-      (setq-local ghostel--title "abcdeYY")
+      (setq-local ghostel-title "abcdeYY")
       (ghostel--buffer-identification-update)
       (let ((seg (car (last mode-line-buffer-identification))))
         (should (equal "abcdeYY"
@@ -388,7 +398,7 @@ Guards against renaming to \"*ghostel: nil*\" before a title is set."
 (ert-deftest ghostel-test-buffer-identification-b-stays-live ()
   "%b expands to the live construct, never a frozen buffer name."
   (with-temp-buffer
-    (setq-local ghostel--title "title")
+    (setq-local ghostel-title "title")
     (let ((construct (ghostel--buffer-identification "%b (%t)")))
       (should (equal '("%b") (nth 1 construct)))
       ;; No segment carries a snapshot of the current buffer name.
@@ -399,7 +409,7 @@ Guards against renaming to \"*ghostel: nil*\" before a title is set."
 (ert-deftest ghostel-test-buffer-identification-nil-format-leaves-mode-line ()
   "A nil `ghostel-buffer-identification-format' leaves the mode line alone."
   (with-temp-buffer
-    (setq-local ghostel--title "title")
+    (setq-local ghostel-title "title")
     (let ((before mode-line-buffer-identification)
           (ghostel-buffer-identification-format nil))
       (ghostel--buffer-identification-update)
@@ -428,7 +438,7 @@ Guards against renaming to \"*ghostel: nil*\" before a title is set."
                            mode-line-buffer-identification))
             ;; Reinitializing a reused buffer drops the stale title.
             (ghostel--init-buffer buf)
-            (should (null ghostel--title))
+            (should (null ghostel-title))
             (should (equal '("%b") mode-line-buffer-identification))))
       (when (buffer-live-p buf) (kill-buffer buf)))))
 

--- a/test/ghostel-buffers-test.el
+++ b/test/ghostel-buffers-test.el
@@ -204,9 +204,9 @@ Each BINDING is (VAR NAME [DIR [IDENTITY]])."
 (ert-deftest ghostel-test-annotate-buffer-title ()
   "`ghostel-annotate-buffer' caps the title at `ghostel-annotation-title-width'."
   (ghostel-buffers-test--with-bufs ((a "*ghostel-a*"))
-    (with-current-buffer a (setq-local ghostel--title "make test"))
+    (with-current-buffer a (setq-local ghostel-title "make test"))
     (should (equal "  make test" (ghostel-annotate-buffer (buffer-name a))))
-    (with-current-buffer a (setq-local ghostel--title (make-string 60 ?x)))
+    (with-current-buffer a (setq-local ghostel-title (make-string 60 ?x)))
     (let* ((ghostel-annotation-title-width 30)
            (annotation (ghostel-annotate-buffer (buffer-name a))))
       (should (<= (string-width annotation) 32))

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -55,10 +55,10 @@
           (ghostel--write-pty ghostel--term (format "\e]2;%s\e\\" title))
           (ghostel-test--wait-until
            (lambda ()
-             (and (equal title ghostel--title)
+             (and (equal title ghostel-title)
                   (equal expected (buffer-name))))
            proc 5)
-          (should (equal title ghostel--title))
+          (should (equal title ghostel-title))
           (should (equal expected (buffer-name))))))))
 
 (ert-deftest ghostel-test-osc2-empty-title-clears ()
@@ -76,12 +76,12 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
                                  (setq round (1+ round)))))
               (ghostel--write-pty ghostel--term (format "\e]2;%s\e\\" title))
               (ghostel-test--wait-until
-               (lambda () (equal title ghostel--title)) proc 5)
+               (lambda () (equal title ghostel-title)) proc 5)
               (should (equal (format "*ghostel: %s*" title) (buffer-name)))
               (ghostel--write-pty ghostel--term clear)
               (ghostel-test--wait-until
-               (lambda () (null ghostel--title)) proc 5)
-              (should (null ghostel--title))
+               (lambda () (null ghostel-title)) proc 5)
+              (should (null ghostel-title))
               (should (equal expected (buffer-name)))
               (should (equal expected ghostel--managed-buffer-name)))))))))
 
@@ -95,11 +95,11 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
               (title (format "RIS Stale %S" backend)))
           (ghostel--write-vt ghostel--term (format "\e]2;%s\e\\" title))
           (ghostel-test--wait-until
-           (lambda () (equal title ghostel--title)) proc 5)
+           (lambda () (equal title ghostel-title)) proc 5)
           (should (equal (format "*ghostel: %s*" title) (buffer-name)))
           (ghostel--write-vt ghostel--term "\ec")
           (ghostel-test--wait-until
-           (lambda () (null ghostel--title)) proc 5)
+           (lambda () (null ghostel-title)) proc 5)
           (should (equal expected (buffer-name)))
           (should (equal expected ghostel--managed-buffer-name)))))))
 
@@ -117,7 +117,7 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
           (ghostel--write-vt ghostel--term "\ec\e]2;SENTINEL\e\\")
           ;; Effects are FIFO, so observing SENTINEL drains any RIS callback.
           (ghostel-test--wait-until
-           (lambda () (equal "SENTINEL" ghostel--title)) proc 5)
+           (lambda () (equal "SENTINEL" ghostel-title)) proc 5)
           (should (equal 1 calls)))))))
 
 (ert-deftest ghostel-test-title-stack-restores-title ()
@@ -129,18 +129,18 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
             (inner (format "Inner %S" backend)))
         (ghostel--write-vt ghostel--term (format "\e]2;%s\e\\" outer))
         (ghostel-test--wait-until
-         (lambda () (equal outer ghostel--title)) proc 5)
+         (lambda () (equal outer ghostel-title)) proc 5)
         (ghostel--write-vt ghostel--term
                            (format "\e[22;0t\e]2;%s\e\\" inner))
         (ghostel-test--wait-until
-         (lambda () (equal inner ghostel--title)) proc 5)
+         (lambda () (equal inner ghostel-title)) proc 5)
         (ghostel--write-vt ghostel--term "\e[23;0t")
         (ghostel-test--wait-until
-         (lambda () (equal outer ghostel--title)) proc 5)
+         (lambda () (equal outer ghostel-title)) proc 5)
         ;; Push again to verify that pop restored terminal state as well as Elisp state.
         (ghostel--write-vt ghostel--term "\e[22;0t\e]2;transient\e\\\e[23;0t")
         (ghostel-test--wait-until
-         (lambda () (equal outer ghostel--title)) proc 5)))))
+         (lambda () (equal outer ghostel-title)) proc 5)))))
 
 (ert-deftest ghostel-test-title-stack-drops-push-when-full ()
   "Pushes beyond xterm's 10-entry title stack limit are dropped."
@@ -153,11 +153,11 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
                            (format "\e]2;T%d\e\\\e[22;0t" i)))
       (ghostel--write-vt ghostel--term "\e]2;final\e\\\e[23;0t")
       (ghostel-test--wait-until
-       (lambda () (equal "T9" ghostel--title)) proc 5)
+       (lambda () (equal "T9" ghostel-title)) proc 5)
       (dotimes (_ 9)
         (ghostel--write-vt ghostel--term "\e[23;0t"))
       (ghostel-test--wait-until
-       (lambda () (equal "T0" ghostel--title)) proc 5))))
+       (lambda () (equal "T0" ghostel-title)) proc 5))))
 
 (ert-deftest ghostel-test-title-stack-restores-no-title ()
   "Vim's push/set/pop sequence restores an unset title."
@@ -170,10 +170,10 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
                                  "\e]2;file +  - VIM\a"
                                  "\e]2;Thanks for flying Vim\a"))
       (ghostel-test--wait-until
-       (lambda () (equal "Thanks for flying Vim" ghostel--title)) proc 5)
+       (lambda () (equal "Thanks for flying Vim" ghostel-title)) proc 5)
       (ghostel--write-vt ghostel--term "\e[23;2t\e[23;1t")
       (ghostel-test--wait-until
-       (lambda () (null ghostel--title)) proc 5))))
+       (lambda () (null ghostel-title)) proc 5))))
 
 (ert-deftest ghostel-test-title-stack-empty-pop-is-no-op ()
   "Popping an empty title stack leaves the title unchanged."
@@ -182,7 +182,7 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
     (ghostel-test--with-raw-echo-buffer (buf proc)
       (ghostel--write-vt ghostel--term "\e]2;KEEP\e\\\e[23;0t")
       (ghostel-test--wait-until
-       (lambda () (equal "KEEP" ghostel--title)) proc 5))))
+       (lambda () (equal "KEEP" ghostel-title)) proc 5))))
 
 (ert-deftest ghostel-test-title-stack-indexed-operations-are-no-ops ()
   "Indexed title stack operations leave the default stack unchanged."
@@ -193,17 +193,17 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
       ;; Since the indexed push is ignored, the pop has nothing to restore.
       (ghostel--write-vt ghostel--term "\e[22;0;5t\e]2;IDX\e\\\e[23;0t")
       (ghostel-test--wait-until
-       (lambda () (equal "IDX" ghostel--title)) proc 5)
+       (lambda () (equal "IDX" ghostel-title)) proc 5)
       ;; Push IDX onto the default stack, set the title to AFTER, then try
       ;; indexed pop 5.  The indexed pop leaves AFTER displayed and IDX saved.
       (ghostel--write-vt ghostel--term
                          "\e[22;0t\e]2;AFTER\e\\\e[23;0;5t")
       (ghostel-test--wait-until
-       (lambda () (equal "AFTER" ghostel--title)) proc 5)
+       (lambda () (equal "AFTER" ghostel-title)) proc 5)
       ;; A default pop restores IDX, proving that indexed pop 5 did not consume it.
       (ghostel--write-vt ghostel--term "\e[23;0t")
       (ghostel-test--wait-until
-       (lambda () (equal "IDX" ghostel--title)) proc 5))))
+       (lambda () (equal "IDX" ghostel-title)) proc 5))))
 
 (ert-deftest ghostel-test-full-reset-clears-title-stack ()
   "RIS discards saved title stack entries."
@@ -213,7 +213,7 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
       (ghostel--write-vt ghostel--term
                          "\e]2;BEFORE\e\\\e[22;0t\ec\e]2;AFTER\e\\\e[23;0t")
       (ghostel-test--wait-until
-       (lambda () (equal "AFTER" ghostel--title)) proc 5))))
+       (lambda () (equal "AFTER" ghostel-title)) proc 5))))
 
 (ert-deftest ghostel-test-osc9-notification ()
   "OSC 9 iTerm2-style notifications reach `ghostel-notification-function'."

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -821,7 +821,7 @@ and typed text was invisible."
       (ghostel--write-vt term "\e]2;My Title\e\\")
       (should (equal "My Title"
                      (ghostel-test--wait-until
-                      (lambda () ghostel--title) nil 1))))))
+                      (lambda () ghostel-title) nil 1))))))
 
 
 ;;; Scrollback materialization and eviction


### PR DESCRIPTION
## Summary

- rename the buffer-local terminal title state from `ghostel--title` to public `ghostel-title`
- document the public variable and update core, OSC, picker, render, and consult tests
- add coverage confirming terminal titles remain buffer-local

## Testing

- byte-compiled the changed package files
- ran the relevant Elisp and native buffer-name, buffer-picker, OSC, and render test suites
- ran `make test-consult`
- ran targeted checkdoc and docquote checks