### PR TITLE
Fix evil copy-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ All notable changes to this project will be documented in this file.
   `bottom` moves it all above the grid, `top` (the default) keeps it
   below.  Graphical frames on Emacs 29+ only.
 
+### Fixed
+- `evil-ghostel`: `C-c C-t` now enters copy mode in Evil normal state and
+  printable Vim navigation keys no longer trigger Ghostel's read-only fast
+  exit.  Copy mode stays frozen until `C-c C-t` or another explicit
+  input-mode switch exits it; accidentally entering insert state remains
+  recoverable with `ESC`, including on legacy TTY frames and over an
+  alt-screen terminal.
+
 ## [0.52.0] — 2026-08-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ If you're an evil user you can install the [evil-ghostel](https://melpa.org/#/ev
   :hook (ghostel-mode . evil-ghostel-mode))
 ```
 
+With evil-ghostel active, `C-c C-t` enters frozen copy mode in normal state.
+Vim navigation keys therefore stay in the frozen buffer; `C-c C-t` toggles
+copy mode off again. Printable keys do not trigger Ghostel's read-only
+fast-exit behavior in evil-ghostel buffers. If you enter insert state in a
+read-only mode, `ESC` returns to normal state without exiting that mode.
+
 Note: in alt-screen apps — vim, less, fullscreen TUIs like Claude Code
 (`/tui fullscreen`) — ESC is by default sent to the app instead of switching
 to normal state, so you stay in insert state and a leader key like `SPC` goes

--- a/README.org
+++ b/README.org
@@ -1496,6 +1496,12 @@ subdirectory inside the ghostel monorepo:
 When =evil-ghostel-mode= is active:
 
 - Ghostel starts in *insert state* (terminal input works normally).
+- =C-c C-t= enters frozen copy mode in *normal state*, so Vim navigation keys
+  move through the buffer without leaving copy mode.  Press =C-c C-t= again (or
+  use another explicit input-mode switch) to exit; printable keys do not exit
+  Ghostel's read-only modes while =evil-ghostel-mode= is active.  If you enter
+  insert state in a read-only mode, =ESC= returns to normal state without
+  unfreezing or exiting it.
 - Pressing *ESC* enters normal state and snaps point to the terminal cursor
   (outside alt-screen; see [[#evil-escape-routing][ESC routing]] below).
 - Normal-mode navigation (=h=, =j=, =k=, =l=, =w=, =b=, =e=, =0=, =$=, ...) works as expected.

--- a/extensions/evil-ghostel/evil-ghostel.el
+++ b/extensions/evil-ghostel/evil-ghostel.el
@@ -765,6 +765,22 @@ YANK-HANDLER is used by Evil outside live terminal input.  Covers P."
 Bindings for normal/visual editing commands and insert-state Ctrl
 passthrough are installed via `evil-define-key*'.")
 
