### PR TITLE
Add ghostel-window-padding-balance to align the grid vertically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `ghostel-window-padding-balance`: places the fractional-row space a
+  window leaves under the grid whenever nothing precedes the first row
+  (alternate screen, fresh primary screen): `center` splits it between
+  the top and the bottom like ghostty's option of the same name,
+  `bottom` moves it all above the grid, `top` (the default) keeps it
+  below.  Graphical frames on Emacs 29+ only.
+
 ## [0.52.0] — 2026-08-31
 
 ### Added

--- a/README.org
+++ b/README.org
@@ -869,6 +869,12 @@ TRAMP-aware =auth-source-pick-first-password= example.
   reader and Emacs is notified only when callbacks or redraws are needed.
 - Cursor position updates even without cell changes.
 - Theme-aware color palette (syncs with the Emacs theme via =ghostel-sync-theme=).
+- =ghostel-window-padding-balance= places the fractional-row space under
+  the grid whenever nothing precedes the first row, e.g. on the alternate
+  screen: =center= splits it between the top and the bottom (as ghostty's
+  option of the same name does), =bottom= moves it all above the grid so
+  the last row sits flush against the mode line.  =top= (the default)
+  keeps it at the bottom.
 
 ** Inline images (Kitty graphics protocol)
 :properties:

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -646,6 +646,15 @@ Customize the faces `ghostel-fake-cursor' and
 `ghostel-fake-cursor-box' to tune the appearance."
   :type 'boolean)
 
