### PR TITLE
Report terminal color scheme via CSI 996 and Mode 2031

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Color-scheme DSR is implemented: CSI `? 996 n` reports light/dark
-  from the protocol background (OSC 11), and enabling Mode 2031 now
-  actually produces CSI `? 997` reports when the Emacs theme changes.
+  from the last synchronized `ghostel-default` background, and enabling
+  Mode 2031 now actually produces CSI `? 997` reports when the Emacs theme
+  changes or `ghostel-sync-theme` is called explicitly.
   Previously ghostel stored Mode 2031 but never answered 996 or pushed
   997, so multiplexers (herdr) kept a stale OSC 11 cache and TUIs that
   paint from it (Codex's composer) did not follow light/dark.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Color-scheme DSR is implemented: CSI `? 996 n` reports light/dark
+  from the protocol background (OSC 11), and enabling Mode 2031 now
+  actually produces CSI `? 997` reports when the Emacs theme changes.
+  Previously ghostel stored Mode 2031 but never answered 996 or pushed
+  997, so multiplexers (herdr) kept a stale OSC 11 cache and TUIs that
+  paint from it (Codex's composer) did not follow light/dark.
 - Directory tracking no longer corrupts or silently stalls on paths
   containing `#` or percent-escapes.  The bash and zsh integrations
   report the cwd with kitty's `kitty-shell-cwd://` OSC 7 scheme (path

--- a/README.org
+++ b/README.org
@@ -687,9 +687,11 @@ read-only buffer (Emacs or copy).
   Emacs face colors.
 - *CSI ? 996 / Mode 2031* - color-scheme DSR.  A query (=CSI ? 996 n=)
   is answered with =CSI ? 997 ; 1 n= (dark) or =; 2 n= (light), inferred
-  from the OSC 11 background.  Clients that enable Mode 2031 also get
-  an unsolicited 997 when =ghostel-sync-theme= updates the protocol
-  defaults, so multiplexers can refresh their OSC 11 cache.
+  from the last synchronized =ghostel-default= background.  Theme changes
+  synchronize it automatically; after changing =ghostel-default= directly,
+  run =ghostel-sync-theme=.  Clients that enable Mode 2031 also get an
+  unsolicited 997 on synchronization, so multiplexers can refresh their
+  OSC 11 cache.
 - *OSC 9 / OSC 777* - desktop notifications and ConEmu progress reports (see
   [[#notifications-and-progress][Notifications and Progress]]).
 - Text attributes: bold, italic, faint, underline (single/double/curly/dotted/dashed, with color), strikethrough, inverse.

--- a/README.org
+++ b/README.org
@@ -685,6 +685,11 @@ read-only buffer (Emacs or copy).
   foreground, and background colors, so tools like =duf=, =btop=, =delta=, and
   anything else using =termenv= auto-detect the right light/dark theme from the
   Emacs face colors.
+- *CSI ? 996 / Mode 2031* - color-scheme DSR.  A query (=CSI ? 996 n=)
+  is answered with =CSI ? 997 ; 1 n= (dark) or =; 2 n= (light), inferred
+  from the OSC 11 background.  Clients that enable Mode 2031 also get
+  an unsolicited 997 when =ghostel-sync-theme= updates the protocol
+  defaults, so multiplexers can refresh their OSC 11 cache.
 - *OSC 9 / OSC 777* - desktop notifications and ConEmu progress reports (see
   [[#notifications-and-progress][Notifications and Progress]]).
 - Text attributes: bold, italic, faint, underline (single/double/curly/dotted/dashed, with color), strikethrough, inverse.

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3636,7 +3636,11 @@ URL does not match the local machine, construct a TRAMP path."
 
 (defun ghostel-sync-theme ()
   "Re-apply terminal color palette in all ghostel buffers.
-Call this after changing the Emacs theme so terminals match."
+Call this after changing the Emacs theme so terminals match.
+
+Re-seeds OSC 10/11 protocol defaults from `ghostel-default'.  When a
+client has enabled Mode 2031, also writes CSI ? 997 n (dark=1, light=2)
+so multiplexers such as herdr re-query those colors."
   (interactive)
   (dolist (buf (buffer-list))
     (with-current-buffer buf

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3636,7 +3636,8 @@ URL does not match the local machine, construct a TRAMP path."
 
 (defun ghostel-sync-theme ()
   "Re-apply terminal color palette in all ghostel buffers.
-Call this after changing the Emacs theme so terminals match.
+Theme changes call this automatically.  Call it manually after changing
+`ghostel-default' or palette faces directly.
 
 Re-seeds OSC 10/11 protocol defaults from `ghostel-default'.  When a
 client has enabled Mode 2031, also writes CSI ? 997 n (dark=1, light=2)

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -113,8 +113,10 @@ pub fn vtWrite(self: *Self, data: []const u8) !void {
     self.unlockTerm();
 }
 
-/// CSI ? 997 report for the current protocol background, or null when
-/// Mode 2031 is off or no child PTY is attached.
+/// CSI ? 997 report for the last synchronized default background, or null when
+/// Mode 2031 is off or no child PTY is attached. The default is intentional:
+/// a child OSC 11 override is terminal-session state, not a host appearance
+/// change.
 pub fn colorSchemeReport(self: *Self, env: emacs.Env) ?[]const u8 {
     const mode = gt.modes.modeFromInt(2031, false) orelse return null;
     if (!self.terminal.modes.get(mode)) return null;

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -113,6 +113,20 @@ pub fn vtWrite(self: *Self, data: []const u8) !void {
     self.unlockTerm();
 }
 
+/// CSI ? 997 report for the current protocol background, or null when
+/// Mode 2031 is off or no child PTY is attached.
+pub fn colorSchemeReport(self: *Self, env: emacs.Env) ?[]const u8 {
+    const mode = gt.modes.modeFromInt(2031, false) orelse return null;
+    if (!self.terminal.modes.get(mode)) return null;
+    if (self.process == null and env.isNil(env.symbolValue("ghostel--process"))) {
+        return null;
+    }
+    return if (utils.backgroundIsLight(self.terminal.colors.background.default))
+        "\x1b[?997;2n"
+    else
+        "\x1b[?997;1n";
+}
+
 pub fn ptyWrite(self: *Self, data: []const u8) !void {
     const env = emacs.current_env orelse return error.MissingEmacsEnv;
     if (self.process) |proc| {
@@ -662,6 +676,9 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 defer term.unlockTerm();
                 term.terminal.colors.foreground.default = try gt.color.RGB.parse(fg_str);
                 term.terminal.colors.background.default = try gt.color.RGB.parse(bg_str);
+                if (term.colorSchemeReport(env)) |report| {
+                    try term.ptyWrite(report);
+                }
                 return env.t();
             }
         },

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -8,6 +8,7 @@ const Allocator = std.mem.Allocator;
 const emacs = @import("emacs.zig");
 const gt = @import("ghostty-vt");
 const GhostelTerm = @import("GhostelTerm.zig");
+const utils = @import("utils.zig");
 
 const log = std.log.scoped(.GhostelHandler);
 
@@ -35,6 +36,7 @@ pub fn GhostelHandler(Context: type) type {
             };
             self.inner.effects.write_pty = &writePtyCallback;
             self.inner.effects.bell = &bellCallback;
+            self.inner.effects.color_scheme = &colorSchemeCallback;
             self.inner.effects.device_attributes = &deviceAttributesCallback;
             self.inner.effects.title_changed = &titleChangedCallback;
             self.inner.effects.size = &sizeCallback;
@@ -102,6 +104,22 @@ pub fn GhostelHandler(Context: type) type {
         fn bellCallback(handler: *gt.TerminalStream.Handler) void {
             const self: *Self = @fieldParentPtr("inner", handler);
             self.context.effect("ding", .{});
+        }
+
+        // `device_status.ColorScheme` is not re-exported from ghostty-vt.
+        const ColorSchemeFn = @typeInfo(
+            @typeInfo(
+                @FieldType(gt.TerminalStream.Handler.Effects, "color_scheme"),
+            ).optional.child,
+        ).pointer.child;
+        const ColorScheme = @typeInfo(ColorSchemeFn).@"fn".return_type.?;
+
+        /// CSI ? 996 n — report light/dark from the protocol background color.
+        fn colorSchemeCallback(handler: *gt.TerminalStream.Handler) ColorScheme {
+            return if (utils.backgroundIsLight(handler.terminal.colors.background.default))
+                .light
+            else
+                .dark;
         }
 
         // TODO: DeviceAttributes is not exported from ghostty-vt for some reason.

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -114,7 +114,8 @@ pub fn GhostelHandler(Context: type) type {
         ).pointer.child;
         const ColorScheme = @typeInfo(ColorSchemeFn).@"fn".return_type.?;
 
-        /// CSI ? 996 n — report light/dark from the protocol background color.
+        /// CSI ? 996 n — report the last synchronized default background.
+        /// Do not let a child OSC 11 override redefine the host color scheme.
         fn colorSchemeCallback(handler: *gt.TerminalStream.Handler) ColorScheme {
             return if (utils.backgroundIsLight(handler.terminal.colors.background.default))
                 .light

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,13 +1,27 @@
+const std = @import("std");
 const gt = @import("ghostty-vt");
 
 const emacs = @import("emacs.zig");
 
-/// ITU-R BT.601 luma.  Matches herdr's OSC 11 → light/dark cutoff (128).
-/// Unset protocol background is treated as dark (libghostty's seed).
+/// Classify an OSC 11 default background using the convention from Neovim's
+/// terminal background detection: ITU-R BT.601 luma split at the 0.5 midpoint.
+/// https://github.com/neovim/neovim/blob/2fbc82820b5168b0da4e918c192c05832dfd6211/runtime/lua/vim/_core/defaults.lua
+///
+/// Ghostel has no separate light/dark appearance state. Instead, CSI 996/997
+/// classifies the `ghostel-default` background most recently seeded by
+/// `ghostel-sync-theme`. Theme changes trigger that sync automatically; direct
+/// face changes require an explicit sync. An unset background is treated as dark
+/// (libghostty's seed).
 pub fn backgroundIsLight(rgb: ?gt.color.RGB) bool {
     const c = rgb orelse return false;
     const y = @as(u32, c.r) * 299 + @as(u32, c.g) * 587 + @as(u32, c.b) * 114;
-    return y >= 128_000;
+    return y >= 127_500;
+}
+
+test backgroundIsLight {
+    try std.testing.expect(!backgroundIsLight(null));
+    try std.testing.expect(!backgroundIsLight(.{ .r = 127, .g = 127, .b = 127 }));
+    try std.testing.expect(backgroundIsLight(.{ .r = 128, .g = 128, .b = 127 }));
 }
 
 pub fn cellCharCount(page: *gt.Page, cell: *gt.Cell) usize {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -2,6 +2,14 @@ const gt = @import("ghostty-vt");
 
 const emacs = @import("emacs.zig");
 
+/// ITU-R BT.601 luma.  Matches herdr's OSC 11 → light/dark cutoff (128).
+/// Unset protocol background is treated as dark (libghostty's seed).
+pub fn backgroundIsLight(rgb: ?gt.color.RGB) bool {
+    const c = rgb orelse return false;
+    const y = @as(u32, c.r) * 299 + @as(u32, c.g) * 587 + @as(u32, c.b) * 114;
+    return y >= 128_000;
+}
+
 pub fn cellCharCount(page: *gt.Page, cell: *gt.Cell) usize {
     if (cell.wide == .spacer_head or cell.wide == .spacer_tail) {
         return 0;

--- a/test/ghostel-dnd-test.el
+++ b/test/ghostel-dnd-test.el
@@ -234,8 +234,7 @@ layer runs no default handler such as `find-file'."
              (payload (concat "\e[200~" quoted "\e[201~")))
         (ghostel-test--with-exec-buffer
             (buf proc python
-                 (list "-c" ghostel-test--pty-byte-recorder-script
-                       (number-to-string (length payload))))
+                 (ghostel-test--pty-byte-recorder-args (length payload)))
           (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
           (ghostel--write-vt ghostel--term "\e[?2004h")
           (ghostel--drop (ghostel-test--drop-event 'file "/tmp/a b.png"))

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -143,8 +143,7 @@ SETUP, when non-nil, is called before sending the key."
     (unless python (ert-skip "python3 not available"))
     (ghostel-test--with-exec-buffer
         (buf proc python
-             (list "-c" ghostel-test--pty-byte-recorder-script
-                   (number-to-string byte-count)))
+             (ghostel-test--pty-byte-recorder-args byte-count))
       (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
       (when setup (funcall setup))
       (ghostel--send-encoded key mods)
@@ -347,8 +346,7 @@ SETUP, when non-nil, is called before sending the paste."
     (unless python (ert-skip "python3 not available"))
     (ghostel-test--with-exec-buffer
         (buf proc python
-             (list "-c" ghostel-test--pty-byte-recorder-script
-                   (number-to-string byte-count)))
+             (ghostel-test--pty-byte-recorder-args byte-count))
       (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
       (when setup (funcall setup))
       (ghostel--paste-text text)

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -866,7 +866,7 @@ fresh."
     (ghostel-test--with-pty-matrix backend
       (ghostel-test--with-exec-buffer
           (buf proc python
-               (list "-u" "-c" ghostel-test--pty-byte-recorder-script "9"))
+               (ghostel-test--pty-byte-recorder-args 9))
         (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
         (ghostel--set-default-colors ghostel--term "#eeeeee" "#111111")
         (ghostel--write-vt ghostel--term "\e[?996n")
@@ -875,7 +875,7 @@ fresh."
                         "GHOSTEL_INPUT_HEX:" #'identity proc 5))))
       (ghostel-test--with-exec-buffer
           (buf proc python
-               (list "-u" "-c" ghostel-test--pty-byte-recorder-script "9"))
+               (ghostel-test--pty-byte-recorder-args 9))
         (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
         (ghostel--set-default-colors ghostel--term "#111111" "#f7f3fa")
         (ghostel--write-vt ghostel--term "\e[?996n")
@@ -890,7 +890,7 @@ fresh."
     (ghostel-test--with-pty-matrix backend
       (ghostel-test--with-exec-buffer
           (buf proc python
-               (list "-u" "-c" ghostel-test--pty-byte-recorder-script "9"))
+               (ghostel-test--pty-byte-recorder-args 9))
         (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
         (ghostel--write-vt ghostel--term "\e[?2031h")
         (ghostel--set-default-colors ghostel--term "#eeeeee" "#111111")

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -859,6 +859,45 @@ fresh."
                             (:equal (should (equal arg reply)))
                             (:match (should (string-match-p arg reply))))))))))))
 
+(ert-deftest ghostel-test-csi996-reports-light-and-dark ()
+  "CSI ? 996 n reports 997;1 for a dark OSC 11 background, 997;2 for light."
+  :tags '(native)
+  (let ((python (ghostel-test--python)))
+    (ghostel-test--with-pty-matrix backend
+      (ghostel-test--with-exec-buffer
+          (buf proc python
+               (list "-u" "-c" ghostel-test--pty-byte-recorder-script "9"))
+        (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
+        (ghostel--set-default-colors ghostel--term "#eeeeee" "#111111")
+        (ghostel--write-vt ghostel--term "\e[?996n")
+        (should (equal "1b5b3f3939373b316e"
+                       (ghostel-test--wait-for-marker-payload
+                        "GHOSTEL_INPUT_HEX:" #'identity proc 5))))
+      (ghostel-test--with-exec-buffer
+          (buf proc python
+               (list "-u" "-c" ghostel-test--pty-byte-recorder-script "9"))
+        (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
+        (ghostel--set-default-colors ghostel--term "#111111" "#f7f3fa")
+        (ghostel--write-vt ghostel--term "\e[?996n")
+        (should (equal "1b5b3f3939373b326e"
+                       (ghostel-test--wait-for-marker-payload
+                        "GHOSTEL_INPUT_HEX:" #'identity proc 5)))))))
+
+(ert-deftest ghostel-test-mode-2031-pushes-997-on-color-change ()
+  "With Mode 2031 enabled, set-default-colors writes an unsolicited 997."
+  :tags '(native)
+  (let ((python (ghostel-test--python)))
+    (ghostel-test--with-pty-matrix backend
+      (ghostel-test--with-exec-buffer
+          (buf proc python
+               (list "-u" "-c" ghostel-test--pty-byte-recorder-script "9"))
+        (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
+        (ghostel--write-vt ghostel--term "\e[?2031h")
+        (ghostel--set-default-colors ghostel--term "#eeeeee" "#111111")
+        (should (equal "1b5b3f3939373b316e"
+                       (ghostel-test--wait-for-marker-payload
+                        "GHOSTEL_INPUT_HEX:" #'identity proc 5)))))))
+
 (ert-deftest ghostel-test-osc52-eval ()
   "Test that OSC 52;e dispatches to whitelisted functions."
   (let* ((called-with nil)

--- a/test/ghostel-test-helpers.el
+++ b/test/ghostel-test-helpers.el
@@ -405,26 +405,52 @@ PROCESS and TIMEOUT are passed to `ghostel-test--wait-until'."
 
 (defconst ghostel-test--pty-byte-recorder-script
   (string-join
-   '("import os, select, sys, tty, time"
-     "fd = sys.stdin.fileno()"
-     "if os.isatty(fd):"
-     "    tty.setraw(fd)"
-     "count = int(sys.argv[1])"
-     "sys.stdout.buffer.write(b'GHOSTEL_RECORDER_READY\\r\\n')"
-     "sys.stdout.buffer.flush()"
-     "buf = b''"
-     "deadline = time.time() + 5"
-     "while len(buf) < count and time.time() < deadline:"
-     "    readable, _, _ = select.select([fd], [], [], 0.05)"
-     "    if readable:"
-     "        chunk = os.read(fd, count - len(buf))"
+   '("import os, queue, sys, threading, time"
+     "sys.path.insert(0, sys.argv[1])"
+     "from pty_setup import set_raw_stdio"
+     "set_raw_stdio()"
+     "stdin_fd = sys.stdin.fileno()"
+     "stdout_fd = sys.stdout.fileno()"
+     "count = int(sys.argv[2])"
+     "input_queue = queue.Queue()"
+     "def read_input():"
+     "    while True:"
+     "        chunk = os.read(stdin_fd, 4096)"
+     "        input_queue.put(chunk)"
      "        if not chunk:"
-     "            break"
-     "        buf += chunk"
-     "sys.stdout.buffer.write(b'\\r\\nGHOSTEL_INPUT_HEX:' + buf.hex().encode('ascii') + b'\\r\\n')"
-     "sys.stdout.buffer.flush()")
+     "            return"
+     "def write_all(data):"
+     "    while data:"
+     "        data = data[os.write(stdout_fd, data):]"
+     "write_all(b'GHOSTEL_RECORDER_READY\\r\\n')"
+     "threading.Thread(target=read_input, daemon=True).start()"
+     "buf = bytearray()"
+     "deadline = time.monotonic() + 5"
+     "while len(buf) < count:"
+     "    remaining = deadline - time.monotonic()"
+     "    if remaining <= 0:"
+     "        break"
+     "    try:"
+     "        chunk = input_queue.get(timeout=remaining)"
+     "    except queue.Empty:"
+     "        break"
+     "    if not chunk:"
+     "        break"
+     "    buf.extend(chunk[: count - len(buf)])"
+     "write_all(b'\\r\\nGHOSTEL_INPUT_HEX:' + buf.hex().encode('ascii') + b'\\r\\n')")
    "\n")
-  "Python code that reads N bytes from stdin and prints them as hex.")
+  "Python code that reads N bytes from stdin and prints them as hex.
+The first argument locates the portable PTY setup module; the second is
+the number of stdin bytes to capture.  Raw mode uses `pty_setup` so the
+recorder works on POSIX PTYs and Windows ConPTY.  After printing
+`GHOSTEL_RECORDER_READY', the script prints `GHOSTEL_INPUT_HEX:' followed
+by the captured bytes as lowercase hex.")
+
+(defun ghostel-test--pty-byte-recorder-args (byte-count)
+  "Return Python argv that records BYTE-COUNT bytes from the child PTY."
+  (list "-u" "-c" ghostel-test--pty-byte-recorder-script
+        (ghostel-test--fixture-directory)
+        (number-to-string byte-count)))
 
 (defun ghostel-test--last-marker-payload (marker)
   "Return the last hex-like payload following MARKER in terminal text."


### PR DESCRIPTION
## Summary

- Answer CSI `? 996 n` with the terminal's dark/light color scheme.
- Emit CSI `? 997` after synchronized default colors change when Mode 2031 is enabled.
- Classify the last synchronized `ghostel-default` background using Neovim's BT.601 midpoint convention.
- Keep child OSC 11 overrides separate from the host color scheme.

## Why

libghostty already parses CSI 996 and tracks Mode 2031, but Ghostel did not provide the color-scheme callback or send change reports. Multiplexers could therefore keep stale host color caches after an Emacs theme change.

Ghostel does not store a separate light/dark appearance value. Its protocol background is seeded from the resolved `ghostel-default` face, which users can customize independently from the rest of Emacs. CSI 996/997 therefore classify the most recently synchronized default background. Theme changes synchronize it through the existing hook; after changing `ghostel-default` directly, users can call `ghostel-sync-theme`.

The implementation deliberately reads the default background rather than the current OSC 11 override. An OSC 11 override belongs to the child-controlled terminal session and should not redefine the host terminal's appearance.

The RGB classification follows the same BT.601 luma and 0.5 midpoint convention used by [Neovim's terminal background detection](https://github.com/neovim/neovim/blob/2fbc82820b5168b0da4e918c192c05832dfd6211/runtime/lua/vim/_core/defaults.lua).

## Testing

- `zig build --prefix .`
- `zig build test`
- Native OSC test suite: 30/30 passed
- `git diff --check`