+(defun evil-ghostel-copy-mode ()
+  "Toggle `ghostel-copy-mode', entering Evil normal state on entry.
+Copy mode must not inherit Evil's insert state: otherwise its first
+printable motion key is handled as self-insert.  With Ghostel's fast
+read-only exit enabled, that key would immediately leave copy mode and
+reach the terminal instead of navigating the frozen buffer."
+  (interactive)
+  (ghostel-copy-mode)
+  (when (eq ghostel--input-mode 'copy)
+    (evil-normal-state)))
+
+;; Keep the core binding (and any user binding of `ghostel-copy-mode') while
+;; adding Evil's state transition whenever the command is invoked.
+(define-key evil-ghostel-mode-map [remap ghostel-copy-mode]
+            #'evil-ghostel-copy-mode)
+
 (defconst evil-ghostel--ctrl-passthrough-keys
   '("a" "b" "d" "e" "f" "k" "l" "n" "o" "p" "q" "r" "s" "t" "u" "v" "w" "y")
   "Ctrl+key combinations to pass through to the terminal in insert state.
@@ -865,26 +881,33 @@ Valid values: `auto', `terminal', `evil'.")
 
 (defun evil-ghostel--escape ()
   "Dispatch insert-state ESC based on `evil-ghostel--escape-mode'.
-Terminal-bound ESC runs through `ghostel--on-user-input'.  Falling back to
-evil uses `evil-force-normal-state' when the `evil-insert-state-map'
+In copy and Emacs modes, always return to Evil normal state.  Otherwise,
+terminal-bound ESC runs through `ghostel--on-user-input'.  Falling back
+to evil uses `evil-force-normal-state' when the `evil-insert-state-map'
 binding is missing or a chord prefix (e.g. `evil-escape''s `jk'), so the
 keystroke is never dropped."
   (interactive)
-  (let* ((mode evil-ghostel--escape-mode)
-         (to-terminal (or (eq mode 'terminal)
-                          (and (eq mode 'auto)
-                               (ghostel-alt-screen-p)))))
-    (if to-terminal
-        (progn
-          (ghostel--on-user-input)
-          (ghostel--send-encoded "escape" "")
-          (when (and (eq mode 'auto) (not evil-ghostel--escape-hint-shown))
-            (setq evil-ghostel--escape-hint-shown t)
-            (message (substitute-command-keys
-                      "ESC sent to the terminal app (alt-screen); \
+  ;; Insert state cannot edit a read-only Ghostel view.  ESC must remain a
+  ;; reliable way back to normal state there, even when the frozen terminal
+  ;; is an alt-screen app whose ESC would normally be routed to the PTY.
+  (if (memq ghostel--input-mode '(copy emacs))
+      (evil-force-normal-state)
+    (let* ((mode evil-ghostel--escape-mode)
+           (to-terminal (or (eq mode 'terminal)
+                            (and (eq mode 'auto)
+                                 (ghostel-alt-screen-p)))))
+      (if to-terminal
+          (progn
+            (ghostel--on-user-input)
+            (ghostel--send-encoded "escape" "")
+            (when (and (eq mode 'auto) (not evil-ghostel--escape-hint-shown))
+              (setq evil-ghostel--escape-hint-shown t)
+              (message (substitute-command-keys
+                        "ESC sent to the terminal app (alt-screen); \
 \\[evil-ghostel-toggle-send-escape] routes it to evil instead"))))
-      (let ((cmd (lookup-key evil-insert-state-map (kbd "<escape>"))))
-        (call-interactively (if (commandp cmd) cmd #'evil-force-normal-state))))))
+        (let ((cmd (lookup-key evil-insert-state-map (kbd "<escape>"))))
+          (call-interactively
+           (if (commandp cmd) cmd #'evil-force-normal-state)))))))
 
 (defun evil-ghostel-toggle-send-escape (&optional arg)
   "Toggle or set the ESC routing mode for the current buffer.
@@ -919,9 +942,10 @@ the default."
 
 ;; The <escape> function-key event exists on GUI frames, on ttys with
 ;; the kitty keyboard protocol (kkp.el), and on legacy ttys in ghostel
-;; terminal-input buffers via ghostel's lone-ESC `input-decode-map'
-;; filter.  Fast C-c M-... chords still decode as meta there: the
-;; filter sees the pending follow-up byte and leaves ESC alone.
+;; buffers via ghostel's lone-ESC `input-decode-map' filter (extended below
+;; to Evil insert state in read-only modes).  Fast C-c M-... chords still
+;; decode as Meta: the filter sees the pending follow-up byte and leaves
+;; ESC alone.
 (define-key evil-ghostel-mode-map (kbd "C-c <escape>")
             #'evil-force-normal-state)
 
@@ -963,6 +987,48 @@ is nil, or when the table is already installed."
     (set-syntax-table evil-ghostel--saved-syntax-table)
     (setq evil-ghostel--saved-syntax-table nil)))
 
+(defun evil-ghostel--around-tty-esc (orig-fn map)
+  "Let lone TTY ESC reach Evil insert state in read-only Ghostel modes.
+ORIG-FN is `ghostel--tty-esc' and MAP is its wrapped decode map.
+Ghostel normally translates ESC only in terminal-input modes; temporarily
+present a read-only Evil insert state as semi-char so ESC becomes the
+`escape' event, while Meta chords and terminal escape sequences still pass
+through MAP unchanged."
+  (if (and evil-ghostel-mode
+           (evil-insert-state-p)
+           (memq ghostel--input-mode '(copy emacs)))
+      (let ((ghostel--input-mode 'semi-char))
+        (funcall orig-fn map))
+    (funcall orig-fn map)))
+
+(defvar-local evil-ghostel--saved-readonly-fast-exit nil
+  "Saved buffer-local state of `ghostel-readonly-fast-exit'.
+The value is (WAS-LOCAL VALUE), or nil when there is nothing to restore.")
+
+(defun evil-ghostel--disable-readonly-fast-exit ()
+  "Keep Ghostel's read-only modes active while Evil navigation runs."
+  (unless evil-ghostel--saved-readonly-fast-exit
+    (setq evil-ghostel--saved-readonly-fast-exit
+          (list (local-variable-p 'ghostel-readonly-fast-exit)
+                ghostel-readonly-fast-exit)))
+  (setq-local ghostel-readonly-fast-exit nil)
+  ;; `setq-local' bypasses the option's custom setter.  Refresh a read-only
+  ;; map explicitly when evil-ghostel is enabled after copy/Emacs mode.
+  (when (memq ghostel--input-mode '(copy emacs))
+    (use-local-map (ghostel--readonly-keymap))))
+
+(defun evil-ghostel--restore-readonly-fast-exit ()
+  "Restore the setting saved by `evil-ghostel--disable-readonly-fast-exit'."
+  (when evil-ghostel--saved-readonly-fast-exit
+    (pcase-let ((`(,was-local ,value)
+                 evil-ghostel--saved-readonly-fast-exit))
+      (if was-local
+          (setq-local ghostel-readonly-fast-exit value)
+        (kill-local-variable 'ghostel-readonly-fast-exit)))
+    (kill-local-variable 'evil-ghostel--saved-readonly-fast-exit)
+    (when (memq ghostel--input-mode '(copy emacs))
+      (use-local-map (ghostel--readonly-keymap)))))
+
 (defun evil-ghostel--any-active-elsewhere-p (except-buffer)
   "Return non-nil if any buffer but EXCEPT-BUFFER has `evil-ghostel-mode' on.
 Decides whether the global advice can be removed on the last disable."
@@ -993,6 +1059,10 @@ Enabling installs global advice while any buffer has the mode enabled."
         ;; so it still picks its own mode.
         (setq-local ghostel-mark-activation-input-mode nil)
         (evil-ghostel--install-word-boundaries)
+        ;; Evil's navigation keys are printable characters.  A copy-mode
+        ;; entered from insert state must keep them in the frozen buffer
+        ;; instead of treating the first one as Ghostel's fast exit.
+        (evil-ghostel--disable-readonly-fast-exit)
         (add-hook 'evil-insert-state-entry-hook
                   #'evil-ghostel--insert-state-entry nil t)
         ;; Reuse the insert-state sync when entering emacs-state — both
@@ -1006,6 +1076,8 @@ Enabling installs global advice while any buffer has the mode enabled."
         (advice-add 'ghostel--redraw :around #'evil-ghostel--around-redraw)
         (advice-add 'ghostel--apply-cursor-style :around
                     #'evil-ghostel--override-cursor-style)
+        (advice-add 'ghostel--tty-esc :around
+                    #'evil-ghostel--around-tty-esc)
         (evil-refresh-cursor))
     (remove-hook 'evil-insert-state-entry-hook
                  #'evil-ghostel--insert-state-entry t)
@@ -1014,12 +1086,15 @@ Enabling installs global advice while any buffer has the mode enabled."
     (remove-hook 'ghostel-inhibit-anchor-functions
                  #'evil-ghostel--anchor-inhibit t)
     (kill-local-variable 'ghostel-mark-activation-input-mode)
+    (evil-ghostel--restore-readonly-fast-exit)
     (evil-ghostel--restore-word-boundaries)
     (kill-local-variable 'evil-ghostel--saved-syntax-table)
     (unless (evil-ghostel--any-active-elsewhere-p (current-buffer))
       (advice-remove 'ghostel--redraw #'evil-ghostel--around-redraw)
       (advice-remove 'ghostel--apply-cursor-style
-                     #'evil-ghostel--override-cursor-style))))
+                     #'evil-ghostel--override-cursor-style)
+      (advice-remove 'ghostel--tty-esc
+                     #'evil-ghostel--around-tty-esc))))
 
 (provide 'evil-ghostel)
 ;;; evil-ghostel.el ends here

--- a/test/evil-ghostel-test.el
+++ b/test/evil-ghostel-test.el
@@ -135,10 +135,86 @@ overwrite the position evil assigns at operator/visual completion."
 (ert-deftest evil-ghostel-test-mode-deactivation ()
   "Test that `evil-ghostel-mode' cleans up on deactivation."
   (evil-ghostel-test--with-evil-buffer
+   (should (local-variable-p 'ghostel-readonly-fast-exit))
+   (should-not ghostel-readonly-fast-exit)
    (evil-ghostel-mode -1)
    (should-not evil-ghostel-mode)
+   (should-not (local-variable-p 'ghostel-readonly-fast-exit))
+   (should ghostel-readonly-fast-exit)
    (should-not (memq 'evil-ghostel--insert-state-entry
                      evil-insert-state-entry-hook))))
+
+(ert-deftest evil-ghostel-test-disable-restores-local-readonly-fast-exit ()
+  "Disabling evil-ghostel restores a pre-existing buffer-local fast-exit value."
+  (with-temp-buffer
+    (ghostel-mode)
+    (setq-local ghostel-readonly-fast-exit t)
+    (evil-local-mode 1)
+    (evil-ghostel-mode 1)
+    (should-not ghostel-readonly-fast-exit)
+    (evil-ghostel-mode -1)
+    (should (local-variable-p 'ghostel-readonly-fast-exit))
+    (should ghostel-readonly-fast-exit)))
+
+(ert-deftest evil-ghostel-test-copy-mode-enters-normal-and-toggles ()
+  "The Evil copy-mode remap freezes navigation until explicitly toggled off."
+  (evil-ghostel-test--with-evil-buffer
+   (insert "abc")
+   (goto-char (point-max))
+   (should (evil-insert-state-p))
+   (should (eq #'evil-ghostel-copy-mode
+               (command-remapping #'ghostel-copy-mode)))
+   (evil-ghostel-copy-mode)
+   (should (eq ghostel--input-mode 'copy))
+   (should (evil-normal-state-p))
+   (should-not ghostel-readonly-fast-exit)
+   (should (eq (current-local-map) ghostel-readonly-mode-map))
+   (should (eq (key-binding (kbd "h")) #'evil-backward-char))
+   (let ((before (point)))
+     (call-interactively (key-binding (kbd "h")))
+     (should (< (point) before)))
+   (should (eq ghostel--input-mode 'copy))
+   ;; Entering insert state cannot modify the read-only buffer, but ESC is
+   ;; still a recovery path to normal state and must not unfreeze copy mode.
+   (call-interactively (key-binding (kbd "i")))
+   (should (evil-insert-state-p))
+   (let ((last-command-event ?x))
+     (should-error (self-insert-command 1) :type 'buffer-read-only))
+   (let (sent)
+     (cl-letf (((symbol-function 'ghostel--alt-screen-p)
+                (lambda (&rest _) t))
+               ((symbol-function 'ghostel--send-encoded)
+                (lambda (&rest _) (setq sent t))))
+       (evil-ghostel--escape))
+     (should-not sent))
+   (should (evil-normal-state-p))
+   (should (eq ghostel--input-mode 'copy))
+   (evil-ghostel-copy-mode)
+   (should (eq ghostel--input-mode 'semi-char))))
+
+(ert-deftest evil-ghostel-test-tty-esc-recovers-from-readonly-insert-state ()
+  "A lone legacy-TTY ESC is decoded while Evil insert state is read-only."
+  (evil-ghostel-test--with-evil-buffer
+   (evil-ghostel-copy-mode)
+   (evil-insert 1)
+   (setq-local ghostel--term 'fake)
+   (let ((saved-map (make-sparse-keymap)))
+     (cl-letf (((symbol-function 'this-single-command-keys)
+                (lambda () [27]))
+               ((symbol-function 'sit-for) (lambda (_seconds) t)))
+       (should (equal [escape] (ghostel--tty-esc saved-map)))))))
+
+(ert-deftest evil-ghostel-test-enable-in-copy-mode-refreshes-keymap ()
+  "Enabling evil-ghostel replaces an already-active fast-exit map."
+  (with-temp-buffer
+    (ghostel-mode)
+    (ghostel-copy-mode)
+    (should (eq (current-local-map) ghostel-readonly-fast-exit-mode-map))
+    (evil-local-mode 1)
+    (evil-ghostel-mode 1)
+    (should-not ghostel-readonly-fast-exit)
+    (should (eq (current-local-map) ghostel-readonly-mode-map))
+    (evil-ghostel-mode -1)))
 
 (ert-deftest evil-ghostel-test-visual-inhibits-mark-copy-mode ()
   "Entering evil visual must not flip ghostel into copy mode.
@@ -174,7 +250,7 @@ buffer-locally so that chain yields to evil's own selection model."
    (should-not (local-variable-p 'ghostel-mark-activation-input-mode))))
 
 (ert-deftest evil-ghostel-test-advice-survives-disable-in-other-buffer ()
-  "Global `ghostel--redraw' / cursor-style advice survives one buffer disabling.
+  "Global redraw, cursor-style, and TTY ESC advice survives one disable.
 The advice is global but the mode is buffer-local; `advice-remove'
 during disable must wait until the LAST `evil-ghostel-mode' buffer
 is gone, otherwise toggling off in one buffer silently strips the
@@ -195,18 +271,24 @@ wrapper from every other ghostel buffer."
             (evil-ghostel-mode 1))
           (should (advice-member-p #'evil-ghostel--around-redraw
                                    'ghostel--redraw))
+          (should (advice-member-p #'evil-ghostel--around-tty-esc
+                                   'ghostel--tty-esc))
           ;; Disable in A — B still has the mode on, advice must stay.
           (with-current-buffer a (evil-ghostel-mode -1))
           (should (advice-member-p #'evil-ghostel--around-redraw
                                    'ghostel--redraw))
           (should (advice-member-p #'evil-ghostel--override-cursor-style
                                    'ghostel--apply-cursor-style))
+          (should (advice-member-p #'evil-ghostel--around-tty-esc
+                                   'ghostel--tty-esc))
           ;; Disable in B — no buffers left, advice removed.
           (with-current-buffer b (evil-ghostel-mode -1))
           (should-not (advice-member-p #'evil-ghostel--around-redraw
                                        'ghostel--redraw))
           (should-not (advice-member-p #'evil-ghostel--override-cursor-style
-                                       'ghostel--apply-cursor-style)))
+                                       'ghostel--apply-cursor-style))
+          (should-not (advice-member-p #'evil-ghostel--around-tty-esc
+                                       'ghostel--tty-esc)))
       (when (buffer-live-p a) (kill-buffer a))
       (when (buffer-live-p b) (kill-buffer b)))))
 


### PR DESCRIPTION
Keep copy mode active for Vim motions and allow ESC to recover from read-only insert state.