### PR TITLE
Scope titles set during a command to that command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- A title set while a command runs is now restored when the command
+  finishes, so programs that set a title and exit without clearing it
+  (Claude Code, for example) no longer leave it in the mode line.
+  Disable with `ghostel-restore-title-after-command`.
+
 ## [0.53.0] — 2026-09-02
 
 ### Added

--- a/README.org
+++ b/README.org
@@ -849,7 +849,10 @@ TRAMP-aware =auth-source-pick-first-password= example.
   =C-c M-n= / =C-c M-p=.
 - *OSC 2* - title tracking (the title is shown in the mode line; see
   =ghostel-buffer-identification-format=.  Set =ghostel-buffer-name-function= to
-  rename the buffer from the title instead).
+  rename the buffer from the title instead).  A title set while a command
+  runs is restored when the command finishes, so a program that exits
+  without clearing its title can't leave it behind (see
+  =ghostel-restore-title-after-command=).
 - *OSC 52;e* - call whitelisted Emacs functions from shell scripts (see [[#calling-elisp-from-the-shell][Calling
   Elisp from the Shell]]).
 - *OSC 52* - clipboard support (opt-in, for remote sessions).
@@ -1356,6 +1359,7 @@ tables below group them by area; defaults shown are the out-of-the-box values.
 | =ghostel-exit-functions=               | =nil=                                           | Hook run with =(BUFFER EVENT)= when the terminal process exits.                                                                                                                                            |
 | =ghostel-command-start-functions=      | =(ghostel--query-before-killing-on-cmd-start)=  | Hook run with =(BUFFER)= on OSC 133 C (command start).                                                                                                                                                     |
 | =ghostel-command-finish-functions=     | =(ghostel--query-before-killing-on-cmd-finish)= | Hook run with =(BUFFER EXIT-STATUS)= on OSC 133 D (command finish).                                                                                                                                        |
+| =ghostel-restore-title-after-command=  | =t=                                             | Restore the pre-command title when a command finishes, so a program that exits without clearing its title doesn't leave it in the mode line.                                                               |
 | =ghostel-bookmark-check-dir=           | =t=                                             | Restore the working directory when jumping to a ghostel [[#bookmarks][bookmark]] (=cd= into a reused buffer that moved).                                                                                                   |
 
 ** Native module

--- a/lisp/ghostel-shell.el
+++ b/lisp/ghostel-shell.el
@@ -37,11 +37,13 @@
 (declare-function ghostel--enter-readonly-input-mode "ghostel")
 (declare-function ghostel--resource-root "ghostel-module-install")
 (declare-function ghostel--run-hook-safely "ghostel")
+(declare-function ghostel--set-title "ghostel")
 (declare-function ghostel--ssh-install-enabled-p "ghostel")
 (declare-function ghostel--terminfo-directory "ghostel")
 (defvar ghostel-prompt-navigation-input-mode)
 (defvar ghostel-shell)
 (defvar ghostel--input-mode)
+(defvar ghostel-title)
 
 
 ;;; Customization
@@ -184,6 +186,19 @@ non-nil so the debugger can fire)."
   :type 'hook
   :group 'ghostel)
 
+(defcustom ghostel-restore-title-after-command t
+  "Non-nil means a title set during a command is restored when it finishes.
+Some programs (Claude Code, for example) set a title and exit
+without clearing it, so the stale title stays in the mode line.
+With this enabled, the title goes back to its pre-command value
+when the command finishes.  Titles set outside a command are
+never touched, and programs that clean up their own title are
+unaffected.
+
+Requires shell integration, like `ghostel-command-finish-functions'."
+  :type 'boolean
+  :group 'ghostel)
+
 
 ;;; Buffer-local state
 
@@ -193,6 +208,10 @@ Nil for buffers running an arbitrary command (`ghostel-exec').")
 
 (defvar-local ghostel--command-running nil
   "Non-nil between OSC 133 command-start and command-finish markers.")
+
+(defvar-local ghostel--pre-command-title nil
+  "Value of `ghostel-title' when the current command started.
+Restored at command finish by `ghostel-restore-title-after-command'.")
 
 (defvar-local ghostel--prompt-positions nil
   "List of prompt positions as (buffer-line . exit-status) pairs.
@@ -565,16 +584,24 @@ not here.  This handler only tracks prompt positions and exit status."
      ;; Command output start — notify `ghostel-command-start-functions'.
      (ghostel--run-hook-safely 'ghostel-command-start-functions
                                (current-buffer))
-     (setq ghostel--command-running t))
+     (setq ghostel--command-running t
+           ghostel--pre-command-title ghostel-title))
     ("D"
      ;; Command finished — store exit status on the most recent entry
      ;; and notify `ghostel-command-finish-functions'.
-     (let ((exit (and param (string-to-number param))))
+     (let ((exit (and param (string-to-number param)))
+           (was-running ghostel--command-running))
        (when (and ghostel--prompt-positions param)
          (setcdr (car ghostel--prompt-positions) exit))
        (ghostel--run-hook-safely 'ghostel-command-finish-functions
-                                 (current-buffer) exit))
-     (setq ghostel--command-running nil))))
+                                 (current-buffer) exit)
+       (setq ghostel--command-running nil)
+       ;; Restore the pre-command title, after the finish hooks so they
+       ;; still see the command's title; `was-running' skips prompt redraws.
+       (when (and was-running
+                  ghostel-restore-title-after-command
+                  (not (equal ghostel-title ghostel--pre-command-title)))
+         (ghostel--set-title ghostel--pre-command-title))))))
 
 (defun ghostel--prompt-input-start ()
   "From the start of a `ghostel-prompt' region, move past the prefix.

--- a/test/ghostel-osc-test.el
+++ b/test/ghostel-osc-test.el
@@ -215,6 +215,42 @@ Covers OSC 2 with ST and BEL terminators and the OSC 0 form."
       (ghostel-test--wait-until
        (lambda () (equal "AFTER" ghostel-title)) proc 5))))
 