+(defcustom ghostel-window-padding-balance 'top
+  "Where a GUI window's fractional-row leftover pixels go.
+`top' keeps them below the last row, `center' (or t) splits them top
+and bottom (like ghostty's `window-padding-balance'),
+`bottom' moves them all above the first row."
+  :type '(choice (const :tag "Top (default)" top)
+                 (const :tag "Center" center)
+                 (const :tag "Bottom" bottom)))
+
 (defcustom ghostel-initial-input-mode 'semi-char
   "Input mode a freshly started `ghostel' terminal begins in.
 One of `semi-char' (default), `char', or `line'.  `line' engages on
@@ -3798,14 +3807,15 @@ kernel hostname drifts between NAME and NAME.local with network state,
 while the function `system-name' keeps the value from Emacs startup."
   (or (null host)
       (string= host "")
-      (let ((host (if (string-suffix-p ".local" host t)
-                      (substring host 0 (- (length host) (length ".local")))
-                    host)))
-        (or (eq t (compare-strings host nil nil "localhost" nil nil t))
-            (eq t (compare-strings host nil nil (system-name) nil nil t))
-            (eq t (compare-strings
-                   host nil nil
-                   (car (split-string (system-name) "\\.")) nil nil t))))))
+      (save-match-data
+        (let ((host (if (string-suffix-p ".local" host t)
+                        (substring host 0 (- (length host) (length ".local")))
+                      host)))
+          (or (eq t (compare-strings host nil nil "localhost" nil nil t))
+              (eq t (compare-strings host nil nil (system-name) nil nil t))
+              (eq t (compare-strings
+                     host nil nil
+                     (car (split-string (system-name) "\\.")) nil nil t)))))))
 
 (defun ghostel--resolve-local-executable (program)
   "Return the absolute local executable path for PROGRAM.
@@ -4386,15 +4396,75 @@ would not, since the function predates the form.  Emacs 28 falls back to
 line-count anchoring, exact for ghostel's uniform row heights.")
 
 (defun ghostel--pixel-anchor (window target)
-  "Return (START . VSCROLL) anchoring TARGET at WINDOW's bottom.
+  "Return (START VSCROLL HEIGHT) anchoring TARGET at WINDOW's bottom.
 Ask Emacs redisplay for the exact pixel position that places TARGET at
-the bottom of WINDOW."
+the bottom of WINDOW.  HEIGHT is the pixel height of START..TARGET."
   (when-let* ((body-height (window-body-height window t))
               ((> body-height 0))
               (size (window-text-pixel-size
                      window (cons target (- body-height)) target nil nil))
               (start (nth 2 size)))
-    (cons start (max 0 (- (nth 1 size) body-height)))))
+    (list start (max 0 (- (nth 1 size) body-height)) (nth 1 size))))
+
+(defvar-local ghostel--top-pad-overlay nil
+  "Empty overlay at `point-min' whose `before-string' pads above the first row.
+See `ghostel-window-padding-balance'.")
+
+(defvar-local ghostel--top-pad 0
+  "Pixels `ghostel--top-pad-overlay' currently adds above the first row.")
+
+(defun ghostel--top-pad-set (pad)
+  "Pad PAD pixels above the first row; 0 removes the pad.
+The pad is a PAD-pixel display line: a newline in a tiny face whose
+`line-height' sets the height.  A `line-height' on the first row's own
+newline would not do: redisplay drops it when the row fills the window
+width, and the renderer rewrites that newline."
+  (unless (eql pad ghostel--top-pad)
+    (if (= pad 0)
+        (delete-overlay ghostel--top-pad-overlay)
+      (let ((ov (or ghostel--top-pad-overlay
+                    (setq ghostel--top-pad-overlay
+                          (make-overlay (point-min) (point-min))))))
+        (unless (overlay-buffer ov)
+          (move-overlay ov (point-min) (point-min)))
+        (overlay-put ov 'before-string
+                     (propertize "\n" 'face '(:inherit default :height 10)
+                                 'line-height pad))))
+    (setq ghostel--top-pad pad)))
+
+(defun ghostel--top-pad-leftover (window target anchor)
+  "Return the pixels WINDOW leaves free below TARGET, 0 unless it shows row 1.
+ANCHOR is WINDOW's `ghostel--pixel-anchor' for TARGET, measured when
+nil.  Call only with the pad cleared - see `ghostel--balance-top-pad'."
+  (pcase (or anchor (ghostel--pixel-anchor window target))
+    (`(,start ,_ ,height)
+     (if (= start (point-min))
+         (max 0 (- (window-body-height window t) height))
+       0))
+    (_ 0)))
+
+(defun ghostel--balance-top-pad (window target)
+  "Return WINDOW's pixel anchor for TARGET, its free space padded on top."
+  ;; Measure with the pad cleared: whether a measurement counts the pad
+  ;; line varies with build and geometry, and a tainted leftover feeds
+  ;; back into the next pad.
+  (ghostel--top-pad-set 0)
+  (when-let* ((anchor (ghostel--pixel-anchor window target)))
+    (when (memq ghostel-window-padding-balance '(center bottom t))
+      (let ((leftover most-positive-fixnum))
+        (dolist (w (ghostel--windows (current-buffer) t))
+          (when (display-graphic-p (window-frame w))
+            (setq leftover
+                  (min leftover
+                       (ghostel--top-pad-leftover
+                        w target (and (eq w window) anchor))))))
+        ;; A row or more means an unfilled grid, not a fractional-row gap.
+        (unless (>= leftover (default-font-height))
+          (ghostel--top-pad-set
+           (if (eq ghostel-window-padding-balance 'bottom)
+               leftover
+             (/ leftover 2))))))
+    anchor))
 
 (defun ghostel--anchor-window (&optional window force following)
   "Scroll WINDOW so that the last row is aligned to the bottom of the window.
@@ -4441,12 +4511,12 @@ mode keeps the user's point."
                                   (line-beginning-position))))
                (anchor (or (and (display-graphic-p (window-frame window))
                                 ghostel--pixel-anchor-supported-p
-                                (ghostel--pixel-anchor window target))
+                                (ghostel--balance-top-pad window target))
                            (save-excursion
                              (goto-char target)
                              (forward-line
                               (- (floor (window-screen-lines))))
-                             (cons (point) 0))))
+                             (list (point) 0))))
                (start (if (and cursor-bol (< cursor-bol (car anchor)))
                           cursor-bol
                         (car anchor)))
