### PR TITLE
Expose live terminal send boundary

### DIFF
--- a/README.org
+++ b/README.org
@@ -2011,21 +2011,25 @@ to show it in every buffer prompt (=C-x b=, =consult-buffer=, and ghostel's own)
 :end:
 #+findex: ghostel-send-string
 #+findex: ghostel-send-key
+#+findex: ghostel-paste-string
 
 For packages that need to inject input into a running ghostel buffer (agent
-integrations, custom keymaps, ...), two public functions
+integrations, custom keymaps, ...), three public functions
 are provided:
 
 #+begin_src emacs-lisp
 (ghostel-send-string "ls -la\n")      ; send raw bytes, newline included
+(ghostel-paste-string "ls -la")       ; send a bracketed paste
 (ghostel-send-key "return")           ; send a named key through the encoder
 (ghostel-send-key "a" "ctrl")         ; C-a - respects the current terminal mode
 (ghostel-send-key "up" "shift,ctrl")  ; modifiers are comma-separated
 #+end_src
 
-Both operate on the current buffer; wrap in =with-current-buffer= when driving
-another ghostel buffer.  Calling either outside a ghostel buffer signals a
-=user-error=.
+All operate on the current buffer; wrap in =with-current-buffer= when driving
+another ghostel buffer.  Calling one outside a ghostel buffer signals a
+=user-error=.  =ghostel-paste-string= and =ghostel-send-key= also signal
+=user-error= if the terminal is no longer live or exits before the send
+completes.
 
 ** Creating and listing terminals from Lisp
 :properties:
@@ -2034,6 +2038,7 @@ another ghostel buffer.  Calling either outside a ghostel buffer signals a
 #+findex: ghostel-create
 #+findex: ghostel-exec
 #+findex: ghostel-buffer-list
+#+findex: ghostel-buffer-live-p
 #+findex: ghostel-project-buffer-list
 
 For packages that build on ghostel, a small public API creates and enumerates
@@ -2047,7 +2052,8 @@ terminals without reaching into internals:
 
 (ghostel-exec (get-buffer-create "*tig*") "tig")  ; run one program in a TTY instead of a shell
 
-(ghostel-buffer-list)                 ; all live ghostel buffers
+(ghostel-buffer-list)                 ; all live Ghostel buffers, including exited terminals
+(ghostel-buffer-live-p buffer)        ; terminal in BUFFER can accept input
 (ghostel-project-buffer-list)         ; ghostel buffers in the current project
 #+end_src
 
@@ -2056,6 +2062,10 @@ but always creating a fresh terminal; =ghostel-exec= runs a single program in
 a real TTY with no shell integration.  Both read =default-directory=, and both
 accept an optional IDENTITY alist stored as the buffer's =ghostel-identity=
 for later lookup.
+=ghostel-buffer-list= returns live Ghostel buffers even after their terminal
+process exits.  Filter its results with =ghostel-buffer-live-p= before sending
+input; the process can still exit immediately after that check, so the public
+paste and key send functions signal =user-error= for that race.
 =ghostel-project-buffer-list= prompts to choose a project when there is no
 current one.
 

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1679,10 +1679,28 @@ dead terminals and compile-style buffers."
 
 ;;; Public input API
 
