### PR TITLE
Keep sentinel cleanup in the terminal buffer after exit functions run

### DIFF
--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3771,17 +3771,16 @@ EVENT is the state-change description passed by Emacs."
         (ghostel--spinner-stop)
         (remove-hook 'pre-redisplay-functions #'ghostel--fake-cursor-update t)
         (ghostel--fake-cursor-clear)
-        (run-hook-with-args 'ghostel-exit-functions buf event)
-        ;; Dead terminal: restore the plain read-only barrier.
-        (ghostel--sync-read-only)
-        ;; Only a live shell restores usefully.
-        ;; Drop the buffer from future desktop saves.
-        (setq desktop-save-buffer nil)
-        (if ghostel-kill-buffer-on-exit
-            (kill-buffer buf)
-          (let ((inhibit-read-only t))
-            (goto-char (point-max))
-            (insert "\n[Process exited]\n")))))))
+        (ghostel--run-hook-safely 'ghostel-exit-functions buf event))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf
+          (ghostel--sync-read-only)  ; Restore the plain read-only barrier
+          (setq desktop-save-buffer nil)  ; Don't save/restore dead sessions
+          (if ghostel-kill-buffer-on-exit
+              (kill-buffer buf)
+            (let ((inhibit-read-only t))
+              (goto-char (point-max))
+              (insert "\n[Process exited]\n"))))))))
 
 (defun ghostel--local-host-p (host)
   "Return non-nil if HOST refers to the local machine.

--- a/test/ghostel-exec-test.el
+++ b/test/ghostel-exec-test.el
@@ -262,6 +262,46 @@ is nil, SIGHUP is ignored."
           (ghostel-test--cleanup-exec-buffer buf))
         (delete-directory dir t)))))
 
+(ert-deftest ghostel-test-exec-exit-hook-window-delete-keeps-origin-writable ()
+  "An exit function deleting the selected window leaves other buffers alone.
+Deleting the selected window switches the current buffer; the sentinel's
+cleanup must not leak into it."
+  :tags '(native posix)
+  (skip-unless (file-executable-p "/bin/sh"))
+  (ghostel-test--with-pty-matrix backend
+    (let* ((origin (generate-new-buffer " *ghostel-test-exit-origin*"))
+           (buf (generate-new-buffer " *ghostel-test-exit-window*"))
+           proc pid window-deleted)
+      (unwind-protect
+          (save-window-excursion
+            (delete-other-windows)
+            (set-window-buffer (selected-window) origin)
+            (set-window-buffer (select-window (split-window)) buf)
+            (let ((ghostel-kill-buffer-on-exit t))
+              (with-current-buffer buf
+                (setq proc (ghostel-exec
+                            buf "/bin/sh"
+                            (list "-c" (ghostel-test-exec--loop-script))))
+                (add-hook 'ghostel-exit-functions
+                          (lambda (buffer _event)
+                            (when-let* ((win (get-buffer-window buffer)))
+                              (delete-window win)
+                              (setq window-deleted t)))
+                          nil t)
+                (ghostel-test--wait-for-text "GHOSTEL_LIFECYCLE_READY" proc 5)
+                (setq pid ghostel--pid))
+              (signal-process pid 'TERM)
+              (ghostel-test--wait-until
+               (lambda () (not (buffer-live-p buf))) proc 5))
+            ;; Guard against a vacuous pass: the leak only happens when the
+            ;; hook really deleted the selected window.
+            (should window-deleted)
+            (should-not (buffer-local-value 'buffer-read-only origin)))
+        (ghostel-test-exec--kill-pid pid)
+        (when (buffer-live-p buf)
+          (ghostel-test--cleanup-exec-buffer buf))
+        (kill-buffer origin)))))
+
 (ert-deftest ghostel-test-exec-delete-process-kills-sighup-ignoring-child ()
   "Deleting the lifecycle process kills the child even when it ignores SIGHUP."
   :tags '(native posix)


### PR DESCRIPTION
Fixes #630 (the remaining variant after #632).

An exit function may delete the terminal's selected window or kill its buffer. Deleting the selected window selects another window, which also switches the current buffer, so the sentinel's remaining cleanup ran in whatever buffer that window showed: `ghostel--sync-read-only` locked it read-only (the reported symptom — the buffer the user came from turned read-only after `C-d`/`exit`) and its `desktop-save-buffer` was clobbered. This bypassed `ghostel--enter-readonly*`, which is why the read-only logging advice in the issue never fired.

The sentinel now runs the post-hook cleanup in an explicit `with-current-buffer` on the terminal buffer, skipping it when an exit function already killed the buffer.

Includes a regression test reproducing the exact scenario (window-deleting exit hook, origin buffer in the surviving window); it fails against the previous sentinel and passes now. `make -j8 all` is green, and the fix was verified in a live session: with a window-deleting `ghostel-exit-functions` hook, the origin buffer stays writable after the shell exits.