@@ -4455,7 +4525,7 @@ mode keeps the user's point."
                ;; boundary anyway.
                (vscroll (if (and cursor-bol (= cursor-bol start))
                             0
-                          (cdr anchor))))
+                          (nth 1 anchor))))
           (set-window-start window start)
           (ghostel--set-window-vscroll window vscroll t t)
           (set-window-point window (if (eq ghostel--input-mode 'line)
@@ -4810,7 +4880,8 @@ A mode change runs `kill-all-local-variables', wiping the buffer-locals
 the native module and PTY depend on; once the process is dead the mode
 may change freely (`ghostel-compile' finalize relies on this)."
   (when (process-live-p ghostel--process)
-    (user-error "Cannot change major mode in a live ghostel buffer")))
+    (user-error "Cannot change major mode in a live ghostel buffer"))
+  (ghostel--top-pad-set 0))
 
 ;; Like `term-mode': the buffer is not for ordinary text editing, and
 ;; `read-only-mode' must not drag in `view-mode' under `view-read-only'.
@@ -5010,6 +5081,7 @@ spawn after initialization."
           ghostel--cursor-pos nil
           ghostel--cursor-char-pos nil
           ghostel--repainted-region nil)
+    (ghostel--top-pad-set 0)
     ;; Reused buffers hold the previous session's title; drop it from
     ;; the mode line along with the buffer-local reset above.
     (ghostel--buffer-identification-update)

--- a/test/ghostel-scroll-test.el
+++ b/test/ghostel-scroll-test.el
@@ -901,5 +901,235 @@ apply to it."
       (set-window-buffer (selected-window) previous-buffer)
       (kill-buffer buf))))
 
+;;; Window padding balance
+
+(defun ghostel-test-scroll--pad-px ()
+  "Pixels the pad overlay adds above row 1, 0 without one."
+  (let ((ov ghostel--top-pad-overlay))
+    (if (and ov (overlay-buffer ov) (= (overlay-start ov) (point-min)))
+        (get-text-property 0 'line-height (overlay-get ov 'before-string))
+      0)))
+
+(defmacro ghostel-test-scroll--with-pixel-layout (body-px vscrolls &rest body)
+  "Run BODY under a simulated graphical layout of 20-px rows in a BODY-PX body.
+`ghostel--pixel-anchor' is answered from line counts and never counts
+the pad's display line, like the environments whose measurement
+excludes it - the pad code must only measure with the pad cleared.
+`set-window-vscroll' records into the hash table VSCROLLS."
+  (declare (indent 2))
+  `(let ((ghostel--pixel-anchor-supported-p t))
+     (cl-letf (((symbol-function 'display-graphic-p) (lambda (&optional _) t))
+               ((symbol-function 'default-font-height) (lambda () 20))
+               ((symbol-function 'window-body-height)
+                (lambda (&optional _window _pixelwise) ,body-px))
+               ((symbol-function 'set-window-vscroll)
+                (lambda (win vscroll &optional _pixels-p &rest _)
+                  (puthash win vscroll ,vscrolls)))
+               ((symbol-function 'ghostel--pixel-anchor)
+                (lambda (window target)
+                  (let* ((body (window-body-height window t))
+                         (lines (count-lines (point-min) target))
+                         (rows (min lines (ceiling body 20)))
+                         (start (save-excursion
+                                  (goto-char target)
+                                  (forward-line (- rows))
+                                  (point)))
+                         (height (* rows 20)))
+                    (list start (max 0 (- height body)) height)))))
+       ,@body)))
+
+(ert-deftest ghostel-test-padding-balance-splits-alt-screen-leftover ()
+  "On the alternate screen half of the fractional-row space pads row 1."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (let ((vscrolls (make-hash-table :test 'eq))
+          (ghostel-window-padding-balance 'center))
+      (ghostel--write-vt term "\e[?1049h")
+      (ghostel-test-scroll--write-lines term "alt" 9)
+      (ghostel--redraw term t)
+      ;; 10 rows of 20 px in a 212 px body: 12 px left over.
+      (ghostel-test-scroll--with-pixel-layout 212 vscrolls
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 6 ghostel--top-pad))
+        (should (= 6 (ghostel-test-scroll--pad-px)))
+        (should (= 0 (gethash (selected-window) vscrolls)))
+        (should (= (point-min) (window-start (selected-window))))
+        ;; Steady state: the pad stays put across anchors.
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 6 ghostel--top-pad))))))
+
+(ert-deftest ghostel-test-padding-balance-survives-row-1-rewrite ()
+  "A render that rewrites row 1 leaves the pad in place."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (let ((vscrolls (make-hash-table :test 'eq))
+          (ghostel-window-padding-balance 'center))
+      (ghostel--write-vt term "\e[?1049hfirst\r\n")
+      (ghostel--redraw term t)
+      (ghostel-test-scroll--with-pixel-layout 212 vscrolls
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 6 ghostel--top-pad))
+        (ghostel--write-vt term "\e[H\e[2Ka longer first row")
+        (ghostel--redraw-now buf)
+        (should (= 6 (ghostel-test-scroll--pad-px)))
+        ;; An empty row 1 must not matter either.
+        (ghostel--write-vt term "\e[H\e[2K")
+        (ghostel--redraw-now buf)
+        (should (= 6 (ghostel-test-scroll--pad-px)))))))
+
+(ert-deftest ghostel-test-padding-balance-rebalances-after-sub-row-shrink ()
+  "A shrink smaller than a row re-splits the remaining space in one anchor."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (let ((vscrolls (make-hash-table :test 'eq))
+          (ghostel-window-padding-balance 'center))
+      (ghostel--write-vt term "\e[?1049h")
+      (ghostel--redraw term t)
+      (ghostel-test-scroll--with-pixel-layout 212 vscrolls
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 6 ghostel--top-pad)))
+      (ghostel-test-scroll--with-pixel-layout 204 vscrolls
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 2 ghostel--top-pad))
+        (should (= 0 (gethash (selected-window) vscrolls)))))))
+
+(ert-deftest ghostel-test-padding-balance-dropped-on-major-mode-change ()
+  "Changing the major mode of an exited terminal removes the pad overlay."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (let ((vscrolls (make-hash-table :test 'eq))
+          (ghostel-window-padding-balance 'center))
+      (ghostel--write-vt term "\e[?1049h")
+      (ghostel--redraw term t)
+      (ghostel-test-scroll--with-pixel-layout 212 vscrolls
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 6 ghostel--top-pad)))
+      (let ((ov ghostel--top-pad-overlay))
+        (fundamental-mode)
+        (should-not (overlay-buffer ov))))))
+
+(ert-deftest ghostel-test-padding-balance-rounds-down-the-top ()
+  "An odd leftover gives the bottom the extra pixel."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (let ((vscrolls (make-hash-table :test 'eq))
+          (ghostel-window-padding-balance 'center))
+      (ghostel--write-vt term "\e[?1049h")
+      (ghostel--redraw term t)
+      (ghostel-test-scroll--with-pixel-layout 211 vscrolls
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 5 ghostel--top-pad))))))
+
+(ert-deftest ghostel-test-padding-balance-toggles-with-option ()
+  "The pad tracks the option value on the next anchor; t means `center'."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (let ((vscrolls (make-hash-table :test 'eq))
+          (ghostel-window-padding-balance nil))
+      (ghostel--write-vt term "\e[?1049h")
+      (ghostel--redraw term t)
+      (ghostel-test-scroll--with-pixel-layout 212 vscrolls
+        (ghostel--anchor-window (selected-window) t)
+        (should-not ghostel--top-pad-overlay)
+        (setq ghostel-window-padding-balance t)
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 6 ghostel--top-pad))
+        (setq ghostel-window-padding-balance 'bottom)
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 12 ghostel--top-pad))
+        (setq ghostel-window-padding-balance 'top)
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 0 ghostel--top-pad))
+        (should-not (overlay-buffer ghostel--top-pad-overlay))))))
+
+(ert-deftest ghostel-test-padding-balance-bottom-takes-all-leftover ()
+  "With `bottom' the whole fractional-row space pads row 1."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (let ((vscrolls (make-hash-table :test 'eq))
+          (ghostel-window-padding-balance 'bottom))
+      (ghostel--write-vt term "\e[?1049h")
+      (ghostel--redraw term t)
+      ;; 10 rows of 20 px in a 212 px body: all 12 leftover px on top.
+      (ghostel-test-scroll--with-pixel-layout 212 vscrolls
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 12 ghostel--top-pad))
+        (should (= 0 (gethash (selected-window) vscrolls)))
+        (should (= (point-min) (window-start (selected-window))))
+        ;; Steady state: the pad stays put across anchors.
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 12 ghostel--top-pad))))))
+
+(ert-deftest ghostel-test-padding-balance-skips-unfilled-grid ()
+  "A grid shorter than the window gets no pad; the gap is real bottom space."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (let ((vscrolls (make-hash-table :test 'eq))
+          (ghostel-window-padding-balance 'bottom))
+      (ghostel--write-vt term "\e[?1049h")
+      (ghostel--redraw term t)
+      ;; 10 rows of 20 px in a 400 px body: the window is half empty.
+      (ghostel-test-scroll--with-pixel-layout 400 vscrolls
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 0 ghostel--top-pad))))))
+
+(ert-deftest ghostel-test-padding-balance-oversized-pad-recovers ()
+  "A stale oversized pad re-settles to the true leftover in one anchor."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (let ((vscrolls (make-hash-table :test 'eq))
+          (ghostel-window-padding-balance 'bottom))
+      (ghostel--write-vt term "\e[?1049h")
+      (ghostel--redraw term t)
+      (ghostel-test-scroll--with-pixel-layout 212 vscrolls
+        (ghostel--top-pad-set 300)
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 12 ghostel--top-pad))))))
+
+(ert-deftest ghostel-test-padding-balance-yields-to-scrollback ()
+  "Once scrollback precedes row 1 the pad goes and the anchor is re-measured."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (let ((vscrolls (make-hash-table :test 'eq))
+          (ghostel-window-padding-balance 'center))
+      ;; Fresh primary screen: grid only, so the pad applies.
+      (ghostel-test-scroll--write-lines term "row" 9)
+      (ghostel--redraw term t)
+      (ghostel-test-scroll--with-pixel-layout 212 vscrolls
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 6 ghostel--top-pad))
+        ;; One more line scrolls a row into scrollback.
+        (ghostel--write-vt term "more\r\n")
+        (ghostel--redraw term t)
+        (ghostel--anchor-window (selected-window) t)
+        (should (= 0 ghostel--top-pad))
+        ;; 11 rows = 220 px in 212 px: 8 px clipped off the top, no pad.
+        (should (= 8 (gethash (selected-window) vscrolls)))
+        (should (= (point-min) (window-start (selected-window))))))))
+
+(ert-deftest ghostel-test-padding-balance-follows-smallest-window ()
+  "The buffer-wide pad fits the smallest graphical window showing the buffer."
+  :tags '(native)
+  (ghostel-test-scroll--with-buffer (buf term 10 40 200)
+    (let ((vscrolls (make-hash-table :test 'eq))
+          (ghostel-window-padding-balance 'center)
+          (other (split-window)))
+      (unwind-protect
+          (progn
+            (set-window-buffer other buf)
+            (ghostel--write-vt term "\e[?1049h")
+            (ghostel--redraw term t)
+            ;; 204 px body in the other window: 4 px left over.
+            (ghostel-test-scroll--with-pixel-layout 212 vscrolls
+              (cl-letf* ((orig (symbol-function 'window-body-height))
+                         ((symbol-function 'window-body-height)
+                          (lambda (&optional window pixelwise)
+                            (if (and pixelwise (eq window other))
+                                204
+                              (funcall orig window pixelwise)))))
+                (ghostel--anchor-window (selected-window) t)
+                (should (= 2 ghostel--top-pad)))))
+        (delete-window other)))))
+
 (provide 'ghostel-scroll-test)
 ;;; ghostel-scroll-test.el ends here

--- a/test/ghostel-shell-test.el
+++ b/test/ghostel-shell-test.el
@@ -458,6 +458,14 @@ the path, `%0D' decodes to a carriage return, and when only the raw
                            (track (concat "file://" host base "/cr%0Dq"))))))
       (delete-directory base t))))
 
+(ert-deftest ghostel-test-local-host-p-preserves-match-data ()
+  "`ghostel--local-host-p' keeps the caller's match data intact.
+The glued-drive parse reads `match-string' after probing the host; a
+dotted host reaches the `split-string' clause, which matches internally."
+  (string-match "\\`\\(foo\\)\\(bar\\)\\'" "foobar")
+  (ghostel--local-host-p "somehost.local")
+  (should (equal "bar" (match-string 2 "foobar"))))
+
 (ert-deftest ghostel-test-update-directory-windows-drive-glued-host ()
   "A drive glued onto the local authority tracks as the drive path.
 No TRAMP host is fabricated from the glued spelling."


### PR DESCRIPTION
Fixes #663.

A window is rarely a whole number of terminal rows tall. When nothing precedes the first row (alternate screen, unscrolled primary screen) the leftover pixels sit as a gap below the last row — so tmux's status bar floats above the mode line, while a fixed top row (htop, `emacs -nw`) looks truncated.

## What this adds

`ghostel-window-padding-balance` (graphical frames on Emacs 29+ only) picks where the leftover goes:

- `top` (default) — below the last row, as before.
- `center` — split between top and bottom, like ghostty's `window-padding-balance`. `t` is accepted as `center`.
- `bottom` — all of it above the first row, so the last row sits flush against the mode line. Natural for a shell under tmux, and consistent with how the primary screen already clips at the top once scrollback exists.

Any other value falls back to `top`.

## Implementation

The pad is a `before-string` display line above grid row 1 — an empty overlay at `point-min` whose before-string is a tiny-face newline carrying `line-height` = pad pixels. A `line-height` on row 1's *own* newline was tried first but redisplay drops it when the row fills the window width (`emacs -nw` menu bar, full echo lines), and the native renderer rewrites that newline; the separate pad line is immune to both. The pad is buffer-wide (the smallest graphical window showing the buffer bounds it), removed once scrollback precedes row 1, and dropped on major-mode change and buffer reuse.

A leftover of a row or more never pads: it means the grid does not fill the window yet (startup, pre-resize), or the body-capped pixel measurement lost the pad row. Without this guard, enabling the option before the terminal started seeded an oversized pad that ratcheted up without bound (found in live testing); such a pad now self-heals on the next anchor.

## Default = no impact

With `top` the pad overlay is never created and `window-start`/`vscroll` are byte-for-byte what they were before; the anchor path adds ~0.28 µs of pure elisp per anchor (no extra `window-text-pixel-size` call), well under 1% of an anchor.

## Testing

- 11 native ERT tests (`test/ghostel-scroll-test.el`): alt-screen split, floor rounding, bottom takes the full leftover, unfilled grid gets no pad, oversized-pad recovery, row-1 rewrite (full-width and empty), sub-row shrink rebalance, scrollback yield, buffer-wide min across windows, option toggling (including `t` = center), major-mode drop. The mocked pixel measurement models the real body-capped scan: a pad of a row or more is not counted.
- Verified live under GUI elate sessions: clean start with `bottom` set before the terminal (the previously wedging case) settles at the exact sub-row leftover and stays put across output floods; runtime toggling between all three values; pixelwise resize re-settling; plus the original alt-screen matrix (tmux, htop, less, vim, `emacs -nw`) and dynamic-geometry/lifecycle paths.

`make -j8 all` green.