+(defun ghostel-buffer-live-p (buffer)
+  "Return non-nil when BUFFER is a Ghostel buffer that can accept input.
+BUFFER must be live, use `ghostel-mode', retain its terminal, and have a
+live lifecycle process.  A terminal can exit immediately after this function
+returns; `ghostel-paste-string' and `ghostel-send-key' detect that race and
+signal `user-error'."
+  (and (buffer-live-p buffer)
+       (with-current-buffer buffer
+         (and (derived-mode-p 'ghostel-mode)
+              ghostel--term
+              (process-live-p ghostel--process)))))
+
 (defun ghostel--ensure-ghostel-buffer ()
   "Signal a `user-error' unless the current buffer is a ghostel buffer."
   (unless (derived-mode-p 'ghostel-mode)
     (user-error "Must be called from a ghostel buffer")))
+
+(defun ghostel--ensure-live-ghostel-buffer ()
+  "Signal a `user-error' unless the current buffer can accept input."
+  (ghostel--ensure-ghostel-buffer)
+  (unless (ghostel-buffer-live-p (current-buffer))
+    (user-error "Ghostel terminal cannot accept input")))
 
 (defun ghostel-send-string (string)
   "Send STRING to the terminal process in the current ghostel buffer.
@@ -1700,22 +1718,40 @@ comma-separated modifier string like \"ctrl\" or \"shift,ctrl\", or
 nil for no modifiers.  The encoder respects the terminal's current
 mode (application cursor keys, Kitty keyboard protocol, etc.).
 
-Signals a `user-error' when called outside a ghostel buffer."
-  (ghostel--ensure-ghostel-buffer)
+Signals a `user-error' when called outside a ghostel buffer or when the
+terminal cannot accept input."
+  (ghostel--ensure-live-ghostel-buffer)
   (ghostel--on-user-input)
-  (ghostel--send-encoded key-name (or mods "")))
+  (ghostel--ensure-live-ghostel-buffer)
+  (let (result)
+    (condition-case err
+        (setq result (ghostel--send-encoded key-name (or mods "")))
+      (error
+       (user-error "Ghostel terminal cannot accept input: %s"
+                   (error-message-string err))))
+    (ghostel--ensure-live-ghostel-buffer)
+    result))
 
 (defun ghostel-paste-string (string)
   "Send STRING to the terminal using bracketed paste.
-Signals a `user-error' when called outside a ghostel buffer.
+Signals a `user-error' when called outside a ghostel buffer or when the
+terminal cannot accept input.
 
 Unlike `ghostel-send-string', this wraps STRING in bracketed paste
 markers (ESC [200~ / ESC [201~) when the terminal supports bracketed
 paste mode (mode 2004), so the shell treats the input as an atomic
 paste rather than character-by-character typed keystrokes."
-  (ghostel--ensure-ghostel-buffer)
+  (ghostel--ensure-live-ghostel-buffer)
   (ghostel--on-user-input)
-  (ghostel--paste-text string))
+  (ghostel--ensure-live-ghostel-buffer)
+  (let (result)
+    (condition-case err
+        (setq result (ghostel--paste-text string))
+      (error
+       (user-error "Ghostel terminal cannot accept input: %s"
+                   (error-message-string err))))
+    (ghostel--ensure-live-ghostel-buffer)
+    result))
 
 
 ;;; Terminal control commands (C-c prefix)
@@ -5287,7 +5323,10 @@ Returns the buffer."
 (defun ghostel-buffer-list ()
   "Return all live `ghostel-mode' buffers, sorted alphabetically by name.
 Sorted (not `buffer-list' order) so cycle commands advance through
-the same sequence regardless of recent buffer-switch history."
+the same sequence regardless of recent buffer-switch history.
+
+The list includes buffers whose terminal process has exited.  Use
+`ghostel-buffer-live-p' to select buffers that can accept input."
   (sort (cl-remove-if-not
          (lambda (b) (with-current-buffer b (derived-mode-p 'ghostel-mode)))
          (buffer-list))

--- a/test/ghostel-keys-test.el
+++ b/test/ghostel-keys-test.el
@@ -10,6 +10,18 @@
 
 (require 'ghostel-test-helpers)
 
+(defmacro ghostel-test--with-public-send-buffer (live &rest body)
+  "Run BODY in a Ghostel buffer whose lifecycle state follows LIVE."
+  (declare (indent 2))
+  `(with-temp-buffer
+     (ghostel-mode)
+     (let ((ghostel-scroll-on-input nil))
+       (setq-local ghostel--term 'fake
+                   ghostel--process 'fake)
+       (cl-letf (((symbol-function 'process-live-p)
+                  (lambda (_process) ,live)))
+         ,@body))))
+
 (ert-deftest ghostel-test-raw-key-sequences ()
   "Test the Elisp raw key sequence builder."
   ;; Basic keys
@@ -959,26 +971,26 @@ inject raw bytes a kitty-protocol child cannot parse."
 
 (ert-deftest ghostel-test-send-key-routes-to-send-encoded ()
   "`ghostel-send-key' forwards key-name and mods to `ghostel--send-encoded'."
-  (with-temp-buffer
-    (ghostel-mode)
-    (let (captured-key captured-mods)
-      (cl-letf (((symbol-function 'ghostel--send-encoded)
-                 (lambda (key mods &optional _utf8)
-                   (setq captured-key key captured-mods mods))))
-        (ghostel-send-key "return" "ctrl")
-        (should (equal captured-key "return"))
-        (should (equal captured-mods "ctrl"))))))
+  (let ((live t))
+    (ghostel-test--with-public-send-buffer live
+      (let (captured-key captured-mods)
+        (cl-letf (((symbol-function 'ghostel--send-encoded)
+                   (lambda (key mods &optional _utf8)
+                     (setq captured-key key captured-mods mods))))
+          (ghostel-send-key "return" "ctrl")
+          (should (equal captured-key "return"))
+          (should (equal captured-mods "ctrl")))))))
 
 (ert-deftest ghostel-test-send-key-nil-mods-becomes-empty-string ()
   "`ghostel-send-key' passes an empty string when MODS is omitted."
-  (with-temp-buffer
-    (ghostel-mode)
-    (let (captured-mods)
-      (cl-letf (((symbol-function 'ghostel--send-encoded)
-                 (lambda (_key mods &optional _utf8)
-                   (setq captured-mods mods))))
-        (ghostel-send-key "up")
-        (should (equal captured-mods ""))))))
+  (let ((live t))
+    (ghostel-test--with-public-send-buffer live
+      (let (captured-mods)
+        (cl-letf (((symbol-function 'ghostel--send-encoded)
+                   (lambda (_key mods &optional _utf8)
+                     (setq captured-mods mods))))
+          (ghostel-send-key "up")
+          (should (equal captured-mods "")))))))
 
 (ert-deftest ghostel-test-send-key-errors-outside-ghostel-buffer ()
   "`ghostel-send-key' signals `user-error' when not in a ghostel buffer."
@@ -997,18 +1009,66 @@ External packages may still call the old internal name."
 
 (ert-deftest ghostel-test-paste-string-routes-to-paste-text ()
   "`ghostel-paste-string' forwards its argument to `ghostel--paste-text'."
-  (with-temp-buffer
-    (ghostel-mode)
-    (let (received)
-      (cl-letf (((symbol-function 'ghostel--paste-text)
-                 (lambda (str) (setq received str))))
-        (ghostel-paste-string "hello world")
-        (should (equal received "hello world"))))))
+  (let ((live t))
+    (ghostel-test--with-public-send-buffer live
+      (let (received)
+        (cl-letf (((symbol-function 'ghostel--paste-text)
+                   (lambda (str) (setq received str))))
+          (ghostel-paste-string "hello world")
+          (should (equal received "hello world")))))))
 
 (ert-deftest ghostel-test-paste-string-errors-outside-ghostel-buffer ()
   "`ghostel-paste-string' signals `user-error' when not in a ghostel buffer."
   (with-temp-buffer
     (should-error (ghostel-paste-string "x") :type 'user-error)))
+
+(ert-deftest ghostel-test-buffer-live-p-requires-live-terminal ()
+  "`ghostel-buffer-live-p' excludes dead and non-Ghostel buffers."
+  (let ((live t))
+    (ghostel-test--with-public-send-buffer live
+      (should (ghostel-buffer-live-p (current-buffer)))
+      (setq live nil)
+      (should-not (ghostel-buffer-live-p (current-buffer)))))
+  (with-temp-buffer
+    (should-not (ghostel-buffer-live-p (current-buffer))))
+  (let ((buffer (generate-new-buffer " *ghostel-test-killed*")))
+    (kill-buffer buffer)
+    (should-not (ghostel-buffer-live-p buffer))))
+
+(ert-deftest ghostel-test-public-sends-error-for-exited-terminal ()
+  "Public paste and key sends reject a Ghostel terminal that already exited."
+  (let ((live nil))
+    (ghostel-test--with-public-send-buffer live
+      (let (pasted key)
+        (cl-letf (((symbol-function 'ghostel--paste-text)
+                   (lambda (text) (setq pasted text)))
+                  ((symbol-function 'ghostel--send-encoded)
+                   (lambda (name mods &optional _utf8)
+                     (setq key (cons name mods)))))
+          (should-error (ghostel-paste-string "text") :type 'user-error)
+          (should-error (ghostel-send-key "return") :type 'user-error)
+          (should-not pasted)
+          (should-not key))))))
+
+(ert-deftest ghostel-test-public-sends-error-when-terminal-exits-during-send ()
+  "Public paste and key sends reject a terminal that exits during a write."
+  (let ((live t))
+    (ghostel-test--with-public-send-buffer live
+      (let (pasted key)
+        (cl-letf (((symbol-function 'ghostel--paste-text)
+                   (lambda (text)
+                     (setq pasted text
+                           live nil)
+                     (error "PTY exited")))
+                  ((symbol-function 'ghostel--send-encoded)
+                   (lambda (name mods &optional _utf8)
+                     (setq key (cons name mods)
+                           live nil))))
+          (should-error (ghostel-paste-string "text") :type 'user-error)
+          (setq live t)
+          (should-error (ghostel-send-key "return") :type 'user-error)
+          (should (equal pasted "text"))
+          (should (equal key '("return" . ""))))))))
 
 (ert-deftest ghostel-test-tty-esc-filter-translates-lone-esc ()
   "`ghostel--tty-esc' yields [escape] in terminal-input ghostel buffers."


### PR DESCRIPTION
## Summary

- add the public `ghostel-buffer-live-p` predicate for input-ready Ghostel buffers
- make `ghostel-paste-string` and `ghostel-send-key` signal `user-error` when a PTY is already dead or exits around a write
- document the liveness and send-failure contracts
- cover live, exited, and exit-racing sends at the public Elisp boundary

## Testing

- focused pure-Elisp key suite: 64/64 passed
- complete native test target: passed with 8 environment-dependent skips
- byte compilation, Checkdoc, docquote lint, `check-parens`, and `git diff --check` passed