### PR TITLE
Regroup ghostel.el functions into topic sections

### DIFF
--- a/lisp/ghostel-shell.el
+++ b/lisp/ghostel-shell.el
@@ -36,6 +36,7 @@
 (declare-function ghostel--ensure-ghostel-buffer "ghostel")
 (declare-function ghostel--enter-readonly-input-mode "ghostel")
 (declare-function ghostel--resource-root "ghostel-module-install")
+(declare-function ghostel--run-hook-safely "ghostel")
 (declare-function ghostel--ssh-install-enabled-p "ghostel")
 (declare-function ghostel--terminfo-directory "ghostel")
 (defvar ghostel-prompt-navigation-input-mode)
@@ -574,19 +575,6 @@ not here.  This handler only tracks prompt positions and exit status."
        (ghostel--run-hook-safely 'ghostel-command-finish-functions
                                  (current-buffer) exit))
      (setq ghostel--command-running nil))))
-
-(defun ghostel--run-hook-safely (hook &rest args)
-  "Run HOOK with ARGS, isolating errors per handler.
-Each handler is wrapped in `with-demoted-errors' so a raising
-handler logs and the remaining hooks still run.  As with the rest
-of Emacs, `with-demoted-errors' re-signals when `debug-on-error'
-is non-nil so the debugger fires for hook authors who want it."
-  (run-hook-wrapped
-   hook
-   (lambda (fn)
-     (with-demoted-errors "ghostel: error in hook: %S"
-       (apply fn args))
-     nil)))
 
 (defun ghostel--prompt-input-start ()
   "From the start of a `ghostel-prompt' region, move past the prefix.

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -2236,14 +2236,7 @@ the prompt."
         (ghostel--paste-text text)))))
 
 
-;;; Input modes — state helpers
-
-(defvar-local ghostel--saved-cursor-type nil
-  "Saved `cursor-type' before entering a read-only mode.")
-
-(defvar-local ghostel--saved-hl-line-mode nil
-  "Non-nil if line highlighting was active when `ghostel-mode' suppressed it.
-Covers both `global-hl-line-mode' and buffer-local `hl-line-mode'.")
+;;; Mode line
 
 (defvar ghostel--password-mode-p)         ; forward decls; defined below.
 (defvar ghostel--password-handled-cursor) ;
@@ -2329,6 +2322,16 @@ OSC 9;4 packet, and same-value packets must not fire FMLU."
     (unless (equal new-val mode-line-process)
       (setq mode-line-process new-val)
       (force-mode-line-update))))