+(ert-deftest ghostel-test-title-restored-after-command ()
+  "A title set while a command runs is restored when the command finishes."
+  :tags '(native)
+  (ghostel-test--with-pty-matrix backend
+    (ghostel-test--with-raw-echo-buffer (buf proc)
+      (ghostel--write-vt ghostel--term "\e]133;C\e\\\e]2;Command Title\e\\")
+      (ghostel-test--wait-until
+       (lambda () (equal "Command Title" ghostel-title)) proc 5)
+      (ghostel--write-vt ghostel--term "\e]133;D;0\e\\")
+      (ghostel-test--wait-until
+       (lambda () (null ghostel-title)) proc 5))))
+
+(ert-deftest ghostel-test-title-restore-scope ()
+  "Scoping rules for `ghostel-restore-title-after-command'.
+A title set during a command is restored when it finishes; a
+prompt-redraw D leaves a prompt-set title alone; nil disables
+the restore."
+  (with-temp-buffer
+    (let ((ghostel-buffer-name-function nil)
+          (ghostel-buffer-identification-format nil))
+      (ghostel--set-title "before")
+      (ghostel--osc133-marker "C" nil)
+      (ghostel--set-title "during")
+      (ghostel--osc133-marker "D" "0")
+      (should (equal "before" ghostel-title))
+      ;; D without a command (prompt redraw): the title stays.
+      (ghostel--set-title "prompt title")
+      (ghostel--osc133-marker "D" "0")
+      (should (equal "prompt title" ghostel-title))
+      ;; Option off: the command's title stays.
+      (let ((ghostel-restore-title-after-command nil))
+        (ghostel--osc133-marker "C" nil)
+        (ghostel--set-title "sticky")
+        (ghostel--osc133-marker "D" "0")
+        (should (equal "sticky" ghostel-title))))))
+
 (ert-deftest ghostel-test-osc9-notification ()
   "OSC 9 iTerm2-style notifications reach `ghostel-notification-function'."
   :tags '(native)


### PR DESCRIPTION
Follow-up to #619 and a complement to #639 (released in 0.51.0): the terminal-reset and title-stack handling from #639 help programs that ask for their title to be cleaned up, but many programs never ask — they set a title and exit. Claude Code is a concrete example: it writes progress summaries to the terminal title while it runs but never clears the title and doesn't use the title stack (verified against the installed binary), so after quitting, its last summary stays in the mode line next to an idle prompt.

## Problem

A program that sets a title and exits without any cleanup — no reset, no title-stack pop, no empty-title write — leaves that title in `ghostel-title` forever. As #639 notes, ghostty itself hides this because its shell integration rewrites the title at every prompt; ghostel's shell integration deliberately never touches the title, so a stale one never goes away.

## Fix

When shell integration is active, a title set during a command now lasts only until the command finishes: the OSC 133 C (command start) handler saves the current title, and the D (command finished) handler restores it if the command changed it.

- The restore runs after `ghostel-command-finish-functions`, so those hooks still see the command's title.
- Titles set at the prompt are left alone: a D without a preceding C (a prompt redraw) restores nothing.
- Programs that clean up properly are unaffected: their cleanup has already run by the time D arrives, so there is nothing to restore.
- New defcustom `ghostel-restore-title-after-command` (default t) turns it off.

Elisp only — the C/D handling in ghostel-shell.el plus one defcustom and one buffer-local variable. No module changes.

## Tests

Two new tests in test/ghostel-osc-test.el, next to #639's title-stack tests: an end-to-end test through the native module (a title set during a command is restored when it finishes) and a unit test of the scoping rules (restore on and off, prompt redraws leave prompt-set titles alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
