### PR TITLE
Report the terminal color scheme via CSI 996 and Mode 2031

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Color-scheme DSR is implemented: CSI `? 996 n` reports light/dark
+  from the last synchronized `ghostel-default` background, and enabling
+  Mode 2031 now actually produces CSI `? 997` reports when the Emacs theme
+  changes or `ghostel-sync-theme` is called explicitly.
+  Previously ghostel stored Mode 2031 but never answered 996 or pushed
+  997, so multiplexers (herdr) kept a stale OSC 11 cache and TUIs that
+  paint from it (Codex's composer) did not follow light/dark.
 - Directory tracking no longer corrupts or silently stalls on paths
   containing `#` or percent-escapes.  The bash and zsh integrations
   report the cwd with kitty's `kitty-shell-cwd://` OSC 7 scheme (path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,6 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Color-scheme DSR is implemented: CSI `? 996 n` reports light/dark
-  from the last synchronized `ghostel-default` background, and enabling
-  Mode 2031 now actually produces CSI `? 997` reports when the Emacs theme
-  changes or `ghostel-sync-theme` is called explicitly.
-  Previously ghostel stored Mode 2031 but never answered 996 or pushed
-  997, so multiplexers (herdr) kept a stale OSC 11 cache and TUIs that
-  paint from it (Codex's composer) did not follow light/dark.
 - Directory tracking no longer corrupts or silently stalls on paths
   containing `#` or percent-escapes.  The bash and zsh integrations
   report the cwd with kitty's `kitty-shell-cwd://` OSC 7 scheme (path
@@ -27,6 +20,10 @@ All notable changes to this project will be documented in this file.
   the updated scripts.
 
 ### Added
+- Color-scheme DSR: CSI `? 996 n` is answered with light/dark as Emacs
+  classifies the `ghostel-default` background, and clients that enabled
+  Mode 2031 receive an unsolicited CSI `? 997 n` when that classification
+  changes (theme change or `ghostel-sync-theme`).
 - The terminal title is now public as the buffer-local `ghostel-title`
   variable (formerly the private `ghostel--title`).  It holds the current
   title reported via OSC 0/2, or nil when no title is set.

--- a/README.org
+++ b/README.org
@@ -685,6 +685,13 @@ read-only buffer (Emacs or copy).
   foreground, and background colors, so tools like =duf=, =btop=, =delta=, and
   anything else using =termenv= auto-detect the right light/dark theme from the
   Emacs face colors.
+- *CSI ? 996 / Mode 2031* - color-scheme DSR.  A query (=CSI ? 996 n=)
+  is answered with =CSI ? 997 ; 1 n= (dark) or =; 2 n= (light), inferred
+  from the last synchronized =ghostel-default= background.  Theme changes
+  synchronize it automatically; after changing =ghostel-default= directly,
+  run =ghostel-sync-theme=.  Clients that enable Mode 2031 also get an
+  unsolicited 997 on synchronization, so multiplexers can refresh their
+  OSC 11 cache.
 - *OSC 9 / OSC 777* - desktop notifications and ConEmu progress reports (see
   [[#notifications-and-progress][Notifications and Progress]]).
 - Text attributes: bold, italic, faint, underline (single/double/curly/dotted/dashed, with color), strikethrough, inverse.

--- a/README.org
+++ b/README.org
@@ -685,13 +685,11 @@ read-only buffer (Emacs or copy).
   foreground, and background colors, so tools like =duf=, =btop=, =delta=, and
   anything else using =termenv= auto-detect the right light/dark theme from the
   Emacs face colors.
-- *CSI ? 996 / Mode 2031* - color-scheme DSR.  A query (=CSI ? 996 n=)
-  is answered with =CSI ? 997 ; 1 n= (dark) or =; 2 n= (light), inferred
-  from the last synchronized =ghostel-default= background.  Theme changes
-  synchronize it automatically; after changing =ghostel-default= directly,
-  run =ghostel-sync-theme=.  Clients that enable Mode 2031 also get an
-  unsolicited 997 on synchronization, so multiplexers can refresh their
-  OSC 11 cache.
+- *CSI ? 996 / Mode 2031* - color-scheme DSR.  =CSI ? 996 n= is answered
+  with =CSI ? 997 ; 1 n= (dark) or =; 2 n= (light) as Emacs classifies the
+  =ghostel-default= background (=color-dark-p=); a child's own OSC 11 override
+  does not change it.  Clients that enabled Mode 2031 get an unsolicited 997
+  when the classification changes (=ghostel-sync-theme=, automatic on theme change).
 - *OSC 9 / OSC 777* - desktop notifications and ConEmu progress reports (see
   [[#notifications-and-progress][Notifications and Progress]]).
 - Text attributes: bold, italic, faint, underline (single/double/curly/dotted/dashed, with color), strikethrough, inverse.

--- a/lisp/ghostel-faces.el
+++ b/lisp/ghostel-faces.el
@@ -164,5 +164,13 @@ Falls back to white (for :foreground) or black (for :background)."
                    color)))))
       (if (eq attr :foreground) "#ffffff" "#000000")))
 
+(defun ghostel--hex-color-scheme (hex)
+  "Return `light' or `dark' for HEX (\"#RRGGBB\") as `color-dark-p' judges it."
+  (if (color-dark-p (mapcar (lambda (i)
+                              (/ (string-to-number (substring hex i (+ i 2)) 16)
+                                 255.0))
+                            '(1 3 5)))
+      'dark 'light))
+
 (provide 'ghostel-faces)
 ;;; ghostel-faces.el ends here

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3609,10 +3609,10 @@ URL does not match the local machine, construct a TRAMP path."
 (defun ghostel--apply-palette (term)
   "Apply face-derived protocol defaults and palette colors to TERM."
   (when term
-    (ghostel--set-default-colors
-     term
-     (ghostel--face-hex-color 'ghostel-default :foreground)
-     (ghostel--face-hex-color 'ghostel-default :background))
+    (let ((bg (ghostel--face-hex-color 'ghostel-default :background)))
+      (ghostel--set-default-colors
+       term (ghostel--face-hex-color 'ghostel-default :foreground) bg
+       (ghostel--hex-color-scheme bg)))
     (when ghostel-color-palette
       (let ((colors
              (mapconcat
@@ -3636,21 +3636,18 @@ URL does not match the local machine, construct a TRAMP path."
 
 (defun ghostel-sync-theme ()
   "Re-apply terminal color palette in all ghostel buffers.
-Theme changes call this automatically.  Call it manually after changing
-`ghostel-default' or palette faces directly.
-
-Re-seeds OSC 10/11 protocol defaults from `ghostel-default'.  When a
-client has enabled Mode 2031, also writes CSI ? 997 n (dark=1, light=2)
-so multiplexers such as herdr re-query those colors."
+Theme changes call this automatically; call it manually after changing
+`ghostel-default' or palette faces directly."
   (interactive)
   (dolist (buf (buffer-list))
-    (with-current-buffer buf
-      (when (and (derived-mode-p 'ghostel-mode) ghostel--term)
-        (ghostel--apply-palette ghostel--term)
-        (ghostel--apply-bold-config ghostel--term)
-        (when (ghostel--terminal-live-p)
-          (setq ghostel--force-next-redraw t)
-          (ghostel--redraw-now buf))))))
+    (when (buffer-live-p buf)
+      (with-current-buffer buf
+        (when (and (derived-mode-p 'ghostel-mode) ghostel--term)
+          (ghostel--apply-palette ghostel--term)
+          (ghostel--apply-bold-config ghostel--term)
+          (when (ghostel--terminal-live-p)
+            (setq ghostel--force-next-redraw t)
+            (ghostel--redraw-now buf)))))))
 
 (defun ghostel--on-theme-change (&rest _args)
   "Hook function to sync terminal colors after theme change."
@@ -3658,7 +3655,9 @@ so multiplexers such as herdr re-query those colors."
 
 (if (boundp 'enable-theme-functions)
     ;; Emacs 29+
-    (add-hook 'enable-theme-functions #'ghostel--on-theme-change)
+    (progn
+      (add-hook 'enable-theme-functions #'ghostel--on-theme-change)
+      (add-hook 'disable-theme-functions #'ghostel--on-theme-change))
   ;; Emacs < 29 fallback
   (advice-add 'load-theme :after #'ghostel--on-theme-change))
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -3636,7 +3636,12 @@ URL does not match the local machine, construct a TRAMP path."
 
 (defun ghostel-sync-theme ()
   "Re-apply terminal color palette in all ghostel buffers.
-Call this after changing the Emacs theme so terminals match."
+Theme changes call this automatically.  Call it manually after changing
+`ghostel-default' or palette faces directly.
+
+Re-seeds OSC 10/11 protocol defaults from `ghostel-default'.  When a
+client has enabled Mode 2031, also writes CSI ? 997 n (dark=1, light=2)
+so multiplexers such as herdr re-query those colors."
   (interactive)
   (dolist (buf (buffer-list))
     (with-current-buffer buf

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -113,6 +113,22 @@ pub fn vtWrite(self: *Self, data: []const u8) !void {
     self.unlockTerm();
 }
 
+/// CSI ? 997 report for the last synchronized default background, or null when
+/// Mode 2031 is off or no child PTY is attached. The default is intentional:
+/// a child OSC 11 override is terminal-session state, not a host appearance
+/// change.
+pub fn colorSchemeReport(self: *Self, env: emacs.Env) ?[]const u8 {
+    const mode = gt.modes.modeFromInt(2031, false) orelse return null;
+    if (!self.terminal.modes.get(mode)) return null;
+    if (self.process == null and env.isNil(env.symbolValue("ghostel--process"))) {
+        return null;
+    }
+    return if (utils.backgroundIsLight(self.terminal.colors.background.default))
+        "\x1b[?997;2n"
+    else
+        "\x1b[?997;1n";
+}
+
 pub fn ptyWrite(self: *Self, data: []const u8) !void {
     const env = emacs.current_env orelse return error.MissingEmacsEnv;
     if (self.process) |proc| {
@@ -662,6 +678,9 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 defer term.unlockTerm();
                 term.terminal.colors.foreground.default = try gt.color.RGB.parse(fg_str);
                 term.terminal.colors.background.default = try gt.color.RGB.parse(bg_str);
+                if (term.colorSchemeReport(env)) |report| {
+                    try term.ptyWrite(report);
+                }
                 return env.t();
             }
         },

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -9,6 +9,7 @@ const emacs = @import("emacs.zig");
 const gt = @import("ghostty-vt");
 const GhostelHandler = @import("handler.zig").GhostelHandler;
 const Renderer = @import("Renderer.zig");
+const RecursiveMutex = @import("RecursiveMutex.zig");
 const input = @import("input.zig");
 const kitty_graphics = @import("kitty_graphics.zig");
 const utils = @import("utils.zig");
@@ -24,6 +25,7 @@ const Self = @This();
 
 alloc: Allocator,
 io: std.Io,
+mutex: RecursiveMutex = .{},
 terminal: gt.Terminal,
 stream: gt.Stream(GhostelHandler(*Self)),
 string_buffer: ?[]u8 = null,
@@ -56,7 +58,7 @@ pub fn init(
     };
     errdefer term.terminal.deinit(alloc);
 
-    term.stream = .initAlloc(alloc, .init(alloc, term, &term.terminal));
+    term.stream = .initAlloc(alloc, .init(alloc, term, term));
     errdefer term.stream.deinit();
 
     term.renderer = try .init(alloc, env, &term.terminal);
@@ -79,8 +81,8 @@ pub fn deinit(self: *Self) void {
 }
 
 pub fn redraw(self: *Self, force_full: bool, force_sync: bool) !bool {
-    try self.lockTerm();
-    defer self.unlockTerm();
+    try self.lock();
+    defer self.unlock();
 
     const env = emacs.current_env orelse return false;
     const pre_size = .{ self.terminal.cols, self.terminal.rows };
@@ -103,20 +105,16 @@ pub fn redraw(self: *Self, force_full: bool, force_sync: bool) !bool {
     return true;
 }
 
-/// Set the color palette (256 entries).
-pub fn setColorPalette(self: *Self, palette: gt.color.Palette) void {
+/// Set the color palette (256 entries). The terminal must be locked.
+fn setColorPaletteLocked(self: *Self, palette: gt.color.Palette) void {
     self.terminal.colors.palette.changeDefault(palette);
     self.terminal.flags.dirty.palette = true;
 }
 
 pub fn vtWrite(self: *Self, data: []const u8) !void {
-    try self.lockTerm();
+    try self.lock();
+    defer self.unlock();
     self.stream.nextSlice(data);
-    self.unlockTerm();
-}
-
-pub fn colorScheme(self: *Self) gt.device_status.ColorScheme {
-    return self.color_scheme;
 }
 
 pub fn ptyWrite(self: *Self, data: []const u8) !void {
@@ -154,10 +152,15 @@ pub fn encode(
     buf: []u8,
     event: gt.input.KeyEvent,
 ) !?[]const u8 {
-    var options = gt.input.KeyEncodeOptions.fromTerminal(&self.terminal);
-    // Emacs resolves option-vs-meta before the event reaches us, so a
-    // meta modifier always means alt.
-    options.macos_option_as_alt = .true;
+    const options = blk: {
+        try self.lock();
+        defer self.unlock();
+        var options = gt.input.KeyEncodeOptions.fromTerminal(&self.terminal);
+        // Emacs resolves option-vs-meta before the event reaches us, so a
+        // meta modifier always means alt.
+        options.macos_option_as_alt = .true;
+        break :blk options;
+    };
 
     // Encode
     var writer = std.Io.Writer.fixed(buf);
@@ -177,14 +180,18 @@ pub fn encodeMouse(
     col: i64,
     mods_val: i64,
 ) !bool {
-    const options = gt.input.MouseEncodeOptions.fromTerminal(&self.terminal, .{
-        .screen = .{
-            .width = self.terminal.cols,
-            .height = self.terminal.rows,
-        },
-        .cell = .{ .width = 1, .height = 1 },
-        .padding = .{ .top = 0, .bottom = 0, .right = 0, .left = 0 },
-    });
+    const options = blk: {
+        try self.lock();
+        defer self.unlock();
+        break :blk gt.input.MouseEncodeOptions.fromTerminal(&self.terminal, .{
+            .screen = .{
+                .width = self.terminal.cols,
+                .height = self.terminal.rows,
+            },
+            .cell = .{ .width = 1, .height = 1 },
+            .padding = .{ .top = 0, .bottom = 0, .right = 0, .left = 0 },
+        });
+    };
 
     const event = gt.input.MouseEncodeEvent{
         .action = @enumFromInt(action),
@@ -205,6 +212,13 @@ pub fn encodeMouse(
 }
 
 pub fn encodeFocus(self: *Self, gained: bool) !bool {
+    const enabled = blk: {
+        try self.lock();
+        defer self.unlock();
+        break :blk self.terminal.modes.get(.focus_event);
+    };
+    if (!enabled) return false;
+
     const event = if (gained) gt.input.FocusEvent.gained else gt.input.FocusEvent.lost;
     var buf: [8]u8 = undefined;
     var writer = std.Io.Writer.fixed(&buf);
@@ -216,10 +230,12 @@ pub fn encodeFocus(self: *Self, gained: bool) !bool {
 }
 
 pub fn encodePaste(self: *Self, data: []u8) !bool {
-    const slices = gt.input.encodePaste(
-        data,
-        gt.input.PasteOptions.fromTerminal(&self.terminal),
-    );
+    const options = blk: {
+        try self.lock();
+        defer self.unlock();
+        break :blk gt.input.PasteOptions.fromTerminal(&self.terminal);
+    };
+    const slices = gt.input.encodePaste(data, options);
 
     var wrote = false;
     for (slices) |slice| {
@@ -234,17 +250,17 @@ pub fn encodePaste(self: *Self, data: []u8) !bool {
 /// to ensure that the we fully render the very latest state in case any rows
 /// get promoted to scrollback due to vertical shrinking of the viewport.
 pub fn resize(self: *Self, cols: u16, rows: u16, cell_w: u16, cell_h: u16) !void {
-    try self.lockTerm();
-    defer self.unlockTerm();
+    try self.lock();
+    defer self.unlock();
     try self.renderer.resize(cols, rows, cell_w, cell_h);
 }
 
-pub fn lockTerm(self: *Self) !void {
-    if (self.process) |process| try process.lockTerm();
+pub fn lock(self: *Self) !void {
+    try self.mutex.lock(self.io);
 }
 
-pub fn unlockTerm(self: *Self) void {
-    if (self.process) |handler| handler.unlockTerm();
+pub fn unlock(self: *Self) void {
+    self.mutex.unlock(self.io);
 }
 
 pub fn spawnNativeProcess(
@@ -256,16 +272,21 @@ pub fn spawnNativeProcess(
 ) !ProcessPid {
     if (command.len == 0) return error.InvalidCommand;
 
+    const initial_size = blk: {
+        try self.lock();
+        defer self.unlock();
+        break :blk .{ self.terminal.cols, self.terminal.rows };
+    };
+
     const process = try self.alloc.create(NativeProcess);
     errdefer self.alloc.destroy(process);
     try process.init(
         self.alloc,
         self.io,
-        self.terminal.cols,
-        self.terminal.rows,
+        initial_size[0],
+        initial_size[1],
         ProcessParams{ .file = command[0], .args = command, .env = env, .cwd = cwd },
-        &self.terminal,
-        &self.color_scheme,
+        self,
         event_fd,
     );
     self.process = process;
@@ -594,9 +615,6 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
             pub fn call(env: emacs.Env, _: isize, args: [*c]emacs.Value) !emacs.Value {
                 if (env.isNil(args[0])) return env.nil();
                 const term = env.getUserPtr(Self, args[0]) orelse return error.InvalidTerminalHandle;
-                if (!term.terminal.modes.get(gt.modes.Mode.focus_event)) {
-                    return env.nil();
-                }
                 const gained = env.isNotNil(args[1]);
                 return if (try term.encodeFocus(gained)) env.t() else env.nil();
             }
@@ -633,15 +651,15 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 var str_buf: [2048]u8 = undefined;
                 const colors_str = try env.extractString(args[1], &str_buf);
                 if (colors_str.len < 16 * 7) return error.InvalidPaletteLength;
-                try term.lockTerm();
-                defer term.unlockTerm();
+                try term.lock();
+                defer term.unlock();
                 var palette = term.terminal.colors.palette.current;
                 var idx: usize = 0;
                 while (idx < 16) : (idx += 1) {
                     const pos = idx * 7;
                     palette[idx] = try gt.color.RGB.parse(colors_str[pos .. pos + 7]);
                 }
-                term.setColorPalette(palette);
+                term.setColorPaletteLocked(palette);
                 return env.t();
             }
         },
@@ -671,8 +689,8 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 const scheme: gt.device_status.ColorScheme =
                     if (env.eq(args[3], emacs.sym.light)) .light else .dark;
                 const report = blk: {
-                    try term.lockTerm();
-                    defer term.unlockTerm();
+                    try term.lock();
+                    defer term.unlock();
                     term.terminal.colors.foreground.default = try gt.color.RGB.parse(fg_str);
                     term.terminal.colors.background.default = try gt.color.RGB.parse(bg_str);
                     const changed = term.color_scheme != scheme;
@@ -736,8 +754,8 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 const mode: gt.modes.Mode = gt.modes.modeFromInt(mode_int, false) orelse {
                     return error.InvalidModeValue;
                 };
-                try term.lockTerm();
-                defer term.unlockTerm();
+                try term.lock();
+                defer term.unlock();
                 return if (term.terminal.modes.get(mode)) env.t() else env.nil();
             }
         },
@@ -753,8 +771,8 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
         .impl = struct {
             pub fn call(env: emacs.Env, _: isize, args: [*c]emacs.Value) !emacs.Value {
                 const term = env.getUserPtr(Self, args[0]) orelse return error.InvalidTerminalHandle;
-                try term.lockTerm();
-                defer term.unlockTerm();
+                try term.lock();
+                defer term.unlock();
                 return if (term.terminal.screens.active_key == .alternate) env.t() else env.nil();
             }
         },
@@ -775,8 +793,8 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                     .unwrap = true,
                     .trim = true,
                 };
-                try term.lockTerm();
-                defer term.unlockTerm();
+                try term.lock();
+                defer term.unlock();
                 var formatter = gt.formatter.TerminalFormatter.init(&term.terminal, options);
                 var writer = std.Io.Writer.Allocating.init(module_alloc);
                 defer writer.deinit();

--- a/src/GhostelTerm.zig
+++ b/src/GhostelTerm.zig
@@ -29,6 +29,8 @@ stream: gt.Stream(GhostelHandler(*Self)),
 string_buffer: ?[]u8 = null,
 renderer: Renderer,
 process: ?*NativeProcess = null,
+/// Light/dark as classified by Emacs for `ghostel-default`; reported via CSI 996/997.
+color_scheme: gt.device_status.ColorScheme = .dark,
 
 /// Create a new terminal with the given dimensions and scrollback.
 pub fn init(
@@ -113,20 +115,8 @@ pub fn vtWrite(self: *Self, data: []const u8) !void {
     self.unlockTerm();
 }
 
-/// CSI ? 997 report for the last synchronized default background, or null when
-/// Mode 2031 is off or no child PTY is attached. The default is intentional:
-/// a child OSC 11 override is terminal-session state, not a host appearance
-/// change.
-pub fn colorSchemeReport(self: *Self, env: emacs.Env) ?[]const u8 {
-    const mode = gt.modes.modeFromInt(2031, false) orelse return null;
-    if (!self.terminal.modes.get(mode)) return null;
-    if (self.process == null and env.isNil(env.symbolValue("ghostel--process"))) {
-        return null;
-    }
-    return if (utils.backgroundIsLight(self.terminal.colors.background.default))
-        "\x1b[?997;2n"
-    else
-        "\x1b[?997;1n";
+pub fn colorScheme(self: *Self) gt.device_status.ColorScheme {
+    return self.color_scheme;
 }
 
 pub fn ptyWrite(self: *Self, data: []const u8) !void {
@@ -275,6 +265,7 @@ pub fn spawnNativeProcess(
         self.terminal.rows,
         ProcessParams{ .file = command[0], .args = command, .env = env, .cwd = cwd },
         &self.terminal,
+        &self.color_scheme,
         event_fd,
     );
     self.process = process;
@@ -657,7 +648,7 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
     },
     .{
         .name = "ghostel--set-default-colors",
-        .arity = .{ 3, 3 },
+        .arity = .{ 4, 4 },
         .doc =
         \\Set protocol default foreground and background colors.
         \\
@@ -665,7 +656,10 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
         \\color state.  The renderer intentionally does not emit them as
         \\default-cell face properties.
         \\
-        \\(ghostel--set-default-colors TERM FG-HEX BG-HEX)
+        \\(ghostel--set-default-colors TERM FG-HEX BG-HEX SCHEME)
+        \\
+        \\SCHEME is `light' or `dark'.  When it changes and the child enabled
+        \\Mode 2031, a CSI ? 997 n report is written to the PTY.
         ,
         .impl = struct {
             pub fn call(env: emacs.Env, _: isize, args: [*c]emacs.Value) !emacs.Value {
@@ -674,12 +668,24 @@ pub const emacs_functions = [_]emacs.FunctionEntry{
                 var bg_buf: [16]u8 = undefined;
                 const fg_str = try env.extractString(args[1], &fg_buf);
                 const bg_str = try env.extractString(args[2], &bg_buf);
-                try term.lockTerm();
-                defer term.unlockTerm();
-                term.terminal.colors.foreground.default = try gt.color.RGB.parse(fg_str);
-                term.terminal.colors.background.default = try gt.color.RGB.parse(bg_str);
-                if (term.colorSchemeReport(env)) |report| {
-                    try term.ptyWrite(report);
+                const scheme: gt.device_status.ColorScheme =
+                    if (env.eq(args[3], emacs.sym.light)) .light else .dark;
+                const report = blk: {
+                    try term.lockTerm();
+                    defer term.unlockTerm();
+                    term.terminal.colors.foreground.default = try gt.color.RGB.parse(fg_str);
+                    term.terminal.colors.background.default = try gt.color.RGB.parse(bg_str);
+                    const changed = term.color_scheme != scheme;
+                    term.color_scheme = scheme;
+                    break :blk changed and term.terminal.modes.get(.report_color_scheme);
+                };
+                // Written outside the lock: a full PTY must not stall the reader thread.
+                // Best effort: a client can re-query with CSI ? 996 n.
+                if (report) {
+                    var buf: [gt.device_status.max_color_scheme_report_encode_size]u8 = undefined;
+                    var writer = std.Io.Writer.fixed(&buf);
+                    try gt.device_status.encodeColorSchemeReport(&writer, scheme);
+                    term.ptyWrite(writer.buffered()) catch {};
                 }
                 return env.t();
             }

--- a/src/NativeProcess.zig
+++ b/src/NativeProcess.zig
@@ -39,6 +39,8 @@ event_buf: FixedArrayList(u8, 16 * 1024) = .{},
 
 term_mutex: RecursiveMutex = .{},
 term: *gt.Terminal,
+/// GhostelTerm.color_scheme, read under term_mutex for the CSI 996 answer.
+color_scheme: *const gt.device_status.ColorScheme,
 stream: gt.Stream(GhostelHandler(*Self)),
 
 quit: bool = false,
@@ -62,6 +64,7 @@ pub fn init(
     initial_rows: u16,
     params: ProcessParams,
     term: *gt.Terminal,
+    color_scheme: *const gt.device_status.ColorScheme,
     event_fd: ChannelFd,
 ) !void {
     var backend = try Backend.init(alloc, io, initial_cols, initial_rows, params);
@@ -84,10 +87,15 @@ pub fn init(
         .pid = backend.pidValue(),
         .replica_name = replica_name,
         .term = term,
+        .color_scheme = color_scheme,
         .stream = stream,
         .thread = undefined,
     };
     self.thread = try std.Thread.spawn(.{}, Self.run, .{self});
+}
+
+pub fn colorScheme(self: *Self) gt.device_status.ColorScheme {
+    return self.color_scheme.*;
 }
 
 pub fn lockTerm(self: *Self) !void {

--- a/src/NativeProcess.zig
+++ b/src/NativeProcess.zig
@@ -7,8 +7,8 @@ const gt = @import("ghostty-vt");
 const backend_types = @import("backend_types.zig");
 const emacs = @import("emacs.zig");
 const GhostelHandler = @import("handler.zig").GhostelHandler;
+const GhostelTerm = @import("GhostelTerm.zig");
 const FixedArrayList = @import("fixed_array_list.zig").FixedArrayList;
-const RecursiveMutex = @import("RecursiveMutex.zig");
 
 const Backend = switch (builtin.os.tag) {
     .windows => @import("ConPtyProcess.zig"),
@@ -37,10 +37,7 @@ replica_name: [:0]u8,
 // few writes to Emacs.
 event_buf: FixedArrayList(u8, 16 * 1024) = .{},
 
-term_mutex: RecursiveMutex = .{},
-term: *gt.Terminal,
-/// GhostelTerm.color_scheme, read under term_mutex for the CSI 996 answer.
-color_scheme: *const gt.device_status.ColorScheme,
+owner: *GhostelTerm,
 stream: gt.Stream(GhostelHandler(*Self)),
 
 quit: bool = false,
@@ -50,8 +47,8 @@ const LockedStream = struct {
     process: *Self,
 
     pub fn nextSlice(self: *LockedStream, data: []const u8) !void {
-        try self.process.term_mutex.lock(self.process.io);
-        defer self.process.term_mutex.unlock(self.process.io);
+        try self.process.owner.lock();
+        defer self.process.owner.unlock();
         self.process.stream.nextSlice(data);
     }
 };
@@ -63,8 +60,7 @@ pub fn init(
     initial_cols: u16,
     initial_rows: u16,
     params: ProcessParams,
-    term: *gt.Terminal,
-    color_scheme: *const gt.device_status.ColorScheme,
+    owner: *GhostelTerm,
     event_fd: ChannelFd,
 ) !void {
     var backend = try Backend.init(alloc, io, initial_cols, initial_rows, params);
@@ -73,7 +69,7 @@ pub fn init(
     var event_writer = try EventWriter.init(event_fd);
     errdefer event_writer.close();
 
-    var stream: @TypeOf(self.stream) = .initAlloc(alloc, .init(alloc, self, term));
+    var stream: @TypeOf(self.stream) = .initAlloc(alloc, .init(alloc, owner, self));
     errdefer stream.deinit();
 
     const replica_name = try alloc.dupeZ(u8, backend.replicaName());
@@ -86,24 +82,11 @@ pub fn init(
         .event_writer = event_writer,
         .pid = backend.pidValue(),
         .replica_name = replica_name,
-        .term = term,
-        .color_scheme = color_scheme,
+        .owner = owner,
         .stream = stream,
         .thread = undefined,
     };
     self.thread = try std.Thread.spawn(.{}, Self.run, .{self});
-}
-
-pub fn colorScheme(self: *Self) gt.device_status.ColorScheme {
-    return self.color_scheme.*;
-}
-
-pub fn lockTerm(self: *Self) !void {
-    try self.term_mutex.lock(self.io);
-}
-
-pub fn unlockTerm(self: *Self) void {
-    self.term_mutex.unlock(self.io);
 }
 
 pub fn ptyWrite(self: *Self, env: emacs.Env, data: []const u8) !void {

--- a/src/emacs.zig
+++ b/src/emacs.zig
@@ -522,6 +522,7 @@ const interned_symbols = [_][:0]const u8{
     "insert",
     "italic",
     "keymap",
+    "light",
     "line",
     "line-number-at-pos",
     "list",

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -14,22 +14,24 @@ const log = std.log.scoped(.GhostelHandler);
 // xterm limits the title stack to 10 entries.
 const title_stack_max = 10;
 
-pub fn GhostelHandler(Context: type) type {
+pub fn GhostelHandler(Effects: type) type {
     return struct {
         const Self = @This();
 
         alloc: Allocator,
-        context: Context,
+        term: *GhostelTerm,
+        effects: Effects,
         inner: gt.TerminalStream.Handler,
         // Null entries represent an unset title.
         title_stack: [title_stack_max]?[]u8,
         title_stack_len: usize,
 
-        pub fn init(alloc: Allocator, context: Context, terminal: *gt.Terminal) Self {
+        pub fn init(alloc: Allocator, term: *GhostelTerm, effects: Effects) Self {
             var self = Self{
                 .alloc = alloc,
-                .context = context,
-                .inner = .init(terminal),
+                .term = term,
+                .effects = effects,
+                .inner = .init(&term.terminal),
                 .title_stack = @splat(null),
                 .title_stack_len = 0,
             };
@@ -96,19 +98,20 @@ pub fn GhostelHandler(Context: type) type {
         fn writePtyCallback(handler: *gt.TerminalStream.Handler, data: [:0]const u8) void {
             const self: *Self = @fieldParentPtr("inner", handler);
             if (data.len == 0) return;
-            self.context.ptyWriteFromTerminal(data);
+            self.effects.ptyWriteFromTerminal(data);
         }
 
         /// Called when the terminal receives BEL.
         fn bellCallback(handler: *gt.TerminalStream.Handler) void {
             const self: *Self = @fieldParentPtr("inner", handler);
-            self.context.effect("ding", .{});
+            self.effects.effect("ding", .{});
         }
 
         /// CSI ? 996 n - the scheme Emacs assigned, not the OSC 11 color.
         fn colorSchemeCallback(handler: *gt.TerminalStream.Handler) ?gt.device_status.ColorScheme {
             const self: *Self = @fieldParentPtr("inner", handler);
-            return self.context.colorScheme();
+            // Streams are advanced only while their GhostelTerm is locked.
+            return self.term.color_scheme;
         }
 
         // TODO: DeviceAttributes is not exported from ghostty-vt for some reason.
@@ -154,7 +157,7 @@ pub fn GhostelHandler(Context: type) type {
         fn titleChangedCallback(handler: *gt.TerminalStream.Handler) void {
             const self: *Self = @fieldParentPtr("inner", handler);
             const title = handler.terminal.getTitle() orelse "";
-            self.context.effect("ghostel--set-title", .{title});
+            self.effects.effect("ghostel--set-title", .{title});
         }
 
         // ---------------------------------------------------------------------------
@@ -215,7 +218,7 @@ pub fn GhostelHandler(Context: type) type {
             else
                 null;
 
-            self.context.effect("ghostel--osc133-marker", .{ &type_str, param_val });
+            self.effects.effect("ghostel--osc133-marker", .{ &type_str, param_val });
         }
 
         // ---------------------------------------------------------------------------
@@ -225,7 +228,7 @@ pub fn GhostelHandler(Context: type) type {
         /// Update Emacs from the reported PWD.
         fn handleReportPwd(self: *Self, v: gt.StreamAction.ReportPwd) void {
             if (v.url.len == 0) return;
-            self.context.effect("ghostel--update-directory", .{v.url});
+            self.effects.effect("ghostel--update-directory", .{v.url});
         }
 
         // ---------------------------------------------------------------------------
@@ -244,10 +247,10 @@ pub fn GhostelHandler(Context: type) type {
             if (v.data.len == 1 and v.data[0] == '?') return;
 
             switch (v.kind) {
-                'e' => _ = self.context.effect("ghostel--osc52-eval", .{v.data}),
+                'e' => _ = self.effects.effect("ghostel--osc52-eval", .{v.data}),
                 else => {
                     const kind_str: [1]u8 = .{v.kind};
-                    _ = self.context.effect("ghostel--osc52-handle", .{ &kind_str, v.data });
+                    _ = self.effects.effect("ghostel--osc52-handle", .{ &kind_str, v.data });
                 },
             }
         }
@@ -262,7 +265,7 @@ pub fn GhostelHandler(Context: type) type {
         /// it at the FFI boundary rather than pay the call for nothing.
         fn handleNotification(self: *Self, v: gt.StreamAction.ShowDesktopNotification) void {
             if (v.title.len == 0 and v.body.len == 0) return;
-            self.context.effect("ghostel--handle-notification", .{ v.title, v.body });
+            self.effects.effect("ghostel--handle-notification", .{ v.title, v.body });
         }
 
         // ---------------------------------------------------------------------------
@@ -279,7 +282,7 @@ pub fn GhostelHandler(Context: type) type {
                 .pause => "pause",
             };
             const progress_val = if (v.progress) |p| p else null;
-            self.context.effect("ghostel--osc-progress", .{ state_str, progress_val });
+            self.effects.effect("ghostel--osc-progress", .{ state_str, progress_val });
         }
     };
 }

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -8,6 +8,7 @@ const Allocator = std.mem.Allocator;
 const emacs = @import("emacs.zig");
 const gt = @import("ghostty-vt");
 const GhostelTerm = @import("GhostelTerm.zig");
+const utils = @import("utils.zig");
 
 const log = std.log.scoped(.GhostelHandler);
 
@@ -35,6 +36,7 @@ pub fn GhostelHandler(Context: type) type {
             };
             self.inner.effects.write_pty = &writePtyCallback;
             self.inner.effects.bell = &bellCallback;
+            self.inner.effects.color_scheme = &colorSchemeCallback;
             self.inner.effects.device_attributes = &deviceAttributesCallback;
             self.inner.effects.title_changed = &titleChangedCallback;
             self.inner.effects.size = &sizeCallback;
@@ -102,6 +104,23 @@ pub fn GhostelHandler(Context: type) type {
         fn bellCallback(handler: *gt.TerminalStream.Handler) void {
             const self: *Self = @fieldParentPtr("inner", handler);
             self.context.effect("ding", .{});
+        }
+
+        // `device_status.ColorScheme` is not re-exported from ghostty-vt.
+        const ColorSchemeFn = @typeInfo(
+            @typeInfo(
+                @FieldType(gt.TerminalStream.Handler.Effects, "color_scheme"),
+            ).optional.child,
+        ).pointer.child;
+        const ColorScheme = @typeInfo(ColorSchemeFn).@"fn".return_type.?;
+
+        /// CSI ? 996 n — report the last synchronized default background.
+        /// Do not let a child OSC 11 override redefine the host color scheme.
+        fn colorSchemeCallback(handler: *gt.TerminalStream.Handler) ColorScheme {
+            return if (utils.backgroundIsLight(handler.terminal.colors.background.default))
+                .light
+            else
+                .dark;
         }
 
         // TODO: DeviceAttributes is not exported from ghostty-vt for some reason.

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -8,7 +8,6 @@ const Allocator = std.mem.Allocator;
 const emacs = @import("emacs.zig");
 const gt = @import("ghostty-vt");
 const GhostelTerm = @import("GhostelTerm.zig");
-const utils = @import("utils.zig");
 
 const log = std.log.scoped(.GhostelHandler);
 
@@ -106,21 +105,10 @@ pub fn GhostelHandler(Context: type) type {
             self.context.effect("ding", .{});
         }
 
-        // `device_status.ColorScheme` is not re-exported from ghostty-vt.
-        const ColorSchemeFn = @typeInfo(
-            @typeInfo(
-                @FieldType(gt.TerminalStream.Handler.Effects, "color_scheme"),
-            ).optional.child,
-        ).pointer.child;
-        const ColorScheme = @typeInfo(ColorSchemeFn).@"fn".return_type.?;
-
-        /// CSI ? 996 n — report the last synchronized default background.
-        /// Do not let a child OSC 11 override redefine the host color scheme.
-        fn colorSchemeCallback(handler: *gt.TerminalStream.Handler) ColorScheme {
-            return if (utils.backgroundIsLight(handler.terminal.colors.background.default))
-                .light
-            else
-                .dark;
+        /// CSI ? 996 n - the scheme Emacs assigned, not the OSC 11 color.
+        fn colorSchemeCallback(handler: *gt.TerminalStream.Handler) ?gt.device_status.ColorScheme {
+            const self: *Self = @fieldParentPtr("inner", handler);
+            return self.context.colorScheme();
         }
 
         // TODO: DeviceAttributes is not exported from ghostty-vt for some reason.

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,28 +1,6 @@
-const std = @import("std");
 const gt = @import("ghostty-vt");
 
 const emacs = @import("emacs.zig");
-
-/// Classify an OSC 11 default background using the convention from Neovim's
-/// terminal background detection: ITU-R BT.601 luma split at the 0.5 midpoint.
-/// https://github.com/neovim/neovim/blob/2fbc82820b5168b0da4e918c192c05832dfd6211/runtime/lua/vim/_core/defaults.lua
-///
-/// Ghostel has no separate light/dark appearance state. Instead, CSI 996/997
-/// classifies the `ghostel-default` background most recently seeded by
-/// `ghostel-sync-theme`. Theme changes trigger that sync automatically; direct
-/// face changes require an explicit sync. An unset background is treated as dark
-/// (libghostty's seed).
-pub fn backgroundIsLight(rgb: ?gt.color.RGB) bool {
-    const c = rgb orelse return false;
-    const y = @as(u32, c.r) * 299 + @as(u32, c.g) * 587 + @as(u32, c.b) * 114;
-    return y >= 127_500;
-}
-
-test backgroundIsLight {
-    try std.testing.expect(!backgroundIsLight(null));
-    try std.testing.expect(!backgroundIsLight(.{ .r = 127, .g = 127, .b = 127 }));
-    try std.testing.expect(backgroundIsLight(.{ .r = 128, .g = 128, .b = 127 }));
-}
 
 pub fn cellCharCount(page: *gt.Page, cell: *gt.Cell) usize {
     if (cell.wide == .spacer_head or cell.wide == .spacer_tail) {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,6 +1,28 @@
+const std = @import("std");
 const gt = @import("ghostty-vt");
 
 const emacs = @import("emacs.zig");
+
+/// Classify an OSC 11 default background using the convention from Neovim's
+/// terminal background detection: ITU-R BT.601 luma split at the 0.5 midpoint.
+/// https://github.com/neovim/neovim/blob/2fbc82820b5168b0da4e918c192c05832dfd6211/runtime/lua/vim/_core/defaults.lua
+///
+/// Ghostel has no separate light/dark appearance state. Instead, CSI 996/997
+/// classifies the `ghostel-default` background most recently seeded by
+/// `ghostel-sync-theme`. Theme changes trigger that sync automatically; direct
+/// face changes require an explicit sync. An unset background is treated as dark
+/// (libghostty's seed).
+pub fn backgroundIsLight(rgb: ?gt.color.RGB) bool {
+    const c = rgb orelse return false;
+    const y = @as(u32, c.r) * 299 + @as(u32, c.g) * 587 + @as(u32, c.b) * 114;
+    return y >= 127_500;
+}
+
+test backgroundIsLight {
+    try std.testing.expect(!backgroundIsLight(null));
+    try std.testing.expect(!backgroundIsLight(.{ .r = 127, .g = 127, .b = 127 }));
+    try std.testing.expect(backgroundIsLight(.{ .r = 128, .g = 128, .b = 127 }));
+}
 
 pub fn cellCharCount(page: *gt.Page, cell: *gt.Cell) usize {
     if (cell.wide == .spacer_head or cell.wide == .spacer_tail) {

--- a/test/fixtures/pty_setup.py
+++ b/test/fixtures/pty_setup.py
@@ -1,7 +1,10 @@
 """Portable terminal setup for PTY integration-test children."""
 
 import os
+import queue
 import sys
+import threading
+import time
 
 
 def set_raw_stdio():
@@ -40,3 +43,43 @@ def set_raw_stdio():
         import tty
 
         tty.setraw(sys.stdin.fileno())
+
+
+def start_reader():
+    """Read stdin on a daemon thread; return its chunk queue (b"" marks EOF)."""
+    fd = sys.stdin.fileno()
+    chunks = queue.Queue()
+
+    def run():
+        while True:
+            chunk = os.read(fd, 4096)
+            chunks.put(chunk)
+            if not chunk:
+                return
+
+    threading.Thread(target=run, daemon=True).start()
+    return chunks
+
+
+def write_all(data):
+    fd = sys.stdout.fileno()
+    while data:
+        data = data[os.write(fd, data):]
+
+
+def read_for(chunks, timeout, count=None):
+    """Collect from CHUNKS until TIMEOUT seconds, EOF, or at least COUNT bytes."""
+    buf = bytearray()
+    deadline = time.monotonic() + timeout
+    while count is None or len(buf) < count:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            chunk = chunks.get(timeout=remaining)
+        except queue.Empty:
+            break
+        if not chunk:
+            break
+        buf.extend(chunk)
+    return buf

--- a/test/ghostel-dnd-test.el
+++ b/test/ghostel-dnd-test.el
@@ -234,8 +234,7 @@ layer runs no default handler such as `find-file'."
              (payload (concat "\e[200~" quoted "\e[201~")))
         (ghostel-test--with-exec-buffer
             (buf proc python
-                 (list "-c" ghostel-test--pty-byte-recorder-script
-                       (number-to-string (length payload))))
+                 (ghostel-test--pty-byte-recorder-args (length payload)))
           (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
           (ghostel--write-vt ghostel--term "\e[?2004h")
           (ghostel--drop (ghostel-test--drop-event 'file "/tmp/a b.png"))

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -139,18 +139,8 @@ Covers punctuation, digits, uppercase, space, and lowercase letters."
 (defun ghostel-test--send-key-and-read-hex (key mods byte-count &optional setup)
   "Send KEY/MODS to a byte-recorder child and return BYTE-COUNT bytes as hex.
 SETUP, when non-nil, is called before sending the key."
-  (let ((python (executable-find "python3")))
-    (unless python (ert-skip "python3 not available"))
-    (ghostel-test--with-exec-buffer
-        (buf proc python
-             (ghostel-test--pty-byte-recorder-args byte-count))
-      (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
-      (when setup (funcall setup))
-      (ghostel--send-encoded key mods)
-      (ghostel-test--wait-for-marker-payload
-       "GHOSTEL_INPUT_HEX:"
-       (lambda (hex) (= (length hex) (* 2 byte-count)))
-       proc 5))))
+  (ghostel-test--record-pty-bytes
+   byte-count (lambda () (when setup (funcall setup)) (ghostel--send-encoded key mods))))
 
 (ert-deftest ghostel-test-encode-key-kitty-backspace ()
   "Test that backspace is correctly encoded when kitty keyboard mode is active."
@@ -342,18 +332,8 @@ Without this guard a flood would spawn a storm of redraw timers."
 (defun ghostel-test--paste-and-read-hex (text byte-count &optional setup)
   "Paste TEXT to a byte-recorder child and return BYTE-COUNT bytes as hex.
 SETUP, when non-nil, is called before sending the paste."
-  (let ((python (executable-find "python3")))
-    (unless python (ert-skip "python3 not available"))
-    (ghostel-test--with-exec-buffer
-        (buf proc python
-             (ghostel-test--pty-byte-recorder-args byte-count))
-      (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
-      (when setup (funcall setup))
-      (ghostel--paste-text text)
-      (ghostel-test--wait-for-marker-payload
-       "GHOSTEL_INPUT_HEX:"
-       (lambda (hex) (= (length hex) (* 2 byte-count)))
-       proc 5))))
+  (ghostel-test--record-pty-bytes
+   byte-count (lambda () (when setup (funcall setup)) (ghostel--paste-text text))))
 
 (ert-deftest ghostel-test-encode-paste-bracketed ()
   "Bracketed-paste mode wraps pasted data via libghostty's paste encoder."

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -143,8 +143,7 @@ SETUP, when non-nil, is called before sending the key."
     (unless python (ert-skip "python3 not available"))
     (ghostel-test--with-exec-buffer
         (buf proc python
-             (list "-c" ghostel-test--pty-byte-recorder-script
-                   (number-to-string byte-count)))
+             (ghostel-test--pty-byte-recorder-args byte-count))
       (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
       (when setup (funcall setup))
       (ghostel--send-encoded key mods)
@@ -347,8 +346,7 @@ SETUP, when non-nil, is called before sending the paste."
     (unless python (ert-skip "python3 not available"))
     (ghostel-test--with-exec-buffer
         (buf proc python
-             (list "-c" ghostel-test--pty-byte-recorder-script
-                   (number-to-string byte-count)))
+             (ghostel-test--pty-byte-recorder-args byte-count))
       (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
       (when setup (funcall setup))
       (ghostel--paste-text text)

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -859,6 +859,45 @@ fresh."
                             (:equal (should (equal arg reply)))
                             (:match (should (string-match-p arg reply))))))))))))
 
+(ert-deftest ghostel-test-csi996-reports-light-and-dark ()
+  "CSI ? 996 n reports 997;1 for a dark OSC 11 background, 997;2 for light."
+  :tags '(native)
+  (let ((python (ghostel-test--python)))
+    (ghostel-test--with-pty-matrix backend
+      (ghostel-test--with-exec-buffer
+          (buf proc python
+               (ghostel-test--pty-byte-recorder-args 9))
+        (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
+        (ghostel--set-default-colors ghostel--term "#eeeeee" "#111111")
+        (ghostel--write-vt ghostel--term "\e[?996n")
+        (should (equal "1b5b3f3939373b316e"
+                       (ghostel-test--wait-for-marker-payload
+                        "GHOSTEL_INPUT_HEX:" #'identity proc 5))))
+      (ghostel-test--with-exec-buffer
+          (buf proc python
+               (ghostel-test--pty-byte-recorder-args 9))
+        (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
+        (ghostel--set-default-colors ghostel--term "#111111" "#f7f3fa")
+        (ghostel--write-vt ghostel--term "\e[?996n")
+        (should (equal "1b5b3f3939373b326e"
+                       (ghostel-test--wait-for-marker-payload
+                        "GHOSTEL_INPUT_HEX:" #'identity proc 5)))))))
+
+(ert-deftest ghostel-test-mode-2031-pushes-997-on-color-change ()
+  "With Mode 2031 enabled, set-default-colors writes an unsolicited 997."
+  :tags '(native)
+  (let ((python (ghostel-test--python)))
+    (ghostel-test--with-pty-matrix backend
+      (ghostel-test--with-exec-buffer
+          (buf proc python
+               (ghostel-test--pty-byte-recorder-args 9))
+        (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
+        (ghostel--write-vt ghostel--term "\e[?2031h")
+        (ghostel--set-default-colors ghostel--term "#eeeeee" "#111111")
+        (should (equal "1b5b3f3939373b316e"
+                       (ghostel-test--wait-for-marker-payload
+                        "GHOSTEL_INPUT_HEX:" #'identity proc 5)))))))
+
 (ert-deftest ghostel-test-osc52-eval ()
   "Test that OSC 52;e dispatches to whitelisted functions."
   (let* ((called-with nil)

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -860,43 +860,51 @@ fresh."
                             (:match (should (string-match-p arg reply))))))))))))
 
 (ert-deftest ghostel-test-csi996-reports-light-and-dark ()
-  "CSI ? 996 n reports 997;1 for a dark OSC 11 background, 997;2 for light."
+  "A child's CSI ? 996 n gets 997;1 for a dark default background, 997;2 for light."
   :tags '(native)
-  (let ((python (ghostel-test--python)))
-    (ghostel-test--with-pty-matrix backend
+  (ghostel-test--with-pty-matrix backend
+    (dolist (case '((dark . "1b5b3f3939373b316e") (light . "1b5b3f3939373b326e")))
       (ghostel-test--with-exec-buffer
-          (buf proc python
-               (ghostel-test--pty-byte-recorder-args 9))
-        (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
-        (ghostel--set-default-colors ghostel--term "#eeeeee" "#111111")
-        (ghostel--write-vt ghostel--term "\e[?996n")
-        (should (equal "1b5b3f3939373b316e"
-                       (ghostel-test--wait-for-marker-payload
-                        "GHOSTEL_INPUT_HEX:" #'identity proc 5))))
-      (ghostel-test--with-exec-buffer
-          (buf proc python
-               (ghostel-test--pty-byte-recorder-args 9))
-        (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
-        (ghostel--set-default-colors ghostel--term "#111111" "#f7f3fa")
-        (ghostel--write-vt ghostel--term "\e[?996n")
-        (should (equal "1b5b3f3939373b326e"
-                       (ghostel-test--wait-for-marker-payload
-                        "GHOSTEL_INPUT_HEX:" #'identity proc 5)))))))
+          (buf proc (ghostel-test--python)
+               (list "-c" ghostel-test--pty-reply-probe-script
+                     (ghostel-test--fixture-directory) "0.15"
+                     (ghostel-test--hex-encode-string "\e[?996n")))
+        (ghostel--set-default-colors ghostel--term "#eeeeee" "#111111" (car case))
+        (should (equal (cdr case) (ghostel-test--wait-for-pty-reply 0 proc 6)))))))
 
-(ert-deftest ghostel-test-mode-2031-pushes-997-on-color-change ()
-  "With Mode 2031 enabled, set-default-colors writes an unsolicited 997."
+(ert-deftest ghostel-test-csi996-ignores-osc11-override ()
+  "A child OSC 11 override does not change the CSI ? 996 n answer."
   :tags '(native)
-  (let ((python (ghostel-test--python)))
-    (ghostel-test--with-pty-matrix backend
-      (ghostel-test--with-exec-buffer
-          (buf proc python
-               (ghostel-test--pty-byte-recorder-args 9))
-        (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
-        (ghostel--write-vt ghostel--term "\e[?2031h")
-        (ghostel--set-default-colors ghostel--term "#eeeeee" "#111111")
-        (should (equal "1b5b3f3939373b316e"
-                       (ghostel-test--wait-for-marker-payload
-                        "GHOSTEL_INPUT_HEX:" #'identity proc 5)))))))
+  (ghostel-test--with-pty-matrix backend
+    (should (equal "1b5b3f3939373b326e"
+                   (ghostel-test--record-pty-bytes
+                    9 (lambda ()
+                        (ghostel--set-default-colors ghostel--term "#111111" "#f7f3fa" 'light)
+                        (ghostel--write-vt ghostel--term "\e]11;#111111\e\\\e[?996n")))))))
+
+(ert-deftest ghostel-test-mode-2031-off-does-not-push-997 ()
+  "Without Mode 2031, a dark→light re-seed pushes nothing ahead of the query's own answer."
+  :tags '(native)
+  (ghostel-test--with-pty-matrix backend
+    (should (equal "1b5b3f3939373b326e"
+                   (ghostel-test--record-pty-bytes
+                    9 (lambda ()
+                        (ghostel--set-default-colors ghostel--term "#eeeeee" "#111111" 'dark)
+                        (ghostel--set-default-colors ghostel--term "#111111" "#f7f3fa" 'light)
+                        (ghostel--write-vt ghostel--term "\e[?996n")))))))
+
+(ert-deftest ghostel-test-mode-2031-pushes-997-on-scheme-change ()
+  "With Mode 2031 enabled, a 997 is pushed once per scheme change, not per re-seed."
+  :tags '(native)
+  (ghostel-test--with-pty-matrix backend
+    (should (equal "1b5b3f3939373b326e1b5b3f3939373b316e"
+                   (ghostel-test--record-pty-bytes
+                    18 (lambda ()
+                         (ghostel--set-default-colors ghostel--term "#eeeeee" "#111111" 'dark)
+                         (ghostel--write-vt ghostel--term "\e[?2031h")
+                         (ghostel--set-default-colors ghostel--term "#111111" "#f7f3fa" 'light)
+                         (ghostel--set-default-colors ghostel--term "#111111" "#fafafa" 'light)
+                         (ghostel--set-default-colors ghostel--term "#eeeeee" "#111111" 'dark)))))))
 
 (ert-deftest ghostel-test-osc52-eval ()
   "Test that OSC 52;e dispatches to whitelisted functions."

--- a/test/ghostel-render-test.el
+++ b/test/ghostel-render-test.el
@@ -768,6 +768,12 @@ and typed text was invisible."
       (should (string-match-p "\\`#[0-9a-fA-F]\\{6\\}\\'" bg))
       (should-not (string= fg bg)))))
 
+(ert-deftest ghostel-test-hex-color-scheme ()
+  "Light/dark follows `color-dark-p', including mid-grey it calls dark."
+  (should (eq 'dark (ghostel--hex-color-scheme "#000000")))
+  (should (eq 'light (ghostel--hex-color-scheme "#ffffff")))
+  (should (eq 'dark (ghostel--hex-color-scheme "#808080"))))
+
 (ert-deftest ghostel-test-sync-theme ()
   "Test that ghostel-sync-theme reapplies palette and requests redraws."
   (let ((palette-calls nil)

--- a/test/ghostel-test-helpers.el
+++ b/test/ghostel-test-helpers.el
@@ -405,26 +405,52 @@ PROCESS and TIMEOUT are passed to `ghostel-test--wait-until'."
 
 (defconst ghostel-test--pty-byte-recorder-script
   (string-join
-   '("import os, select, sys, tty, time"
-     "fd = sys.stdin.fileno()"
-     "if os.isatty(fd):"
-     "    tty.setraw(fd)"
-     "count = int(sys.argv[1])"
-     "sys.stdout.buffer.write(b'GHOSTEL_RECORDER_READY\\r\\n')"
-     "sys.stdout.buffer.flush()"
-     "buf = b''"
-     "deadline = time.time() + 5"
-     "while len(buf) < count and time.time() < deadline:"
-     "    readable, _, _ = select.select([fd], [], [], 0.05)"
-     "    if readable:"
-     "        chunk = os.read(fd, count - len(buf))"
+   '("import os, queue, sys, threading, time"
+     "sys.path.insert(0, sys.argv[1])"
+     "from pty_setup import set_raw_stdio"
+     "set_raw_stdio()"
+     "stdin_fd = sys.stdin.fileno()"
+     "stdout_fd = sys.stdout.fileno()"
+     "count = int(sys.argv[2])"
+     "input_queue = queue.Queue()"
+     "def read_input():"
+     "    while True:"
+     "        chunk = os.read(stdin_fd, 4096)"
+     "        input_queue.put(chunk)"
      "        if not chunk:"
-     "            break"
-     "        buf += chunk"
-     "sys.stdout.buffer.write(b'\\r\\nGHOSTEL_INPUT_HEX:' + buf.hex().encode('ascii') + b'\\r\\n')"
-     "sys.stdout.buffer.flush()")
+     "            return"
+     "def write_all(data):"
+     "    while data:"
+     "        data = data[os.write(stdout_fd, data):]"
+     "write_all(b'GHOSTEL_RECORDER_READY\\r\\n')"
+     "threading.Thread(target=read_input, daemon=True).start()"
+     "buf = bytearray()"
+     "deadline = time.monotonic() + 5"
+     "while len(buf) < count:"
+     "    remaining = deadline - time.monotonic()"
+     "    if remaining <= 0:"
+     "        break"
+     "    try:"
+     "        chunk = input_queue.get(timeout=remaining)"
+     "    except queue.Empty:"
+     "        break"
+     "    if not chunk:"
+     "        break"
+     "    buf.extend(chunk[: count - len(buf)])"
+     "write_all(b'\\r\\nGHOSTEL_INPUT_HEX:' + buf.hex().encode('ascii') + b'\\r\\n')")
    "\n")
-  "Python code that reads N bytes from stdin and prints them as hex.")
+  "Python code that reads N bytes from stdin and prints them as hex.
+The first argument locates the portable PTY setup module; the second is
+the number of stdin bytes to capture.  Raw mode uses `pty_setup` so the
+recorder works on POSIX PTYs and Windows ConPTY.  After printing
+`GHOSTEL_RECORDER_READY', the script prints `GHOSTEL_INPUT_HEX:' followed
+by the captured bytes as lowercase hex.")
+
+(defun ghostel-test--pty-byte-recorder-args (byte-count)
+  "Return Python argv that records BYTE-COUNT bytes from the child PTY."
+  (list "-u" "-c" ghostel-test--pty-byte-recorder-script
+        (ghostel-test--fixture-directory)
+        (number-to-string byte-count)))
 
 (defun ghostel-test--last-marker-payload (marker)
   "Return the last hex-like payload following MARKER in terminal text."

--- a/test/ghostel-test-helpers.el
+++ b/test/ghostel-test-helpers.el
@@ -299,16 +299,11 @@ to the lifecycle process returned by `ghostel-exec'; see
   (string-join
    '("import os, sys"
      "sys.path.insert(0, sys.argv[1])"
-     "from pty_setup import set_raw_stdio"
+     "from pty_setup import set_raw_stdio, write_all"
      "set_raw_stdio()"
-     "stdin_fd = sys.stdin.fileno()"
-     "stdout_fd = sys.stdout.fileno()"
-     "def write_all(data):"
-     "    while data:"
-     "        data = data[os.write(stdout_fd, data):]"
      "write_all(b'GHOSTEL_RAW_ECHO_READY')"
      "while True:"
-     "    data = os.read(stdin_fd, 4096)"
+     "    data = os.read(sys.stdin.fileno(), 4096)"
      "    if not data:"
      "        break"
      "    write_all(data)")
@@ -347,40 +342,15 @@ returned as terminal output without line-discipline rewriting."
 
 (defconst ghostel-test--pty-reply-probe-script
   (string-join
-   '("import os, queue, sys, threading, time"
+   '("import sys"
      "sys.path.insert(0, sys.argv[1])"
-     "from pty_setup import set_raw_stdio"
+     "from pty_setup import set_raw_stdio, start_reader, write_all, read_for"
      "set_raw_stdio()"
-     "stdin_fd = sys.stdin.fileno()"
-     "stdout_fd = sys.stdout.fileno()"
      "timeout = float(sys.argv[2])"
-     "payloads = sys.argv[3:]"
-     "input_queue = queue.Queue()"
-     "def read_input():"
-     "    while True:"
-     "        chunk = os.read(stdin_fd, 4096)"
-     "        input_queue.put(chunk)"
-     "        if not chunk:"
-     "            return"
-     "def write_all(data):"
-     "    while data:"
-     "        data = data[os.write(stdout_fd, data):]"
-     "threading.Thread(target=read_input, daemon=True).start()"
-     "for idx, payload_hex in enumerate(payloads):"
+     "chunks = start_reader()"
+     "for idx, payload_hex in enumerate(sys.argv[3:]):"
      "    write_all(bytes.fromhex(payload_hex))"
-     "    buf = bytearray()"
-     "    deadline = time.monotonic() + timeout"
-     "    while True:"
-     "        remaining = deadline - time.monotonic()"
-     "        if remaining <= 0:"
-     "            break"
-     "        try:"
-     "            chunk = input_queue.get(timeout=remaining)"
-     "        except queue.Empty:"
-     "            break"
-     "        if not chunk:"
-     "            break"
-     "        buf.extend(chunk)"
+     "    buf = read_for(chunks, timeout)"
      "    marker = ('\\r\\nGHOSTEL_PTY_REPLY_%d_HEX:' % idx).encode('ascii')"
      "    write_all(marker + buf.hex().encode('ascii') + b'\\r\\n')")
    "\n")
@@ -405,52 +375,30 @@ PROCESS and TIMEOUT are passed to `ghostel-test--wait-until'."
 
 (defconst ghostel-test--pty-byte-recorder-script
   (string-join
-   '("import os, queue, sys, threading, time"
+   '("import sys"
      "sys.path.insert(0, sys.argv[1])"
-     "from pty_setup import set_raw_stdio"
+     "from pty_setup import set_raw_stdio, start_reader, write_all, read_for"
      "set_raw_stdio()"
-     "stdin_fd = sys.stdin.fileno()"
-     "stdout_fd = sys.stdout.fileno()"
-     "count = int(sys.argv[2])"
-     "input_queue = queue.Queue()"
-     "def read_input():"
-     "    while True:"
-     "        chunk = os.read(stdin_fd, 4096)"
-     "        input_queue.put(chunk)"
-     "        if not chunk:"
-     "            return"
-     "def write_all(data):"
-     "    while data:"
-     "        data = data[os.write(stdout_fd, data):]"
      "write_all(b'GHOSTEL_RECORDER_READY\\r\\n')"
-     "threading.Thread(target=read_input, daemon=True).start()"
-     "buf = bytearray()"
-     "deadline = time.monotonic() + 5"
-     "while len(buf) < count:"
-     "    remaining = deadline - time.monotonic()"
-     "    if remaining <= 0:"
-     "        break"
-     "    try:"
-     "        chunk = input_queue.get(timeout=remaining)"
-     "    except queue.Empty:"
-     "        break"
-     "    if not chunk:"
-     "        break"
-     "    buf.extend(chunk[: count - len(buf)])"
+     "buf = read_for(start_reader(), 5, int(sys.argv[2]))"
      "write_all(b'\\r\\nGHOSTEL_INPUT_HEX:' + buf.hex().encode('ascii') + b'\\r\\n')")
    "\n")
-  "Python code that reads N bytes from stdin and prints them as hex.
-The first argument locates the portable PTY setup module; the second is
-the number of stdin bytes to capture.  Raw mode uses `pty_setup` so the
-recorder works on POSIX PTYs and Windows ConPTY.  After printing
-`GHOSTEL_RECORDER_READY', the script prints `GHOSTEL_INPUT_HEX:' followed
-by the captured bytes as lowercase hex.")
+  "Python code that reads at least N bytes from stdin and prints them as hex.")
 
 (defun ghostel-test--pty-byte-recorder-args (byte-count)
   "Return Python argv that records BYTE-COUNT bytes from the child PTY."
   (list "-u" "-c" ghostel-test--pty-byte-recorder-script
         (ghostel-test--fixture-directory)
         (number-to-string byte-count)))
+
+(defun ghostel-test--record-pty-bytes (byte-count action)
+  "Call ACTION in a fresh recorder buffer; return the next BYTE-COUNT PTY bytes as hex."
+  (ghostel-test--with-exec-buffer
+      (buf proc (ghostel-test--python) (ghostel-test--pty-byte-recorder-args byte-count))
+    (ghostel-test--wait-for-text "GHOSTEL_RECORDER_READY" proc 5)
+    (funcall action)
+    (ghostel-test--wait-for-marker-payload
+     "GHOSTEL_INPUT_HEX:" (lambda (hex) (>= (length hex) (* 2 byte-count))) proc 5)))
 
 (defun ghostel-test--last-marker-payload (marker)
   "Return the last hex-like payload following MARKER in terminal text."


### PR DESCRIPTION
Supersedes #657 by @ayanamists — the first commit is that PR squashed verbatim; the second reworks it.

## What

- Answer `CSI ? 996 n` with `CSI ? 997 ; 1 n` (dark) / `; 2 n` (light).
- Push an unsolicited `CSI ? 997 n` to clients that enabled Mode 2031 when the classification changes (theme change, `disable-theme`, `ghostel-sync-theme`).
- A child's own OSC 11 override never affects the answer.

## Changes relative to #657

- **Light/dark comes from Emacs, not a luma cutoff.** Every OSC 11 consumer uses a different heuristic (Neovim BT.601 ≥ 0.5, Emacs TUI unweighted average < 0.6, Emacs GUI `color-dark-p`), so the terminal reports what Emacs itself considers dark: `color-dark-p` on the `ghostel-default` background, passed to the module as a 4th argument of `ghostel--set-default-colors`. `#808080` is dark, as in Emacs. The Zig classifier and its (never compiled) unit test are gone.
- **997 only on an actual change.** The PR pushed on every `set-default-colors`, and `load-theme` fires `enable-theme-functions` twice (`user` pseudo-theme + theme), so every theme change produced two identical reports.
- **PTY write outside the terminal lock**, and best effort. Writing under `term_mutex` could stall the reader thread on a full PTY; a write error no longer escapes the theme hook after the scheme is committed.
- `disable-theme` re-syncs; `ghostel-sync-theme` skips buffers killed by re-entrant sentinels.
- Tests: the 996 query is sent through the child so the native reader-thread path is exercised; the recorder no longer truncates, so duplicate reports fail; 2031 test asserts one push per change across three re-seeds. The PR's ConPTY port of the recorder script is kept, with the reader/deadline loop shared by the recorder, reply-probe and raw-echo scripts via `test/fixtures/pty_setup.py`.

## Verified live (both PTY backends)

996 answers under modus-vivendi/operandi and mid-grey backgrounds, exactly one 997 per light↔dark switch, per-buffer 2031 gating, dead-process write silent, OSC 11 override ignored, RIS keeps the scheme, OSC 10/11/4 palette sync unchanged.

## Not addressed here

The pinned libghostty's `OSC 111` (reset background) copies `default` into `override`, so after a child resets, `OSC 11;?` returns the stale colour across theme switches (fixed upstream). This — not 997, which Neovim 0.12 ignores — is what sets nvim's `&background`; needs a ghostty bump.

Reloading an already-active theme emits two transient 997s (disable → enable); accepted as harmless.