+
+
+;;; Input modes - state helpers
+
+(defvar-local ghostel--saved-cursor-type nil
+  "Saved `cursor-type' before entering a read-only mode.")
+
+(defvar-local ghostel--saved-hl-line-mode nil
+  "Non-nil if line highlighting was active when `ghostel-mode' suppressed it.
+Covers both `global-hl-line-mode' and buffer-local `hl-line-mode'.")
 
 (defun ghostel--enter-readonly-state ()
   "Common setup when entering copy or Emacs mode.
@@ -3455,83 +3458,6 @@ No-op when `ghostel-buffer-identification-format' is nil."
         (setq-local mode-line-buffer-identification new)
         (force-mode-line-update)))))
 
-(defun ghostel--cursor-blink-stop ()
-  "Cancel the blink timer, restore the cursor, and remove the blink hooks.
-Restores via `ghostel--cursor-blink-window' rather than this buffer's
-current window, which may already show another buffer."
-  (when ghostel--cursor-blink-timer
-    (cancel-timer ghostel--cursor-blink-timer)
-    (setq ghostel--cursor-blink-timer nil))
-  (when (window-live-p ghostel--cursor-blink-window)
-    (internal-show-cursor ghostel--cursor-blink-window t))
-  (setq ghostel--cursor-blink-window nil)
-  (remove-hook 'window-buffer-change-functions
-               #'ghostel--cursor-blink-restore-window t)
-  (remove-hook 'kill-buffer-hook #'ghostel--cursor-blink-stop t))
-
-(defun ghostel--cursor-blink-restore-window (window)
-  "Show WINDOW's cursor after this buffer enters or leaves it.
-A buffer-local `window-buffer-change-functions' entry.  The blink sets
-a per-window \"cursor off\" flag via `internal-show-cursor', which would
-hide the cursor of whatever buffer the window shows next.  The restore
-is deferred to a 0-delay timer because `internal-show-cursor' is inert
-during redisplay, which is when these functions run."
-  (run-at-time 0 nil
-               (lambda ()
-                 (when (window-live-p window)
-                   (internal-show-cursor window t)))))
-
-(defun ghostel--cursor-blink-tick (buffer)
-  "Toggle BUFFER's cursor visibility.
-Self-stops when BUFFER is no longer the selected window or has
-left terminal input mode, so the navigation cursor stays solid."
-  (when (buffer-live-p buffer)
-    (with-current-buffer buffer
-      (let ((win (get-buffer-window buffer)))
-        (if (and win
-                 (eq win (selected-window))
-                 (ghostel--terminal-input-mode-p))
-            (progn
-              (setq ghostel--cursor-blink-window win)
-              (internal-show-cursor win (not (internal-show-cursor-p win))))
-          (ghostel--cursor-blink-stop))))))
-
-(defun ghostel--cursor-blink-start ()
-  "Begin blinking the cursor.
-No-op on text terminals, when already blinking, or when the global
-`blink-cursor-mode' already drives the blink (avoids a double beat)."
-  (when (and (display-graphic-p)
-             (not ghostel--cursor-blink-timer)
-             (not blink-cursor-mode))
-    (add-hook 'kill-buffer-hook #'ghostel--cursor-blink-stop nil t)
-    ;; Restore the cursor when the blinked window switches buffers, so a window
-    ;; left in the blink's "off" phase never hides the next buffer's cursor.
-    (add-hook 'window-buffer-change-functions
-              #'ghostel--cursor-blink-restore-window nil t)
-    (setq ghostel--cursor-blink-window (selected-window))
-    (setq ghostel--cursor-blink-timer
-          (run-with-timer blink-cursor-interval blink-cursor-interval
-                          #'ghostel--cursor-blink-tick (current-buffer)))))
-
-(defun ghostel--apply-cursor-style ()
-  "Apply the cursor style and blink published by the native renderer.
-Kept in Elisp so input modes and integrations can decide whether
-`cursor-type' should change.  Reads the buffer-local
-`ghostel--cursor-style' and `ghostel--cursor-blinking'."
-  (when (and (ghostel--terminal-input-mode-p)
-             (not ghostel-ignore-cursor-change))
-    (setq cursor-type
-		  (pcase ghostel--cursor-style
-			(0 '(bar . 2))       ; bar
-			(1 'box)             ; block
-			(2 '(hbar . 2))      ; underline
-			(3 'hollow)          ; hollow block
-			('nil nil)
-			(_ 'box)))
-    (if (and ghostel--cursor-style ghostel--cursor-blinking)
-        (ghostel--cursor-blink-start)
-      (ghostel--cursor-blink-stop))))
-
 (defun ghostel--windows-local-path (path)
   "Return PATH in a spelling native Windows Emacs can resolve.
 Strips the slash from a slash-drive form (\"/d:/foo\"), which
@@ -3650,6 +3576,86 @@ URL does not match the local machine, construct a TRAMP path."
         (ghostel--rename-managed
          (funcall ghostel-buffer-name-function ghostel-title)))
       (ghostel--buffer-identification-update))))
+
+
+;;; Cursor style
+
+(defun ghostel--cursor-blink-stop ()
+  "Cancel the blink timer, restore the cursor, and remove the blink hooks.
+Restores via `ghostel--cursor-blink-window' rather than this buffer's
+current window, which may already show another buffer."
+  (when ghostel--cursor-blink-timer
+    (cancel-timer ghostel--cursor-blink-timer)
+    (setq ghostel--cursor-blink-timer nil))
+  (when (window-live-p ghostel--cursor-blink-window)
+    (internal-show-cursor ghostel--cursor-blink-window t))
+  (setq ghostel--cursor-blink-window nil)
+  (remove-hook 'window-buffer-change-functions
+               #'ghostel--cursor-blink-restore-window t)
+  (remove-hook 'kill-buffer-hook #'ghostel--cursor-blink-stop t))
+
+(defun ghostel--cursor-blink-restore-window (window)
+  "Show WINDOW's cursor after this buffer enters or leaves it.
+A buffer-local `window-buffer-change-functions' entry.  The blink sets
+a per-window \"cursor off\" flag via `internal-show-cursor', which would
+hide the cursor of whatever buffer the window shows next.  The restore
+is deferred to a 0-delay timer because `internal-show-cursor' is inert
+during redisplay, which is when these functions run."
+  (run-at-time 0 nil
+               (lambda ()
+                 (when (window-live-p window)
+                   (internal-show-cursor window t)))))
+
+(defun ghostel--cursor-blink-tick (buffer)
+  "Toggle BUFFER's cursor visibility.
+Self-stops when BUFFER is no longer the selected window or has
+left terminal input mode, so the navigation cursor stays solid."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (let ((win (get-buffer-window buffer)))
+        (if (and win
+                 (eq win (selected-window))
+                 (ghostel--terminal-input-mode-p))
+            (progn
+              (setq ghostel--cursor-blink-window win)
+              (internal-show-cursor win (not (internal-show-cursor-p win))))
+          (ghostel--cursor-blink-stop))))))
+
+(defun ghostel--cursor-blink-start ()
+  "Begin blinking the cursor.
+No-op on text terminals, when already blinking, or when the global
+`blink-cursor-mode' already drives the blink (avoids a double beat)."
+  (when (and (display-graphic-p)
+             (not ghostel--cursor-blink-timer)
+             (not blink-cursor-mode))
+    (add-hook 'kill-buffer-hook #'ghostel--cursor-blink-stop nil t)
+    ;; Restore the cursor when the blinked window switches buffers, so a window
+    ;; left in the blink's "off" phase never hides the next buffer's cursor.
+    (add-hook 'window-buffer-change-functions
+              #'ghostel--cursor-blink-restore-window nil t)
+    (setq ghostel--cursor-blink-window (selected-window))
+    (setq ghostel--cursor-blink-timer
+          (run-with-timer blink-cursor-interval blink-cursor-interval
+                          #'ghostel--cursor-blink-tick (current-buffer)))))
+
+(defun ghostel--apply-cursor-style ()
+  "Apply the cursor style and blink published by the native renderer.
+Kept in Elisp so input modes and integrations can decide whether
+`cursor-type' should change.  Reads the buffer-local
+`ghostel--cursor-style' and `ghostel--cursor-blinking'."
+  (when (and (ghostel--terminal-input-mode-p)
+             (not ghostel-ignore-cursor-change))
+    (setq cursor-type
+		  (pcase ghostel--cursor-style
+			(0 '(bar . 2))       ; bar
+			(1 'box)             ; block
+			(2 '(hbar . 2))      ; underline
+			(3 'hollow)          ; hollow block
+			('nil nil)
+			(_ 'box)))
+    (if (and ghostel--cursor-style ghostel--cursor-blinking)
+        (ghostel--cursor-blink-start)
+      (ghostel--cursor-blink-stop))))
 
 
 ;;; Palette
@@ -5038,6 +5044,60 @@ prevent redraw flicker."
     (hl-line-mode -1)))
 
 
+;;; Buffer identity
+
+(defun ghostel--identity-normalize (identity)
+  "Return a copy of IDENTITY with its pairs sorted by key name."
+  (sort (copy-sequence identity)
+        (lambda (a b) (string< (symbol-name (car a)) (symbol-name (car b))))))
+
+(defun ghostel--identity-equal (a b)
+  "Return non-nil when identities A and B contain the same pairs."
+  (equal (ghostel--identity-normalize a) (ghostel--identity-normalize b)))
+
+(defun ghostel-identity-match-p (pattern identity)
+  "Return non-nil when every (KEY . VALUE) pair of PATTERN is in IDENTITY.
+PATTERN and IDENTITY are `ghostel-identity' alists."
+  (seq-every-p (lambda (pair)
+                 (equal (alist-get (car pair) identity) (cdr pair)))
+               pattern))
+
+(defun ghostel--normalize-root (root)
+  "Return ROOT as a normalized directory path for `project-root' keys.
+Remote ROOTs are used as-is; TRAMP expansion and abbreviation
+depend on connection state and would make the key unstable."
+  (if (file-remote-p root)
+      (file-name-as-directory root)
+    (abbreviate-file-name (file-name-as-directory (expand-file-name root)))))
+
+(defun ghostel--next-instance (context)
+  "Return 1 + the highest slot instance in use for CONTEXT.
+CONTEXT is an identity alist without its `instance' pair."
+  (let ((max 0))
+    (dolist (b (buffer-list))
+      (let ((id (buffer-local-value 'ghostel-identity b)))
+        (when (and id
+                   (ghostel--identity-equal
+                    context (assq-delete-all 'instance (copy-alist id))))
+          (setq max (max max (or (alist-get 'instance id) 0))))))
+    (1+ max)))
+
+(defun ghostel--find-buffer-by-identity (identity &optional predicate)
+  "Return the first live ghostel buffer whose identity equals IDENTITY, or nil.
+Only `ghostel-mode' buffers are considered: the permanent-local
+identity outlives a major-mode change, but the slot claim must not.
+Non-nil PREDICATE further filters candidates (called with the buffer),
+so several buffers sharing IDENTITY cannot shadow one the caller wants."
+  (seq-find (lambda (b)
+              (and (buffer-live-p b)
+                   (with-current-buffer b
+                     (and (derived-mode-p 'ghostel-mode)
+                          (ghostel--identity-equal ghostel-identity
+                                                   identity)))
+                   (if predicate (funcall predicate b) t)))
+            (buffer-list)))
+
+
 ;;; Entry point
 
 (defun ghostel--init-buffer (buffer &optional rows cols)
@@ -5152,57 +5212,6 @@ or quit, the partially created buffer is killed before re-signaling."
        (when (buffer-live-p buffer)
          (kill-buffer buffer))
        (signal (car err) (cdr err))))))
-
-(defun ghostel--identity-normalize (identity)
-  "Return a copy of IDENTITY with its pairs sorted by key name."
-  (sort (copy-sequence identity)
-        (lambda (a b) (string< (symbol-name (car a)) (symbol-name (car b))))))
-
-(defun ghostel--identity-equal (a b)
-  "Return non-nil when identities A and B contain the same pairs."
-  (equal (ghostel--identity-normalize a) (ghostel--identity-normalize b)))
-
-(defun ghostel-identity-match-p (pattern identity)
-  "Return non-nil when every (KEY . VALUE) pair of PATTERN is in IDENTITY.
-PATTERN and IDENTITY are `ghostel-identity' alists."
-  (seq-every-p (lambda (pair)
-                 (equal (alist-get (car pair) identity) (cdr pair)))
-               pattern))
-
-(defun ghostel--normalize-root (root)
-  "Return ROOT as a normalized directory path for `project-root' keys.
-Remote ROOTs are used as-is; TRAMP expansion and abbreviation
-depend on connection state and would make the key unstable."
-  (if (file-remote-p root)
-      (file-name-as-directory root)
-    (abbreviate-file-name (file-name-as-directory (expand-file-name root)))))
-
-(defun ghostel--next-instance (context)
-  "Return 1 + the highest slot instance in use for CONTEXT.
-CONTEXT is an identity alist without its `instance' pair."
-  (let ((max 0))
-    (dolist (b (buffer-list))
-      (let ((id (buffer-local-value 'ghostel-identity b)))
-        (when (and id
-                   (ghostel--identity-equal
-                    context (assq-delete-all 'instance (copy-alist id))))
-          (setq max (max max (or (alist-get 'instance id) 0))))))
-    (1+ max)))
-
-(defun ghostel--find-buffer-by-identity (identity &optional predicate)
-  "Return the first live ghostel buffer whose identity equals IDENTITY, or nil.
-Only `ghostel-mode' buffers are considered: the permanent-local
-identity outlives a major-mode change, but the slot claim must not.
-Non-nil PREDICATE further filters candidates (called with the buffer),
-so several buffers sharing IDENTITY cannot shadow one the caller wants."
-  (seq-find (lambda (b)
-              (and (buffer-live-p b)
-                   (with-current-buffer b
-                     (and (derived-mode-p 'ghostel-mode)
-                          (ghostel--identity-equal ghostel-identity
-                                                   identity)))
-                   (if predicate (funcall predicate b) t)))
-            (buffer-list)))
 
 (defun ghostel--apply-initial-input-mode ()
   "Switch a new `ghostel' terminal to `ghostel-initial-input-mode'.

--- a/lisp/ghostel.el
+++ b/lisp/ghostel.el
@@ -1023,6 +1023,27 @@ The spinner object itself lives in spinner.el's buffer-local
 something to gate teardown on.")
 
 
+;;; Internal helpers
+
+(defun ghostel--ensure-ghostel-buffer ()
+  "Signal a `user-error' unless the current buffer is a ghostel buffer."
+  (unless (derived-mode-p 'ghostel-mode)
+    (user-error "Must be called from a ghostel buffer")))
+
+(defun ghostel--run-hook-safely (hook &rest args)
+  "Run HOOK with ARGS, isolating errors per handler.
+Each handler is wrapped in `with-demoted-errors' so a raising
+handler logs and the remaining hooks still run.  As with the rest
+of Emacs, `with-demoted-errors' re-signals when `debug-on-error'
+is non-nil so the debugger fires for hook authors who want it."
+  (run-hook-wrapped
+   hook
+   (lambda (fn)
+     (with-demoted-errors "ghostel: error in hook: %S"
+       (apply fn args))
+     nil)))
+
+
 ;;; Scroll intercept via emulation-mode-map-alists
 ;;
 ;; We need highest-priority interception of wheel events so that terminal
@@ -1688,11 +1709,6 @@ dead terminals and compile-style buffers."
 
 ;;; Public input API
 
-(defun ghostel--ensure-ghostel-buffer ()
-  "Signal a `user-error' unless the current buffer is a ghostel buffer."
-  (unless (derived-mode-p 'ghostel-mode)
-    (user-error "Must be called from a ghostel buffer")))
-
 (defun ghostel-send-string (string)
   "Send STRING to the terminal process in the current ghostel buffer.
 Signals a `user-error' when called outside a ghostel buffer.  STRING
@@ -1726,7 +1742,7 @@ paste rather than character-by-character typed keystrokes."
   (ghostel--on-user-input)
   (ghostel--paste-text string))
 
-
+
 ;;; Terminal control commands (C-c prefix)
 
 (defun ghostel-send-C-c ()
@@ -1942,40 +1958,6 @@ into the terminal shown in the event's window."
     ;; Send form-feed to the shell so it redraws its prompt.
     (ghostel--write-pty ghostel--term "\f")))
 
-(defun ghostel--forward-scroll-event (event button)
-  "Try to forward a scroll EVENT as mouse BUTTON to the terminal.
-Return non-nil if the event was encoded and sent."
-  (when (and event (ghostel--terminal-input-mode-p))
-    (let* ((posn (event-start event))
-           (col-row (posn-col-row posn))
-           (col (car col-row))
-           (row (cdr col-row)))
-      (ghostel--mouse-event ghostel--term
-                            0  ; press
-                            button
-                            row col
-                            (ghostel--mouse-mods event)))))
-
-(defun ghostel-readonly-end-of-buffer ()
-  "Move to the bottom of the buffer (current viewport) in read-only mode."
-  (interactive)
-  (goto-char (point-max))
-  (skip-chars-backward " \t\n")
-  (when (and ghostel--cursor-char-pos
-             (<= ghostel--cursor-char-pos (point-max))
-             (> ghostel--cursor-char-pos (point)))
-    (goto-char ghostel--cursor-char-pos)))
-
-;; Let isearch treat this as the buffer-end motion command.
-(put 'ghostel-readonly-end-of-buffer 'isearch-motion
-     (cons (lambda () (goto-char (point-max)) (recenter -1 t)) 'backward))
-
-(defun ghostel-readonly-end-of-line ()
-  "Move to the last non-whitespace character on the line."
-  (interactive)
-  (end-of-line)
-  (skip-chars-backward " \t"))
-
 
 ;;; Mouse input
 
@@ -2029,6 +2011,20 @@ running program receives a live motion stream during the drag.")
     (when (memq 'control mods) (setq result (logior result 4)))
     (when (memq 'meta mods) (setq result (logior result 2)))
     result))
+
+(defun ghostel--forward-scroll-event (event button)
+  "Try to forward a scroll EVENT as mouse BUTTON to the terminal.
+Return non-nil if the event was encoded and sent."
+  (when (and event (ghostel--terminal-input-mode-p))
+    (let* ((posn (event-start event))
+           (col-row (posn-col-row posn))
+           (col (car col-row))
+           (row (cdr col-row)))
+      (ghostel--mouse-event ghostel--term
+                            0  ; press
+                            button
+                            row col
+                            (ghostel--mouse-mods event)))))
 
 (defun ghostel--mouse-press (event)
   "Handle mouse button press EVENT for terminal mouse tracking.
@@ -2620,13 +2616,6 @@ command set the region, so the selection survives the switch."
              (not ghostel--inhibit-insert-forwarding))
     (ghostel--enter-readonly-input-mode ghostel-mark-activation-input-mode)))
 
-(defun ghostel--pos-on-cursor-p (pos)
-  "Non-nil if POS rides the live terminal cursor: on it, or at `point-max'.
-Positions between the cursor and `point-max' do not count."
-  (and ghostel--cursor-char-pos
-       (or (= pos ghostel--cursor-char-pos)
-           (= pos (point-max)))))
-
 (defun ghostel-maybe-leave-input (&rest _)
   "Leave semi-char for `ghostel-point-leave-input-mode' if point left the input.
 A no-op unless, in semi-char mode, point has moved off the live terminal
@@ -2703,6 +2692,29 @@ press anywhere else exits and forwards a CR to the terminal."
                  (memq target '(semi-char char)))
         (ghostel--send-encoded "return" "")))))
 
+(defun ghostel-readonly-end-of-buffer ()
+  "Move to the bottom of the buffer (current viewport) in read-only mode."
+  (interactive)
+  (goto-char (point-max))
+  (skip-chars-backward " \t\n")
+  (when (and ghostel--cursor-char-pos
+             (<= ghostel--cursor-char-pos (point-max))
+             (> ghostel--cursor-char-pos (point)))
+    (goto-char ghostel--cursor-char-pos)))
+
+;; Let isearch treat this as the buffer-end motion command.
+(put 'ghostel-readonly-end-of-buffer 'isearch-motion
+     (cons (lambda () (goto-char (point-max)) (recenter -1 t)) 'backward))
+
+(defun ghostel-readonly-end-of-line ()
+  "Move to the last non-whitespace character on the line."
+  (interactive)
+  (end-of-line)
+  (skip-chars-backward " \t"))
+
+
+;;; Copying text
+
 (defun ghostel--filter-soft-wraps (text)
   "Remove newlines from TEXT that were inserted by soft line wrapping.
 These are newlines with the `ghostel-wrap' text property."
@@ -2745,7 +2757,16 @@ When `ghostel-readonly-fast-exit' is non-nil, also exits read-only mode."
   (when ghostel-readonly-fast-exit
     (ghostel-readonly-exit)))
 
+(defun ghostel-copy-all ()
+  "Copy the entire scrollback buffer to the kill ring."
+  (interactive)
+  (when ghostel--term
+    (let ((text (ghostel--copy-all-text ghostel--term)))
+      (when (and text (> (length text) 0))
+        (kill-new text)
+        (message "Copied %d characters to kill ring" (length text))))))
 
+
 ;;; Prompt and cursor-state queries
 
 (defun ghostel--regex-prompt-end (pos)
@@ -2856,7 +2877,6 @@ prompt prefix.  On other rows, point moves to the line beginning."
      (regex-target     (goto-char regex-target))
      (t                (move-beginning-of-line 1)))))
 
-
 
 ;; Public cursor-state queries
 
@@ -2869,6 +2889,13 @@ necessarily at the end of typed content.
 
 Returns nil when no terminal cursor is available."
   ghostel--cursor-char-pos)
+
+(defun ghostel--pos-on-cursor-p (pos)
+  "Non-nil if POS rides the live terminal cursor: on it, or at `point-max'.
+Positions between the cursor and `point-max' do not count."
+  (and ghostel--cursor-char-pos
+       (or (= pos ghostel--cursor-char-pos)
+           (= pos (point-max)))))
 
 (defun ghostel--viewport-row-at (pos)
   "Return the 0-indexed viewport row of POS, or nil.
@@ -2891,16 +2918,6 @@ available."
            (trow (cdr ghostel--cursor-pos))
            (prow (ghostel--viewport-row-at p)))
       (and prow (= prow trow)))))
-
-
-(defun ghostel-copy-all ()
-  "Copy the entire scrollback buffer to the kill ring."
-  (interactive)
-  (when ghostel--term
-    (let ((text (ghostel--copy-all-text ghostel--term)))
-      (when (and text (> (length text) 0))
-        (kill-new text)
-        (message "Copied %d characters to kill ring" (length text))))))
 
 
 ;;; Password prompt detection
@@ -3531,6 +3548,23 @@ Cygwin \"/cygdrive/d/foo\" mounts to the existing \"d:/foo\" directory."
           translated
         path))))
 
+(defun ghostel--local-host-p (host)
+  "Return non-nil if HOST refers to the local machine.
+A trailing \".local\" (mDNS) suffix on HOST is ignored: the macOS
+kernel hostname drifts between NAME and NAME.local with network state,
+while the function `system-name' keeps the value from Emacs startup."
+  (or (null host)
+      (string= host "")
+      (save-match-data
+        (let ((host (if (string-suffix-p ".local" host t)
+                        (substring host 0 (- (length host) (length ".local")))
+                      host)))
+          (or (eq t (compare-strings host nil nil "localhost" nil nil t))
+              (eq t (compare-strings host nil nil (system-name) nil nil t))
+              (eq t (compare-strings
+                     host nil nil
+                     (car (split-string (system-name) "\\.")) nil nil t)))))))
+
 (defun ghostel--update-directory (dir)
   "Update `default-directory' from terminal's OSC 7 report.
 DIR may be a kitty-shell-cwd:// URL (raw, unencoded path), a file://
@@ -3799,23 +3833,6 @@ EVENT is the state-change description passed by Emacs."
             (let ((inhibit-read-only t))
               (goto-char (point-max))
               (insert "\n[Process exited]\n"))))))))
-
-(defun ghostel--local-host-p (host)
-  "Return non-nil if HOST refers to the local machine.
-A trailing \".local\" (mDNS) suffix on HOST is ignored: the macOS
-kernel hostname drifts between NAME and NAME.local with network state,
-while the function `system-name' keeps the value from Emacs startup."
-  (or (null host)
-      (string= host "")
-      (save-match-data
-        (let ((host (if (string-suffix-p ".local" host t)
-                        (substring host 0 (- (length host) (length ".local")))
-                      host)))
-          (or (eq t (compare-strings host nil nil "localhost" nil nil t))
-              (eq t (compare-strings host nil nil (system-name) nil nil t))
-              (eq t (compare-strings
-                     host nil nil
-                     (car (split-string (system-name) "\\.")) nil nil t)))))))
 
 (defun ghostel--resolve-local-executable (program)
   "Return the absolute local executable path for PROGRAM.
@@ -4744,6 +4761,9 @@ When BUFFER is non-nil, only refit windows showing BUFFER."
            (not (advice-member-p #'ghostel--around-global-font-scale
                                  'global-text-scale-adjust)))
   (advice-add 'global-text-scale-adjust :around #'ghostel--around-global-font-scale))
+
+
+;;; Mode hooks
 
 (defun ghostel--sync-tty-composition (window)
   "Sync `auto-composition-mode' with WINDOW's frame for ghostel buffers.


### PR DESCRIPTION
Pure moves in `lisp/ghostel.el` (plus one function relocated from `ghostel-shell.el`); no function bodies or docstrings change.

**Commit 1 — misplaced functions**
- New `;;; Internal helpers` section for `ghostel--ensure-ghostel-buffer` and `ghostel--run-hook-safely`. The latter moves from `ghostel-shell.el` into core (its callers are `ghostel--sentinel` and the OSC 133 handlers); `ghostel-shell.el` now forward-declares it.
- New `;;; Copying text` section: `ghostel--filter-soft-wraps`, `ghostel--clean-copy-text`, `ghostel--filter-buffer-substring`, `ghostel-readonly-copy`, `ghostel-copy-all`.
- New `;;; Mode hooks` section for the hook functions that had accumulated at the end of "Window resize".
- `ghostel--forward-scroll-event` → Mouse input; `ghostel-readonly-end-of-buffer` / `-end-of-line` → next to the other read-only commands; `ghostel--pos-on-cursor-p` → cursor-state queries; `ghostel--local-host-p` → beside `ghostel--update-directory`, its only caller.
- Form-feed lines added to the two section headers that lacked them.

**Commit 2 — new sections for shared groups**
- `;;; Mode line`: the `ghostel--mode-line-*` tag/progress helpers (driven by input modes, OSC 9;4 progress, the spinner and the password indicator).
- `;;; Cursor style`: cursor blink and `ghostel--apply-cursor-style` (were under "Callbacks from native module").
- `;;; Buffer identity`: the identity functions shared with bookmark, desktop, consult-ghostel and compile (were under "Entry point").

`make -j8 all` passes after each commit.
